### PR TITLE
General: Functions for current context

### DIFF
--- a/openpype/host/host.py
+++ b/openpype/host/host.py
@@ -100,6 +100,30 @@ class HostBase(object):
 
         pass
 
+    def get_current_project_name(self):
+        """
+        Returns:
+            Union[str, None]: Current project name.
+        """
+
+        return os.environ.get("AVALON_PROJECT")
+
+    def get_current_asset_name(self):
+        """
+        Returns:
+            Union[str, None]: Current asset name.
+        """
+
+        return os.environ.get("AVALON_ASSET")
+
+    def get_current_task_name(self):
+        """
+        Returns:
+            Union[str, None]: Current task name.
+        """
+
+        return os.environ.get("AVALON_ASSET")
+
     def get_current_context(self):
         """Get current context information.
 
@@ -111,19 +135,14 @@ class HostBase(object):
         Default implementation returns values from 'legacy_io.Session'.
 
         Returns:
-            dict: Context with 3 keys 'project_name', 'asset_name' and
-                'task_name'. All of them can be 'None'.
+            Dict[str, Union[str, None]]: Context with 3 keys 'project_name',
+                'asset_name' and 'task_name'. All of them can be 'None'.
         """
 
-        from openpype.pipeline import legacy_io
-
-        if legacy_io.is_installed():
-            legacy_io.install()
-
         return {
-            "project_name": legacy_io.Session["AVALON_PROJECT"],
-            "asset_name": legacy_io.Session["AVALON_ASSET"],
-            "task_name": legacy_io.Session["AVALON_TASK"]
+            "project_name": self.get_current_project_name(),
+            "asset_name": self.get_current_asset_name(),
+            "task_name": self.get_current_task_name()
         }
 
     def get_context_title(self):

--- a/openpype/host/host.py
+++ b/openpype/host/host.py
@@ -1,3 +1,4 @@
+import os
 import logging
 import contextlib
 from abc import ABCMeta, abstractproperty

--- a/openpype/pipeline/__init__.py
+++ b/openpype/pipeline/__init__.py
@@ -86,6 +86,12 @@ from .context_tools import (
     registered_host,
     deregister_host,
     get_process_id,
+
+    get_current_context,
+    get_current_host_name,
+    get_current_project_name,
+    get_current_asset_name,
+    get_current_task_name,
 )
 install = install_host
 uninstall = uninstall_host
