### PR TITLE
Global | Nuke: Creator placeholders in workfile template builder

### DIFF
--- a/openpype/hosts/maya/api/workfile_template_builder.py
+++ b/openpype/hosts/maya/api/workfile_template_builder.py
@@ -28,7 +28,7 @@ class MayaTemplateBuilder(AbstractTemplateBuilder):
 
         Args:
             path (str): A path to current template (usually given by
-            get_template_path implementation)
+            get_template_preset implementation)
 
         Returns:
             bool: Wether the template was succesfully imported or not

--- a/openpype/hosts/maya/api/workfile_template_builder.py
+++ b/openpype/hosts/maya/api/workfile_template_builder.py
@@ -240,7 +240,7 @@ class MayaPlaceholderLoadPlugin(PlaceholderPlugin, PlaceholderLoadMixin):
         cmds.setAttr(node + ".hiddenInOutliner", True)
 
     def load_succeed(self, placeholder, container):
-        self._parent_in_hierarhchy(placeholder, container)
+        self._parent_in_hierarchy(placeholder, container)
 
     def _parent_in_hierarchy(self, placeholder, container):
         """Parent loaded container to placeholder's parent.

--- a/openpype/hosts/nuke/api/lib.py
+++ b/openpype/hosts/nuke/api/lib.py
@@ -2865,10 +2865,11 @@ def get_group_io_nodes(nodes):
                 break
 
         if input_node is None:
-            raise ValueError("No Input found")
+            log.warning("No Input found")
 
         if output_node is None:
-            raise ValueError("No Output found")
+            log.warning("No Output found")
+
     return input_node, output_node
 
 

--- a/openpype/hosts/nuke/api/pipeline.py
+++ b/openpype/hosts/nuke/api/pipeline.py
@@ -35,6 +35,7 @@ from .lib import (
 )
 from .workfile_template_builder import (
     NukePlaceholderLoadPlugin,
+    NukePlaceholderCreatePlugin,
     build_workfile_template,
     update_workfile_template,
     create_placeholder,
@@ -139,7 +140,8 @@ def _show_workfiles():
 
 def get_workfile_build_placeholder_plugins():
     return [
-        NukePlaceholderLoadPlugin
+        NukePlaceholderLoadPlugin,
+        NukePlaceholderCreatePlugin
     ]
 
 

--- a/openpype/hosts/nuke/api/pipeline.py
+++ b/openpype/hosts/nuke/api/pipeline.py
@@ -217,10 +217,6 @@ def _install_menu():
         "Build Workfile from template",
         lambda: build_workfile_template()
     )
-    menu_template.addCommand(
-        "Update Workfile",
-        lambda: update_workfile_template()
-    )
     menu_template.addSeparator()
     menu_template.addCommand(
         "Create Place Holder",

--- a/openpype/hosts/nuke/api/workfile_template_builder.py
+++ b/openpype/hosts/nuke/api/workfile_template_builder.py
@@ -574,6 +574,9 @@ class NukePlaceholderCreatePlugin(
         placeholder_data["delete"] = False
         return placeholder_data
 
+    def _before_instance_create(self, placeholder):
+        placeholder.data["nodes_init"] = nuke.allNodes()
+
     def collect_placeholders(self):
         output = []
         scene_placeholders = self._collect_scene_placeholders()

--- a/openpype/hosts/nuke/api/workfile_template_builder.py
+++ b/openpype/hosts/nuke/api/workfile_template_builder.py
@@ -76,8 +76,7 @@ class NukePlaceholderPlugin(PlaceholderPlugin):
 
                     node_knobs = node.knobs()
                     if (
-                        "builder_type" not in node_knobs
-                        or "is_placeholder" not in node_knobs
+                        "is_placeholder" not in node_knobs
                         or not node.knob("is_placeholder").value()
                     ):
                         continue
@@ -756,16 +755,9 @@ class NukePlaceholderCreatePlugin(
 
         created_nodes = placeholder.data["last_created"]
         created_nodes_set = set(created_nodes)
-        data = {"repre_id": str(placeholder.data["last_repre_id"])}
 
         for node in created_nodes:
             node_knobs = node.knobs()
-            if "builder_type" not in node_knobs:
-                # save the id of representation for all imported nodes
-                imprint(node, data)
-                node.knob("repre_id").setVisible(False)
-                refresh_node(node)
-                continue
 
             if (
                 "is_placeholder" not in node_knobs

--- a/openpype/hosts/nuke/api/workfile_template_builder.py
+++ b/openpype/hosts/nuke/api/workfile_template_builder.py
@@ -588,7 +588,7 @@ class NukePlaceholderCreatePlugin(
                 continue
 
             placeholder_data = self._parse_placeholder_node_data(node)
-            # TODO do data validations and maybe updgrades if are invalid
+
             output.append(
                 CreatePlaceholderItem(node_name, placeholder_data, self)
             )

--- a/openpype/hosts/nuke/api/workfile_template_builder.py
+++ b/openpype/hosts/nuke/api/workfile_template_builder.py
@@ -7,7 +7,9 @@ from openpype.pipeline.workfile.workfile_template_builder import (
     AbstractTemplateBuilder,
     PlaceholderPlugin,
     LoadPlaceholderItem,
+    CreatePlaceholderItem,
     PlaceholderLoadMixin,
+    PlaceholderCreateMixin
 )
 from openpype.tools.workfile_template_build import (
     WorkfileBuildPlaceholderDialog,
@@ -32,7 +34,7 @@ PLACEHOLDER_SET = "PLACEHOLDERS_SET"
 
 
 class NukeTemplateBuilder(AbstractTemplateBuilder):
-    """Concrete implementation of AbstractTemplateBuilder for maya"""
+    """Concrete implementation of AbstractTemplateBuilder for nuke"""
 
     def import_template(self, path):
         """Import template into current scene.
