### PR TITLE
Loader thumbnails with smooth edges

### DIFF
--- a/openpype/tools/loader/widgets.py
+++ b/openpype/tools/loader/widgets.py
@@ -786,7 +786,10 @@ class ThumbnailWidget(QtWidgets.QLabel):
 
     def scale_pixmap(self, pixmap):
         return pixmap.scaled(
-            self.width(), self.height(), QtCore.Qt.KeepAspectRatio
+            self.width(),
+            self.height(),
+            QtCore.Qt.KeepAspectRatio,
+            QtCore.Qt.SmoothTransformation
         )
 
     def set_thumbnail(self, entity=None):


### PR DESCRIPTION
Loader thumbnail widget has ugly jagged edges. This fixes the transformation to be nice and smooth.