@@ -176,6 +182,13 @@ __all__ = (
     "register_host",
     "registered_host",
     "deregister_host",
+    "get_process_id",
+
+    "get_current_context",
+    "get_current_host_name",
+    "get_current_project_name",
+    "get_current_asset_name",
+    "get_current_task_name",
 
     # Backwards compatible function names
     "install",

--- a/openpype/pipeline/context_tools.py
+++ b/openpype/pipeline/context_tools.py
@@ -306,6 +306,22 @@ def debug_host():
     return host
 
 
+def get_current_host_name():
+    """Current host name.
+
+    Function is based on currently registered host integration or environment
+    variant 'AVALON_APP'.
+
+    Returns:
+        Union[str, None]: Name of host integration in current process or None.
+    """
+
+    host = registered_host()
+    if host is not None and hasattr(host, "name"):
+        return host.name
+    return os.environ.get("AVALON_APP")
+
+
 def get_global_context():
     return {
         "project_name": os.environ.get("AVALON_PROJECT"),

--- a/openpype/pipeline/context_tools.py
+++ b/openpype/pipeline/context_tools.py
@@ -306,6 +306,42 @@ def debug_host():
     return host
 
 
+def get_global_context():
+    return {
+        "project_name": os.environ.get("AVALON_PROJECT"),
+        "asset_name": os.environ.get("AVALON_ASSET"),
+        "task_name": os.environ.get("AVALON_TASK"),
+    }
+
+
+def get_current_context():
+    host = registered_host()
+    if host is not None and hasattr(host, "get_current_context"):
+        return host.get_current_context()
+    return get_global_context()
+
+
+def get_current_project_name():
+    host = registered_host()
+    if host is not None and hasattr(host, "get_current_project_name"):
+        return host.get_current_project_name()
+    return get_global_context()["project_name"]
+
+
+def get_current_asset_name():
+    host = registered_host()
+    if host is not None and hasattr(host, "get_current_asset_name"):
+        return host.get_current_asset_name()
+    return get_global_context()["asset_name"]
+
+
+def get_current_task_name():
+    host = registered_host()
+    if host is not None and hasattr(host, "get_current_task_name"):
+        return host.get_current_task_name()
+    return get_global_context()["task_name"]
+
+
 def get_current_project(fields=None):
     """Helper function to get project document based on global Session.
 
@@ -316,7 +352,7 @@ def get_current_project(fields=None):
         None: Project is not set.
     """
 
-    project_name = legacy_io.active_project()
+    project_name = get_current_project_name()
     return get_project(project_name, fields=fields)
 
 
@@ -341,12 +377,12 @@ def get_current_project_asset(asset_name=None, asset_id=None, fields=None):
         None: Asset is not set or not exist.
     """
 
-    project_name = legacy_io.active_project()
+    project_name = get_current_project_name()
     if asset_id:
         return get_asset_by_id(project_name, asset_id, fields=fields)
 
     if not asset_name:
-        asset_name = legacy_io.Session.get("AVALON_ASSET")
+        asset_name = get_current_asset_name()
         # Skip if is not set even on context
         if not asset_name:
             return None
@@ -363,7 +399,7 @@ def is_representation_from_latest(representation):
         bool: Whether the representation is of latest version.
     """
 
-    project_name = legacy_io.active_project()
+    project_name = get_current_project_name()
     return version_is_latest(project_name, representation["parent"])
 
 

--- a/openpype/pipeline/context_tools.py
+++ b/openpype/pipeline/context_tools.py
@@ -11,6 +11,7 @@ import pyblish.api
 from pyblish.lib import MessageHandler
 
 import openpype
+from openpype.host import HostBase
 from openpype.client import (
     get_project,
     get_asset_by_id,
@@ -317,7 +318,7 @@ def get_current_host_name():
     """
 
     host = registered_host()
-    if host is not None and hasattr(host, "name"):
+    if isinstance(host, HostBase):
         return host.name
     return os.environ.get("AVALON_APP")
 
@@ -332,28 +333,28 @@ def get_global_context():
 
 def get_current_context():
     host = registered_host()
-    if host is not None and hasattr(host, "get_current_context"):
+    if isinstance(host, HostBase):
         return host.get_current_context()
     return get_global_context()
 
 
 def get_current_project_name():
     host = registered_host()
-    if host is not None and hasattr(host, "get_current_project_name"):
+    if isinstance(host, HostBase):
         return host.get_current_project_name()
     return get_global_context()["project_name"]
 
 
 def get_current_asset_name():
     host = registered_host()
-    if host is not None and hasattr(host, "get_current_asset_name"):
+    if isinstance(host, HostBase):
         return host.get_current_asset_name()
     return get_global_context()["asset_name"]
 
 
 def get_current_task_name():
     host = registered_host()
-    if host is not None and hasattr(host, "get_current_task_name"):
+    if isinstance(host, HostBase):
         return host.get_current_task_name()
     return get_global_context()["task_name"]
 


### PR DESCRIPTION
## Brief description
Defined more functions to receive current context information and added the methods to host integration so host can affect the result.

## Description
This is one of steps to reduce usage of `legacy_io.Session`. This change define how to receive current context information -> call functions instead of accessing `legacy_io.Session` or `os.environ` directly. Plus, direct access on session or environments is unfortunatelly not enough for some DCCs where multiple workfiles can be opened at one time which can heavily affect the context but host integration sometimes can't affect that at all.

`HostBase` already had implemented `get_current_context`, that was enhanced by adding more specific methods `get_current_project_name`, `get_current_asset_name` and `get_current_task_name`. The same functions were added to `~/openpype/pipeline/cotext_tools.py`. The functions in context tools are calling host integration methods (if are available) otherwise are using environent variables as default implementation does. Also was added `get_current_host_name` to receive host name from registered host if is available or from environment variable.

## Additional info
Didn't change usages of `legacy_io.Session` anywhere. We should make a decision and agree on an approach and then start replace current usages. Anyway there must be backwards compatibility for some time.

### Possible changes
- Use `legacy_io.Session` instead of `os.environ`. But I wanted to avoid that as the goal is to reduce usage of  `legacy_io`. Those functions are for "reading", "change" of current context in legacy_io is changing environemnts too (if does not then it should).
- Add `set_current_context` function to replace `change_current_context` and some logic in workfiles tool.
- The functionality is doubled in default implementation of host and in context tools (I didn't find out good or better solution).

## Testing notes:
It's more about decisions. Any comments are welcome