@@ -508,6 +510,412 @@ class NukePlaceholderLoadPlugin(NukePlaceholderPlugin, PlaceholderLoadMixin):
 
         last_input, last_output = get_group_io_nodes(
             placeholder.data["last_loaded"]
+        )
+        siblings = get_nodes_by_names(placeholder.data["siblings"])
+        siblings_input, siblings_output = get_group_io_nodes(siblings)
+        copy_input = copies[siblings_input.name()]
+        copy_output = copies[siblings_output.name()]
+
+        for node_init in siblings:
+            if node_init == siblings_output:
+                continue
+
+            node_copy = copies[node_init.name()]
+            for node in node_init.dependent():
+                for idx in range(node.inputs()):
+                    if node.input(idx) != node_init:
+                        continue
+
+                    if node in siblings:
+                        copies[node.name()].setInput(idx, node_copy)
+                    else:
+                        last_input.setInput(0, node_copy)
+
+            for node in node_init.dependencies():
+                for idx in range(node_init.inputs()):
+                    if node_init.input(idx) != node:
+                        continue
+
+                    if node_init == siblings_input:
+                        copy_input.setInput(idx, node)
+                    elif node in siblings:
+                        node_copy.setInput(idx, copies[node.name()])
+                    else:
+                        node_copy.setInput(idx, last_output)
+
+        siblings_input.setInput(0, copy_output)
+
+
+class NukePlaceholderCreatePlugin(
+    NukePlaceholderPlugin, PlaceholderCreateMixin
+):
+    identifier = "nuke.create"
+    label = "Nuke create"
+
+    def _parse_placeholder_node_data(self, node):
+        placeholder_data = super(
+            NukePlaceholderCreatePlugin, self
+        )._parse_placeholder_node_data(node)
+
+        node_knobs = node.knobs()
+        nb_children = 0
+        if "nb_children" in node_knobs:
+            nb_children = int(node_knobs["nb_children"].getValue())
+        placeholder_data["nb_children"] = nb_children
+
+        siblings = []
+        if "siblings" in node_knobs:
+            siblings = node_knobs["siblings"].values()
+        placeholder_data["siblings"] = siblings
+
+        node_full_name = node.fullName()
+        placeholder_data["group_name"] = node_full_name.rpartition(".")[0]
+        placeholder_data["last_loaded"] = []
+        placeholder_data["delete"] = False
+        return placeholder_data
+
+    def collect_placeholders(self):
+        output = []
+        scene_placeholders = self._collect_scene_placeholders()
+        for node_name, node in scene_placeholders.items():
+            plugin_identifier_knob = node.knob("plugin_identifier")
+            if (
+                plugin_identifier_knob is None
+                or plugin_identifier_knob.getValue() != self.identifier
+            ):
+                continue
+
+            placeholder_data = self._parse_placeholder_node_data(node)
+            # TODO do data validations and maybe updgrades if are invalid
+            output.append(
+                CreatePlaceholderItem(node_name, placeholder_data, self)
+            )
+
+        return output
+
+    def populate_placeholder(self, placeholder):
+        self.populate_create_placeholder(placeholder)
+
+    def repopulate_placeholder(self, placeholder):
+        self.populate_create_placeholder(placeholder)
+
+    def get_placeholder_options(self, options=None):
+        return self.get_create_plugin_options(options)
+
+    def cleanup_placeholder(self, placeholder, failed):
+        # deselect all selected nodes
+        placeholder_node = nuke.toNode(placeholder.scene_identifier)
+
+        # getting the latest nodes added
+        nodes_init = placeholder.data["nodes_init"]
+        nodes_created = list(set(nuke.allNodes()) - set(nodes_init))
+        self.log.debug("Created nodes: {}".format(nodes_created))
+        if not nodes_created:
+            return
+
+        placeholder.data["delete"] = True
+
+        nodes_created = self._move_to_placeholder_group(
+            placeholder, nodes_created
+        )
+        placeholder.data["last_created"] = nodes_created
+        refresh_nodes(nodes_created)
+
+        # positioning of the created nodes
+        min_x, min_y, _, _ = get_extreme_positions(nodes_created)
+        for node in nodes_created:
+            xpos = (node.xpos() - min_x) + placeholder_node.xpos()
+            ypos = (node.ypos() - min_y) + placeholder_node.ypos()
+            node.setXYpos(xpos, ypos)
+        refresh_nodes(nodes_created)
+
+        # fix the problem of z_order for backdrops
+        self._fix_z_order(placeholder)
+        self._imprint_siblings(placeholder)
+
+        if placeholder.data["nb_children"] == 0:
+            # save initial nodes postions and dimensions, update them
+            # and set inputs and outputs of created nodes
+
+            self._imprint_inits()
+            self._update_nodes(placeholder, nuke.allNodes(), nodes_created)
+            self._set_created_connections(placeholder)
+
+        elif placeholder.data["siblings"]:
+            # create copies of placeholder siblings for the new created nodes,
+            # set their inputs and outpus and update all nodes positions and
+            # dimensions and siblings names
+
+            siblings = get_nodes_by_names(placeholder.data["siblings"])
+            refresh_nodes(siblings)
+            copies = self._create_sib_copies(placeholder)
+            new_nodes = list(copies.values())  # copies nodes
+            self._update_nodes(new_nodes, nodes_created)
+            placeholder_node.removeKnob(placeholder_node.knob("siblings"))
+            new_nodes_name = get_names_from_nodes(new_nodes)
+            imprint(placeholder_node, {"siblings": new_nodes_name})
+            self._set_copies_connections(placeholder, copies)
+
+            self._update_nodes(
+                nuke.allNodes(),
+                new_nodes + nodes_created,
+                20
+            )
+
+            new_siblings = get_names_from_nodes(new_nodes)
+            placeholder.data["siblings"] = new_siblings
+
+        else:
+            # if the placeholder doesn't have siblings, the created
+            # nodes will be placed in a free space
+
+            xpointer, ypointer = find_free_space_to_paste_nodes(
+                nodes_created, direction="bottom", offset=200
+            )
+            node = nuke.createNode("NoOp")
+            reset_selection()
+            nuke.delete(node)
+            for node in nodes_created:
+                xpos = (node.xpos() - min_x) + xpointer
+                ypos = (node.ypos() - min_y) + ypointer
+                node.setXYpos(xpos, ypos)
+
+        placeholder.data["nb_children"] += 1
+        reset_selection()
+
+        # remove placeholders marked as delete
+        if (
+            placeholder.data.get("delete")
+            and not placeholder.data.get("keep_placeholder")
+        ):
+            self.log.debug("Deleting node: {}".format(placeholder_node.name()))
+            nuke.delete(placeholder_node)
+
+        # go back to root group
+        nuke.root().begin()
+
+    def _move_to_placeholder_group(self, placeholder, nodes_created):
+        """
+        opening the placeholder's group and copying created nodes in it.
+
+        Returns :
+            nodes_created (list): the new list of pasted nodes
+        """
+        groups_name = placeholder.data["group_name"]
+        reset_selection()
+        select_nodes(nodes_created)
+        if groups_name:
+            with node_tempfile() as filepath:
+                nuke.nodeCopy(filepath)
+                for node in nuke.selectedNodes():
+                    nuke.delete(node)
+                group = nuke.toNode(groups_name)
+                group.begin()
+                nuke.nodePaste(filepath)
+                nodes_created = nuke.selectedNodes()
+        return nodes_created
+
+    def _fix_z_order(self, placeholder):
+        """Fix the problem of z_order when a backdrop is create."""
+
+        nodes_created = placeholder.data["last_created"]
+        created_backdrops = []
+        bd_orders = set()
+        for node in nodes_created:
+            if isinstance(node, nuke.BackdropNode):
+                created_backdrops.append(node)
+                bd_orders.add(node.knob("z_order").getValue())
+
+        if not bd_orders:
+            return
+
+        sib_orders = set()
+        for node_name in placeholder.data["siblings"]:
+            node = nuke.toNode(node_name)
+            if isinstance(node, nuke.BackdropNode):
+                sib_orders.add(node.knob("z_order").getValue())
+
+        if not sib_orders:
+            return
+
+        min_order = min(bd_orders)
+        max_order = max(sib_orders)
+        for backdrop_node in created_backdrops:
+            z_order = backdrop_node.knob("z_order").getValue()
+            backdrop_node.knob("z_order").setValue(
+                z_order + max_order - min_order + 1)
+
+    def _imprint_siblings(self, placeholder):
+        """
+        - add siblings names to placeholder attributes (nodes created with it)
+        - add Id to the attributes of all the other nodes
+        """
+
+        created_nodes = placeholder.data["last_created"]
+        created_nodes_set = set(created_nodes)
+        data = {"repre_id": str(placeholder.data["last_repre_id"])}
+
+        for node in created_nodes:
+            node_knobs = node.knobs()
+            if "builder_type" not in node_knobs:
+                # save the id of representation for all imported nodes
+                imprint(node, data)
+                node.knob("repre_id").setVisible(False)
+                refresh_node(node)
+                continue
+
+            if (
+                "is_placeholder" not in node_knobs
+                or (
+                    "is_placeholder" in node_knobs
+                    and node.knob("is_placeholder").value()
+                )
+            ):
+                siblings = list(created_nodes_set - {node})
+                siblings_name = get_names_from_nodes(siblings)
+                siblings = {"siblings": siblings_name}
+                imprint(node, siblings)
+
+    def _imprint_inits(self):
+        """Add initial positions and dimensions to the attributes"""
+
+        for node in nuke.allNodes():
+            refresh_node(node)
+            imprint(node, {"x_init": node.xpos(), "y_init": node.ypos()})
+            node.knob("x_init").setVisible(False)
+            node.knob("y_init").setVisible(False)
+            width = node.screenWidth()
+            height = node.screenHeight()
+            if "bdwidth" in node.knobs():
+                imprint(node, {"w_init": width, "h_init": height})
+                node.knob("w_init").setVisible(False)
+                node.knob("h_init").setVisible(False)
+            refresh_node(node)
+
+    def _update_nodes(
+        self, placeholder, nodes, considered_nodes, offset_y=None
+    ):
+        """Adjust backdrop nodes dimensions and positions.
+
+        Considering some nodes sizes.
+
+        Args:
+            nodes (list): list of nodes to update
+            considered_nodes (list): list of nodes to consider while updating
+                positions and dimensions
+            offset (int): distance between copies
+        """
+
+        placeholder_node = nuke.toNode(placeholder.scene_identifier)
+
+        min_x, min_y, max_x, max_y = get_extreme_positions(considered_nodes)
+
+        diff_x = diff_y = 0
+        contained_nodes = []  # for backdrops
+
+        if offset_y is None:
+            width_ph = placeholder_node.screenWidth()
+            height_ph = placeholder_node.screenHeight()
+            diff_y = max_y - min_y - height_ph
+            diff_x = max_x - min_x - width_ph
+            contained_nodes = [placeholder_node]
+            min_x = placeholder_node.xpos()
+            min_y = placeholder_node.ypos()
+        else:
+            siblings = get_nodes_by_names(placeholder.data["siblings"])
+            minX, _, maxX, _ = get_extreme_positions(siblings)
+            diff_y = max_y - min_y + 20
+            diff_x = abs(max_x - min_x - maxX + minX)
+            contained_nodes = considered_nodes
+
+        if diff_y <= 0 and diff_x <= 0:
+            return
+
+        for node in nodes:
+            refresh_node(node)
+
+            if (
+                node == placeholder_node
+                or node in considered_nodes
+            ):
+                continue
+
+            if (
+                not isinstance(node, nuke.BackdropNode)
+                or (
+                    isinstance(node, nuke.BackdropNode)
+                    and not set(contained_nodes) <= set(node.getNodes())
+                )
+            ):
+                if offset_y is None and node.xpos() >= min_x:
+                    node.setXpos(node.xpos() + diff_x)
+
+                if node.ypos() >= min_y:
+                    node.setYpos(node.ypos() + diff_y)
+
+            else:
+                width = node.screenWidth()
+                height = node.screenHeight()
+                node.knob("bdwidth").setValue(width + diff_x)
+                node.knob("bdheight").setValue(height + diff_y)
+
+            refresh_node(node)
+
+    def _set_created_connections(self, placeholder):
+        """
+        set inputs and outputs of created nodes"""
+
+        placeholder_node = nuke.toNode(placeholder.scene_identifier)
+        input_node, output_node = get_group_io_nodes(
+            placeholder.data["last_created"]
+        )
+        for node in placeholder_node.dependent():
+            for idx in range(node.inputs()):
+                if node.input(idx) == placeholder_node and output_node:
+                    node.setInput(idx, output_node)
+
+        for node in placeholder_node.dependencies():
+            for idx in range(placeholder_node.inputs()):
+                if placeholder_node.input(idx) == node and input_node:
+                    input_node.setInput(0, node)
+
+    def _create_sib_copies(self, placeholder):
+        """ creating copies of the palce_holder siblings (the ones who were
+        created with it) for the new nodes added
+
+        Returns :
+            copies (dict) : with copied nodes names and their copies
+        """
+
+        copies = {}
+        siblings = get_nodes_by_names(placeholder.data["siblings"])
+        for node in siblings:
+            new_node = duplicate_node(node)
+
+            x_init = int(new_node.knob("x_init").getValue())
+            y_init = int(new_node.knob("y_init").getValue())
+            new_node.setXYpos(x_init, y_init)
+            if isinstance(new_node, nuke.BackdropNode):
+                w_init = new_node.knob("w_init").getValue()
+                h_init = new_node.knob("h_init").getValue()
+                new_node.knob("bdwidth").setValue(w_init)
+                new_node.knob("bdheight").setValue(h_init)
+                refresh_node(node)
+
+            if "repre_id" in node.knobs().keys():
+                node.removeKnob(node.knob("repre_id"))
+            copies[node.name()] = new_node
+        return copies
+
+    def _set_copies_connections(self, placeholder, copies):
+        """Set inputs and outputs of the copies.
+
+        Args:
+            copies (dict): Copied nodes by their names.
+        """
+
+        last_input, last_output = get_group_io_nodes(
+            placeholder.data["last_created"]
         )
         siblings = get_nodes_by_names(placeholder.data["siblings"])
         siblings_input, siblings_output = get_group_io_nodes(siblings)

