### PR TITLE
Global: extract colorspace is not failing

### DIFF
--- a/openpype/pipeline/colorspace.py
+++ b/openpype/pipeline/colorspace.py
@@ -344,9 +344,9 @@ def get_imageio_config(
     imageio_global, imageio_host = _get_imageio_settings(
         project_settings, host_name)
 
-    config_host = imageio_host["ocio_config"]
+    config_host = imageio_host.get("ocio_config", {})
 
-    if config_host["enabled"]:
+    if config_host.get("enabled"):
         config_data = _get_config_data(
             config_host["filepath"], anatomy_data
         )

--- a/openpype/pipeline/publish/publish_plugins.py
+++ b/openpype/pipeline/publish/publish_plugins.py
@@ -372,6 +372,12 @@ class ExtractorColormanaged(Extractor):
             ```
 
         """
+        ext = representation["ext"]
+        # check extension
+        self.log.debug("__ ext: `{}`".format(ext))
+        if ext.lower() not in self.allowed_ext:
+            return
+
         if colorspace_settings is None:
             colorspace_settings = self.get_colorspace_settings(context)
 
@@ -385,12 +391,6 @@ class ExtractorColormanaged(Extractor):
 
         self.log.info("Config data is : `{}`".format(
             config_data))
-
-        ext = representation["ext"]
-        # check extension
-        self.log.debug("__ ext: `{}`".format(ext))
-        if ext.lower() not in self.allowed_ext:
-            return
 
         project_name = context.data["projectName"]
         host_name = context.data["hostName"]


### PR DESCRIPTION
## Brief description
Extract colorspace data is fixed

## Description
Plugin is not failing due missing config data. 

## Additional info
Order in `openpype\pipeline\publish\publish_plugins.py` had to be prioritised to first check supported file extension before a imageio settings should be equired. Also the host config settings are now optional since some older projects might have imageio group setting override with missing config and rules. 

## Testing notes:
1. open Maya and publish pointcache
2. all should be published without hiccups ;)