### PR TITLE
Fix key for shortcut in gizmo definitions

### DIFF
--- a/openpype/hosts/nuke/api/gizmo_menu.py
+++ b/openpype/hosts/nuke/api/gizmo_menu.py
@@ -58,7 +58,7 @@ class GizmoMenu():
                         item["title"],
                         command=str(item["command"]),
                         icon=item.get("icon"),
-                        shortcut=item.get("hotkey")
+                        shortcut=item.get("shortcut")
                     )
 
                 # add separator


### PR DESCRIPTION
## Brief description
Fix the key called in the gizmo definition for the shortcuts

## Additional info
The label is "Hotkey" in the OP gizmo definition interface but the real key name is "shortcut"