--- a/openpype/hosts/nuke/api/workfile_template_builder.py
+++ b/openpype/hosts/nuke/api/workfile_template_builder.py
@@ -40,7 +40,7 @@ class NukeTemplateBuilder(AbstractTemplateBuilder):
 
         Args:
             path (str): A path to current template (usually given by
-            get_template_path implementation)
+            get_template_preset implementation)
 
         Returns:
             bool: Wether the template was succesfully imported or not
@@ -273,6 +273,15 @@ class NukePlaceholderLoadPlugin(NukePlaceholderPlugin, PlaceholderLoadMixin):
 
         placeholder.data["nb_children"] += 1
         reset_selection()
+
+        # remove placeholders marked as delete
+        if (
+            placeholder.data.get("delete")
+            and not placeholder.data.get("keep_placeholder")
+        ):
+            self.log.debug("Deleting node: {}".format(placeholder_node.name()))
+            nuke.delete(placeholder_node)
+
         # go back to root group
         nuke.root().begin()
 
@@ -454,12 +463,12 @@ class NukePlaceholderLoadPlugin(NukePlaceholderPlugin, PlaceholderLoadMixin):
         )
         for node in placeholder_node.dependent():
             for idx in range(node.inputs()):
-                if node.input(idx) == placeholder_node:
+                if node.input(idx) == placeholder_node and output_node:
                     node.setInput(idx, output_node)
 
         for node in placeholder_node.dependencies():
             for idx in range(placeholder_node.inputs()):
