### PR TITLE
Maya: Fix udim support for e.g. uppercase <UDIM> tag

### DIFF
--- a/openpype/hosts/maya/plugins/publish/collect_look.py
+++ b/openpype/hosts/maya/plugins/publish/collect_look.py
@@ -109,16 +109,18 @@ def node_uses_image_sequence(node, node_path):
     """
 
     # useFrameExtension indicates an explicit image sequence
-    # The following tokens imply a sequence
-    patterns = ["<udim>", "<tile>", "<uvtile>",
-                "u<u>_v<v>", "<frame0", "<f4>"]
     try:
         use_frame_extension = cmds.getAttr('%s.useFrameExtension' % node)
     except ValueError:
         use_frame_extension = False
+    if use_frame_extension:
+        return True
 
-    return (use_frame_extension or
-            any(pattern in node_path for pattern in patterns))
+    # The following tokens imply a sequence
+    patterns = ["<udim>", "<tile>", "<uvtile>",
+                "u<u>_v<v>", "<frame0", "<f4>"]
+    node_path_lowered = node_path.lower()
+    return any(pattern in node_path_lowered for pattern in patterns)
 
 
 def seq_to_glob(path):


### PR DESCRIPTION
## Brief description

Fixes bug reported [here](https://github.com/pypeclub/OpenPype/pull/3190#discussion_r884826648).

## Description

Sequence file paths were broken with #3190 if e.g. the file sequence tag like `<UDIM>` wasn't lowercase in the path string.

I have also moved the logic closer together for readability purposes.

## Testing notes:
1. Load a UDIM file in Maya lookdev with `<UDIM>` as filetag.
2. It will fail to collect the files on disk.