### PR TITLE
Feature: Keep synced hero representations up-to-date.

### DIFF
--- a/openpype/plugins/publish/integrate_hero_version.py
+++ b/openpype/plugins/publish/integrate_hero_version.py
@@ -386,6 +386,25 @@ class IntegrateHeroVersion(pyblish.api.InstancePlugin):
                     repre["_id"] = old_repre["_id"]
                     update_data = prepare_representation_update_data(
                         old_repre, repre)
+
+                    # Keep previously synchronized sites up-to-date
+                    # by comparing old and new sites and adding old sites
+                    # if missing in new ones
+                    old_repre_files_sites = [
+                        f.get("sites", []) for f in old_repre.get("files", [])
+                    ]
+                    for i, file in enumerate(repre.get("files", [])):
+                        repre_sites_names = {
+                            s["name"] for s in file.get("sites", [])
+                        }
+                        for site in old_repre_files_sites[i]:
+                            if site["name"] not in repre_sites_names:
+                                # Pop the date to tag for sync
+                                site.pop("created_dt")
+                                file["sites"].append(site)
+
+                        update_data["files"][i] = file
+                    
                     op_session.update_entity(
                         project_name,
                         old_repre["type"],

--- a/openpype/plugins/publish/integrate_hero_version.py
+++ b/openpype/plugins/publish/integrate_hero_version.py
@@ -400,7 +400,7 @@ class IntegrateHeroVersion(pyblish.api.InstancePlugin):
                         for site in old_repre_files_sites[i]:
                             if site["name"] not in repre_sites_names:
                                 # Pop the date to tag for sync
-                                site.pop("created_dt")
+                                site.pop("created_dt", None)
                                 file["sites"].append(site)
 
                         update_data["files"][i] = file

--- a/openpype/plugins/publish/integrate_hero_version.py
+++ b/openpype/plugins/publish/integrate_hero_version.py
@@ -404,7 +404,7 @@ class IntegrateHeroVersion(pyblish.api.InstancePlugin):
                                 file["sites"].append(site)
 
                         update_data["files"][i] = file
-                    
+
                     op_session.update_entity(
                         project_name,
                         old_repre["type"],


### PR DESCRIPTION
## Brief description
Keep previously synchronized sites up-to-date by comparing old and new sites and adding old sites if missing in new ones.

Fix #4331

## Testing notes:
1. Publish a version from a site A
2. Using the loader, download the hero version
3. Publish the same subset from site B
4. It's being synchronized in site A