### PR TITLE
Maya: Bug - Multiverse extractor executed on plain animation family

### DIFF
--- a/openpype/hosts/maya/plugins/publish/extract_multiverse_usd.py
+++ b/openpype/hosts/maya/plugins/publish/extract_multiverse_usd.py
@@ -4,6 +4,7 @@ import six
 from maya import cmds
 from maya import mel
 
+import pyblish.api
 from openpype.pipeline import publish
 from openpype.hosts.maya.api.lib import maintained_selection
 
@@ -156,13 +157,6 @@ class ExtractMultiverseUsd(publish.Extractor):
         return members
 
     def process(self, instance):
-        # check if there is "usd" in families because of
-        # `ExtractMultiverseUsdAnim` that inherits this and should
-        # run on animation family too.
-        families = set(instance.data["families"])
-        families.add(instance.data["family"])
-        if "usd" not in families:
-            return
 
         # Load plugin first
         cmds.loadPlugin("MultiverseForMaya", quiet=True)
@@ -262,7 +256,8 @@ class ExtractMultiverseUsdAnim(ExtractMultiverseUsd):
     Upon publish a .usd sparse cache will be written.
     """
     label = "Extract Multiverse USD Animation Sparse Cache"
-    families = ["animation"]
+    families = ["animation", "usd"]
+    match = pyblish.api.Subset
 
     def get_default_options(self):
         anim_options = self.default_options

--- a/openpype/hosts/maya/plugins/publish/extract_multiverse_usd.py
+++ b/openpype/hosts/maya/plugins/publish/extract_multiverse_usd.py
@@ -156,6 +156,14 @@ class ExtractMultiverseUsd(publish.Extractor):
         return members
 
     def process(self, instance):
+        # check if there is "usd" in families because of
+        # `ExtractMultiverseUsdAnim` that inherits this and should
+        # run on animation family too.
+        families = set(instance.data["families"])
+        families.add(instance.data["family"])
+        if "usd" not in families:
+            return
+
         # Load plugin first
         cmds.loadPlugin("MultiverseForMaya", quiet=True)
 


### PR DESCRIPTION
## Fix

Fix for when animation was published from rig, `Extract Multiverse USD` was triggered even if no usd extraction was required.

### Testing

Publish animation from rig.