### PR TITLE
Sort families by alphabetical order in the Create plugin

### DIFF
--- a/openpype/tools/creator/model.py
+++ b/openpype/tools/creator/model.py
@@ -39,6 +39,7 @@ class CreatorsModel(QtGui.QStandardItemModel):
             item.setData(QtCore.Qt.ItemIsEnabled, False)
             items.append(item)
 
+        items.sort(key=lambda item: item.text())
         self.invisibleRootItem().appendRows(items)
 
     def get_creator_by_id(self, item_id):


### PR DESCRIPTION
## Brief description
In the Create menu, sort the families by alphabetical order for better readability.