### PR TITLE
Ftrack: Fix receive of host ip on MacOs

### DIFF
--- a/openpype/modules/ftrack/event_handlers_user/action_where_run_ask.py
+++ b/openpype/modules/ftrack/event_handlers_user/action_where_run_ask.py
@@ -3,6 +3,7 @@ import socket
 import getpass
 
 from openpype_modules.ftrack.lib import BaseAction
+from openpype_modules.ftrack.ftrack_server.lib import get_host_ip
 
 
 class ActionWhereIRun(BaseAction):
@@ -53,8 +54,7 @@ class ActionWhereIRun(BaseAction):
         try:
             host_name = socket.gethostname()
             msgs["Hostname"] = host_name
-            host_ip = socket.gethostbyname(host_name)
-            msgs["IP"] = host_ip
+            msgs["IP"] = get_host_ip() or "N/A"
         except Exception:
             pass
 

--- a/openpype/modules/ftrack/ftrack_server/event_server_cli.py
+++ b/openpype/modules/ftrack/ftrack_server/event_server_cli.py
@@ -26,6 +26,7 @@ from openpype_modules.ftrack import (
 )
 from openpype_modules.ftrack.lib import credentials
 from openpype_modules.ftrack.ftrack_server import socket_thread
+from openpype_modules.ftrack.ftrack_server.lib import get_host_ip
 
 
 class MongoPermissionsError(Exception):
@@ -167,22 +168,6 @@ def legacy_server(ftrack_url):
             subproc_last_failed = _subproc_last_failed
 
         time.sleep(1)
-
-
-def get_host_ip():
-    host_name = socket.gethostname()
-    try:
-        return socket.gethostbyname(host_name)
-    except Exception:
-        pass
-
-    try:
-        import ipaddress
-        return socket.gethostbyname(str(ipaddress.ip_address(8888)))
-
-    except Exception:
-        pass
-    return None
 
 
 def main_loop(ftrack_url):

--- a/openpype/modules/ftrack/ftrack_server/event_server_cli.py
+++ b/openpype/modules/ftrack/ftrack_server/event_server_cli.py
@@ -169,6 +169,22 @@ def legacy_server(ftrack_url):
         time.sleep(1)
 
 
+def get_host_ip():
+    host_name = socket.gethostname()
+    try:
+        return socket.gethostbyname(host_name)
+    except Exception:
+        pass
+
+    try:
+        import ipaddress
+        return socket.gethostbyname(str(ipaddress.ip_address(8888)))
+
+    except Exception:
+        pass
+    return None
+
+
 def main_loop(ftrack_url):
     """ This is main loop of event handling.
 
@@ -245,11 +261,13 @@ def main_loop(ftrack_url):
     )
 
     host_name = socket.gethostname()
+    host_ip = get_host_ip()
+
     main_info = [
         ["created_at", datetime.datetime.now().strftime("%Y.%m.%d %H:%M:%S")],
         ["Username", getpass.getuser()],
         ["Host Name", host_name],
-        ["Host IP", socket.gethostbyname(host_name)],
+        ["Host IP", host_ip or "N/A"],
         ["OpenPype executable", get_openpype_execute_args()[-1]],
         ["OpenPype version", get_openpype_version() or "N/A"],
         ["OpenPype build version", get_build_version() or "N/A"]

--- a/openpype/modules/ftrack/ftrack_server/lib.py
+++ b/openpype/modules/ftrack/ftrack_server/lib.py
@@ -9,8 +9,9 @@ import time
 import queue
 import collections
 import appdirs
-import pymongo
+import socket
 
+import pymongo
 import requests
 import ftrack_api
 import ftrack_api.session
@@ -30,6 +31,22 @@ from openpype.lib import Logger
 
 TOPIC_STATUS_SERVER = "openpype.event.server.status"
 TOPIC_STATUS_SERVER_RESULT = "openpype.event.server.status.result"
+
+
+def get_host_ip():
+    host_name = socket.gethostname()
+    try:
+        return socket.gethostbyname(host_name)
+    except Exception:
+        pass
+
+    try:
+        import ipaddress
+        return socket.gethostbyname(str(ipaddress.ip_address(8888)))
+
+    except Exception:
+        pass
+    return None
 
 
 class SocketBaseEventHub(ftrack_api.event.hub.EventHub):

--- a/openpype/modules/ftrack/ftrack_server/lib.py
+++ b/openpype/modules/ftrack/ftrack_server/lib.py
@@ -40,12 +40,6 @@ def get_host_ip():
     except Exception:
         pass
 
-    try:
-        import ipaddress
-        return socket.gethostbyname(str(ipaddress.ip_address(8888)))
-
-    except Exception:
-        pass
     return None
 
 

--- a/openpype/modules/ftrack/scripts/sub_event_status.py
+++ b/openpype/modules/ftrack/scripts/sub_event_status.py
@@ -15,7 +15,8 @@ from openpype_modules.ftrack.ftrack_server.lib import (
     SocketSession,
     StatusEventHub,
     TOPIC_STATUS_SERVER,
-    TOPIC_STATUS_SERVER_RESULT
+    TOPIC_STATUS_SERVER_RESULT,
+    get_host_ip
 )
 from openpype.lib import (
     Logger,
@@ -29,10 +30,10 @@ log = Logger.get_logger("Event storer")
 action_identifier = (
     "event.server.status" + os.environ["FTRACK_EVENT_SUB_ID"]
 )
-host_ip = socket.gethostbyname(socket.gethostname())
+host_ip = get_host_ip()
 action_data = {
     "label": "OpenPype Admin",
-    "variant": "- Event server Status ({})".format(host_ip),
+    "variant": "- Event server Status ({})".format(host_ip or "IP N/A"),
     "description": "Get Infromation about event server",
     "actionIdentifier": action_identifier
 }


### PR DESCRIPTION
## Brief description
Fix issue with getting host IP address on MacOs machines.

## Description
There are 2 ways how host IP is tried to receive. If both fail `N/A` is used instead.

## Testing notes:
1. Start ftrack event server on MacOs machine -> report if other issues with appear