### PR TITLE
Hooks: Tweak logging grammar

### DIFF
--- a/openpype/lib/applications.py
+++ b/openpype/lib/applications.py
@@ -1044,8 +1044,8 @@ class ApplicationLaunchContext:
                     hook = klass(self)
                     if not hook.is_valid:
                         self.log.debug(
-                            "Hook is not valid for current "
-                            "launch context: {}".format(klass.__name__)
+                            "Skipped hook invalid for current launch context: "
+                            "{}".format(klass.__name__)
                         )
                         continue
 


### PR DESCRIPTION
## Brief description

This tweaks the Hooks logging grammar to (I think) be more valid plus it also adds the actual Hook's name that is being skipped due to not being valid for a context.

## Testing notes:
1. Launch an app from tray and note the logs about the Hooks