### PR TITLE
Houdini: Do not visualize the hidden OpenPypeContext node

### DIFF
--- a/openpype/hosts/houdini/api/pipeline.py
+++ b/openpype/hosts/houdini/api/pipeline.py
@@ -144,8 +144,7 @@ class HoudiniHost(HostBase, IWorkfileHost, ILoadHost, IPublishHost):
 
         """
         obj_network = hou.node("/obj")
-        op_ctx = obj_network.createNode(
-            "null", node_name="OpenPypeContext")
+        op_ctx = obj_network.createNode("null", node_name="OpenPypeContext")
 
         # A null in houdini by default comes with content inside to visualize
         # the null. However since we explicitly want to hide the node lets

--- a/openpype/hosts/houdini/api/pipeline.py
+++ b/openpype/hosts/houdini/api/pipeline.py
@@ -146,11 +146,19 @@ class HoudiniHost(HostBase, IWorkfileHost, ILoadHost, IPublishHost):
         obj_network = hou.node("/obj")
         op_ctx = obj_network.createNode(
             "null", node_name="OpenPypeContext")
+
+        # A null in houdini by default comes with content inside to visualize
+        # the null. However since we explicitly want to hide the node lets
+        # remove the content and disable the display flag of the node
+        for node in op_ctx.children():
+            node.destroy()
+
         op_ctx.moveToGoodPosition()
         op_ctx.setBuiltExplicitly(False)
         op_ctx.setCreatorState("OpenPype")
         op_ctx.setComment("OpenPype node to hold context metadata")
         op_ctx.setColor(hou.Color((0.081, 0.798, 0.810)))
+        op_ctx.setDisplayFlag(False)
         op_ctx.hide(True)
         return op_ctx
 


### PR DESCRIPTION
## Brief description

Using the new publisher UI would generate a visible 'null' locator at the origin. It's confusing to the user since it's supposed to be 'hidden'.

## Description

Before this PR the user would see a locator/null at the origin which was the 'hidden' `/obj/OpenPypeContext` node. This null would suddenly appear if the user would've ever opened the Publisher UI once.

![afbeelding](https://user-images.githubusercontent.com/2439881/214876858-38fe453c-cc9f-4718-9b40-79a1c7d229ca.png)

After this PR it will not show:

![afbeelding](https://user-images.githubusercontent.com/2439881/214877048-887087c0-5efd-4e47-af38-476b55e28374.png)

Nice and tidy.

## Additional info

This does NOT change it for existing scenes that already had the OpenPypeContext generated with it visual. It'll only change it for new scenes where it's generated the first time.

## Testing notes:

1. Open Houdini
2. Use new publisher