### PR TITLE
Added validator for source files for Standalone Publisher

### DIFF
--- a/openpype/hosts/standalonepublisher/plugins/publish/validate_sources.py
+++ b/openpype/hosts/standalonepublisher/plugins/publish/validate_sources.py
@@ -1,0 +1,37 @@
+import pyblish.api
+import openpype.api
+
+import os
+
+
+class ValidateSources(pyblish.api.InstancePlugin):
+    """Validates source files.
+
+        Loops through all 'files' in 'stagingDir' if actually exist. They might
+        got deleted between starting of SP and now.
+
+    """
+
+    order = openpype.api.ValidateContentsOrder
+    label = "Check source files"
+
+    optional = True  # only for unforeseeable cases
+
+    hosts = ["standalonepublisher"]
+
+    def process(self, instance):
+        self.log.info("instance {}".format(instance.data))
+
+        for repr in instance.data["representations"]:
+            files = []
+            if isinstance(repr["files"], str):
+                files.append(repr["files"])
+            else:
+                files = list(repr["files"])
+
+            for file_name in files:
+                source_file = os.path.join(repr["stagingDir"],
+                                           file_name)
+
+                if not os.path.exists(source_file):
+                    raise ValueError("File {} not found".format(source_file))


### PR DESCRIPTION
Closes: #1105
Closes: OP-1063

This validator might be useful for other hosts, but I am not sure that this naive approach would work everywhere. I tested multiple use cases in SP and it worked there.