### PR TITLE
Pre-commit: Remove black

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,7 +10,3 @@ repos:
     -   id: check-added-large-files
     -   id: no-commit-to-branch
         args: [ '--pattern', '^(?!((enhancement|feature|bugfix|documentation|tests|local|chore)\/[a-zA-Z0-9\-]+)$).*' ]
--   repo: https://github.com/psf/black
-    rev: 22.12.0
-    hooks:
-    -   id: black


### PR DESCRIPTION
## Change

This PR is removing [black](https://github.com/psf/black) from pre-commit hooks.

Black was making automatic unintended changes in the code that were sometimes incompatible with the Houd rules. This can be configured, but lets remove it for now.