### PR TITLE
Global, Nuke, Maya - Workfile template builder workflow update

### DIFF
--- a/openpype/hosts/maya/api/workfile_template_builder.py
+++ b/openpype/hosts/maya/api/workfile_template_builder.py
@@ -28,7 +28,7 @@ class MayaTemplateBuilder(AbstractTemplateBuilder):
 
         Args:
             path (str): A path to current template (usually given by
-            get_template_path implementation)
+            get_template_preset implementation)
 
         Returns:
             bool: Wether the template was succesfully imported or not

--- a/openpype/hosts/nuke/api/lib.py
+++ b/openpype/hosts/nuke/api/lib.py
@@ -2865,10 +2865,11 @@ def get_group_io_nodes(nodes):
                 break
 
         if input_node is None:
-            raise ValueError("No Input found")
+            log.warning("No Input found")
 
         if output_node is None:
-            raise ValueError("No Output found")
+            log.warning("No Output found")
+
     return input_node, output_node
 
 

--- a/openpype/hosts/nuke/api/pipeline.py
+++ b/openpype/hosts/nuke/api/pipeline.py
@@ -217,10 +217,6 @@ def _install_menu():
         "Build Workfile from template",
         lambda: build_workfile_template()
     )
-    menu_template.addCommand(
-        "Update Workfile",
-        lambda: update_workfile_template()
-    )
     menu_template.addSeparator()
     menu_template.addCommand(
         "Create Place Holder",

--- a/openpype/hosts/nuke/api/workfile_template_builder.py
+++ b/openpype/hosts/nuke/api/workfile_template_builder.py
@@ -40,7 +40,7 @@ class NukeTemplateBuilder(AbstractTemplateBuilder):
 
         Args:
             path (str): A path to current template (usually given by
-            get_template_path implementation)
+            get_template_preset implementation)
 
         Returns:
             bool: Wether the template was succesfully imported or not
@@ -273,6 +273,15 @@ class NukePlaceholderLoadPlugin(NukePlaceholderPlugin, PlaceholderLoadMixin):
 
         placeholder.data["nb_children"] += 1
         reset_selection()
+
+        # remove placeholders marked as delete
+        if (
+            placeholder.data.get("delete")
+            and not placeholder.data.get("keep_placeholder")
+        ):
+            self.log.debug("Deleting node: {}".format(placeholder_node.name()))
+            nuke.delete(placeholder_node)
+
         # go back to root group
         nuke.root().begin()
 
@@ -454,12 +463,12 @@ class NukePlaceholderLoadPlugin(NukePlaceholderPlugin, PlaceholderLoadMixin):
         )
         for node in placeholder_node.dependent():
             for idx in range(node.inputs()):
-                if node.input(idx) == placeholder_node:
+                if node.input(idx) == placeholder_node and output_node:
                     node.setInput(idx, output_node)
 
         for node in placeholder_node.dependencies():
             for idx in range(placeholder_node.inputs()):
-                if placeholder_node.input(idx) == node:
+                if placeholder_node.input(idx) == node and input_node:
                     input_node.setInput(0, node)
 
     def _create_sib_copies(self, placeholder):

--- a/openpype/pipeline/workfile/workfile_template_builder.py
+++ b/openpype/pipeline/workfile/workfile_template_builder.py
@@ -419,6 +419,9 @@ class AbstractTemplateBuilder(object):
                 passed.
             level_limit (int): Limit of populate loops. Related to
                 'populate_scene_placeholders' method.
+            keep_placeholders (bool): Add flag to placeholder data for
+                hosts to decide if they want to remove
+                placeholder after it is used.
         """
         template_preset = self.get_template_preset()
 
@@ -518,6 +521,9 @@ class AbstractTemplateBuilder(object):
 
         Args:
             level_limit (int): Level of loops that can happen. Default is 1000.
+            keep_placeholders (bool): Add flag to placeholder data for
+                hosts to decide if they want to remove
+                placeholder after it is used.
         """
 
         if not self.placeholder_plugins:

--- a/openpype/settings/entities/schemas/projects_schema/schemas/schema_templated_workfile_build.json
+++ b/openpype/settings/entities/schemas/projects_schema/schemas/schema_templated_workfile_build.json
@@ -25,8 +25,15 @@
                     {
                         "key": "path",
                         "label": "Path to template",
-                        "type": "text",
-                        "object_type": "text"
+                        "type": "path",
+                        "multiplatform": false,
+                        "multipath": false
+                    },
+                    {
+                        "key": "placeholder_keep",
+                        "label": "Keep placeholders",
+                        "type": "boolean",
+                        "default": true
                     }
                 ]
             }


### PR DESCRIPTION
## Brief description
Updating workflow for on demand placeholder removal.

## Description
Presets for workfile template builder are having new attribute for keeping placeholders after they are used. To maintain backward compatibility for deployed studios who are using this workflow we are keeping default as keep and we can remove them in Nuke on demand. 

## Additional info
Global and Maya should work as it was.

## Testing notes [ Nuke ]:
1. Test in `\OP02_VFX_demo` ideally on **sh020**  
2. download [following zip](https://drive.google.com/file/d/1cJCKO8AJzO9Nm7i5-zMMu8D0p2EtDo8Z/view?usp=sharing) and upack it in project structure as follows.
![image](https://user-images.githubusercontent.com/40640033/209120941-0a8c73d0-6df7-4777-959f-822398ed8115.png)
3. create preset in your test project settings `project_settings/nuke/templated_workfile_build`
4. In case you  already had some preset then `DO NOT SAVE` and test backward compatibility in Nuke by building from template. All should work as it was. 
5.a If you are creating new preset then paste following onto `project_settings/nuke/templated_workfile_build` and fix the path to your in case it is different.
```
{
    "profiles": [
        {
            "task_types": [
                "Compositing"
            ],
            "task_names": [],
            "path": "{root[work]}/OP02_VFX_demo/templates/comp.nk",
            "placeholder_keep": false
        }
    ]
}
```
5.b [dowload this settings patch](https://drive.google.com/file/d/1zu6AtXZQ8-35C9YDGoymX9JLXGKmIFxa/view?usp=sharing) then copy context of the file to clipboard. Go to `project_settings/nuke/imageio` and RMB click at the ImageIO and __paste__. It will take about 5mins to update and then save the settings.
6. then go to Nuke and 
![image](https://user-images.githubusercontent.com/40640033/209121413-b1a806c7-7e97-4665-8f33-15822d0a55a0.png)
7. template should show in script and no Placeholders should stay in the scene under loaded Read nodes. 
8. Try it again but switch the settings `placeholder_keep` to active.
9. Placeholders should stay in the scene after the template is builded. 