### PR TITLE
Maya: Fix Validate Attributes plugin

### DIFF
--- a/openpype/hosts/maya/plugins/publish/validate_attributes.py
+++ b/openpype/hosts/maya/plugins/publish/validate_attributes.py
@@ -58,23 +58,23 @@ class ValidateAttributes(pyblish.api.ContextPlugin):
             # Filter families.
             families = [instance.data["family"]]
             families += instance.data.get("families", [])
-            families = list(set(families) & set(self.attributes.keys()))
+            families = list(set(families) & set(cls.attributes.keys()))
             if not families:
                 continue
 
             # Get all attributes to validate.
             attributes = {}
             for family in families:
-                for preset in self.attributes[family]:
+                for preset in cls.attributes[family]:
                     [node_name, attribute_name] = preset.split(".")
                     try:
                         attributes[node_name].update(
-                            {attribute_name: self.attributes[family][preset]}
+                            {attribute_name: cls.attributes[family][preset]}
                         )
                     except KeyError:
                         attributes.update({
                             node_name: {
-                                attribute_name: self.attributes[family][preset]
+                                attribute_name: cls.attributes[family][preset]
                             }
                         })
 


### PR DESCRIPTION
## Brief description

Code was broken. So either plug-in was unused or it had gone unnoticed.

## Description

Looking at the commit history of the plug-in itself it seems this might have been broken somewhere between two to three years. I think it's broken since two years since [this commit](https://github.com/BigRoy/OpenPype/commit/4a300e0b087fb40e044a99f3a0d0d5c3835f0a19#diff-805f60be6c0433010b43f2495f96f7901397109d588b9b030dff36ccd24911aa).

Should this plug-in be removed completely?
@tokejepsen Is there still a use case where we should have this plug-in? (You created the original one)

## Testing notes:

1. Validate Attributes in maya, yay!