### PR TITLE
3dsmax: enhance alembic loader update function

### DIFF
--- a/openpype/hosts/max/api/menu.py
+++ b/openpype/hosts/max/api/menu.py
@@ -119,7 +119,7 @@ class OpenPypeMenu(object):
 
     def manage_callback(self):
         """Callback to show Scene Manager/Inventory tool."""
-        host_tools.show_subset_manager(parent=self.main_widget)
+        host_tools.show_scene_inventory(parent=self.main_widget)
 
     def library_callback(self):
         """Callback to show Library Loader tool."""

--- a/openpype/hosts/max/api/pipeline.py
+++ b/openpype/hosts/max/api/pipeline.py
@@ -2,6 +2,7 @@
 """Pipeline tools for OpenPype Houdini integration."""
 import os
 import logging
+from operator import attrgetter
 
 import json
 
@@ -141,5 +142,26 @@ def ls() -> list:
         if rt.getUserProp(obj, "id") == AVALON_CONTAINER_ID
     ]
 
-    for container in sorted(containers, key=lambda name: container.name):
+    for container in sorted(containers, key=attrgetter("name")):
         yield lib.read(container)
+
+
+def containerise(name: str, nodes: list, context, loader=None, suffix="_CON"):
+    data = {
+        "schema": "openpype:container-2.0",
+        "id": AVALON_CONTAINER_ID,
+        "name": name,
+        "namespace": "",
+        "loader": loader,
+        "representation": context["representation"]["_id"],
+    }
+
+    container_name = f"{name}{suffix}"
+    container = rt.container(name=container_name)
+    print(nodes)
+    for node in nodes:
+        node.Parent = container
+
+    if not lib.imprint(container_name, data):
+        print(f"imprinting of {container_name} failed.")
+    return container

--- a/openpype/hosts/max/api/pipeline.py
+++ b/openpype/hosts/max/api/pipeline.py
@@ -158,7 +158,6 @@ def containerise(name: str, nodes: list, context, loader=None, suffix="_CON"):
 
     container_name = f"{name}{suffix}"
     container = rt.container(name=container_name)
-    print(nodes)
     for node in nodes:
         node.Parent = container
 

--- a/openpype/hosts/max/plugins/load/load_pointcache.py
+++ b/openpype/hosts/max/plugins/load/load_pointcache.py
@@ -6,8 +6,10 @@ Because of limited api, alembics can be only loaded, but not easily updated.
 """
 import os
 from openpype.pipeline import (
-    load
+    load, get_representation_path
 )
+from openpype.hosts.max.api.pipeline import containerise
+from openpype.hosts.max.api import lib
 
 
 class AbcLoader(load.LoaderPlugin):
@@ -52,14 +54,47 @@ importFile @"{file_path}" #noPrompt
 
         abc_container = abc_containers.pop()
 
-        container_name = f"{name}_CON"
-        container = rt.container(name=container_name)
-        abc_container.Parent = container
+        return containerise(
+            name, [abc_container], context, loader=self.__class__.__name__)
 
-        return container
+    def update(self, container, representation):
+        from pymxs import runtime as rt
+
+        path = get_representation_path(representation)
+        node = rt.getNodeByName(container["instance_node"])
+
+        alembic_objects = self.get_container_children(node, "AlembicObject")
+        for alembic_object in alembic_objects:
+            alembic_object.source = path
+
+        lib.imprint(container["instance_node"], {
+            "representation": str(representation["_id"])
+        })
+
+    def switch(self, container, representation):
+        self.update(container, representation)
 
     def remove(self, container):
         from pymxs import runtime as rt
 
         node = container["node"]
         rt.delete(node)
+
+    @staticmethod
+    def get_container_children(parent, type_name):
+        from pymxs import runtime as rt
+
+        def list_children(node):
+            children = []
+            for c in node.Children:
+                children.append(c)
+                children = children + list_children(c)
+            return children
+
+        filtered = []
+        for child in list_children(parent):
+            class_type = str(rt.classOf(child.baseObject))
+            if class_type == type_name:
+                filtered.append(child)
+
+        return filtered

--- a/openpype/hosts/max/plugins/load/load_pointcache.py
+++ b/openpype/hosts/max/plugins/load/load_pointcache.py
@@ -88,7 +88,7 @@ importFile @"{file_path}" #noPrompt
             children = []
             for c in node.Children:
                 children.append(c)
-                children = children + list_children(c)
+                children += list_children(c)
             return children
 
         filtered = []


### PR DESCRIPTION
## Enhancement

This PR is adding update/switch ability to pointcache/alembic loader in 3dsmax and fixing wrong tool shown when clicking on "Manage" item on OpenPype menu, that is now correctly Scene Inventory (but was Subset Manager).

Alembic update has still one caveat - it doesn't cope with changed number of object inside alembic, since loading alembic in max involves creating all those objects as first class nodes. So it will keep the objects in scene, just update path to alembic file on them.