### PR TITLE
General: Python 2 compatibility of instance collector

### DIFF
--- a/openpype/plugins/publish/collect_from_create_context.py
+++ b/openpype/plugins/publish/collect_from_create_context.py
@@ -37,7 +37,6 @@ class CollectFromCreateContext(pyblish.api.ContextPlugin):
             context.data["projectName"] = project_name
 
         for created_instance in create_context.instances:
-            self.log.info(f"created_instance:: {created_instance}")
             instance_data = created_instance.data_to_store()
             if instance_data["active"]:
                 thumbnail_path = thumbnail_paths_by_instance_id.get(


### PR DESCRIPTION
## Brief description
Removed line breaking Python 2 compatibility in collector for new publishing.

## Testing notes:
1. Instances should be collected in new publisher during pyblish process