### PR TITLE
Tools: Stylesheets are applied after tool show

### DIFF
--- a/openpype/tools/utils/host_tools.py
+++ b/openpype/tools/utils/host_tools.py
@@ -40,7 +40,6 @@ class HostToolsHelper:
     def get_workfiles_tool(self, parent):
         """Create, cache and return workfiles tool window."""
         if self._workfiles_tool is None:
-            from avalon import style
             from openpype.tools.workfiles.app import (
                 Window, validate_host_requirements
             )
@@ -49,13 +48,14 @@ class HostToolsHelper:
             validate_host_requirements(host)
 
             workfiles_window = Window(parent=parent)
-            workfiles_window.setStyleSheet(style.load_stylesheet())
             self._workfiles_tool = workfiles_window
 
         return self._workfiles_tool
 
     def show_workfiles(self, parent=None, use_context=None, save=None):
         """Workfiles tool for changing context and saving workfiles."""
+        from avalon import style
+
         if use_context is None:
             use_context = True
 
@@ -79,24 +79,30 @@ class HostToolsHelper:
         # Pull window to the front.
         workfiles_tool.raise_()
         workfiles_tool.activateWindow()
+        workfiles_tool.setStyleSheet(style.load_stylesheet())
 
     def get_loader_tool(self, parent):
         """Create, cache and return loader tool window."""
         if self._loader_tool is None:
-            from avalon import style
             from openpype.tools.loader import LoaderWindow
 
             loader_window = LoaderWindow(parent=parent or self._parent)
-            loader_window.setStyleSheet(style.load_stylesheet())
             self._loader_tool = loader_window
 
         return self._loader_tool
 
     def show_loader(self, parent=None, use_context=None):
         """Loader tool for loading representations."""
+        from avalon import style
+
+        loader_tool = self.get_loader_tool(parent)
+
+        loader_tool.show()
+        loader_tool.raise_()
+        loader_tool.activateWindow()
+
         if use_context is None:
             use_context = False
-        loader_tool = self.get_loader_tool(parent)
 
         if use_context:
             context = {"asset": avalon.api.Session["AVALON_ASSET"]}
@@ -104,28 +110,27 @@ class HostToolsHelper:
         else:
             loader_tool.refresh()
 
-        loader_tool.show()
-        loader_tool.raise_()
-        loader_tool.activateWindow()
-        loader_tool.refresh()
+        loader_tool.setStyleSheet(style.load_stylesheet())
 
     def get_creator_tool(self, parent):
         """Create, cache and return creator tool window."""
         if self._creator_tool is None:
-            from avalon import style
             from avalon.tools.creator.app import Window
 
             creator_window = Window(parent=parent or self._parent)
-            creator_window.setStyleSheet(style.load_stylesheet())
             self._creator_tool = creator_window
 
         return self._creator_tool
 
     def show_creator(self, parent=None):
         """Show tool to create new instantes for publishing."""
+        from avalon import style
+
         creator_tool = self.get_creator_tool(parent)
         creator_tool.refresh()
         creator_tool.show()
+
+        creator_tool.setStyleSheet(style.load_stylesheet())
 
         # Pull window to the front.
         creator_tool.raise_()
@@ -134,19 +139,21 @@ class HostToolsHelper:
     def get_subset_manager_tool(self, parent):
         """Create, cache and return subset manager tool window."""
         if self._subset_manager_tool is None:
-            from avalon import style
             from avalon.tools.subsetmanager import Window
 
             subset_manager_window = Window(parent=parent or self._parent)
-            subset_manager_window.setStyleSheet(style.load_stylesheet())
             self._subset_manager_tool = subset_manager_window
 
         return self._subset_manager_tool
 
     def show_subset_manager(self, parent=None):
         """Show tool display/remove existing created instances."""
+        from avalon import style
+
         subset_manager_tool = self.get_subset_manager_tool(parent)
         subset_manager_tool.show()
+
+        subset_manager_tool.setStyleSheet(style.load_stylesheet())
 
         # Pull window to the front.
         subset_manager_tool.raise_()
@@ -155,20 +162,21 @@ class HostToolsHelper:
     def get_scene_inventory_tool(self, parent):
         """Create, cache and return scene inventory tool window."""
         if self._scene_inventory_tool is None:
-            from avalon import style
             from avalon.tools.sceneinventory.app import Window
 
             scene_inventory_window = Window(parent=parent or self._parent)
-            scene_inventory_window.setStyleSheet(style.load_stylesheet())
             self._scene_inventory_tool = scene_inventory_window
 
         return self._scene_inventory_tool
 
     def show_scene_inventory(self, parent=None):
         """Show tool maintain loaded containers."""
+        from avalon import style
+
         scene_inventory_tool = self.get_scene_inventory_tool(parent)
         scene_inventory_tool.show()
         scene_inventory_tool.refresh()
+        scene_inventory_tool.setStyleSheet(style.load_stylesheet())
 
         # Pull window to the front.
         scene_inventory_tool.raise_()
@@ -177,24 +185,25 @@ class HostToolsHelper:
     def get_library_loader_tool(self, parent):
         """Create, cache and return library loader tool window."""
         if self._library_loader_tool is None:
-            from avalon import style
             from openpype.tools.libraryloader import LibraryLoaderWindow
 
             library_window = LibraryLoaderWindow(
                 parent=parent or self._parent
             )
-            library_window.setStyleSheet(style.load_stylesheet())
             self._library_loader_tool = library_window
 
         return self._library_loader_tool
 
     def show_library_loader(self, parent=None):
         """Loader tool for loading representations from library project."""
+        from avalon import style
+
         library_loader_tool = self.get_library_loader_tool(parent)
         library_loader_tool.show()
         library_loader_tool.raise_()
         library_loader_tool.activateWindow()
         library_loader_tool.refresh()
+        library_loader_tool.setStyleSheet(style.load_stylesheet())
 
     def show_publish(self, parent=None):
         """Publish UI."""
@@ -205,18 +214,19 @@ class HostToolsHelper:
     def get_look_assigner_tool(self, parent):
         """Create, cache and return look assigner tool window."""
         if self._look_assigner_tool is None:
-            from avalon import style
             import mayalookassigner
 
             mayalookassigner_window = mayalookassigner.App(parent)
-            mayalookassigner_window.setStyleSheet(style.load_stylesheet())
             self._look_assigner_tool = mayalookassigner_window
         return self._look_assigner_tool
 
     def show_look_assigner(self, parent=None):
         """Look manager is Maya specific tool for look management."""
+        from avalon import style
+
         look_assigner_tool = self.get_look_assigner_tool(parent)
         look_assigner_tool.show()
+        look_assigner_tool.setStyleSheet(style.load_stylesheet())
 
     def get_tool_by_name(self, tool_name, parent=None, *args, **kwargs):
         """Show tool by it's name.


### PR DESCRIPTION
## Issue
Stylesheets applied before showing a widget may not be propagated (in houdini) so stylesheet of host are used instead of avalon/openpype stylesheets.
Caused by https://github.com/pypeclub/OpenPype/pull/2139

## Changes
- set stylesheet on tool show and after calling of `show` method

## How to test
- open houdini with openpype and show tools
- all of them should not have houdini styles but styles defined by us