### PR TITLE
Scene Manager: Fix variable name

### DIFF
--- a/openpype/widgets/message_window.py
+++ b/openpype/widgets/message_window.py
@@ -113,7 +113,7 @@ class ScrollMessageBox(QtWidgets.QDialog):
             message_len = max(message_len, len(message))
 
         # guess size of scrollable area
-        max_width = QtWidgets.QApplication.desktop().availableGeometry().width
+        max_width = QtWidgets.QApplication.desktop().availableGeometry().width()
         scroll_widget.setMinimumWidth(
             min(max_width, message_len * 6)
         )

--- a/openpype/widgets/message_window.py
+++ b/openpype/widgets/message_window.py
@@ -113,7 +113,8 @@ class ScrollMessageBox(QtWidgets.QDialog):
             message_len = max(message_len, len(message))
 
         # guess size of scrollable area
-        max_width = QtWidgets.QApplication.desktop().availableGeometry().width()
+        desktop = QtWidgets.QApplication.desktop()
+        max_width = desktop.availableGeometry().width()
         scroll_widget.setMinimumWidth(
             min(max_width, message_len * 6)
         )

--- a/openpype/widgets/message_window.py
+++ b/openpype/widgets/message_window.py
@@ -105,16 +105,18 @@ class ScrollMessageBox(QtWidgets.QDialog):
         content_widget = QtWidgets.QWidget(self)
         scroll_widget.setWidget(content_widget)
 
-        max_len = 0
+        message_len = 0
         content_layout = QtWidgets.QVBoxLayout(content_widget)
         for message in messages:
             label_widget = QtWidgets.QLabel(message, content_widget)
             content_layout.addWidget(label_widget)
-            max_len = max(max_len, len(message))
+            message_len = max(message_len, len(message))
 
         # guess size of scrollable area
         max_width = QtWidgets.QApplication.desktop().availableGeometry().width
-        scroll_widget.setMinimumWidth(min(max_width, max_len * 6))
+        scroll_widget.setMinimumWidth(
+            min(max_width, message_len * 6)
+        )
         layout.addWidget(scroll_widget)
 
         if not cancelable:  # if no specific buttons OK only


### PR DESCRIPTION
## Brief description
Fix access to width of geometry in `ScrollMessageBox`.

## Description
The `ScrollMessageBox` tried to access width of desktop by accessing `width` attribute but it is a method so comparison failed. 
Also renamed variable `max_len` to `message_len`.

## Additional info
We should maybe rewrite the whole dialog as the logic of size definition is not readable much. The dialog also contains "Copy to clipboard" button which is on right side next to OK and Cancel which is not very intuitive. Dialog does not have enabled close.

## Testing notes:
1. Use the dialog (Currently used only in Maya look loader)

Resolves https://github.com/pypeclub/OpenPype/issues/4243#event-8068289765