### PR TITLE
Fix: (un)pause_representation doesn't work programmatically.

### DIFF
--- a/openpype/modules/sync_server/providers/gdrive.py
+++ b/openpype/modules/sync_server/providers/gdrive.py
@@ -328,9 +328,12 @@ class GDriveHandler(AbstractProvider):
             last_tick = status = response = None
             status_val = 0
             while response is None:
-                if server.is_representation_paused(representation['_id'],
-                                                   check_parents=True,
-                                                   project_name=project_name):
+                if server.is_representation_paused(
+                    project_name,
+                    representation['_id'],
+                    site,
+                    check_parents=True
+                ):
                     raise ValueError("Paused during process, please redo.")
                 if status:
                     status_val = float(status.progress())
@@ -415,9 +418,12 @@ class GDriveHandler(AbstractProvider):
             last_tick = status = response = None
             status_val = 0
             while response is None:
-                if server.is_representation_paused(representation['_id'],
-                                                   check_parents=True,
-                                                   project_name=project_name):
+                if server.is_representation_paused(
+                    project_name,
+                    representation['_id'],
+                    site,
+                    check_parents=True
+                ):
                     raise ValueError("Paused during process, please redo.")
                 if status:
                     status_val = float(status.progress())

--- a/openpype/modules/sync_server/providers/gdrive.py
+++ b/openpype/modules/sync_server/providers/gdrive.py
@@ -328,13 +328,6 @@ class GDriveHandler(AbstractProvider):
             last_tick = status = response = None
             status_val = 0
             while response is None:
-                if server.is_representation_paused(
-                    project_name,
-                    representation['_id'],
-                    site,
-                    check_parents=True
-                ):
-                    raise ValueError("Paused during process, please redo.")
                 if status:
                     status_val = float(status.progress())
                 if not last_tick or \
@@ -349,6 +342,13 @@ class GDriveHandler(AbstractProvider):
                                      site=site,
                                      progress=status_val
                                      )
+                if server.is_representation_paused(
+                    project_name,
+                    representation['_id'],
+                    site,
+                    check_parents=True
+                ):
+                    raise ValueError("Paused during process, please redo.")
                 status, response = request.next_chunk()
 
         except errors.HttpError as ex:
@@ -418,13 +418,6 @@ class GDriveHandler(AbstractProvider):
             last_tick = status = response = None
             status_val = 0
             while response is None:
-                if server.is_representation_paused(
-                    project_name,
-                    representation['_id'],
-                    site,
-                    check_parents=True
-                ):
-                    raise ValueError("Paused during process, please redo.")
                 if status:
                     status_val = float(status.progress())
                 if not last_tick or \
@@ -439,6 +432,13 @@ class GDriveHandler(AbstractProvider):
                                      site=site,
                                      progress=status_val
                                      )
+                if server.is_representation_paused(
+                    project_name,
+                    representation['_id'],
+                    site,
+                    check_parents=True
+                ):
+                    raise ValueError("Paused during process, please redo.")
                 status, response = downloader.next_chunk()
 
         return target_name

--- a/openpype/modules/sync_server/sync_server.py
+++ b/openpype/modules/sync_server/sync_server.py
@@ -284,9 +284,6 @@ class SyncServerThread(threading.Thread):
                     # building folder tree structure in memory
                     # call only if needed, eg. DO_UPLOAD or DO_DOWNLOAD
                     for sync in sync_repres:
-                        if self.module.\
-                                is_representation_paused(sync['_id']):
-                            continue
                         if limit <= 0:
                             continue
                         files = sync.get("files") or []

