### PR TITLE
Fix: Hero representation of version is not synchronized.

### DIFF
--- a/openpype/modules/sync_server/sync_server_module.py
+++ b/openpype/modules/sync_server/sync_server_module.py
@@ -16,7 +16,10 @@ from openpype.client import (
     get_representations,
     get_representation_by_id,
 )
-from openpype.client.entities import get_hero_version_by_subset_id, get_representation_parents
+from openpype.client.entities import (
+    get_hero_version_by_subset_id,
+    get_representation_parents,
+)
 from openpype.modules import OpenPypeModule, ITrayModule
 from openpype.settings import (
     get_project_settings,
@@ -1815,7 +1818,7 @@ class SyncServerModule(OpenPypeModule, ITrayModule):
             representation_ids.extend(
                 [repre["_id"] for repre in representations]
             )
-        
+
         query = {"_id": {"$in": representation_ids}}
 
         self.connection.database[project_name].update_many(


### PR DESCRIPTION
## Brief description
Hero version is not created on remote site when a representation is downloaded. This adds the related hero representation in `_update_site` when a version representation is fetched.

Fix #4154

Replaces #4186

## Testing notes:
1. Enable Hero version
1. Publish a workfile with a published subset as input link
2. Using the Loader, download the workfile
3. The hero representation is fetched along the version.