### PR TITLE
Maya: Fix validate frame range repair + fix create render with deadline disabled

### DIFF
--- a/openpype/hosts/maya/plugins/create/create_render.py
+++ b/openpype/hosts/maya/plugins/create/create_render.py
@@ -72,15 +72,19 @@ class CreateRender(plugin.Creator):
     def __init__(self, *args, **kwargs):
         """Constructor."""
         super(CreateRender, self).__init__(*args, **kwargs)
-        deadline_settings = get_system_settings()["modules"]["deadline"]
-        if not deadline_settings["enabled"]:
-            self.deadline_servers = {}
-            return
+
+        # Defaults
         self._project_settings = get_project_settings(
             legacy_io.Session["AVALON_PROJECT"])
         if self._project_settings["maya"]["RenderSettings"]["apply_render_settings"]: # noqa
             lib_rendersettings.RenderSettings().set_default_renderer_settings()
+
+        # Deadline-only
         manager = ModulesManager()
+        deadline_settings = get_system_settings()["modules"]["deadline"]
+        if not deadline_settings["enabled"]:
+            self.deadline_servers = {}
+            return
         self.deadline_module = manager.modules_by_name["deadline"]
         try:
             default_servers = deadline_settings["deadline_urls"]
@@ -193,8 +197,6 @@ class CreateRender(plugin.Creator):
         pool_names = []
         default_priority = 50
 
-        self.server_aliases = list(self.deadline_servers.keys())
-        self.data["deadlineServers"] = self.server_aliases
         self.data["suspendPublishJob"] = False
         self.data["review"] = True
         self.data["extendFrames"] = False
@@ -233,6 +235,9 @@ class CreateRender(plugin.Creator):
             raise RuntimeError("Both Deadline and Muster are enabled")
 
         if deadline_enabled:
+            self.server_aliases = list(self.deadline_servers.keys())
+            self.data["deadlineServers"] = self.server_aliases
+
             try:
                 deadline_url = self.deadline_servers["default"]
             except KeyError:
@@ -254,6 +259,19 @@ class CreateRender(plugin.Creator):
                                                default_priority)
             self.data["tile_priority"] = tile_priority
 
+            pool_setting = (self._project_settings["deadline"]
+                                                  ["publish"]
+                                                  ["CollectDeadlinePools"])
+            primary_pool = pool_setting["primary_pool"]
+            self.data["primaryPool"] = self._set_default_pool(pool_names,
+                                                              primary_pool)
+            # We add a string "-" to allow the user to not
+            # set any secondary pools
+            pool_names = ["-"] + pool_names
+            secondary_pool = pool_setting["secondary_pool"]
+            self.data["secondaryPool"] = self._set_default_pool(pool_names,
+                                                                secondary_pool)
+
         if muster_enabled:
             self.log.info(">>> Loading Muster credentials ...")
             self._load_credentials()
@@ -273,18 +291,6 @@ class CreateRender(plugin.Creator):
                 self.log.info("  - pool: {}".format(pool["name"]))
                 pool_names.append(pool["name"])
 
-        pool_setting = (self._project_settings["deadline"]
-                                              ["publish"]
-                                              ["CollectDeadlinePools"])
-        primary_pool = pool_setting["primary_pool"]
-        self.data["primaryPool"] = self._set_default_pool(pool_names,
-                                                          primary_pool)
-        # We add a string "-" to allow the user to not
-        # set any secondary pools
-        pool_names = ["-"] + pool_names
-        secondary_pool = pool_setting["secondary_pool"]
-        self.data["secondaryPool"] = self._set_default_pool(pool_names,
-                                                            secondary_pool)
         self.options = {"useSelection": False}  # Force no content
 
     def _set_default_pool(self, pool_names, pool_value):

--- a/openpype/hosts/maya/plugins/publish/collect_instances.py
+++ b/openpype/hosts/maya/plugins/publish/collect_instances.py
@@ -174,9 +174,6 @@ class CollectInstances(pyblish.api.ContextPlugin):
                     if "handles" in data:
                         data["handleStart"] = data["handles"]
                         data["handleEnd"] = data["handles"]
-                    else:
-                        data["handleStart"] = 0
-                        data["handleEnd"] = 0
 
                     data["frameStartHandle"] = data["frameStart"] - data["handleStart"]  # noqa: E501
                     data["frameEndHandle"] = data["frameEnd"] + data["handleEnd"]  # noqa: E501

--- a/openpype/hosts/maya/plugins/publish/validate_frame_range.py
+++ b/openpype/hosts/maya/plugins/publish/validate_frame_range.py
@@ -92,10 +92,31 @@ class ValidateFrameRange(pyblish.api.InstancePlugin):
         """
         Repair instance container to match asset data.
         """
-        cmds.setAttr(
-            "{}.frameStart".format(instance.data["name"]),
-            instance.context.data.get("frameStartHandle"))
 
-        cmds.setAttr(
-            "{}.frameEnd".format(instance.data["name"]),
-            instance.context.data.get("frameEndHandle"))
+        node = instance.data["name"]
+        context = instance.context
+
+        frame_start_handle = int(context.data.get("frameStartHandle"))
+        frame_end_handle = int(context.data.get("frameEndHandle"))
+        handle_start = int(context.data.get("handleStart"))
+        handle_end = int(context.data.get("handleEnd"))
+        frame_start = int(context.data.get("frameStart"))
+        frame_end = int(context.data.get("frameEnd"))
+
+        # Start
+        if cmds.attributeQuery("handleStart", node=node, exists=True):
+            cmds.setAttr("{}.handleStart".format(node), handle_start)
+            cmds.setAttr("{}.frameStart".format(node), frame_start)
+        else:
+            # Include start handle in frame start if no separate handleStart
+            # attribute exists on the node
+            cmds.setAttr("{}.frameStart".format(node), frame_start_handle)
+
+        # End
+        if cmds.attributeQuery("handleEnd", node=node, exists=True):
+            cmds.setAttr("{}.handleEnd".format(node), handle_end)
+            cmds.setAttr("{}.frameEnd".format(node), frame_end)
+        else:
+            # Include end handle in frame end if no separate handleEnd
+            # attribute exists on the node
+            cmds.setAttr("{}.frameEnd".format(node), frame_end_handle)


### PR DESCRIPTION
## Brief description

This fixes:
- #4272 - Now handles are set as expected if `handleStart` and `handleEnd` attribute exists on the instance
- #3302 - Render Layer frame ranges are now also repaired - also works with explicit render layer overrides on a layer
- Create Render globals not working (errors) when Deadline module is disabled

## Testing notes:

1. Test Create Render with Deadline module disabled and with it enabled in a scene that **does not yet** have a `renderingMain` globals.
2. Check with different start+end frame + handles settings for an asset on renderlayers, but also on other instances like pointcaches and cameras.