### PR TITLE
Harmony: Added settings for mageSequenceLoader

### DIFF
--- a/openpype/settings/defaults/project_settings/harmony.json
+++ b/openpype/settings/defaults/project_settings/harmony.json
@@ -1,4 +1,20 @@
 {
+    "load": {
+        "ImageSequenceLoader": {
+            "family": [
+                "shot",
+                "render",
+                "image",
+                "plate",
+                "reference"
+            ],
+            "representations": [
+                "jpeg",
+                "png",
+                "jpg"
+            ]
+        }
+    },
     "publish": {
         "CollectPalettes": {
             "allowed_tasks": [

--- a/openpype/settings/entities/schemas/projects_schema/schema_project_harmony.json
+++ b/openpype/settings/entities/schemas/projects_schema/schema_project_harmony.json
@@ -8,6 +8,34 @@
         {
             "type": "dict",
             "collapsible": true,
+            "key": "load",
+            "label": "Loader plugins",
+            "children": [
+                {
+                    "type": "dict",
+                    "collapsible": true,
+                    "key": "ImageSequenceLoader",
+                    "label": "Load Image Sequence",
+                    "children": [
+                        {
+                            "type": "list",
+                            "key": "family",
+                            "label": "Families",
+                            "object_type": "text"
+                        },
+                        {
+                            "type": "list",
+                            "key": "representations",
+                            "label": "Representations",
+                            "object_type": "text"
+                        }
+                    ]
+                }
+            ]
+        },
+        {
+            "type": "dict",
+            "collapsible": true,
             "key": "publish",
             "label": "Publish plugins",
             "children": [


### PR DESCRIPTION
## Brief description
Currently to fix issue with reference representations with wrong names (png_mp4 instead of png), but it could be helpful in the future regardless.


## Testing notes:
1. to fix customer issue add 'png_mp4' in `project_settings/harmony/load/ImageSequenceLoader`
2. try to Load reference in Harmony