### PR TITLE
General: Attribute definitions fixes

### DIFF
--- a/openpype/lib/__init__.py
+++ b/openpype/lib/__init__.py
@@ -30,7 +30,7 @@ from .vendor_bin_utils import (
 )
 
 from .attribute_definitions import (
-    AbtractAttrDef,
+    AbstractAttrDef,
 
     UIDef,
     UISeparatorDef,
@@ -246,7 +246,7 @@ __all__ = [
     "get_ffmpeg_tool_path",
     "is_oiio_supported",
 
-    "AbtractAttrDef",
+    "AbstractAttrDef",
 
     "UIDef",
     "UISeparatorDef",

--- a/openpype/lib/attribute_definitions.py
+++ b/openpype/lib/attribute_definitions.py
@@ -154,7 +154,12 @@ class AbtractAttrDef(object):
     def __eq__(self, other):
         if not isinstance(other, self.__class__):
             return False
-        return self.key == other.key
+        return (
+            self.key == other.key
+            and self.hidden == other.hidden
+            and self.default == other.default
+            and self.disabled == other.disabled
+        )
 
     def __ne__(self, other):
         return not self.__eq__(other)

--- a/openpype/lib/attribute_definitions.py
+++ b/openpype/lib/attribute_definitions.py
@@ -20,7 +20,7 @@ def register_attr_def_class(cls):
     Currently are registered definitions used to deserialize data to objects.
 
     Attrs:
-        cls (AbtractAttrDef): Non-abstract class to be registered with unique
+        cls (AbstractAttrDef): Non-abstract class to be registered with unique
             'type' attribute.
 
     Raises:
@@ -36,7 +36,7 @@ def get_attributes_keys(attribute_definitions):
     """Collect keys from list of attribute definitions.
 
     Args:
-        attribute_definitions (List[AbtractAttrDef]): Objects of attribute
+        attribute_definitions (List[AbstractAttrDef]): Objects of attribute
             definitions.
 
     Returns:
@@ -57,7 +57,7 @@ def get_default_values(attribute_definitions):
     """Receive default values for attribute definitions.
 
     Args:
-        attribute_definitions (List[AbtractAttrDef]): Attribute definitions for
+        attribute_definitions (List[AbstractAttrDef]): Attribute definitions for
             which default values should be collected.
 
     Returns:
@@ -76,15 +76,15 @@ def get_default_values(attribute_definitions):
 
 
 class AbstractAttrDefMeta(ABCMeta):
-    """Meta class to validate existence of 'key' attribute.
+    """Metaclass to validate existence of 'key' attribute.
 
-    Each object of `AbtractAttrDef` mus have defined 'key' attribute.
+    Each object of `AbstractAttrDef` mus have defined 'key' attribute.
     """
 
     def __call__(self, *args, **kwargs):
         obj = super(AbstractAttrDefMeta, self).__call__(*args, **kwargs)
         init_class = getattr(obj, "__init__class__", None)
-        if init_class is not AbtractAttrDef:
+        if init_class is not AbstractAttrDef:
             raise TypeError("{} super was not called in __init__.".format(
                 type(obj)
             ))
@@ -92,7 +92,7 @@ class AbstractAttrDefMeta(ABCMeta):
 
 
 @six.add_metaclass(AbstractAttrDefMeta)
-class AbtractAttrDef(object):
+class AbstractAttrDef(object):
     """Abstraction of attribute definiton.
 
     Each attribute definition must have implemented validation and
@@ -145,7 +145,7 @@ class AbtractAttrDef(object):
         self.disabled = disabled
         self._id = uuid.uuid4().hex
 
-        self.__init__class__ = AbtractAttrDef
+        self.__init__class__ = AbstractAttrDef
 
     @property
     def id(self):
@@ -220,7 +220,7 @@ class AbtractAttrDef(object):
 # UI attribute definitoins won't hold value
 # -----------------------------------------
 
-class UIDef(AbtractAttrDef):
+class UIDef(AbstractAttrDef):
     is_value_def = False
 
     def __init__(self, key=None, default=None, *args, **kwargs):
@@ -245,7 +245,7 @@ class UILabelDef(UIDef):
 # Attribute defintioins should hold value
 # ---------------------------------------
 
-class UnknownDef(AbtractAttrDef):
+class UnknownDef(AbstractAttrDef):
     """Definition is not known because definition is not available.
 
     This attribute can be used to keep existing data unchanged but does not
@@ -262,7 +262,7 @@ class UnknownDef(AbtractAttrDef):
         return value
 
 
-class HiddenDef(AbtractAttrDef):
+class HiddenDef(AbstractAttrDef):
     """Hidden value of Any type.
 
     This attribute can be used for UI purposes to pass values related
@@ -282,7 +282,7 @@ class HiddenDef(AbtractAttrDef):
         return value
 
 
-class NumberDef(AbtractAttrDef):
+class NumberDef(AbstractAttrDef):
     """Number definition.
 
     Number can have defined minimum/maximum value and decimal points. Value
@@ -358,7 +358,7 @@ class NumberDef(AbtractAttrDef):
         return round(float(value), self.decimals)
 
 
-class TextDef(AbtractAttrDef):
+class TextDef(AbstractAttrDef):
     """Text definition.
 
     Text can have multiline option so endline characters are allowed regex
@@ -423,7 +423,7 @@ class TextDef(AbtractAttrDef):
         return data
 
 
-class EnumDef(AbtractAttrDef):
+class EnumDef(AbstractAttrDef):
     """Enumeration of single item from items.
 
     Args:
@@ -531,7 +531,7 @@ class EnumDef(AbtractAttrDef):
 
         return output
 
-class BoolDef(AbtractAttrDef):
+class BoolDef(AbstractAttrDef):
     """Boolean representation.
 
     Args:
@@ -776,7 +776,7 @@ class FileDefItem(object):
         return output
 
 
-class FileDef(AbtractAttrDef):
+class FileDef(AbstractAttrDef):
     """File definition.
     It is possible to define filters of allowed file extensions and if supports
     folders.
@@ -894,7 +894,7 @@ def serialize_attr_def(attr_def):
     """Serialize attribute definition to data.
 
     Args:
-        attr_def (AbtractAttrDef): Attribute definition to serialize.
+        attr_def (AbstractAttrDef): Attribute definition to serialize.
 
     Returns:
         Dict[str, Any]: Serialized data.
@@ -907,7 +907,7 @@ def serialize_attr_defs(attr_defs):
     """Serialize attribute definitions to data.
 
     Args:
-        attr_defs (List[AbtractAttrDef]): Attribute definitions to serialize.
+        attr_defs (List[AbstractAttrDef]): Attribute definitions to serialize.
 
     Returns:
         List[Dict[str, Any]]: Serialized data.

--- a/openpype/lib/attribute_definitions.py
+++ b/openpype/lib/attribute_definitions.py
@@ -156,6 +156,9 @@ class AbtractAttrDef(object):
             return False
         return self.key == other.key
 
+    def __ne__(self, other):
+        return not self.__eq__(other)
+
     @abstractproperty
     def type(self):
         """Attribute definition type also used as identifier of class.

--- a/openpype/pipeline/create/context.py
+++ b/openpype/pipeline/create/context.py
@@ -13,6 +13,9 @@ from openpype.settings import (
     get_system_settings,
     get_project_settings
 )
+from openpype.lib.attribute_definitions import (
+    UnknownDef,
+)
 from openpype.host import IPublishHost
 from openpype.pipeline import legacy_io
 from openpype.pipeline.mongodb import (
@@ -214,8 +217,6 @@ class AttributeValues(object):
     """
 
     def __init__(self, attr_defs, values, origin_data=None):
-        from openpype.lib.attribute_definitions import UnknownDef
-
         if origin_data is None:
             origin_data = copy.deepcopy(values)
         self._origin_data = origin_data

--- a/openpype/pipeline/create/context.py
+++ b/openpype/pipeline/create/context.py
@@ -764,51 +764,6 @@ class CreatedInstance:
         return self.creator.label or self.creator_identifier
 
     @property
-    def create_context(self):
-        return self.creator.create_context
-
-    @property
-    def host(self):
-        return self.create_context.host
-
-    @property
-    def has_set_asset(self):
-        """Asset name is set in data."""
-        return "asset" in self._data
-
-    @property
-    def has_set_task(self):
-        """Task name is set in data."""
-        return "task" in self._data
-
-    @property
-    def has_valid_context(self):
-        """Context data are valid for publishing."""
-        return self.has_valid_asset and self.has_valid_task
-
-    @property
-    def has_valid_asset(self):
-        """Asset set in context exists in project."""
-        if not self.has_set_asset:
-            return False
-        return self._asset_is_valid
-
-    @property
-    def has_valid_task(self):
-        """Task set in context exists in project."""
-        if not self.has_set_task:
-            return False
-        return self._task_is_valid
-
-    def set_asset_invalid(self, invalid):
-        # TODO replace with `set_asset_name`
-        self._asset_is_valid = not invalid
-
-    def set_task_invalid(self, invalid):
-        # TODO replace with `set_task_name`
-        self._task_is_valid = not invalid
-
-    @property
     def id(self):
         """Instance identifier."""
 
@@ -1038,6 +993,49 @@ class CreatedInstance:
                 current_value = self.get(key)
                 if current_value != new_value:
                     self[key] = new_value
+
+    # Context validation related methods/properties
+    @property
+    def has_set_asset(self):
+        """Asset name is set in data."""
+
+        return "asset" in self._data
+
+    @property
+    def has_set_task(self):
+        """Task name is set in data."""
+
+        return "task" in self._data
+
+    @property
+    def has_valid_context(self):
+        """Context data are valid for publishing."""
+
+        return self.has_valid_asset and self.has_valid_task
+
+    @property
+    def has_valid_asset(self):
+        """Asset set in context exists in project."""
+
+        if not self.has_set_asset:
+            return False
+        return self._asset_is_valid
+
+    @property
+    def has_valid_task(self):
+        """Task set in context exists in project."""
+
+        if not self.has_set_task:
+            return False
+        return self._task_is_valid
+
+    def set_asset_invalid(self, invalid):
+        # TODO replace with `set_asset_name`
+        self._asset_is_valid = not invalid
+
+    def set_task_invalid(self, invalid):
+        # TODO replace with `set_task_name`
+        self._task_is_valid = not invalid
 
 
 class ConvertorItem(object):

--- a/openpype/pipeline/create/context.py
+++ b/openpype/pipeline/create/context.py
@@ -891,7 +891,7 @@ class CreatedInstance:
         subset_name = instance_data.get("subset", None)
 
         return cls(
-            family, subset_name, instance_data, creator, new=False
+            family, subset_name, instance_data, creator
         )
 
     def set_publish_plugins(self, attr_plugins):

--- a/openpype/pipeline/create/context.py
+++ b/openpype/pipeline/create/context.py
@@ -753,15 +753,15 @@ class CreatedInstance:
         label = self._data.get("group")
         if label:
             return label
-        return self.creator.get_group_label()
+        return self._group_label
 
     @property
     def creator_identifier(self):
-        return self.creator.identifier
+        return self._data["creator_identifier"]
 
     @property
     def creator_label(self):
-        return self.creator.label or self.creator_identifier
+        return self._creator_label or self.creator_identifier
 
     @property
     def id(self):
@@ -1477,7 +1477,7 @@ class CreateContext:
         self._instances_by_id[instance.id] = instance
         # Prepare publish plugin attributes and set it on instance
         attr_plugins = self._get_publish_plugins_with_attr_for_family(
-            instance.creator.family
+            instance.family
         )
         instance.set_publish_plugins(attr_plugins)
 

--- a/openpype/pipeline/create/context.py
+++ b/openpype/pipeline/create/context.py
@@ -208,7 +208,7 @@ class AttributeValues(object):
     Has dictionary like methods. Not all of them are allowed all the time.
 
     Args:
-        attr_defs(AbtractAttrDef): Defintions of value type and properties.
+        attr_defs(AbstractAttrDef): Defintions of value type and properties.
         values(dict): Values after possible conversion.
         origin_data(dict): Values loaded from host before conversion.
     """

--- a/openpype/pipeline/create/context.py
+++ b/openpype/pipeline/create/context.py
@@ -289,8 +289,13 @@ class AttributeValues(object):
 
     @property
     def attr_defs(self):
-        """Pointer to attribute definitions."""
-        return self._attr_defs
+        """Pointer to attribute definitions.
+
+        Returns:
+            List[AbstractAttrDef]: Attribute definitions.
+        """
+
+        return list(self._attr_defs)
 
     def data_to_store(self):
         """Create new dictionary with data to store."""

--- a/openpype/pipeline/create/context.py
+++ b/openpype/pipeline/create/context.py
@@ -922,7 +922,7 @@ class CreatedInstance:
         }
 
     @classmethod
-    def deserialize_on_remote(cls, serialized_data, creator_items):
+    def deserialize_on_remote(cls, serialized_data):
         """Convert instance data to CreatedInstance.
 
         This is fake instance in remote process e.g. in UI process. The creator

--- a/openpype/pipeline/create/creator_plugins.py
+++ b/openpype/pipeline/create/creator_plugins.py
@@ -425,7 +425,7 @@ class BaseCreator:
         keys/values when plugin attributes change.
 
         Returns:
-            List[AbtractAttrDef]: Attribute definitions that can be tweaked for
+            List[AbstractAttrDef]: Attribute definitions that can be tweaked for
                 created instance.
         """
 
@@ -563,7 +563,7 @@ class Creator(BaseCreator):
             updating keys/values when plugin attributes change.
 
         Returns:
-            List[AbtractAttrDef]: Attribute definitions that can be tweaked for
+            List[AbstractAttrDef]: Attribute definitions that can be tweaked for
                 created instance.
         """
         return self.pre_create_attr_defs

--- a/openpype/pipeline/publish/publish_plugins.py
+++ b/openpype/pipeline/publish/publish_plugins.py
@@ -118,7 +118,7 @@ class OpenPypePyblishPluginMixin:
 
         Attributes available for all families in plugin's `families` attribute.
         Returns:
-            list<AbtractAttrDef>: Attribute definitions for plugin.
+            list<AbstractAttrDef>: Attribute definitions for plugin.
         """
 
         return []

--- a/openpype/pipeline/workfile/workfile_template_builder.py
+++ b/openpype/pipeline/workfile/workfile_template_builder.py
@@ -842,7 +842,7 @@ class PlaceholderPlugin(object):
         """Placeholder options for data showed.
 
         Returns:
-            List[AbtractAttrDef]: Attribute definitions of placeholder options.
+            List[AbstractAttrDef]: Attribute definitions of placeholder options.
         """
 
         return []
@@ -1143,7 +1143,7 @@ class PlaceholderLoadMixin(object):
                 as defaults for attributes.
 
         Returns:
-            List[AbtractAttrDef]: Attribute definitions common for load
+            List[AbstractAttrDef]: Attribute definitions common for load
                 plugins.
         """
 
@@ -1513,7 +1513,7 @@ class PlaceholderCreateMixin(object):
                 as defaults for attributes.
 
         Returns:
-            List[AbtractAttrDef]: Attribute definitions common for create
+            List[AbstractAttrDef]: Attribute definitions common for create
                 plugins.
         """
 

--- a/openpype/tools/attribute_defs/widgets.py
+++ b/openpype/tools/attribute_defs/widgets.py
@@ -4,7 +4,7 @@ import copy
 from qtpy import QtWidgets, QtCore
 
 from openpype.lib.attribute_definitions import (
-    AbtractAttrDef,
+    AbstractAttrDef,
     UnknownDef,
     HiddenDef,
     NumberDef,
@@ -33,9 +33,9 @@ def create_widget_for_attr_def(attr_def, parent=None):
 
 
 def _create_widget_for_attr_def(attr_def, parent=None):
-    if not isinstance(attr_def, AbtractAttrDef):
+    if not isinstance(attr_def, AbstractAttrDef):
         raise TypeError("Unexpected type \"{}\" expected \"{}\"".format(
-            str(type(attr_def)), AbtractAttrDef
+            str(type(attr_def)), AbstractAttrDef
         ))
 
     if isinstance(attr_def, NumberDef):

--- a/openpype/tools/loader/lib.py
+++ b/openpype/tools/loader/lib.py
@@ -2,7 +2,7 @@ import inspect
 from qtpy import QtGui
 import qtawesome
 
-from openpype.lib.attribute_definitions import AbtractAttrDef
+from openpype.lib.attribute_definitions import AbstractAttrDef
 from openpype.tools.attribute_defs import AttributeDefinitionsDialog
 from openpype.tools.utils.widgets import (
     OptionalAction,
@@ -43,7 +43,7 @@ def get_options(action, loader, parent, repre_contexts):
     if not getattr(action, "optioned", False) or not loader_options:
         return options
 
-    if isinstance(loader_options[0], AbtractAttrDef):
+    if isinstance(loader_options[0], AbstractAttrDef):
         qargparse_options = False
         dialog = AttributeDefinitionsDialog(loader_options, parent)
     else:

--- a/openpype/tools/publisher/control.py
+++ b/openpype/tools/publisher/control.py
@@ -910,7 +910,7 @@ class CreatorItem:
 
         pre_create_attributes_defs = None
         if self.pre_create_attributes_defs is not None:
-            instance_attributes_defs = serialize_attr_defs(
+            pre_create_attributes_defs = serialize_attr_defs(
                 self.pre_create_attributes_defs
             )
 

--- a/openpype/tools/publisher/control.py
+++ b/openpype/tools/publisher/control.py
@@ -826,7 +826,6 @@ class CreatorItem:
         label,
         group_label,
         icon,
-        instance_attributes_defs,
         description,
         detailed_description,
         default_variant,
@@ -847,11 +846,7 @@ class CreatorItem:
         self.default_variants = default_variants
         self.create_allow_context_change = create_allow_context_change
         self.create_allow_thumbnail = create_allow_thumbnail
-        self.instance_attributes_defs = instance_attributes_defs
         self.pre_create_attributes_defs = pre_create_attributes_defs
-
-    def get_instance_attr_defs(self):
-        return self.instance_attributes_defs
 
     def get_group_label(self):
         return self.group_label
@@ -891,7 +886,6 @@ class CreatorItem:
             creator.label or identifier,
             creator.get_group_label(),
             creator.get_icon(),
-            creator.get_instance_attr_defs(),
             description,
             detail_description,
             default_variant,
@@ -902,12 +896,6 @@ class CreatorItem:
         )
 
     def to_data(self):
-        instance_attributes_defs = None
-        if self.instance_attributes_defs is not None:
-            instance_attributes_defs = serialize_attr_defs(
-                self.instance_attributes_defs
-            )
-
         pre_create_attributes_defs = None
         if self.pre_create_attributes_defs is not None:
             pre_create_attributes_defs = serialize_attr_defs(
@@ -927,18 +915,11 @@ class CreatorItem:
             "default_variants": self.default_variants,
             "create_allow_context_change": self.create_allow_context_change,
             "create_allow_thumbnail": self.create_allow_thumbnail,
-            "instance_attributes_defs": instance_attributes_defs,
             "pre_create_attributes_defs": pre_create_attributes_defs,
         }
 
     @classmethod
     def from_data(cls, data):
-        instance_attributes_defs = data["instance_attributes_defs"]
-        if instance_attributes_defs is not None:
-            data["instance_attributes_defs"] = deserialize_attr_defs(
-                instance_attributes_defs
-            )
-
         pre_create_attributes_defs = data["pre_create_attributes_defs"]
         if pre_create_attributes_defs is not None:
             data["pre_create_attributes_defs"] = deserialize_attr_defs(

--- a/openpype/tools/publisher/control.py
+++ b/openpype/tools/publisher/control.py
@@ -1860,12 +1860,12 @@ class PublisherController(BasePublisherController):
                 which should be attribute definitions returned.
         """
 
+        # NOTE it would be great if attrdefs would have hash method implemented
+        #   so they could be used as keys in dictionary
         output = []
         _attr_defs = {}
         for instance in instances:
-            creator_identifier = instance.creator_identifier
-            creator_item = self.creator_items[creator_identifier]
-            for attr_def in creator_item.instance_attributes_defs:
+            for attr_def in instance.creator_attribute_defs:
                 found_idx = None
                 for idx, _attr_def in _attr_defs.items():
                     if attr_def == _attr_def:

--- a/openpype/tools/publisher/control_qt.py
+++ b/openpype/tools/publisher/control_qt.py
@@ -136,10 +136,7 @@ class QtRemotePublishController(BasePublisherController):
 
         created_instances = {}
         for serialized_data in serialized_instances:
-            item = CreatedInstance.deserialize_on_remote(
-                serialized_data,
-                self._creator_items
-            )
+            item = CreatedInstance.deserialize_on_remote(serialized_data)
             created_instances[item.id] = item
 
         self._created_instances = created_instances

--- a/openpype/tools/publisher/widgets/widgets.py
+++ b/openpype/tools/publisher/widgets/widgets.py
@@ -1220,7 +1220,8 @@ class GlobalAttrsWidget(QtWidgets.QWidget):
 
         asset_task_combinations = []
         for instance in instances:
-            if instance.creator is None:
+            # NOTE I'm not sure how this can even happen?
+            if instance.creator_identifier is None:
                 editable = False
 
             variants.add(instance.get("variant") or self.unknown_value)

--- a/openpype/tools/utils/widgets.py
+++ b/openpype/tools/utils/widgets.py
@@ -8,7 +8,7 @@ from openpype.style import (
     get_objected_colors,
     get_style_image_path
 )
-from openpype.lib.attribute_definitions import AbtractAttrDef
+from openpype.lib.attribute_definitions import AbstractAttrDef
 
 log = logging.getLogger(__name__)
 
@@ -406,7 +406,7 @@ class OptionalAction(QtWidgets.QWidgetAction):
 
     def set_option_tip(self, options):
         sep = "\n\n"
-        if not options or not isinstance(options[0], AbtractAttrDef):
+        if not options or not isinstance(options[0], AbstractAttrDef):
             mak = (lambda opt: opt["name"] + " :\n    " + opt["help"])
             self.option_tip = sep.join(mak(opt) for opt in options)
             return


### PR DESCRIPTION
## Brief description
Fix possible issues with attribute definitions in publisher if there is unknown attribute on an instance.

## Description
Source of the issue is that attribute definitions from creator plugin could be "expanded" during `CreatedInstance` initialization. Which would affect all other instances using the same list of attributes -> literally object of list. If the same list object is used in "BaseClass" for other creators it would affect all instances (because of 1 instance). There had to be implemented other changes to fix the issue and keep behavior the same.

Object of `CreatedInstance` can be created without reference to creator object. `CreatedInstance` is responsible to give UI attribute definitions (technically is prepared for cases when each instance may have different attribute definitions -> not yet).
Attribute definition has added more conditions for `__eq__` method and have implemented `__ne__` method (which is required for Py 2 compatibility). Renamed `AbtractAttrDef` to `AbstractAttrDef` (fix typo).

### Additional information
Currently multiselection of instances may cause that attributes are not loaded as fast (that because of very inefficient way how to find "common attributes" for all instances. That could be solved by implementing "create hash" method for attribute definitions. The result would be string which would contain all information which makes the attribute unique by combination of all definitions properties (could be huge for enums). We could look into that if we'll find out it's an issue.

```
# Example of attribute definition
NumberDef(
    "my_num",
    minimum=1.0,
    maximum=20.0,
    decimals=1,
    default=5.0,
    hidden=False,
    disabled=False
)

# Simplified possible tempalte for number definition
hast_str_template = "{class}|{key}|{hidde}|{disabled}|{default}|{minimum}|{maximum}|{decimals}"

# The result for the object above
hash_str = "NumberDef|my_num|0|0|5.0|1.0|20.0|1"
```

## Testing notes:
Hosts where is used New Publisher should work as before (or better).
1. Open one of the hosts e.g. TrayPublisher
2. Open publisher UI
3. Create part should show precreate attributes as expected
4. Create few instances
5. Instance attributes in `Publish` category should be shown correctly and they should work on multiselection

More complex testing:
Follow steps in this issue https://github.com/ynput/OpenPype/issues/4379

Resolves https://github.com/ynput/OpenPype/issues/4379