### PR TITLE
Global: fixing in-place source publishing for editorial

### DIFF
--- a/openpype/plugins/publish/collect_otio_subset_resources.py
+++ b/openpype/plugins/publish/collect_otio_subset_resources.py
@@ -1,4 +1,3 @@
-# TODO: this head doc string
 """
 Requires:
     instance -> otio_clip
@@ -153,6 +152,8 @@ class CollectOtioSubsetResources(pyblish.api.InstancePlugin):
             self.log.debug(collection)
             repre = self._create_representation(
                 frame_start, frame_end, collection=collection)
+
+            instance.data["originalBasename"] = collection.format("{head}")
         else:
             _trim = False
             dirname, filename = os.path.split(media_ref.target_url)
@@ -166,6 +167,10 @@ class CollectOtioSubsetResources(pyblish.api.InstancePlugin):
             self.log.debug(filename)
             repre = self._create_representation(
                 frame_start, frame_end, file=filename, trim=_trim)
+
+            instance.data["originalBasename"] = os.path.splitext(filename)[0]
+
+        instance.data["originalDirname"] = self.staging_dir
 
         if repre:
             # add representation to instance data

--- a/openpype/plugins/publish/integrate.py
+++ b/openpype/plugins/publish/integrate.py
@@ -630,8 +630,12 @@ class IntegrateAsset(pyblish.api.InstancePlugin):
                 # that `frameStart` index instead. Thus if that frame start
                 # differs from the collection we want to shift the destination
                 # frame indices from the source collection.
+                # In case source are published in place we need to skip renumbering
                 repre_frame_start = repre.get("frameStart")
-                if repre_frame_start is not None:
+                if (
+                    "originalBasename" not in template
+                    and repre_frame_start is not None
+                ):
                     index_frame_start = int(repre["frameStart"])
                     # Shift destination sequence to the start frame
                     destination_indexes = [

--- a/openpype/plugins/publish/integrate.py
+++ b/openpype/plugins/publish/integrate.py
@@ -630,7 +630,8 @@ class IntegrateAsset(pyblish.api.InstancePlugin):
                 # that `frameStart` index instead. Thus if that frame start
                 # differs from the collection we want to shift the destination
                 # frame indices from the source collection.
-                # In case source are published in place we need to skip renumbering
+                # In case source are published in place we need to
+                # skip renumbering
                 repre_frame_start = repre.get("frameStart")
                 if (
                     "originalBasename" not in template


### PR DESCRIPTION
## Brief description
Editorial now support in-place publishing

## Description
In-place publishing was missing some data to stream source file metadata. Now we are collecting metadata so downstream plugins are publishing it correctly

## Additional info
Exception in Integrate plugin needed to be added for renumbering destination files.

## Testing notes:
1. follow Settings setup from https://github.com/ynput/OpenPype/pull/4157
2. go to `project_settings/global/tools/publish/template_name_profiles` and make sure you have following input 
![image](https://user-images.githubusercontent.com/40640033/212951197-1a776d67-843e-40dd-b08e-585ba34012cd.png)
3. Add some image seqence to your testing project. My where `<project>/source/plates/shot01/v001/<name_of_file>.<number>.<ext>`
4. add the sequence to your testing editorial project in `hiero` or `resolve`
5. Add the clip to fresh timeline and create publishable clip on it
6. publish it
7. check the published file by loading it into Nuke and see that loaded file is pointing to your original path and the name hasn't changes nor the number sequence. 