### PR TITLE
PushToProject: Fix hierarchy of project change

### DIFF
--- a/openpype/pipeline/anatomy.py
+++ b/openpype/pipeline/anatomy.py
@@ -1126,7 +1126,7 @@ class RootItem(FormatObject):
             if _mod_path.startswith(root_path):
                 result = True
                 replacement = "{" + self.full_key() + "}"
-                output = replacement + _mod_path[len(root_path):]
+                output = replacement + mod_path[len(root_path):]
                 break
 
         return (result, output)

--- a/openpype/tools/push_to_project/control_integrate.py
+++ b/openpype/tools/push_to_project/control_integrate.py
@@ -416,7 +416,7 @@ class ProjectPushRepreItem:
             fill_roots[root_name] = "{{root[{}]}}".format(root_name)
         repre_path = StringTemplate.format_template(
             template, fill_repre_context)
-        repre_path = repre_path.replace("\\", "/")
+        repre_path = self._clean_path(repre_path)
         src_dirpath, src_basename = os.path.split(repre_path)
         src_basename = (
             re.escape(src_basename)
@@ -468,7 +468,7 @@ class ProjectPushRepreItem:
             fill_roots[root_name] = "{{root[{}]}}".format(root_name)
         repre_path = StringTemplate.format_template(template,
                                                     fill_repre_context)
-        repre_path = repre_path.replace("\\", "/")
+        repre_path = self._clean_path(repre_path)
         src_dirpath = os.path.dirname(repre_path)
         for file_info in self._repre_doc["files"]:
             filepath_template = self._clean_path(file_info["path"])

--- a/openpype/tools/push_to_project/control_integrate.py
+++ b/openpype/tools/push_to_project/control_integrate.py
@@ -419,7 +419,9 @@ class ProjectPushRepreItem:
         src_basename_regex = re.compile("^{}$".format(src_basename))
         for file_info in self._repre_doc["files"]:
             filepath_template = file_info["path"].replace("\\", "/")
-            filepath = filepath_template.format(root=self._roots)
+            filepath = os.path.normpath(
+                filepath_template.format(root=self._roots)
+            )
             dirpath, basename = os.path.split(filepath_template)
             if (
                 dirpath != src_dirpath

--- a/openpype/tools/push_to_project/control_integrate.py
+++ b/openpype/tools/push_to_project/control_integrate.py
@@ -326,6 +326,13 @@ class ProjectPushRepreItem:
             self.get_source_files()
         return self._resource_files
 
+    @staticmethod
+    def _clean_path(path):
+        new_value = path.replace("\\", "/")
+        while "//" in new_value:
+            new_value = new_value.replace("//", "/")
+        return new_value
+
     @property
     def frame(self):
         """First frame of representation files.
@@ -407,8 +414,8 @@ class ProjectPushRepreItem:
         fill_roots = fill_repre_context["root"]
         for root_name in tuple(fill_roots.keys()):
             fill_roots[root_name] = "{{root[{}]}}".format(root_name)
-        repre_path = StringTemplate.format_template(template,
-                                                    fill_repre_context)
+        repre_path = StringTemplate.format_template(
+            template, fill_repre_context)
         repre_path = repre_path.replace("\\", "/")
         src_dirpath, src_basename = os.path.split(repre_path)
         src_basename = (
@@ -418,10 +425,11 @@ class ProjectPushRepreItem:
         )
         src_basename_regex = re.compile("^{}$".format(src_basename))
         for file_info in self._repre_doc["files"]:
-            filepath_template = file_info["path"].replace("\\", "/")
-            filepath = os.path.normpath(
+            filepath_template = self._clean_path(file_info["path"])
+            filepath = self._clean_path(
                 filepath_template.format(root=self._roots)
             )
+
             dirpath, basename = os.path.split(filepath_template)
             if (
                 dirpath != src_dirpath
@@ -463,8 +471,10 @@ class ProjectPushRepreItem:
         repre_path = repre_path.replace("\\", "/")
         src_dirpath = os.path.dirname(repre_path)
         for file_info in self._repre_doc["files"]:
-            filepath_template = file_info["path"].replace("\\", "/")
-            filepath = filepath_template.format(root=self._roots)
+            filepath_template = self._clean_path(file_info["path"])
+            filepath = self._clean_path(
+                filepath_template.format(root=self._roots))
+
             if filepath_template == repre_path:
                 src_files.append(SourceFile(filepath))
             else:

--- a/openpype/tools/push_to_project/window.py
+++ b/openpype/tools/push_to_project/window.py
@@ -230,9 +230,13 @@ class AssetsModel(QtGui.QStandardItemModel):
             item = self._items.pop(item_id, None)
             if item is None:
                 continue
+            row = item.row()
+            if row < 0:
+                continue
             parent = item.parent()
-            if parent is not None:
-                parent.takeRow(item.row())
+            if parent is None:
+                parent = root_item
+            parent.takeRow(row)
 
         self.items_changed.emit()
 


### PR DESCRIPTION
## Brief description
Fix removement of assets from root hierarchy level on project change in push to project tool.

## Description
Asses from previous project were not removed from root item so they stayed in hierarchy view.

## Testing notes:
Make sure you have at least 2 library projects
1. Run Push To Project action
2. Select 1st project
3. Select 2nd project
4. Assets from 1st project should not be visible in 2nd