### PR TITLE
General: missing comment on standalone and tray publisher

### DIFF
--- a/openpype/modules/ftrack/plugins/publish/integrate_ftrack_note.py
+++ b/openpype/modules/ftrack/plugins/publish/integrate_ftrack_note.py
@@ -130,8 +130,8 @@ class IntegrateFtrackNote(pyblish.api.InstancePlugin):
             if not note_text.solved:
                 self.log.warning((
                     "Note template require more keys then can be provided."
-                    "\nTemplate: {}\nData: {}"
-                ).format(template, format_data))
+                    "\nTemplate: {}\nMissing values for keys:{}\nData: {}"
+                ).format(template, note_text.missing_keys, format_data))
                 continue
 
             if not note_text:

--- a/openpype/modules/ftrack/plugins/publish/integrate_ftrack_note.py
+++ b/openpype/modules/ftrack/plugins/publish/integrate_ftrack_note.py
@@ -45,8 +45,7 @@ class IntegrateFtrackNote(pyblish.api.InstancePlugin):
         host_name = context.data["hostName"]
         app_name = context.data["appName"]
         app_label = context.data["appLabel"]
-        # context comment is fallback until old Pyblish is removed
-        comment = instance.data["comment"] or context.data.get("comment")
+        comment = instance.data["comment"]
         if not comment:
             self.log.info("Comment is not set.")
         else:

--- a/openpype/modules/ftrack/plugins/publish/integrate_ftrack_note.py
+++ b/openpype/modules/ftrack/plugins/publish/integrate_ftrack_note.py
@@ -45,7 +45,8 @@ class IntegrateFtrackNote(pyblish.api.InstancePlugin):
         host_name = context.data["hostName"]
         app_name = context.data["appName"]
         app_label = context.data["appLabel"]
-        comment = instance.data["comment"]
+        # context comment is fallback until old Pyblish is removed
+        comment = instance.data["comment"] or context.data.get("comment")
         if not comment:
             self.log.info("Comment is not set.")
         else:

--- a/openpype/plugins/publish/collect_comment.py
+++ b/openpype/plugins/publish/collect_comment.py
@@ -73,7 +73,9 @@ class CollectComment(
     """
 
     label = "Collect Instance Comment"
-    order = pyblish.api.CollectorOrder + 0.49
+    # TODO change to CollectorOrder after Pyblish is purged
+    # Pyblish allows modifying comment after collect phase
+    order = pyblish.api.ExtractorOrder - 0.49
 
     def process(self, context):
         context_comment = self.cleanup_comment(context.data.get("comment"))


### PR DESCRIPTION
## Brief description
Comment might have not been collected when inserted only after collection phase which resulted in not sending comment to Ftrack.

## Additional info
Clean-up of comment and using only comments on instances is good step, but as far as we are still using old Pyblish, context comment should be kept as a fallback (comment might be filled after collection phase, in this case it is present only on context level. Eg. artists knows/sees that it is filled, but integrator prints it is not there. Another approach would be to disable comments  field after publish is started, but I didn't want to mess with Pyblish.)

Comment field in Publisher is controlled by `project_settings/global/publish/collect_comment_per_instance`. To show comment field this should be set:
![2023-01-10 17_47_24-CollectInstanceCommentDef](https://user-images.githubusercontent.com/4457962/211620385-9f263804-0982-445c-93e2-093df1d93eb3.png)


## Testing notes:
1. publish anything in Standalone Publisher, fill comment only after collecting phase
2. check `Integrate Ftrack note` and Ftrack for presence of comment
3. (btw default note template expects both `intent` and `comment`, skipping `intent` is quite easy in SP, in Publisher field for it is missing completely, imho)