### PR TITLE
Fix - oiiotool wasn't recognized even if present

### DIFF
--- a/openpype/lib/plugin_tools.py
+++ b/openpype/lib/plugin_tools.py
@@ -6,6 +6,7 @@ import logging
 import re
 import json
 import tempfile
+import distutils
 
 from .execute import run_subprocess
 from .profiles_filtering import filter_profiles
@@ -386,10 +387,7 @@ def oiio_supported():
     """
     oiio_path = get_oiio_tools_path()
     if oiio_path:
-        try:
-            _ = run_subprocess([oiio_path, "-v"])
-        except FileNotFoundError:
-            oiio_path = None
+        oiio_path = distutils.spawn.find_executable(oiio_path)
 
     if not oiio_path:
         log.debug("OIIOTool is not configured or not present at {}".


### PR DESCRIPTION
This caused to DWAA support not working even if it could

How to test it:
---------------
I tested it in PS in ExtractBurnin plugin. Without this fix it was logging `OIIOTool is not configured or not present at`
![Screenshot 2021-10-14 120414](https://user-images.githubusercontent.com/4457962/137297532-6b0c8597-f42b-441e-9ff6-4b5609c2f15a.png)

