### PR TITLE
Nuke: new creators fixes

### DIFF
--- a/openpype/hosts/nuke/api/lib.py
+++ b/openpype/hosts/nuke/api/lib.py
@@ -896,7 +896,9 @@ def get_view_process_node():
     ipn_orig = None
     for v in nuke.allNodes(filter="Viewer"):
         ipn = v['input_process_node'].getValue()
-        if "VIEWER_INPUT" not in ipn:
+        if ipn:
+            if "VIEWER_INPUT" not in ipn:
+                return
             ipn_orig = nuke.toNode(ipn)
             ipn_orig.setSelected(True)
 

--- a/openpype/hosts/nuke/api/lib.py
+++ b/openpype/hosts/nuke/api/lib.py
@@ -897,7 +897,7 @@ def get_view_process_node():
     for v in nuke.allNodes(filter="Viewer"):
         ipn = v['input_process_node'].getValue()
         if ipn:
-            if "VIEWER_INPUT" not in ipn:
+            if "VIEWER_INPUT" in ipn:
                 return
             ipn_orig = nuke.toNode(ipn)
             ipn_orig.setSelected(True)

--- a/openpype/hosts/nuke/api/lib.py
+++ b/openpype/hosts/nuke/api/lib.py
@@ -893,17 +893,27 @@ def get_imageio_input_colorspace(filename):
 def get_view_process_node():
     reset_selection()
 
-    ipn_orig = None
-    for v in nuke.allNodes(filter="Viewer"):
-        ipn = v['input_process_node'].getValue()
-        if ipn:
-            if "VIEWER_INPUT" in ipn:
-                return
-            ipn_orig = nuke.toNode(ipn)
-            ipn_orig.setSelected(True)
+    ipn_node = None
+    for v_ in nuke.allNodes(filter="Viewer"):
+        ipn = v_['input_process_node'].getValue()
+        ipn_node = nuke.toNode(ipn)
+        if ipn_node:
+            if ipn == "VIEWER_INPUT":
+                # since it is set by default we can ignore it
+                # nobody usually use this
+                continue
+            else:
+                # in case a Viewer node is transfered from
+                # different workfile with old values
+                raise NameError((
+                    "Input process node name '{}' set in "
+                    "Viewer '{}' is does't exists in nodes"
+                ).format(ipn, v_.name()))
 
-    if ipn_orig:
-        return duplicate_node(ipn_orig)
+        ipn_node.setSelected(True)
+
+    if ipn_node:
+        return duplicate_node(ipn_node)
 
 
 def on_script_load():

--- a/openpype/hosts/nuke/api/plugin.py
+++ b/openpype/hosts/nuke/api/plugin.py
@@ -97,9 +97,15 @@ class NukeCreator(NewCreator):
             if INSTANCE_DATA_KNOB not in node.knobs().keys():
                 continue
             node_data = get_node_data(node, INSTANCE_DATA_KNOB)
+
+            if not node_data:
+                # a node has no instance data
+                continue
+
             # test if subset name is matching
-            if subset_name in node_data.get("subset"):
+            if node_data.get("subset") == subset_name:
                 exists = True
