### PR TITLE
Slack: user groups speedup

### DIFF
--- a/openpype/modules/slack/plugins/publish/integrate_slack_api.py
+++ b/openpype/modules/slack/plugins/publish/integrate_slack_api.py
@@ -62,8 +62,16 @@ class IntegrateSlackAPI(pyblish.api.InstancePlugin):
                     client = SlackPython3Operations(token, self.log)
 
                 if "@" in message:
-                    if users is None:
+                    cache_key = "__cache_ids"
+                    slack_ids = instance.context.data.get(cache_key, None)
+                    if slack_ids is None:
                         users, groups = client.get_users_and_groups()
+                        instance.context.data[cache_key] = {}
+                        instance.context.data[cache_key]["users"] = users
+                        instance.context.data[cache_key]["groups"] = groups
+                    else:
+                        users = slack_ids["users"]
+                        groups = slack_ids["groups"]
                     message = self._translate_users(message, users, groups)
 
                 msg_id, file_ids = client.send_message(channel,

--- a/openpype/modules/slack/plugins/publish/integrate_slack_api.py
+++ b/openpype/modules/slack/plugins/publish/integrate_slack_api.py
@@ -62,7 +62,7 @@ class IntegrateSlackAPI(pyblish.api.InstancePlugin):
                     client = SlackPython3Operations(token, self.log)
 
                 if "@" in message:
-                    cache_key = "__cache_ids"
+                    cache_key = "__cache_slack_ids"
                     slack_ids = instance.context.data.get(cache_key, None)
                     if slack_ids is None:
                         users, groups = client.get_users_and_groups()

--- a/openpype/modules/slack/plugins/publish/integrate_slack_api.py
+++ b/openpype/modules/slack/plugins/publish/integrate_slack_api.py
@@ -39,6 +39,7 @@ class IntegrateSlackAPI(pyblish.api.InstancePlugin):
         token = instance.data["slack_token"]
         if additional_message:
             message = "{} \n".format(additional_message)
+        users = groups = None
         for message_profile in instance.data["slack_channel_message_profiles"]:
             message += self._get_filled_message(message_profile["message"],
                                                 instance,
@@ -60,8 +61,10 @@ class IntegrateSlackAPI(pyblish.api.InstancePlugin):
                 else:
                     client = SlackPython3Operations(token, self.log)
 
-                users, groups = client.get_users_and_groups()
-                message = self._translate_users(message, users, groups)
+                if "@" in message:
+                    if users is None:
+                        users, groups = client.get_users_and_groups()
+                    message = self._translate_users(message, users, groups)
 
                 msg_id, file_ids = client.send_message(channel,
                                                        message,

--- a/openpype/modules/slack/plugins/publish/integrate_slack_api.py
+++ b/openpype/modules/slack/plugins/publish/integrate_slack_api.py
@@ -215,7 +215,7 @@ class IntegrateSlackAPI(pyblish.api.InstancePlugin):
 
     def _translate_users(self, message, users, groups):
         """Replace all occurences of @mentions with proper <@name> format."""
-        matches = re.findall(r"(?<!<)@[^ ]+", message)
+        matches = re.findall(r"(?<!<)@\S+", message)
         in_quotes = re.findall(r"(?<!<)(['\"])(@[^'\"]+)", message)
         for item in in_quotes:
             matches.append(item[1])


### PR DESCRIPTION
## Brief description
Query user and group information only if necessary.

## Description
When message contains '@' character, translation between users and Slack user id is necessar. This operation might hit rate limit and slows down publish process.
Trigger this querying only if absolutely necessary.

## Testing notes:
1. publish something that should trigger Slack notification
2. compare messages with and without @ character