### PR TITLE
Bugfix/handle missing icon in launcher

### DIFF
--- a/pype/tools/launcher/models.py
+++ b/pype/tools/launcher/models.py
@@ -199,6 +199,9 @@ class ActionModel(QtGui.QStandardItemModel):
                 if order is None or action.order < order:
                     order = action.order
 
+            if icon is None:
+                icon = self.default_icon
+
             item = QtGui.QStandardItem(icon, action.label)
             item.setData(actions, self.ACTION_ROLE)
             item.setData(True, self.VARIANT_GROUP_ROLE)


### PR DESCRIPTION
## Issue
- for variants there is not catched situations if none of variants has valid icon in launcher

## Changes
- use default icon if icon for variants was not found