### PR TITLE
Remove OIIO build for macos

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -146,10 +146,6 @@ hash = "b9950f5d2fa3720b52b8be55bacf5f56d33f9e029d38ee86534995f3d8d253d2"
 url = "https://distribute.openpype.io/thirdparty/oiio_tools-2.2.20-linux-centos7.tgz"
 hash = "3894dec7e4e521463891a869586850e8605f5fd604858b674c87323bf33e273d"
 
-[openpype.thirdparty.oiio.darwin]
-url = "https://distribute.openpype.io/thirdparty/oiio-2.2.0-darwin.tgz"
-hash = "sha256:..."
-
 [openpype.thirdparty.ocioconfig]
 url = "https://distribute.openpype.io/thirdparty/OpenColorIO-Configs-1.0.2.zip"
 hash = "4ac17c1f7de83465e6f51dd352d7117e07e765b66d00443257916c828e35b6ce"

--- a/tools/fetch_thirdparty_libs.py
+++ b/tools/fetch_thirdparty_libs.py
@@ -130,8 +130,10 @@ def install_thirdparty(pyproject, openpype_root, platform_name):
             _print("trying to get universal url for all platforms")
             url = v.get("url")
             if not url:
-                _print("cannot get url", 1)
-                sys.exit(1)
+                _print("cannot get url for all platforms", 1)
+                _print((f"Warning: {k} is not installed for current platform "
+                       "and it might be missing in the build"), 1)
+                continue
         else:
             url = v.get(platform_name).get("url")
             destination_path = destination_path / platform_name


### PR DESCRIPTION
## Fix

Since we are not able to provide OpenImageIO tools binaries for macos, we should remove the item from th `pyproject.toml`. This PR is taking care of it.

It is also changing the way `fetch_thirdparty_libs` script works in that it doesn't crash when lib cannot be processed, it only issue warning.


Resolves #3858