### PR TITLE
Maya: fix hashing in Python 3 for tile rendering - backport ↩️ to 3.9.x

### DIFF
--- a/openpype/modules/deadline/plugins/publish/submit_maya_deadline.py
+++ b/openpype/modules/deadline/plugins/publish/submit_maya_deadline.py
@@ -709,7 +709,8 @@ class MayaSubmitDeadline(pyblish.api.InstancePlugin):
                 new_payload["JobInfo"].update(tiles_data["JobInfo"])
                 new_payload["PluginInfo"].update(tiles_data["PluginInfo"])
 
-                job_hash = hashlib.sha256("{}_{}".format(file_index, file))
+                job_hash = hashlib.sha256(
+                    ("{}_{}".format(file_index, file)).encode("utf-8"))
                 frame_jobs[frame] = job_hash.hexdigest()
                 new_payload["JobInfo"]["ExtraInfo0"] = job_hash.hexdigest()
                 new_payload["JobInfo"]["ExtraInfo1"] = file


### PR DESCRIPTION
## Backport of #3447

This is backport to 3.9.x of #3447