### PR TITLE
Maya: Fix validate plugin path attributes

### DIFF
--- a/openpype/hosts/maya/plugins/publish/validate_plugin_path_attributes.py
+++ b/openpype/hosts/maya/plugins/publish/validate_plugin_path_attributes.py
@@ -24,7 +24,7 @@ class ValidatePluginPathAttributes(pyblish.api.InstancePlugin):
         validate_path = (
             instance.context.data["project_settings"]["maya"]["publish"]
         )
-        file_attr = validate_path["ValidatePathForPlugin"]["attribute"]
+        file_attr = validate_path["ValidatePluginPathAttributes"]["attribute"]
         if not file_attr:
             return invalid
 

--- a/openpype/hosts/maya/plugins/publish/validate_plugin_path_attributes.py
+++ b/openpype/hosts/maya/plugins/publish/validate_plugin_path_attributes.py
@@ -39,7 +39,7 @@ class ValidatePluginPathAttributes(pyblish.api.InstancePlugin):
                 filepath = cmds.getAttr(file_attr)
 
                 if filepath and not os.path.exists(filepath):
-                    self.log.error("File {0} not exists".format(filepath)) # noqa
+                    self.log.error("File {0} not exists".format(filepath))  # noqa
                     invalid.append(target)
 
         return invalid


### PR DESCRIPTION
## Brief description

PR #4271 has broken publishing in Maya.
See [my comment here](https://github.com/ynput/OpenPype/pull/4271/files#r1088472107)

This PR solves that issue.

## Testing notes:

1. Publish a workfile.
2. Should now work fine.