### PR TITLE
General: Use class constants of QMessageBox

### DIFF
--- a/openpype/hosts/maya/plugins/publish/validate_assembly_transforms.py
+++ b/openpype/hosts/maya/plugins/publish/validate_assembly_transforms.py
@@ -93,12 +93,12 @@ class ValidateAssemblyModelTransforms(pyblish.api.InstancePlugin):
         from openpype.hosts.maya.api import lib
 
         # Store namespace in variable, cosmetics thingy
-        messagebox = QtWidgets.QMessageBox
-        mode = messagebox.StandardButton.Ok | messagebox.StandardButton.Cancel
-        choice = messagebox.warning(None,
-                                    "Matrix reset",
-                                    cls.prompt_message,
-                                    mode)
+        choice = QtWidgets.QMessageBox.warning(
+            None,
+            "Matrix reset",
+            cls.prompt_message,
+            QtWidgets.QMessageBox.Ok | QtWidgets.QMessageBox.Cancel
+        )
 
         invalid = cls.get_invalid(instance)
         if not invalid:

--- a/openpype/tools/project_manager/project_manager/window.py
+++ b/openpype/tools/project_manager/project_manager/window.py
@@ -248,12 +248,13 @@ class ProjectManagerWindow(QtWidgets.QWidget):
         if not project_name:
             return
 
-        qm = QtWidgets.QMessageBox
-        ans = qm.question(self,
-                          "OpenPype Project Manager",
-                          "Confirm to create starting project folders?",
-                          qm.Yes | qm.No)
-        if ans == qm.Yes:
+        result = QtWidgets.QMessageBox.question(
+            self,
+            "OpenPype Project Manager",
+            "Confirm to create starting project folders?",
+            QtWidgets.QMessageBox.Yes | QtWidgets.QMessageBox.No
+        )
+        if result == QtWidgets.QMessageBox.Yes:
             try:
                 # Invoking OpenPype API to create the project folders
                 create_project_folders(project_name)

--- a/openpype/tools/workfiles/files_widget.py
+++ b/openpype/tools/workfiles/files_widget.py
@@ -525,22 +525,25 @@ class FilesWidget(QtWidgets.QWidget):
 
     def save_changes_prompt(self):
         self._messagebox = messagebox = QtWidgets.QMessageBox(parent=self)
-        messagebox.setWindowFlags(messagebox.windowFlags() |
-                                  QtCore.Qt.FramelessWindowHint)
-        messagebox.setIcon(messagebox.Warning)
+        messagebox.setWindowFlags(
+            messagebox.windowFlags() | QtCore.Qt.FramelessWindowHint
+        )
+        messagebox.setIcon(QtWidgets.QMessageBox.Warning)
         messagebox.setWindowTitle("Unsaved Changes!")
         messagebox.setText(
             "There are unsaved changes to the current file."
             "\nDo you want to save the changes?"
         )
         messagebox.setStandardButtons(
-            messagebox.Yes | messagebox.No | messagebox.Cancel
+            QtWidgets.QMessageBox.Yes
+            | QtWidgets.QMessageBox.No
+            | QtWidgets.QMessageBox.Cancel
         )
 
         result = messagebox.exec_()
-        if result == messagebox.Yes:
+        if result == QtWidgets.QMessageBox.Yes:
             return True
-        if result == messagebox.No:
+        if result == QtWidgets.QMessageBox.No:
             return False
         return None
 


### PR DESCRIPTION
## Brief description
PR fixing usage of constants with QMessageBox with combination with PySide6 (where constants are not available on objects).

## Testing notes:
1. Use workfiles tool where is save changes prompt that crashed
2. This dialog is shown if there are unsaved changes in host
3. The dialog should show and should be possible to select what should happen

Missed that bug in https://github.com/ynput/OpenPype/pull/4255 . There still can be more wrong usage of constants in the code, any reports welcomed.