### PR TITLE
Ftrack: Ignore save warnings exception in Prepare project action

### DIFF
--- a/openpype/modules/default_modules/ftrack/event_handlers_server/action_prepare_project.py
+++ b/openpype/modules/default_modules/ftrack/event_handlers_server/action_prepare_project.py
@@ -3,6 +3,7 @@ import json
 from avalon.api import AvalonMongoDB
 from openpype.api import ProjectSettings
 from openpype.lib import create_project
+from openpype.settings import SaveWarningExc
 
 from openpype_modules.ftrack.lib import (
     ServerAction,
@@ -312,7 +313,6 @@ class PrepareProjectServer(ServerAction):
         if not in_data:
             return
 
-
         root_values = {}
         root_key = "__root__"
         for key in tuple(in_data.keys()):
@@ -392,7 +392,12 @@ class PrepareProjectServer(ServerAction):
             else:
                 attributes_entity[key] = value
 
-        project_settings.save()
+        try:
+            project_settings.save()
+        except SaveWarningExc as exc:
+            self.log.info("Few warnings happened during settings save:")
+            for warning in exc.warnings:
+                self.log.info(str(warning))
 
         # Change custom attributes on project
         if custom_attribute_values:

--- a/openpype/modules/default_modules/ftrack/event_handlers_user/action_prepare_project.py
+++ b/openpype/modules/default_modules/ftrack/event_handlers_user/action_prepare_project.py
@@ -3,6 +3,7 @@ import json
 from avalon.api import AvalonMongoDB
 from openpype.api import ProjectSettings
 from openpype.lib import create_project
+from openpype.settings import SaveWarningExc
 
 from openpype_modules.ftrack.lib import (
     BaseAction,
@@ -417,7 +418,12 @@ class PrepareProjectLocal(BaseAction):
             else:
                 attributes_entity[key] = value
 
-        project_settings.save()
+        try:
+            project_settings.save()
+        except SaveWarningExc as exc:
+            self.log.info("Few warnings happened during settings save:")
+            for warning in exc.warnings:
+                self.log.info(str(warning))
 
         # Change custom attributes on project
         if custom_attribute_values:


### PR DESCRIPTION
## Issue
Save of settings may raise `SaveWarningExc` which is not captured in prepare project action and crashes without important reason.

## Changes
- Prepare project actions catch `SaveWarningExc` exception and log out warnings