### PR TITLE
Fix photoshop workfile save-as

### DIFF
--- a/openpype/hosts/photoshop/api/workio.py
+++ b/openpype/hosts/photoshop/api/workio.py
@@ -25,6 +25,8 @@ def has_unsaved_changes():
 
 def save_file(filepath):
     _, ext = os.path.splitext(filepath)
+    if ext not in file_extensions():
+        ext = '.psd'
     lib.stub().saveAs(filepath, ext[1:], True)
 
 


### PR DESCRIPTION
## Brief description
When opening a png (or other non psd file) in photoshop, the save-as in workfile interface save with png extension intead of psd if we don't touch the select extension dropdown.

## Description
Set default extension to psd if file is not psd or psb.
