### PR TITLE
MacOS: Launching of applications may cause Permissions error

### DIFF
--- a/openpype/lib/applications.py
+++ b/openpype/lib/applications.py
@@ -461,13 +461,8 @@ class ApplicationExecutable:
         # On MacOS check if exists path to executable when ends with `.app`
         # - it is common that path will lead to "/Applications/Blender" but
         #   real path is "/Applications/Blender.app"
-        if (
-            platform.system().lower() == "darwin"
-            and not os.path.exists(executable)
-        ):
-            _executable = executable + ".app"
-            if os.path.exists(_executable):
-                executable = _executable
+        if platform.system().lower() == "darwin":
+            executable = self.macos_executable_prep(executable)
 
         self.executable_path = executable
 
@@ -476,6 +471,45 @@ class ApplicationExecutable:
 
     def __repr__(self):
         return "<{}> {}".format(self.__class__.__name__, self.executable_path)
+
+    @staticmethod
+    def macos_executable_prep(executable):
+        """Try to find full path to executable file.
+
+        Real executable is stored in '*.app/Contents/MacOS/<executable>'.
+
+        Having path to '*.app' gives ability to read it's plist info and
+        use "CFBundleExecutable" key from plist to know what is "executable."
+
+        Plist is stored in '*.app/Contents/Info.plist'.
+
+        This is because some '*.app' directories don't have same permissions
+        as real executable.
+        """
+        # Try to find if there is `.app` file
+        if not os.path.exists(executable):
+            _executable = executable + ".app"
+            if os.path.exists(_executable):
+                executable = _executable
+
+        # Try to find real executable if executable has `Contents` subfolder
+        contents_dir = os.path.join(executable, "Contents")
+        if os.path.exists(contents_dir):
+            executable_filename = None
+            # Load plist file and check for bundle executable
+            plist_filepath = os.path.join(contents_dir, "Info.plist")
+            if os.path.exists(plist_filepath):
+                import plistlib
+
+                parsed_plist = plistlib.readPlist(plist_filepath)
+                executable_filename = parsed_plist.get("CFBundleExecutable")
+
+            if executable_filename:
+                executable = os.path.join(
+                    contents_dir, "MacOS", executable_filename
+                )
+
+        return executable
 
     def as_args(self):
         return [self.executable_path]


### PR DESCRIPTION
## Description
Phostoshop is not launching on MacOS when path is set to `.app` folder launching through OpenPype will crash without showing any error. That is because it crashes on launching Photoshop on `Permission Deined` error.

MacOS executables are not easy to launch. Having path to '.app' direcory may not be enough because '.app' directory has different permissions than real executable stored inside the folder. To get real executable filename it is required to load plist file from the `*.app/Contents/Info.plist` which holds all information about bundle and one of the information is executable filename stored under `CFBundleExecutable` key (this may not be the same executable for headless access).

## Changes
- MacOS executables are calculated from `.app` to full executable path in `ApplicationExecutable`
    - use plist info to get full path to executable

## How to test
I'll use Photoshop as example.
- set path to photoshop to `/Applications/Adobe Photoshop 2021/Adobe Photoshop 2021` (I think that is path from Application store)
- launch photoshop from launcher
- everythink should work

@kalisp please test headless launching because this may have affect on that.