### PR TITLE
Unreal: fix missing `maintained_selection` call

### DIFF
--- a/openpype/hosts/unreal/api/__init__.py
+++ b/openpype/hosts/unreal/api/__init__.py
@@ -18,6 +18,7 @@ from .pipeline import (
     show_tools_popup,
     instantiate,
     UnrealHost,
+    maintained_selection
 )
 
 __all__ = [
@@ -36,4 +37,5 @@ __all__ = [
     "show_tools_popup",
     "instantiate",
     "UnrealHost",
+    "maintained_selection"
 ]

--- a/openpype/hosts/unreal/api/pipeline.py
+++ b/openpype/hosts/unreal/api/pipeline.py
@@ -2,6 +2,7 @@
 import os
 import logging
 from typing import List
+from contextlib import contextmanager
 import semver
 
 import pyblish.api
@@ -447,3 +448,16 @@ def get_subsequences(sequence: unreal.LevelSequence):
     if subscene_track is not None and subscene_track.get_sections():
         return subscene_track.get_sections()
     return []
+
+
+@contextmanager
+def maintained_selection():
+    """Stub to be either implemented or replaced.
+
+    This is needed for old publisher implementation, but
+    it is not supported (yet) in UE.
+    """
+    try:
+        yield
+    finally:
+        pass


### PR DESCRIPTION
## Bugfix

This is quick fix for missing call to `maintained_selection`. This functionality isn't available in Unreal (yet), but it is still called in legacy creator code.