### PR TITLE
SiteSync: sftp connection failing when shouldnt be tested

### DIFF
--- a/openpype/modules/sync_server/providers/dropbox.py
+++ b/openpype/modules/sync_server/providers/dropbox.py
@@ -165,7 +165,7 @@ class DropboxHandler(AbstractProvider):
         Returns:
             (boolean)
         """
-        return self.presets["enabled"] and self.dbx is not None
+        return self.presets.get("enabled") and self.dbx is not None
 
     @classmethod
     def get_configurable_items(cls):

--- a/openpype/modules/sync_server/providers/gdrive.py
+++ b/openpype/modules/sync_server/providers/gdrive.py
@@ -119,7 +119,7 @@ class GDriveHandler(AbstractProvider):
         Returns:
             (boolean)
         """
-        return self.presets["enabled"] and self.service is not None
+        return self.presets.get("enabled") and self.service is not None
 
     @classmethod
     def get_system_settings_schema(cls):

--- a/openpype/modules/sync_server/sync_server.py
+++ b/openpype/modules/sync_server/sync_server.py
@@ -443,9 +443,9 @@ class SyncServerThread(threading.Thread):
         local_site_config = sync_config.get('sites')[local_site]
         remote_site_config = sync_config.get('sites')[remote_site]
         if not all([_site_is_working(self.module, project_name, local_site,
-                                    local_site_config),
+                                     local_site_config),
                     _site_is_working(self.module, project_name, remote_site,
-                                    remote_site_config)]):
+                                     remote_site_config)]):
             self.log.debug(
                 "Some of the sites {} - {} is not working properly".format(
                     local_site, remote_site


### PR DESCRIPTION
## Brief description
Fix check if site is active, eg. correctly configured to be used, only for active and remote site actually set on a project.
Previously it went through all configured sites, even if they weren't used.

## Description


## Additional info
Site might be configured as possible target, but artist might not use it. They are in studio and not using SiteSync at all etc.

Closes https://github.com/ynput/OpenPype/issues/4125

## Testing notes:
- Enable Site Sync module, create a SFTP(or Gdrive without any values filled)  site with wrong credentials and enable it for your production.
- Change your local settings to local and studio (not to the sftp site).
- Restart Tray, and look to the logs, it tries to connect when it shouldn't because the user settings don't ask for it. 