### PR TITLE
Fix - addSite loader handles hero version

### DIFF
--- a/openpype/client/entity_links.py
+++ b/openpype/client/entity_links.py
@@ -164,7 +164,6 @@ def get_linked_representation_id(
         # Recursive graph lookup for inputs
         {"$graphLookup": graph_lookup}
     ]
-
     conn = get_project_connection(project_name)
     result = conn.aggregate(query_pipeline)
     referenced_version_ids = _process_referenced_pipeline_result(
@@ -213,7 +212,7 @@ def _process_referenced_pipeline_result(result, link_type):
 
         for output in sorted(outputs_recursive, key=lambda o: o["depth"]):
             output_links = output.get("data", {}).get("inputLinks")
-            if not output_links:
+            if not output_links and output["type"] != "hero_version":
                 continue
 
             # Leaf
@@ -232,6 +231,9 @@ def _process_referenced_pipeline_result(result, link_type):
 
 
 def _filter_input_links(input_links, link_type, correctly_linked_ids):
+    if not input_links:  # to handle hero versions
+        return
+
     for input_link in input_links:
         if link_type and input_link["type"] != link_type:
             continue

--- a/openpype/plugins/load/add_site.py
+++ b/openpype/plugins/load/add_site.py
@@ -2,12 +2,6 @@ from openpype.client import get_linked_representation_id
 from openpype.modules import ModulesManager
 from openpype.pipeline import load
 from openpype.modules.sync_server.utils import SiteAlreadyPresentError
-from openpype.client.entities import (
-    get_hero_version_by_subset_id,
-    get_representation_by_id,
-    get_version_by_id,
-    get_representation_by_name
-)
 
 
 class AddSyncSite(load.LoaderPlugin):
@@ -84,35 +78,3 @@ class AddSyncSite(load.LoaderPlugin):
     def filepath_from_context(self, context):
         """No real file loading"""
         return ""
-
-    def _add_hero_representation_ids(self, project_name, repre_id):
-        """Find hero version if exists for repre_id.
-
-        Args:
-            project_name (str)
-            repre_id (ObjectId)
-        Returns:
-            (list): at least [repre_id] if no hero version found
-        """
-        representation_ids = [repre_id]
-
-        repre_doc = get_representation_by_id(
-            project_name, repre_id, fields=["_id", "parent", "name"]
-        )
-
-        version_doc = get_version_by_id(project_name, repre_doc["parent"])
-        if version_doc["type"] != "hero_version":
-            hero_version = get_hero_version_by_subset_id(
-                project_name, version_doc["parent"],
-                fields=["_id", "version_id"]
-            )
-            if (hero_version and
-                    hero_version["version_id"] == version_doc["_id"]):
-                hero_repre_doc = get_representation_by_name(
-                    project_name,
-                    repre_doc["name"],
-                    hero_version["_id"]
-                )
-                representation_ids.append(hero_repre_doc["_id"])
-
-        return representation_ids

--- a/openpype/plugins/load/add_site.py
+++ b/openpype/plugins/load/add_site.py
@@ -51,13 +51,13 @@ class AddSyncSite(load.LoaderPlugin):
             data (dict): expects {"site_name": SITE_NAME_TO_ADD}
         """
         # self.log wont propagate
-        print("Adding {} to representation: {}".format(
-              data["site_name"], data["_id"]))
         project_name = context["project"]["name"]
         repre_doc = context["representation"]
         family = repre_doc["context"]["family"]
-        repre_id = [repre_doc["_id"]]
+        repre_id = repre_doc["_id"]
         site_name = data["site_name"]
+        print("Adding {} to representation: {}".format(
+              data["site_name"], repre_id))
 
         self.sync_server.add_site(project_name, repre_id, site_name,
                                   force=True)
@@ -70,6 +70,8 @@ class AddSyncSite(load.LoaderPlugin):
             )
             for link_repre_id in links:
                 try:
+                    print("Adding {} to linked representation: {}".format(
+                        data["site_name"], link_repre_id))
                     self.sync_server.add_site(project_name, link_repre_id,
                                               site_name,
                                               force=False)

--- a/openpype/plugins/load/add_site.py
+++ b/openpype/plugins/load/add_site.py
@@ -82,6 +82,9 @@ class AddSyncSite(load.LoaderPlugin):
     def _add_hero_representation_ids(self, project_name, repre_id):
         """Find hero version if exists for repre_id.
 
+        Args:
+            project_name (str)
+            repre_id (ObjectId)
         Returns:
             (list): at least [repre_id] if no hero version found
         """

--- a/openpype/plugins/load/remove_site.py
+++ b/openpype/plugins/load/remove_site.py
@@ -3,7 +3,10 @@ from openpype.pipeline import load
 
 
 class RemoveSyncSite(load.LoaderPlugin):
-    """Remove sync site and its files on representation"""
+    """Remove sync site and its files on representation.
+
+    Removes files only on local site!
+    """
     representations = ["*"]
     families = ["*"]
 
@@ -24,13 +27,18 @@ class RemoveSyncSite(load.LoaderPlugin):
         return self._sync_server
 
     def load(self, context, name=None, namespace=None, data=None):
-        self.log.info("Removing {} on representation: {}".format(
-            data["site_name"], data["_id"]))
-        self.sync_server.remove_site(data["project_name"],
-                                     data["_id"],
-                                     data["site_name"],
+        project_name = context["project"]["name"]
+        repre_doc = context["representation"]
+        repre_id = repre_doc["_id"]
+        site_name = data["site_name"]
+
+        print("Removing {} on representation: {}".format(site_name, repre_id))
+
+        self.sync_server.remove_site(project_name,
+                                     repre_id,
+                                     site_name,
                                      True)
-        self.log.debug("Site added.")
+        self.log.debug("Site removed.")
 
     def filepath_from_context(self, context):
         """No real file loading"""

--- a/openpype/tools/loader/widgets.py
+++ b/openpype/tools/loader/widgets.py
@@ -1468,23 +1468,21 @@ class RepresentationWidget(QtWidgets.QWidget):
         repre_ids = []
         data_by_repre_id = {}
         selected_side = action_representation.get("selected_side")
+        site_name = "{}_site_name".format(selected_side)
 
         is_sync_loader = tools_lib.is_sync_loader(loader)
         for item in items:
-            item_id = item.get("_id")
-            repre_ids.append(item_id)
+            repre_id = item["_id"]
+            repre_ids.append(repre_id)
             if not is_sync_loader:
                 continue
 
-            site_name = "{}_site_name".format(selected_side)
             data_site_name = item.get(site_name)
             if not data_site_name:
                 continue
 
-            data_by_repre_id[item_id] = {
-                "_id": item_id,
-                "site_name": data_site_name,
-                "project_name": self.dbcon.active_project()
+            data_by_repre_id[repre_id] = {
+                "site_name": data_site_name
             }
 
         repre_contexts = get_repres_contexts(repre_ids, self.dbcon)
@@ -1574,8 +1572,8 @@ def _load_representations_by_loader(loader, repre_contexts,
             version_name = version_doc.get("name")
         try:
             if data_by_repre_id:
-                _id = repre_context["representation"]["_id"]
-                data = data_by_repre_id.get(_id)
+                repre_id = repre_context["representation"]["_id"]
+                data = data_by_repre_id.get(repre_id)
                 options.update(data)
             load_with_repre_context(
                 loader,


### PR DESCRIPTION
## Brief description
If adding site to representation presence of hero version is checked, if found hero version is marked to be donwloaded too.


Replacing https://github.com/ynput/OpenPype/pull/4191

## Testing notes:
1. locate subset which has some hero version in Loader
2.use latest version of said subset and `Download` representation (in right bottom)
3. check that both latest and hero version representation were downloaded