### PR TITLE
General: Loader and Creator plugins can be disabled

### DIFF
--- a/openpype/pipeline/create/legacy_create.py
+++ b/openpype/pipeline/create/legacy_create.py
@@ -20,6 +20,7 @@ class LegacyCreator(object):
     family = None
     defaults = None
     maintain_selection = True
+    enabled = True
 
     dynamic_subset_keys = []
 
@@ -76,11 +77,10 @@ class LegacyCreator(object):
         print(">>> We have preset for {}".format(plugin_name))
         for option, value in plugin_settings.items():
             if option == "enabled" and value is False:
-                setattr(cls, "active", False)
                 print("  - is disabled by preset")
             else:
-                setattr(cls, option, value)
                 print("  - setting `{}`: `{}`".format(option, value))
+            setattr(cls, option, value)
 
     def process(self):
         pass

--- a/openpype/pipeline/load/plugins.py
+++ b/openpype/pipeline/load/plugins.py
@@ -30,6 +30,7 @@ class LoaderPlugin(list):
     representations = list()
     order = 0
     is_multiple_contexts_compatible = False
+    enabled = True
 
     options = []
 
@@ -73,11 +74,10 @@ class LoaderPlugin(list):
         print(">>> We have preset for {}".format(plugin_name))
         for option, value in plugin_settings.items():
             if option == "enabled" and value is False:
-                setattr(cls, "active", False)
                 print("  - is disabled by preset")
             else:
-                setattr(cls, option, value)
                 print("  - setting `{}`: `{}`".format(option, value))
+            setattr(cls, option, value)
 
     @classmethod
     def get_representations(cls):

--- a/openpype/pipeline/workfile/build_workfile.py
+++ b/openpype/pipeline/workfile/build_workfile.py
@@ -120,6 +120,8 @@ class BuildWorkfile:
         # Prepare available loaders
         loaders_by_name = {}
         for loader in discover_loader_plugins():
+            if not loader.enabled:
+                continue
             loader_name = loader.__name__
             if loader_name in loaders_by_name:
                 raise KeyError(

--- a/openpype/pipeline/workfile/workfile_template_builder.py
+++ b/openpype/pipeline/workfile/workfile_template_builder.py
@@ -239,6 +239,8 @@ class AbstractTemplateBuilder(object):
         if self._creators_by_name is None:
             self._creators_by_name = {}
             for creator in discover_legacy_creator_plugins():
+                if not creator.enabled:
+                    continue
                 creator_name = creator.__name__
                 if creator_name in self._creators_by_name:
                     raise KeyError(

--- a/openpype/tools/creator/model.py
+++ b/openpype/tools/creator/model.py
@@ -23,6 +23,8 @@ class CreatorsModel(QtGui.QStandardItemModel):
         items = []
         creators = discover_legacy_creator_plugins()
         for creator in creators:
+            if not creator.enabled:
+                continue
             item_id = str(uuid.uuid4())
             self._creators_by_id[item_id] = creator
 

--- a/openpype/tools/loader/widgets.py
+++ b/openpype/tools/loader/widgets.py
@@ -451,6 +451,8 @@ class SubsetWidget(QtWidgets.QWidget):
         repre_loaders = []
         subset_loaders = []
         for loader in available_loaders:
+            if not loader.enabled:
+                continue
             # Skip if its a SubsetLoader.
             if issubclass(loader, SubsetLoaderPlugin):
                 subset_loaders.append(loader)
@@ -1352,6 +1354,8 @@ class RepresentationWidget(QtWidgets.QWidget):
 
         filtered_loaders = []
         for loader in available_loaders:
+            if not loader.enabled:
+                continue
             # Skip subset loaders
             if issubclass(loader, SubsetLoaderPlugin):
                 continue


### PR DESCRIPTION
## Brief description
Loader and Creator plugins can be disabled.

## Description
Added `enabled` attribute to `LoaderPlugin` and `LegacyCreator` plugins. Check the value in Loader tool and in Creator tool.

## Testing notes:

#### Loader 

1. Set `enabled` to `False` on any Loader plugin
2. From that moment should not appear in loader tool

#### Creator

1. Set `enabled` to `False` on any Creator plugin
2. From that moment should not appear in creator tool