### PR TITLE
Feature: Add subprocess command before sync loop

### DIFF
--- a/openpype/modules/sync_server/rest_api.py
+++ b/openpype/modules/sync_server/rest_api.py
@@ -29,9 +29,21 @@ class SyncServerModuleRestApi:
             self.prefix + "/reset_timer",
             self.reset_timer,
         )
+        self.server_manager.add_route(
+            "POST",
+            self.prefix + "/add_before_loop_cmd",
+            self.add_before_loop_cmd,
+        )
 
     async def reset_timer(self, _request):
         """Force timer to run immediately."""
         self.module.reset_timer()
+
+        return Response(status=200)
+
+    async def add_before_loop_cmd(self, request):
+        """Add a subprocess command to be run before sync loop."""
+        cmd = await request.json()
+        self.module.add_before_loop_cmd(cmd)
 
         return Response(status=200)

--- a/openpype/modules/sync_server/sync_server.py
+++ b/openpype/modules/sync_server/sync_server.py
@@ -253,7 +253,7 @@ class SyncServerThread(threading.Thread):
                     return_exceptions=True,
                 )
                 self.before_loop_cmds.clear()
-                
+
                 import time
                 start_time = time.time()
                 self.module.set_sync_project_settings()  # clean cache
@@ -445,7 +445,10 @@ class SyncServerThread(threading.Thread):
         Args:
             cmd (list): List of program followed by the arguments to execute
         """
-        self.log.debug("Added subprocess command to be executed before sync loop")
+        self.log.debug(
+            "Added subprocess command to be executed before sync loop: "
+            "{}".format(cmd)
+        )
         self.before_loop_cmds.append(cmd)
 
     def _working_sites(self, project_name, sync_config):


### PR DESCRIPTION
## Brief description
Add the possibility to run a subprocess command before the main sync loop is processed.

## Description
This could be very useful if you need to execute processes on published representations without slowing down the pyblish process too much.

## Testing notes:
In an integrator, add:
```
manager = ModulesManager()
sync_server_module = manager.modules_by_name["sync_server"]
sync_server_module.add_before_loop_cmd(["/path/to/blender.exe"])
```
Blender will open when the loop will be executed.