### PR TITLE
Maya: fix model publishing

### DIFF
--- a/openpype/hosts/maya/plugins/publish/extract_look.py
+++ b/openpype/hosts/maya/plugins/publish/extract_look.py
@@ -205,6 +205,9 @@ class ExtractLook(openpype.api.Extractor):
         lookdata = instance.data["lookData"]
         relationships = lookdata["relationships"]
         sets = relationships.keys()
+        if not sets:
+            self.log.info("No sets found")
+            return
 
         results = self.process_resources(instance, staging_dir=dir_path)
         transfers = results["fileTransfers"]


### PR DESCRIPTION
Model publishing was broken when no sets were found during extraction of model render sets. It will bail out now if no sets are found.