-                if placeholder_node.input(idx) == node:
+                if placeholder_node.input(idx) == node and input_node:
                     input_node.setInput(0, node)
 
     def _create_sib_copies(self, placeholder):

--- a/openpype/hosts/nuke/plugins/load/load_backdrop.py
+++ b/openpype/hosts/nuke/plugins/load/load_backdrop.py
@@ -28,7 +28,7 @@ class LoadBackdropNodes(load.LoaderPlugin):
     representations = ["nk"]
     families = ["workfile", "nukenodes"]
 
-    label = "Iport Nuke Nodes"
+    label = "Import Nuke Nodes"
     order = 0
     icon = "eye"
     color = "white"

--- a/openpype/pipeline/create/creator_plugins.py
+++ b/openpype/pipeline/create/creator_plugins.py
@@ -608,7 +608,7 @@ def discover_legacy_creator_plugins():
             plugin.apply_settings(project_settings, system_settings)
         except Exception:
             log.warning(
-                "Failed to apply settings to loader {}".format(
+                "Failed to apply settings to creator {}".format(
                     plugin.__name__
                 ),
                 exc_info=True

--- a/openpype/pipeline/workfile/workfile_template_builder.py
+++ b/openpype/pipeline/workfile/workfile_template_builder.py
@@ -1517,7 +1517,7 @@ class PlaceholderCreateMixin(object):
             for creator_name, creator in creators_by_name.items()
         ]
 
-        creator_items = list(sorted(creator_items, key=lambda i: i[1]))
+        creator_items.sort(key=lambda i: i[1])
         options = options or {}
         return [
             attribute_definitions.UISeparatorDef(),

--- a/openpype/pipeline/workfile/workfile_template_builder.py
+++ b/openpype/pipeline/workfile/workfile_template_builder.py
@@ -675,7 +675,7 @@ class AbstractTemplateBuilder(object):
         # switch to remove placeholders after they are used
         placeholder_keep = profile.get("placeholder_keep")
         # backward compatibility, since default is True
-        if placeholder_keep is not False:
+        if placeholder_keep is None:
             placeholder_keep = True
 
         if not path:

--- a/openpype/pipeline/workfile/workfile_template_builder.py
+++ b/openpype/pipeline/workfile/workfile_template_builder.py
@@ -419,6 +419,9 @@ class AbstractTemplateBuilder(object):
                 passed.
             level_limit (int): Limit of populate loops. Related to
                 'populate_scene_placeholders' method.
+            keep_placeholders (bool): Add flag to placeholder data for
+                hosts to decide if they want to remove
+                placeholder after it is used.
         """
         template_preset = self.get_template_preset()
 
@@ -518,6 +521,9 @@ class AbstractTemplateBuilder(object):
 
         Args:
             level_limit (int): Level of loops that can happen. Default is 1000.
+            keep_placeholders (bool): Add flag to placeholder data for
+                hosts to decide if they want to remove
+                placeholder after it is used.
         """
 
         if not self.placeholder_plugins:

--- a/openpype/pipeline/workfile/workfile_template_builder.py
+++ b/openpype/pipeline/workfile/workfile_template_builder.py
@@ -43,7 +43,6 @@ from openpype.pipeline.load import (
     load_with_repre_context,
 )
 from openpype.pipeline.create import (
-    get_legacy_creator_by_name,
     discover_legacy_creator_plugins
 )
 
@@ -439,7 +438,7 @@ class AbstractTemplateBuilder(object):
             template_path = template_preset["path"]
 
         if keep_placeholders is None:
-            keep_placeholders = template_preset["placeholder_keep"]
+            keep_placeholders = template_preset["keep_placeholder"]
 
         self.import_template(template_path)
         self.populate_scene_placeholders(
@@ -673,10 +672,10 @@ class AbstractTemplateBuilder(object):
         path = profile["path"]
 
         # switch to remove placeholders after they are used
-        placeholder_keep = profile.get("placeholder_keep")
+        keep_placeholder = profile.get("keep_placeholder")
         # backward compatibility, since default is True
-        if placeholder_keep is None:
-            placeholder_keep = True
+        if keep_placeholder is None:
+            keep_placeholder = True
 
         if not path:
             raise TemplateLoadFailed((
@@ -707,7 +706,7 @@ class AbstractTemplateBuilder(object):
             self.log.info("Found template at: '{}'".format(path))
             return {
                 "path": path,
-                "placeholder_keep": placeholder_keep
+                "keep_placeholder": keep_placeholder
             }
 
         solved_path = None
@@ -736,7 +735,7 @@ class AbstractTemplateBuilder(object):
 
         return {
             "path": solved_path,
-            "placeholder_keep": placeholder_keep
+            "keep_placeholder": keep_placeholder
         }
 
 
@@ -991,7 +990,7 @@ class PlaceholderItem(object):
 
     def __init__(self, scene_identifier, data, plugin):
         self._log = None
-        self.name = scene_identifier
+        self._scene_identifier = scene_identifier
         self._data = data
         self._plugin = plugin
 
@@ -1056,7 +1055,13 @@ class PlaceholderItem(object):
         return self._log
 
     def __repr__(self):
-        return "< {} {} >".format(self.__class__.__name__, self.name)
+        name = None
+        if hasattr("name", self):
+            name = self.name
+        if hasattr("_scene_identifier ", self):
+            name = self._scene_identifier
+
+        return "< {} {} >".format(self.__class__.__name__, name)
 
     @property
     def order(self):
@@ -1069,7 +1074,7 @@ class PlaceholderItem(object):
 
     @property
     def scene_identifier(self):
-        return self.name
+        return self._scene_identifier
 
     @property
     def finished(self):

--- a/openpype/pipeline/workfile/workfile_template_builder.py
+++ b/openpype/pipeline/workfile/workfile_template_builder.py
@@ -984,7 +984,7 @@ class PlaceholderItem(object):
 
     def __init__(self, scene_identifier, data, plugin):
         self._log = None
-        self._scene_identifier = scene_identifier
+        self.name = scene_identifier
         self._data = data
         self._plugin = plugin
 
@@ -1062,7 +1062,7 @@ class PlaceholderItem(object):
 
     @property
     def scene_identifier(self):
-        return self._scene_identifier
+        return self.name
 
     @property
     def finished(self):

--- a/openpype/pipeline/workfile/workfile_template_builder.py
+++ b/openpype/pipeline/workfile/workfile_template_builder.py
@@ -1574,7 +1574,7 @@ class PlaceholderCreateMixin(object):
         creator_name = placeholder.data["creator"]
         create_variant = placeholder.data["create_variant"]
 
-        creator_plugin = get_legacy_creator_by_name(creator_name)
+        creator_plugin = self.builder.get_creators_by_name()[creator_name]
 
         # create subset name
         project_name = legacy_io.Session["AVALON_PROJECT"]

--- a/openpype/pipeline/workfile/workfile_template_builder.py
+++ b/openpype/pipeline/workfile/workfile_template_builder.py
@@ -691,7 +691,14 @@ class AbstractTemplateBuilder(object):
             key: value
             for key, value in os.environ.items()
         }
+
         fill_data["root"] = anatomy.roots
+        fill_data["project"] = {
+            "name": project_name,
+            "code": anatomy["attributes"]["code"]
+        }
+
+
         result = StringTemplate.format_template(path, fill_data)
         if result.solved:
             path = result.normalized()

--- a/openpype/pipeline/workfile/workfile_template_builder.py
+++ b/openpype/pipeline/workfile/workfile_template_builder.py
@@ -238,7 +238,14 @@ class AbstractTemplateBuilder(object):
 
     def get_creators_by_name(self):
         if self._creators_by_name is None:
-            self._creators_by_name = discover_legacy_creator_plugins()
+            self._creators_by_name = {}
+            for creator in discover_legacy_creator_plugins():
+                creator_name = creator.__name__
+                if creator_name in self._creators_by_name:
+                    raise KeyError(
+                        "Duplicated creator name {} !".format(creator_name)
+                    )
+                self._creators_by_name[creator_name] = creator
         return self._creators_by_name
 
     def get_shared_data(self, key):
@@ -1497,6 +1504,8 @@ class PlaceholderCreateMixin(object):
         """
 
         creators_by_name = self.builder.get_creators_by_name()
+        print(creators_by_name)
+
         creator_items = [
             (creator_name, creator.label or creator_name)
             for creator_name, creator in creators_by_name.items()

--- a/openpype/pipeline/workfile/workfile_template_builder.py
+++ b/openpype/pipeline/workfile/workfile_template_builder.py
@@ -42,7 +42,10 @@ from openpype.pipeline.load import (
     get_contexts_for_repre_docs,
     load_with_repre_context,
 )
-from openpype.pipeline.create import get_legacy_creator_by_name
+from openpype.pipeline.create import (
+    get_legacy_creator_by_name,
+    discover_legacy_creator_plugins
+)
 
 
 class TemplateNotFound(Exception):
@@ -235,7 +238,7 @@ class AbstractTemplateBuilder(object):
 
     def get_creators_by_name(self):
         if self._creators_by_name is None:
-            self._creators_by_name = get_legacy_creator_by_name()
+            self._creators_by_name = discover_legacy_creator_plugins()
         return self._creators_by_name
 
     def get_shared_data(self, key):
@@ -1463,6 +1466,165 @@ class PlaceholderLoadMixin(object):
         pass
 
 
+class PlaceholderCreateMixin(object):
+    """Mixin prepared for creating placeholder plugins.
+
+    Implementation prepares options for placeholders with
+    'get_create_plugin_options'.
+
+    For placeholder population is implemented 'populate_create_placeholder'.
+
+    PlaceholderItem can have implemented methods:
+    - 'create_failed' - called when creating of an instance failed
+    - 'create_succeed' - called when creating of an instance succeeded
+    """
+
+    def get_create_plugin_options(self, options=None):
+        """Unified attribute definitions for create placeholder.
+
+        Common function for placeholder plugins used for creating of
+        publishable instances. Use it with 'get_placeholder_options'.
+
+        Args:
+            plugin (PlaceholderPlugin): Plugin used for creating of
+                publish instances.
+            options (Dict[str, Any]): Already available options which are used
+                as defaults for attributes.
+
+        Returns:
+            List[AbtractAttrDef]: Attribute definitions common for create
+                plugins.
+        """
+
+        creators_by_name = self.builder.get_creators_by_name()
+        creator_items = [
+            (creator_name, creator.label or creator_name)
+            for creator_name, creator in creators_by_name.items()
+        ]
+
+        creator_items = list(sorted(creator_items, key=lambda i: i[1]))
+        options = options or {}
+        return [
+            attribute_definitions.UISeparatorDef(),
+            attribute_definitions.UILabelDef("Main attributes"),
+            attribute_definitions.UISeparatorDef(),
+
+            attribute_definitions.EnumDef(
+                "creator",
+                label="Creator",
+                default=options.get("creator"),
+                items=creator_items,
+                tooltip=(
+                    "Creator"
+                    "\nDefines what OpenPype creator will be used to"
+                    " create publishable instance."
+                    "\nUseable creator depends on current host's creator list."
+                    "\nField is case sensitive."
+                )
+            ),
+            attribute_definitions.TextDef(
+                "create_variant",
+                label="Variant",
+                default=options.get("create_variant"),
+                placeholder='Main',
+                tooltip=(
+                    "Creator"
+                    "\nDefines variant name which will be use for "
+                    "\ncompiling of subset name."
+                )
+            ),
+            attribute_definitions.UISeparatorDef(),
+            attribute_definitions.NumberDef(
+                "order",
+                label="Order",
+                default=options.get("order") or 0,
+                decimals=0,
+                minimum=0,
+                maximum=999,
+                tooltip=(
+                    "Order"
+                    "\nOrder defines creating instance priority (0 to 999)"
+                    "\nPriority rule is : \"lowest is first to load\"."
+                )
+            )
+        ]
+
+    def populate_create_placeholder(self, placeholder):
+        """Create placeholder is going to create matching publishabe instance.
+
+        Args:
+            placeholder (PlaceholderItem): Placeholder item with information
+                about requested publishable instance.
+        """
+        creator_name = placeholder.data["creator"]
+        create_variant = placeholder.data["create_variant"]
+
+        creator_plugin = get_legacy_creator_by_name(creator_name)
+
+        # create subset name
+        project_name = legacy_io.Session["AVALON_PROJECT"]
+        task_name = legacy_io.Session["AVALON_TASK"]
+        asset_name = legacy_io.Session["AVALON_ASSET"]
+
+        # get asset id
+        asset_doc = get_asset_by_name(project_name, asset_name, fields=["_id"])
+        assert asset_doc, "No current asset found in Session"
+        asset_id = asset_doc['_id']
+
+        subset_name = creator_plugin.get_subset_name(
+            create_variant,
+            task_name,
+            asset_id,
+            project_name
+        )
+
+        creator_data = {
+            "creator_name": creator_name,
+            "create_variant": create_variant,
+            "subset_name": subset_name,
+            "creator_plugin": creator_plugin
+        }
+
+        # compile subset name from variant
+        try:
+            creator_instance = creator_plugin(
+                subset_name,
+                asset_name
+            ).process()
+
+        except Exception:
+            failed = True
+            self.create_failed(placeholder, creator_data)
+
+        else:
+            failed = False
+            self.create_succeed(placeholder, creator_instance)
+
+        self.cleanup_placeholder(placeholder, failed)
+
+    def create_failed(self, placeholder, creator_data):
+        if hasattr(placeholder, "create_failed"):
+            placeholder.create_failed(creator_data)
+
+    def create_succeed(self, placeholder, creator_instance):
+        if hasattr(placeholder, "create_succeed"):
+            placeholder.create_succeed(creator_instance)
+
+    def cleanup_placeholder(self, placeholder, failed):
+        """Cleanup placeholder after load of single representation.
+
+        Can be called multiple times during placeholder item populating and is
+        called even if loading failed.
+
+        Args:
+            placeholder (PlaceholderItem): Item which was just used to load
+                representation.
+            failed (bool): Loading of representation failed.
+        """
+
+        pass
+
+
 class LoadPlaceholderItem(PlaceholderItem):
     """PlaceholderItem for plugin which is loading representations.
 
@@ -1486,3 +1648,28 @@ class LoadPlaceholderItem(PlaceholderItem):
 
     def load_failed(self, representation):
         self._failed_representations.append(representation)
+
+
+class CreatePlaceholderItem(PlaceholderItem):
+    """PlaceholderItem for plugin which is creating publish instance.
+
+    Connected to 'PlaceholderCreateMixin'.
+    """
+
+    def __init__(self, *args, **kwargs):
+        super(CreatePlaceholderItem, self).__init__(*args, **kwargs)
+        self._failed_created_publish_instances = []
+
+    def get_errors(self):
+        if not self._failed_representations:
+            return []
+        message = (
+            "Failed to create {} instance using Creator {}"
+        ).format(
+            len(self._failed_created_publish_instances),
+            self.data["creator"]
+        )
+        return [message]
+
+    def create_failed(self, creator_data):
+        self._failed_created_publish_instances.append(creator_data)

--- a/openpype/pipeline/workfile/workfile_template_builder.py
+++ b/openpype/pipeline/workfile/workfile_template_builder.py
@@ -1594,6 +1594,8 @@ class PlaceholderCreateMixin(object):
             "creator_plugin": creator_plugin
         }
 
+        self._before_instance_create(placeholder)
+
         # compile subset name from variant
         try:
             creator_instance = creator_plugin(
@@ -1630,6 +1632,11 @@ class PlaceholderCreateMixin(object):
                 representation.
             failed (bool): Loading of representation failed.
         """
+
+        pass
+
+    def _before_instance_create(self, placeholder):
+        """Can be overriden. Is called before instance is created."""
 
         pass
 

--- a/openpype/pipeline/workfile/workfile_template_builder.py
+++ b/openpype/pipeline/workfile/workfile_template_builder.py
@@ -1504,7 +1504,6 @@ class PlaceholderCreateMixin(object):
         """
 
         creators_by_name = self.builder.get_creators_by_name()
-        print(creators_by_name)
 
         creator_items = [
             (creator_name, creator.label or creator_name)

--- a/openpype/settings/entities/schemas/projects_schema/schemas/schema_templated_workfile_build.json
+++ b/openpype/settings/entities/schemas/projects_schema/schemas/schema_templated_workfile_build.json
@@ -30,7 +30,7 @@
                         "multipath": false
                     },
                     {
-                        "key": "placeholder_keep",
+                        "key": "keep_placeholder",
                         "label": "Keep placeholders",
                         "type": "boolean",
                         "default": true

--- a/openpype/settings/entities/schemas/projects_schema/schemas/schema_templated_workfile_build.json
+++ b/openpype/settings/entities/schemas/projects_schema/schemas/schema_templated_workfile_build.json
@@ -25,8 +25,15 @@
                     {
                         "key": "path",
                         "label": "Path to template",
-                        "type": "text",
-                        "object_type": "text"
+                        "type": "path",
+                        "multiplatform": false,
+                        "multipath": false
+                    },
+                    {
+                        "key": "placeholder_keep",
+                        "label": "Keep placeholders",
+                        "type": "boolean",
+                        "default": true
                     }
                 ]
             }


### PR DESCRIPTION
## Brief description
Adding Creator Placeholder plugin implementation

## Description
New placeholders for creators are now available. Templates can be now build included publishable instances.

## Additional info
Several global abstractions at parent workfile building classes had to be altered. Creator plugin abstraction can now be implemented also into other hosts. 

## Need to be tested in:
- [ ] Nuke - new creator feature.
- [ ] Maya - is it working as before and nothing had been broken by this PR?

## Testing notes [ Nuke ]:
1. Test in `\OP02_VFX_demo` ideally on **sh020**  because the template is expecting data from this project. Project can be deployed with `/tools/unpack_project.ps1` (follow instructions inside of the .ps1 file), [here](https://drive.google.com/file/d/1LQkF8r-6q-aD1iSELuHa68JEnAx8MVjb) is where you can download it from.
2. Download [following zip](https://drive.google.com/file/d/1cJCKO8AJzO9Nm7i5-zMMu8D0p2EtDo8Z/view?usp=sharing) and unpack it in project structure as follows.
![image](https://user-images.githubusercontent.com/40640033/209120941-0a8c73d0-6df7-4777-959f-822398ed8115.png)
3. create preset in your test project settings `project_settings/nuke/templated_workfile_build`
4. In case you  already had some preset then `DO NOT SAVE` and test backward compatibility in Nuke by building from template. All should work as it was. 
5.a If you are creating new preset then paste following onto `project_settings/nuke/templated_workfile_build` and fix the path to your in case it is different.
```
{
    "profiles": [
        {
            "task_types": [
                "Compositing"
            ],
            "task_names": [],
            "path": "{root[work]}/{project[name]}/templates/comp.nk",
            "keep_placeholder": false
        }
    ]
}
```
5.b [dowload this settings patch](https://drive.google.com/file/d/1zu6AtXZQ8-35C9YDGoymX9JLXGKmIFxa/view?usp=sharing) then copy context of the file to clipboard. Go to `project_settings/nuke/imageio` and RMB click at the ImageIO and __paste__. It will take about 5mins to update and then save the settings.
6. then open Nuke from sh020 and remove all nodes in scene (just not to collide with already created write node)
![image](https://user-images.githubusercontent.com/40640033/209121413-b1a806c7-7e97-4665-8f33-15822d0a55a0.png)
7. template should show in script and no Placeholders should stay in the scene under loaded Read nodes and Render write node should be created at bottom. Here is how it should look 
![image](https://user-images.githubusercontent.com/40640033/209347035-7b314f16-9c1a-40fb-ad88-cb3649abb38a.png)
9. Try it again but switch the settings `placeholder_keep` to active.
10. Placeholders should stay in the scene after the template is builded. 

## Dependencies:
This PR branch is based on https://github.com/pypeclub/OpenPype/pull/4258 and ideally needs to be merged as second.