### PR TITLE
Resolve: Use qtpy in Resolve

### DIFF
--- a/openpype/hosts/resolve/api/menu.py
+++ b/openpype/hosts/resolve/api/menu.py
@@ -1,7 +1,7 @@
 import os
 import sys
 
-from Qt import QtWidgets, QtCore
+from qtpy import QtWidgets, QtCore
 
 from openpype.tools.utils import host_tools
 

--- a/openpype/hosts/resolve/api/plugin.py
+++ b/openpype/hosts/resolve/api/plugin.py
@@ -2,7 +2,7 @@ import re
 import uuid
 
 import qargparse
-from Qt import QtWidgets, QtCore
+from qtpy import QtWidgets, QtCore
 
 from openpype.settings import get_current_project_settings
 from openpype.pipeline.context_tools import get_current_project_asset


### PR DESCRIPTION
## Brief description
Use `qtpy` in resolve host implementation instead of `Qt.py`.

## Additional information
This PR does not change usage in host tools just imports used inside host implementation.

## Testing notes:
Resolve UIs should work as did before.