### PR TITLE
Harmony: fix unable to change workfile on Mac

### DIFF
--- a/openpype/hosts/harmony/api/server.py
+++ b/openpype/hosts/harmony/api/server.py
@@ -40,6 +40,7 @@ class Server(threading.Thread):
 
         # Create a TCP/IP socket
         self.socket = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        self.socket.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
 
         # Bind the socket to the port
         server_address = ("127.0.0.1", port)
@@ -91,7 +92,13 @@ class Server(threading.Thread):
             self.log.info("wait ttt")
             # Receive the data in small chunks and retransmit it
             request = None
-            header = self.connection.recv(10)
+            try:
+                header = self.connection.recv(10)
+            except OSError:
+                # could happen on MacOS
+                self.log.info("")
+                break
+
             if len(header) == 0:
                 # null data received, socket is closing.
                 self.log.info(f"[{self.timestamp()}] Connection closing.")


### PR DESCRIPTION
## Brief description
It was failing on Mac with OSError 9 Bad file descriptor and 48 Address already in use when changing workfile from opened workfile.

## Testing notes:
1. Open Harmony on Mac, select workfile from Workfiles
2. Use Workfiles again and try to open different version of opened workfile