### PR TITLE
Traypublisher: simple editorial multiple edl

### DIFF
--- a/openpype/hosts/traypublisher/api/editorial.py
+++ b/openpype/hosts/traypublisher/api/editorial.py
@@ -171,7 +171,6 @@ class ShotMetadataSolver:
                 _index == 0
                 and parents[-1]["entity_name"] == parent_name
             ):
-                self.log.debug(f" skipping : {parent_name}")
                 continue
 
             # in case first parent is project then start parents from start
@@ -179,7 +178,6 @@ class ShotMetadataSolver:
                 _index == 0
                 and parent_token_type == "Project"
             ):
-                self.log.debug("rebuilding parents from scratch")
                 project_parent = parents[0]
                 parents = [project_parent]
                 continue
@@ -188,8 +186,6 @@ class ShotMetadataSolver:
                 "entity_type": parent_token_type,
                 "entity_name": parent_name
             })
-
-        self.log.debug(f"__ parents: {parents}")
 
         return parents
 
@@ -297,7 +293,6 @@ class ShotMetadataSolver:
         Returns:
             (str, dict): shot name and hierarchy data
         """
-        self.log.info(f"_ source_data: {source_data}")
 
         tasks = {}
         asset_doc = source_data["selected_asset_doc"]

--- a/openpype/hosts/traypublisher/plugins/create/create_editorial.py
+++ b/openpype/hosts/traypublisher/plugins/create/create_editorial.py
@@ -264,9 +264,14 @@ or updating already created. Publishing will create OTIO file.
 
             )
 
+            # alter subset name if multiple files
+            subset_name_edit = subset_name
+            if len(sequence_paths) > 1:
+                subset_name_edit = subset_name + str(index)
+
             # create otio editorial instance
             self._create_otio_instance(
-                subset_name + str(index),
+                subset_name_edit,
                 instance_data,
                 seq_path, media_path,
                 otio_timeline

--- a/openpype/hosts/traypublisher/plugins/publish/collect_shot_instances.py
+++ b/openpype/hosts/traypublisher/plugins/publish/collect_shot_instances.py
@@ -33,8 +33,6 @@ class CollectShotInstance(pyblish.api.InstancePlugin):
     ]
 
     def process(self, instance):
-        self.log.debug(pformat(instance.data))
-
         creator_identifier = instance.data["creator_identifier"]
         if "editorial" not in creator_identifier:
             return
@@ -82,7 +80,6 @@ class CollectShotInstance(pyblish.api.InstancePlugin):
         ]
 
         otio_clip = clips.pop()
-        self.log.debug(f"__ otioclip.parent: {otio_clip.parent}")
 
         return otio_clip
 
@@ -172,7 +169,6 @@ class CollectShotInstance(pyblish.api.InstancePlugin):
         }
 
         parents = instance.data.get('parents', [])
-        self.log.debug(f"parents: {pformat(parents)}")
 
         actual = {name: in_info}
 
@@ -190,7 +186,6 @@ class CollectShotInstance(pyblish.api.InstancePlugin):
 
         # adding hierarchy context to instance
         context.data["hierarchyContext"] = final_context
-        self.log.debug(pformat(final_context))
 
     def _update_dict(self, ex_dict, new_dict):
         """ Recursion function


### PR DESCRIPTION
## Brief description
Traypublisher simple editorial supports multiple sequence files.

## Description
Multilayer edl files are now supported.

## Testing notes:
1. add multilayer edl files to sequence representations
2. add reviewable media
3. hit create and see nothing is broken