### PR TITLE
Hiero: publishing effect first time makes wrong resources path

### DIFF
--- a/openpype/plugins/publish/collect_resources_path.py
+++ b/openpype/plugins/publish/collect_resources_path.py
@@ -68,6 +68,12 @@ class CollectResourcesPath(pyblish.api.InstancePlugin):
             "representation": "TEMP"
         })
 
+        # For the first time publish
+        if instance.data.get("hierarchy"):
+            template_data.update({
+                "hierarchy": instance.data["hierarchy"]
+            })
+
         anatomy_filled = anatomy.format(template_data)
 
         if "folder" in anatomy.templates["publish"]:


### PR DESCRIPTION
This is fixing wrong path for effect resources published from Hiero.

Steps to reproduce:
1. load plate in Hiero timeline
2. add Lut effect to the plate, load some lut
3. create and publish shot
4. note that while the json used to load the effect in Nuke is placed correctly at {root[work]}/{project[name]}/`{hierarchy}`/{asset}/publish/{family}/{subset}/{@version}/resources
the Lut file itself is published to {root[work]}/{project[name]}/{asset}/publish/{family}/{subset}/{@version}/resources
missing the {hierarchy} part of the path
