### PR TITLE
Bugfix/update tasks on extract hierarchy

### DIFF
--- a/pype/plugins/global/publish/extract_hierarchy_avalon.py
+++ b/pype/plugins/global/publish/extract_hierarchy_avalon.py
@@ -78,6 +78,12 @@ class ExtractHierarchyToAvalon(pyblish.api.ContextPlugin):
                 if entity:
                     # Do not override data, only update
                     cur_entity_data = entity.get("data") or {}
+                    new_tasks = data.pop("tasks", [])
+                    if "tasks" in cur_entity_data and new_tasks:
+                        for task_name in new_tasks:
+                            if task_name not in cur_entity_data["tasks"]:
+                                cur_entity_data["tasks"].append(task_name)
+
                     cur_entity_data.update(data)
                     data = cur_entity_data
                 else:


### PR DESCRIPTION
## Issue
- tasks are overriden on asset document during extract avalon hiearachy plugin, so other tasks disappear

## Changes
- tasks are only updated not overriden