### PR TITLE
General: Loader plugin define its own compatibility

### DIFF
--- a/openpype/pipeline/load/plugins.py
+++ b/openpype/pipeline/load/plugins.py
@@ -93,24 +93,33 @@ class LoaderPlugin(list):
             bool
         """
 
+        plugin_repre_names = cls.get_representations()
+        plugin_families = cls.families
+        if not plugin_repre_names or not plugin_families:
+            return False
+
+        repre_doc = context.get("representation")
+        if not repre_doc:
+            return False
+
+        plugin_repre_names = set(plugin_repre_names)
+        if (
+            "*" not in plugin_repre_names
+            and repre_doc["name"] not in plugin_repre_names
+        ):
+            return False
+
         maj_version, _ = schema.get_schema_version(context["subset"]["schema"])
         if maj_version < 3:
             families = context["version"]["data"].get("families", [])
         else:
             families = context["subset"]["data"]["families"]
 
-        representation = context["representation"]
-        has_family = (
-            "*" in cls.families or any(
-                family in cls.families for family in families
-            )
+        plugin_families = set(plugin_families)
+        return (
+            "*" in plugin_families
+            or any(family in plugin_families for family in families)
         )
-        representations = cls.get_representations()
-        has_representation = (
-            "*" in representations
-            or representation["name"] in representations
-        )
-        return has_family and has_representation
 
     @classmethod
     def get_representations(cls):

--- a/openpype/pipeline/load/utils.py
+++ b/openpype/pipeline/load/utils.py
@@ -748,25 +748,9 @@ def is_compatible_loader(Loader, context):
 
     Returns:
         bool
-
     """
-    maj_version, _ = schema.get_schema_version(context["subset"]["schema"])
-    if maj_version < 3:
-        families = context["version"]["data"].get("families", [])
-    else:
-        families = context["subset"]["data"]["families"]
 
-    representation = context["representation"]
-    has_family = (
-        "*" in Loader.families or any(
-            family in Loader.families for family in families
-        )
-    )
-    representations = Loader.get_representations()
-    has_representation = (
-        "*" in representations or representation["name"] in representations
-    )
-    return has_family and has_representation
+    return Loader.is_compatible_loader(context)
 
 
 def loaders_from_repre_context(loaders, repre_context):


### PR DESCRIPTION
## Brief description
This is "idea", how to give loaders more power to decide if can be shown in UI by adding `is_compatible` method on it.

## Description
Add `is_compatible` class method to loader plugin which by default does what `is_compatible` function did but loader can override the method and be more precise in the decision.

## Additional information
There are also SubsetLoaders which didn't use `is_compatible` at all but probably should have that option too. In future we could add objects that would represent items in loader menu so loader does not have to calculate that on it's own. That is missing few more things (like unique identifier of loader plugins, etc.) -> doable, but more complicated.

I didn't test it...

## Testing notes:
1. Loader plugins should be filtered as they were before in Loader and LibraryLoader