### PR TITLE
Add ExtractBurnin to photoshop review

### DIFF
--- a/openpype/hosts/photoshop/plugins/publish/extract_review.py
+++ b/openpype/hosts/photoshop/plugins/publish/extract_review.py
@@ -17,6 +17,10 @@ class ExtractReview(openpype.api.Extractor):
     hosts = ["photoshop"]
     families = ["review"]
 
+    # Extract Options
+    jpg_options = None
+    mov_options = None
+
     def process(self, instance):
         staging_dir = self.staging_dir(instance)
         self.log.info("Outputting image to {}".format(staging_dir))
@@ -53,7 +57,8 @@ class ExtractReview(openpype.api.Extractor):
             "name": "jpg",
             "ext": "jpg",
             "files": output_image,
-            "stagingDir": staging_dir
+            "stagingDir": staging_dir,
+            "tags": self.jpg_options['tags']
         })
         instance.data["stagingDir"] = staging_dir
 
@@ -97,7 +102,7 @@ class ExtractReview(openpype.api.Extractor):
             "frameEnd": 1,
             "fps": 25,
             "preview": True,
-            "tags": ["review", "ftrackreview"]
+            "tags": self.mov_options['tags']
         })
 
         # Required for extract_review plugin (L222 onwards).

--- a/openpype/plugins/publish/extract_burnin.py
+++ b/openpype/plugins/publish/extract_burnin.py
@@ -45,7 +45,8 @@ class ExtractBurnin(openpype.api.Extractor):
         "aftereffects",
         "tvpaint",
         "webpublisher",
-        "aftereffects"
+        "aftereffects",
+        "photoshop"
         # "resolve"
     ]
     optional = True

--- a/openpype/settings/defaults/project_settings/photoshop.json
+++ b/openpype/settings/defaults/project_settings/photoshop.json
@@ -17,6 +17,18 @@
                 "png",
                 "jpg"
             ]
+        },
+        "ExtractReview": {
+            "jpg_options": {
+                "tags": [
+                ]
+            },
+            "mov_options": {
+                "tags": [
+                    "review",
+                    "ftrackreview"
+                ]
+            }
         }
     },
     "workfile_builder": {

--- a/openpype/settings/entities/schemas/projects_schema/schema_project_photoshop.json
+++ b/openpype/settings/entities/schemas/projects_schema/schema_project_photoshop.json
@@ -60,7 +60,39 @@
                             "object_type": "text"
                         }
                     ]
-                }                
+                },
+                {
+                    "type": "dict",
+                    "collapsible": true,
+                    "key": "ExtractReview",
+                    "label": "Extract Review",
+                    "children": [
+                        {
+                            "type": "dict",
+                            "collapsible": false,
+                            "key": "jpg_options",
+                            "label": "Extracted jpg Options",
+                            "children": [
+                                {
+                                    "type": "schema",
+                                    "name": "schema_representation_tags"
+                                }
+                            ]
+                        },
+                        {
+                            "type": "dict",
+                            "collapsible": false,
+                            "key": "mov_options",
+                            "label": "Extracted mov Options",
+                            "children": [
+                                {
+                                    "type": "schema",
+                                    "name": "schema_representation_tags"
+                                }
+                            ]
+                        }
+                    ]
+                }
             ]
         },
         {


### PR DESCRIPTION
The goal is to allow the admin/TD to set the "Add burnin" tags for the extracted reviews from photoshop within the project settings.

### Modifications
- add "photoshop" family to the global ExtractBurnin pyblish plugin
- add tags options for the mov and the jpg image extracted from the Photoshop ExtractReview pyblish plugin

Here is how it looks in the project settings

![image](https://user-images.githubusercontent.com/7955673/136979755-f685a839-6e61-4521-aac1-75a4e14eb2ae.png)
