### PR TITLE
AfterEffects: Fix for audio from mp4 layer

### DIFF
--- a/openpype/plugins/publish/extract_review.py
+++ b/openpype/plugins/publish/extract_review.py
@@ -1038,6 +1038,9 @@ class ExtractReview(pyblish.api.InstancePlugin):
             # Set audio duration
             audio_in_args.append("-to {:0.10f}".format(audio_duration))
 
+            # Ignore video data from audio input
+            audio_in_args.append("-vn")
+
             # Add audio input path
             audio_in_args.append("-i {}".format(
                 path_to_subprocess_arg(audio["filename"])


### PR DESCRIPTION
## Brief description
Adds `-vn` tag in ExtractReview.

## Description
This tag ignores any graphic data from secondary audio input. This solves an issue where audio stream should be used from mp4/mov. Without it ffmpeg uses graphical data from this input too.


## Testing notes:
1. add layer containing audio in mp4 into composition
2. publish from AE to DL
3. Publish to DL with layer containing only .wav