### PR TITLE
Unreal: Don't use mongo queries in 'ExistingLayoutLoader'

### DIFF
--- a/openpype/hosts/unreal/plugins/load/load_layout_existing.py
+++ b/openpype/hosts/unreal/plugins/load/load_layout_existing.py
@@ -282,7 +282,7 @@ class ExistingLayoutLoader(plugin.Loader):
         actors_matched = []
 
         for (repr_data, lasset) in layout_data:
-             # For every actor in the scene, check if it has a representation in
+            # For every actor in the scene, check if it has a representation in
             # those we got from the JSON. If so, create a container for it.
             # Otherwise, remove it from the scene.
             found = False

--- a/openpype/hosts/unreal/plugins/load/load_layout_existing.py
+++ b/openpype/hosts/unreal/plugins/load/load_layout_existing.py
@@ -250,7 +250,7 @@ class ExistingLayoutLoader(plugin.Loader):
         for element in data:
             repre_id = element.get('representation')
             if repre_id:
-                repre_ids.append(repre_id)
+                repre_ids.add(repre_id)
                 elements.append(element)
 
         repre_docs = get_representations(

--- a/openpype/hosts/unreal/plugins/load/load_layout_existing.py
+++ b/openpype/hosts/unreal/plugins/load/load_layout_existing.py
@@ -231,8 +231,8 @@ class ExistingLayoutLoader(plugin.Loader):
 
         return assets
 
-    def _process(self, lib_path):
 
+    def _process(self, lib_path, project_name):
         ar = unreal.AssetRegistryHelpers.get_asset_registry()
 
         actors = EditorLevelLibrary.get_all_level_actors()
@@ -385,7 +385,8 @@ class ExistingLayoutLoader(plugin.Loader):
         if not curr_level:
             raise AssertionError("Current level not saved")
 
-        containers = self._process(self.fname)
+        project_name = context["project"]["name"]
+        containers = self._process(self.fname, project_name)
 
         curr_level_path = Path(
             curr_level.get_outer().get_path_name()).parent.as_posix()
@@ -415,7 +416,8 @@ class ExistingLayoutLoader(plugin.Loader):
         asset_dir = container.get('namespace')
 
         source_path = get_representation_path(representation)
-        containers = self._process(source_path)
+        project_name = legacy_io.active_project()
+        containers = self._process(source_path, project_name)
 
         data = {
             "representation": str(representation["_id"]),

--- a/openpype/hosts/unreal/plugins/load/load_layout_existing.py
+++ b/openpype/hosts/unreal/plugins/load/load_layout_existing.py
@@ -15,7 +15,6 @@ from openpype.pipeline import (
     AVALON_CONTAINER_ID,
     legacy_io,
 )
-from openpype.api import get_current_project_settings
 from openpype.hosts.unreal.api import plugin
 from openpype.hosts.unreal.api import pipeline as upipeline
 
@@ -32,6 +31,17 @@ class ExistingLayoutLoader(plugin.Loader):
     icon = "code-fork"
     color = "orange"
     ASSET_ROOT = "/Game/OpenPype"
+
+    delete_unmatched_assets = True
+
+    @classmethod
+    def apply_settings(cls, project_settings, *args, **kwargs):
+        super(ExistingLayoutLoader, cls).apply_settings(
+            project_settings, *args, **kwargs
+        )
+        cls.delete_unmatched_assets = (
+            project_settings["unreal"]["delete_unmatched_assets"]
+        )
 
     @staticmethod
     def _create_container(
@@ -222,8 +232,6 @@ class ExistingLayoutLoader(plugin.Loader):
         return assets
 
     def _process(self, lib_path):
-        data = get_current_project_settings()
-        delete_unmatched = data["unreal"]["delete_unmatched_assets"]
 
         ar = unreal.AssetRegistryHelpers.get_asset_registry()
 
@@ -360,7 +368,7 @@ class ExistingLayoutLoader(plugin.Loader):
                 continue
             if actor not in actors_matched:
                 self.log.warning(f"Actor {actor.get_name()} not matched.")
-                if delete_unmatched:
+                if self.delete_unmatched_assets:
                     EditorLevelLibrary.destroy_actor(actor)
 
         return containers


### PR DESCRIPTION
## Brief description
Unreal load plugin `ExistingLayoutLoader` used direct mongo calls using `legacy_io.find_one` and imported from `openpype.api`. Both should not be used anymore.

## Description
Use `get_representations` function to get representations instead of direct queries. Replaced querying of representations one by one into 2 chunks. Added class attribute `delete_unmatched_assets` which stores value of `"delete_unmatched_assets"` from unreal settings (overriden classmethod `apply_settings`) -> removed import from `openpype.api`.

## Testing notes:
1. Loader should work as did before this PR (maybe faster)