--- a/openpype/modules/sync_server/sync_server_module.py
+++ b/openpype/modules/sync_server/sync_server_module.py
@@ -508,18 +508,19 @@ class SyncServerModule(OpenPypeModule, ITrayModule):
             Returns:
                 (bool)
         """
-        representation = get_representation_by_id(project_name,
-                                                  representation_id,
-                                                  fields=["files.sites"])
-        if not representation:
-            return False
-
         # Check parents are paused
         if check_parents and (
             self.is_project_paused(project_name)
             or self.is_paused()
         ):
             return True
+
+        # Get representation
+        representation = get_representation_by_id(project_name,
+                                                  representation_id,
+                                                  fields=["files.sites"])
+        if not representation:
+            return False
 
         # Check if representation is paused
         for file_info in representation.get("files", []):

--- a/openpype/modules/sync_server/sync_server_module.py
+++ b/openpype/modules/sync_server/sync_server_module.py
@@ -515,8 +515,10 @@ class SyncServerModule(OpenPypeModule, ITrayModule):
             return False
 
         # Check parents are paused
-        if check_parents and (self.is_project_paused(project_name) or \
-                self.is_paused()):
+        if check_parents and (
+            self.is_project_paused(project_name)
+            or self.is_paused()
+        ):
             return True
 
         # Check if representation is paused

--- a/openpype/modules/sync_server/sync_server_module.py
+++ b/openpype/modules/sync_server/sync_server_module.py
@@ -1484,7 +1484,8 @@ class SyncServerModule(OpenPypeModule, ITrayModule):
                             "$elemMatch": {
                                 "name": {"$in": [remote_site]},
                                 "created_dt": {"$exists": False},
-                                "tries": {"$in": retries_arr}
+                                "tries": {"$in": retries_arr},
+                                "paused": {"$exists": False}
                             }
                         }
                     }]},
@@ -1494,7 +1495,8 @@ class SyncServerModule(OpenPypeModule, ITrayModule):
                             "$elemMatch": {
                                 "name": active_site,
                                 "created_dt": {"$exists": False},
-                                "tries": {"$in": retries_arr}
+                                "tries": {"$in": retries_arr},
+                                "paused": {"$exists": False}
                             }
                         }}, {
                         "files.sites": {

--- a/openpype/modules/sync_server/sync_server_module.py
+++ b/openpype/modules/sync_server/sync_server_module.py
@@ -124,7 +124,6 @@ class SyncServerModule(OpenPypeModule, ITrayModule):
         self.action_show_widget = None
         self._paused = False
         self._paused_projects = set()
-        self._paused_representations = set()
         self._anatomies = {}
 
         self._connection = None
@@ -475,7 +474,6 @@ class SyncServerModule(OpenPypeModule, ITrayModule):
                 site_name (string): 'gdrive', 'studio' etc.
         """
         self.log.info("Pausing SyncServer for {}".format(representation_id))
-        self._paused_representations.add(representation_id)
         self.reset_site_on_representation(project_name, representation_id,
                                           site_name=site_name, pause=True)
 
@@ -492,11 +490,6 @@ class SyncServerModule(OpenPypeModule, ITrayModule):
                 site_name (string): 'gdrive', 'studio' etc.
         """
         self.log.info("Unpausing SyncServer for {}".format(representation_id))
-        try:
-            self._paused_representations.remove(representation_id)
-        except KeyError:
-            pass
-        # self.paused_representations is not persistent
         self.reset_site_on_representation(project_name, representation_id,
                                           site_name=site_name, pause=False)
 


### PR DESCRIPTION
## Brief description
Fix that (un)pausing a representation works only using the sync queue UI.

Fix #4311

## Description
- Added the `paused` condition to `get_sync_representations` aggregation.
- Refactored `is_representation_paused` to check into the database and unified with `is_representation_on_site`.
- Cleaned useless `_paused_representations`.

## Testing notes:
1. Add this integrator to your pipeline and play with pausing blocks
```py
import pyblish.api
from openpype.modules.base import ModulesManager
from openpype.pipeline import legacy_io
class IntegratePauseRepre(pyblish.api.InstancePlugin):

    label = "Integrate Pause Representation"
    order = pyblish.api.IntegratorOrder + 0.1
    optional = True
    hosts = ["blender"]

    def process(self, instance):
        manager = ModulesManager()
        sync_server_module = manager.modules_by_name["sync_server"]
        project_name = legacy_io.active_project()
        published_representations = instance.data.get('published_representations', {}).keys()

        for repre_id in published_representations:
            sites = [sync_server_module.get_active_site(project_name), sync_server_module.get_remote_site(project_name)]
            for site in sites:
                print("pausing", repre_id, site)
                sync_server_module.pause_representation(project_name, repre_id, site)

            for site in sites:
                print(repre_id, "paused", sync_server_module.is_representation_paused(project_name, repre_id, site))

            for site in sites:
                print("unpausing", repre_id, site)
                sync_server_module.unpause_representation(project_name, repre_id, site)

            for site in sites:
                print(repre_id, "unpaused", sync_server_module.is_representation_paused(project_name, repre_id, site))
```