### PR TITLE
General: Added install method with docstring to HostBase

### DIFF
--- a/openpype/host/host.py
+++ b/openpype/host/host.py
@@ -76,6 +76,18 @@ class HostBase(object):
 
         pass
 
+    def install(self):
+        """Install host specific functionality.
+
+        This is where should be added menu with tools, registered callbacks
+        and other host integration initialization.
+
+        It is called automatically when 'openpype.pipeline.install_host' is
+        triggered.
+        """
+
+        pass
+
     @property
     def log(self):
         if self._log is None:


### PR DESCRIPTION
## Brief description
Added `install` method to `HostBase` class with docstrings. The method is not abstract as is not required at least not at this moment.

## Description
The method was added so developers can see what methods should be implemented in host implementation for what cases.

## Testing notes:
Validate grammar and content of the docstring.

Resolves https://github.com/ynput/OpenPype/issues/4054