+
         return exists
 
     def create_instance_node(

--- a/openpype/hosts/nuke/api/plugin.py
+++ b/openpype/hosts/nuke/api/plugin.py
@@ -8,11 +8,6 @@ import string
 from collections import OrderedDict, defaultdict
 from abc import abstractmethod
 
-from openpype.client import (
-    get_asset_by_name,
-    get_subsets,
-)
-
 from openpype.settings import get_current_project_settings
 from openpype.lib import (
     BoolDef,
@@ -98,10 +93,13 @@ class NukeCreator(NewCreator):
         """Check if existing subset name already exists."""
         exists = False
         for node in nuke.allNodes(recurseGroups=True):
+            # make sure testing node is having instance knob
+            if INSTANCE_DATA_KNOB not in node.knobs().keys():
+                continue
             node_data = get_node_data(node, INSTANCE_DATA_KNOB)
+            # test if subset name is matching
             if subset_name in node_data.get("subset"):
                 exists = True
-
         return exists
 
     def create_instance_node(
@@ -316,8 +314,8 @@ class NukeWriteCreator(NukeCreator):
         # make sure subset name is unique
         if self.check_existing_subset(subset_name, instance_data):
             raise NukeCreatorError(
-                ("subset {} is already published"
-                 "definition.").format(subset_name))
+                ("Subset '{}' is already created "
+                 "in nodes! Change variant name!").format(subset_name))
 
         instance_node = self.create_instance_node(
             subset_name,

--- a/openpype/hosts/nuke/plugins/create/create_backdrop.py
+++ b/openpype/hosts/nuke/plugins/create/create_backdrop.py
@@ -45,8 +45,11 @@ class CreateBackdrop(NukeCreator):
     def create(self, subset_name, instance_data, pre_create_data):
         if self.check_existing_subset(subset_name, instance_data):
             raise NukeCreatorError(
-                ("Subset name '{}' is already used. "
-                 "Please specify different Variant.").format(subset_name))
+                (
+                    "Subset '{}' is already created "
+                    "in nodes! Change variant name!"
+                ).format(subset_name)
+            )
 
         instance = super(CreateBackdrop, self).create(
             subset_name,

--- a/openpype/hosts/nuke/plugins/create/create_backdrop.py
+++ b/openpype/hosts/nuke/plugins/create/create_backdrop.py
@@ -43,13 +43,8 @@ class CreateBackdrop(NukeCreator):
             return created_node
 
     def create(self, subset_name, instance_data, pre_create_data):
-        if self.check_existing_subset(subset_name, instance_data):
-            raise NukeCreatorError(
-                (
-                    "Subset '{}' is already created "
-                    "in nodes! Change variant name!"
-                ).format(subset_name)
-            )
+        # make sure subset name is unique
+        self.check_existing_subset(subset_name)
 
         instance = super(CreateBackdrop, self).create(
             subset_name,

--- a/openpype/hosts/nuke/plugins/create/create_camera.py
+++ b/openpype/hosts/nuke/plugins/create/create_camera.py
@@ -46,8 +46,11 @@ class CreateCamera(NukeCreator):
     def create(self, subset_name, instance_data, pre_create_data):
         if self.check_existing_subset(subset_name, instance_data):
             raise NukeCreatorError(
-                ("Subset name '{}' is already used. "
-                 "Please specify different Variant.").format(subset_name))
+                (
+                    "Subset '{}' is already created "
+                    "in nodes! Change variant name!"
+                ).format(subset_name)
+            )
 
         instance = super(CreateCamera, self).create(
             subset_name,

--- a/openpype/hosts/nuke/plugins/create/create_camera.py
+++ b/openpype/hosts/nuke/plugins/create/create_camera.py
@@ -44,13 +44,8 @@ class CreateCamera(NukeCreator):
             return created_node
 
     def create(self, subset_name, instance_data, pre_create_data):
-        if self.check_existing_subset(subset_name, instance_data):
-            raise NukeCreatorError(
-                (
-                    "Subset '{}' is already created "
-                    "in nodes! Change variant name!"
-                ).format(subset_name)
-            )
+        # make sure subset name is unique
+        self.check_existing_subset(subset_name)
 
         instance = super(CreateCamera, self).create(
             subset_name,

--- a/openpype/hosts/nuke/plugins/create/create_gizmo.py
+++ b/openpype/hosts/nuke/plugins/create/create_gizmo.py
@@ -45,13 +45,8 @@ class CreateGizmo(NukeCreator):
             return created_node
 
     def create(self, subset_name, instance_data, pre_create_data):
-        if self.check_existing_subset(subset_name, instance_data):
-            raise NukeCreatorError(
-                (
-                    "Subset '{}' is already created "
-                    "in nodes! Change variant name!"
-                ).format(subset_name)
-            )
+        # make sure subset name is unique
+        self.check_existing_subset(subset_name)
 
         instance = super(CreateGizmo, self).create(
             subset_name,

--- a/openpype/hosts/nuke/plugins/create/create_gizmo.py
+++ b/openpype/hosts/nuke/plugins/create/create_gizmo.py
@@ -47,8 +47,11 @@ class CreateGizmo(NukeCreator):
     def create(self, subset_name, instance_data, pre_create_data):
         if self.check_existing_subset(subset_name, instance_data):
             raise NukeCreatorError(
-                ("Subset name '{}' is already used. "
-                 "Please specify different Variant.").format(subset_name))
+                (
+                    "Subset '{}' is already created "
+                    "in nodes! Change variant name!"
+                ).format(subset_name)
+            )
 
         instance = super(CreateGizmo, self).create(
             subset_name,

--- a/openpype/hosts/nuke/plugins/create/create_model.py
+++ b/openpype/hosts/nuke/plugins/create/create_model.py
@@ -47,8 +47,11 @@ class CreateModel(NukeCreator):
     def create(self, subset_name, instance_data, pre_create_data):
         if self.check_existing_subset(subset_name, instance_data):
             raise NukeCreatorError(
-                ("Subset name '{}' is already used. "
-                 "Please specify different Variant.").format(subset_name))
+                (
+                    "Subset '{}' is already created "
+                    "in nodes! Change variant name!"
+                ).format(subset_name)
+            )
 
         instance = super(CreateModel, self).create(
             subset_name,

--- a/openpype/hosts/nuke/plugins/create/create_model.py
+++ b/openpype/hosts/nuke/plugins/create/create_model.py
@@ -45,13 +45,8 @@ class CreateModel(NukeCreator):
             return created_node
 
     def create(self, subset_name, instance_data, pre_create_data):
-        if self.check_existing_subset(subset_name, instance_data):
-            raise NukeCreatorError(
-                (
-                    "Subset '{}' is already created "
-                    "in nodes! Change variant name!"
-                ).format(subset_name)
-            )
+        # make sure subset name is unique
+        self.check_existing_subset(subset_name)
 
         instance = super(CreateModel, self).create(
             subset_name,

--- a/openpype/hosts/nuke/plugins/create/create_source.py
+++ b/openpype/hosts/nuke/plugins/create/create_source.py
@@ -49,13 +49,7 @@ class CreateSource(NukeCreator):
                 _subset_name = subset_name + node_name
 
                 # make sure subset name is unique
-                if self.check_existing_subset(_subset_name, instance_data):
-                    raise NukeCreatorError(
-                        (
-                            "Subset '{}' is already created "
-                            "in nodes! Change variant name!"
-                        ).format(subset_name)
-                    )
+                self.check_existing_subset(_subset_name)
 
                 instance_node = self.create_instance_node(
                     _subset_name,

--- a/openpype/hosts/nuke/plugins/create/create_source.py
+++ b/openpype/hosts/nuke/plugins/create/create_source.py
@@ -51,8 +51,11 @@ class CreateSource(NukeCreator):
                 # make sure subset name is unique
                 if self.check_existing_subset(_subset_name, instance_data):
                     raise NukeCreatorError(
-                        ("subset {} is already published"
-                         "definition.").format(_subset_name))
+                        (
+                            "Subset '{}' is already created "
+                            "in nodes! Change variant name!"
+                        ).format(subset_name)
+                    )
 
                 instance_node = self.create_instance_node(
                     _subset_name,

--- a/openpype/hosts/nuke/plugins/create/create_write_image.py
+++ b/openpype/hosts/nuke/plugins/create/create_write_image.py
@@ -118,13 +118,7 @@ class CreateWriteImage(napi.NukeWriteCreator):
         self.set_selected_nodes(pre_create_data)
 
         # make sure subset name is unique
-        if self.check_existing_subset(subset_name, instance_data):
-            raise napi.NukeCreatorError(
-                (
-                    "Subset '{}' is already created "
-                    "in nodes! Change variant name!"
-                ).format(subset_name)
-            )
+        self.check_existing_subset(subset_name)
 
         instance_node = self.create_instance_node(
             subset_name,

--- a/openpype/hosts/nuke/plugins/create/create_write_image.py
+++ b/openpype/hosts/nuke/plugins/create/create_write_image.py
@@ -120,8 +120,11 @@ class CreateWriteImage(napi.NukeWriteCreator):
         # make sure subset name is unique
         if self.check_existing_subset(subset_name, instance_data):
             raise napi.NukeCreatorError(
-                ("subset {} is already published"
-                 "definition.").format(subset_name))
+                (
+                    "Subset '{}' is already created "
+                    "in nodes! Change variant name!"
+                ).format(subset_name)
+            )
 
         instance_node = self.create_instance_node(
             subset_name,

--- a/openpype/hosts/nuke/plugins/create/create_write_prerender.py
+++ b/openpype/hosts/nuke/plugins/create/create_write_prerender.py
@@ -135,8 +135,11 @@ class CreateWritePrerender(napi.NukeWriteCreator):
         # make sure subset name is unique
         if self.check_existing_subset(subset_name, instance_data):
             raise napi.NukeCreatorError(
-                ("subset {} is already published"
-                 "definition.").format(subset_name))
+                (
+                    "Subset '{}' is already created "
+                    "in nodes! Change variant name!"
+                ).format(subset_name)
+            )
 
         instance_node = self.create_instance_node(
             subset_name,

--- a/openpype/hosts/nuke/plugins/create/create_write_prerender.py
+++ b/openpype/hosts/nuke/plugins/create/create_write_prerender.py
@@ -133,13 +133,7 @@ class CreateWritePrerender(napi.NukeWriteCreator):
         self.set_selected_nodes(pre_create_data)
 
         # make sure subset name is unique
-        if self.check_existing_subset(subset_name, instance_data):
-            raise napi.NukeCreatorError(
-                (
-                    "Subset '{}' is already created "
-                    "in nodes! Change variant name!"
-                ).format(subset_name)
-            )
+        self.check_existing_subset(subset_name)
 
         instance_node = self.create_instance_node(
             subset_name,

--- a/openpype/hosts/nuke/plugins/create/create_write_render.py
+++ b/openpype/hosts/nuke/plugins/create/create_write_render.py
@@ -124,8 +124,11 @@ class CreateWriteRender(napi.NukeWriteCreator):
         # make sure subset name is unique
         if self.check_existing_subset(subset_name, instance_data):
             raise napi.NukeCreatorError(
-                ("subset {} is already published"
-                 "definition.").format(subset_name))
+                (
+                    "Subset '{}' is already created "
+                    "in nodes! Change variant name!"
+                ).format(subset_name)
+            )
 
         instance_node = self.create_instance_node(
             subset_name,

--- a/openpype/hosts/nuke/plugins/create/create_write_render.py
+++ b/openpype/hosts/nuke/plugins/create/create_write_render.py
@@ -122,13 +122,7 @@ class CreateWriteRender(napi.NukeWriteCreator):
         self.set_selected_nodes(pre_create_data)
 
         # make sure subset name is unique
-        if self.check_existing_subset(subset_name, instance_data):
-            raise napi.NukeCreatorError(
-                (
-                    "Subset '{}' is already created "
-                    "in nodes! Change variant name!"
-                ).format(subset_name)
-            )
+        self.check_existing_subset(subset_name)
 
         instance_node = self.create_instance_node(
             subset_name,

--- a/openpype/hosts/nuke/plugins/publish/extract_render_local.py
+++ b/openpype/hosts/nuke/plugins/publish/extract_render_local.py
@@ -33,12 +33,10 @@ class NukeRenderLocal(publish.Extractor):
             if x.Class() == "Write":
                 node = x
 
-        self.log.debug("instance collected: {}".format(instance.data))
-
         first_frame = instance.data.get("frameStartHandle", None)
 
         last_frame = instance.data.get("frameEndHandle", None)
-        node_subset_name = instance.data.get("name", None)
+        node_subset_name = instance.data["subset"]
 
         self.log.info("Starting render")
         self.log.info("Start frame: {}".format(first_frame))
@@ -65,7 +63,7 @@ class NukeRenderLocal(publish.Extractor):
 
         # Render frames
         nuke.execute(
-            node_subset_name,
+            str(node_subset_name),
             int(first_frame),
             int(last_frame)
         )

--- a/openpype/hosts/nuke/plugins/publish/validate_output_resolution.py
+++ b/openpype/hosts/nuke/plugins/publish/validate_output_resolution.py
@@ -23,7 +23,7 @@ class ValidateOutputResolution(
     order = pyblish.api.ValidatorOrder
     optional = True
     families = ["render"]
-    label = "Write Resolution"
+    label = "Write resolution"
     hosts = ["nuke"]
     actions = [RepairAction]
 

--- a/openpype/plugins/publish/collect_from_create_context.py
+++ b/openpype/plugins/publish/collect_from_create_context.py
@@ -37,7 +37,6 @@ class CollectFromCreateContext(pyblish.api.ContextPlugin):
             context.data["projectName"] = project_name
 
         for created_instance in create_context.instances:
-            self.log.info(f"created_instance:: {created_instance}")
             instance_data = created_instance.data_to_store()
             if instance_data["active"]:
                 thumbnail_path = thumbnail_paths_by_instance_id.get(


### PR DESCRIPTION
## Brief description
New creators correctly checking nodes in scene for existing subset.

## Description
Latest publisher creator plugins are now correctly detecting if nodes in workfile node tree is having a node with the same subset name user wants to create. This way unique subset name is secured.

## Additional info
Error messages were having typos in all creators

## Testing notes:
1. open nuke in your testing workfile already converted with new publisher.
2. open Create from OpenPype menu and set family and variant matching any already created instance node. 
3. Error message should popup with clear message.