### PR TITLE
Maya + Blender: Pyblish plugins removed unused `version` and `category` attributes

### DIFF
--- a/openpype/hosts/blender/plugins/publish/validate_camera_zero_keyframe.py
+++ b/openpype/hosts/blender/plugins/publish/validate_camera_zero_keyframe.py
@@ -19,7 +19,6 @@ class ValidateCameraZeroKeyframe(pyblish.api.InstancePlugin):
     order = ValidateContentsOrder
     hosts = ["blender"]
     families = ["camera"]
-    version = (0, 1, 0)
     label = "Zero Keyframe"
     actions = [openpype.hosts.blender.api.action.SelectInvalidAction]
 

--- a/openpype/hosts/blender/plugins/publish/validate_mesh_has_uv.py
+++ b/openpype/hosts/blender/plugins/publish/validate_mesh_has_uv.py
@@ -14,7 +14,6 @@ class ValidateMeshHasUvs(pyblish.api.InstancePlugin):
     order = ValidateContentsOrder
     hosts = ["blender"]
     families = ["model"]
-    category = "geometry"
     label = "Mesh Has UV's"
     actions = [openpype.hosts.blender.api.action.SelectInvalidAction]
     optional = True

--- a/openpype/hosts/blender/plugins/publish/validate_mesh_no_negative_scale.py
+++ b/openpype/hosts/blender/plugins/publish/validate_mesh_no_negative_scale.py
@@ -14,7 +14,6 @@ class ValidateMeshNoNegativeScale(pyblish.api.Validator):
     order = ValidateContentsOrder
     hosts = ["blender"]
     families = ["model"]
-    category = "geometry"
     label = "Mesh No Negative Scale"
     actions = [openpype.hosts.blender.api.action.SelectInvalidAction]
 

--- a/openpype/hosts/blender/plugins/publish/validate_no_colons_in_name.py
+++ b/openpype/hosts/blender/plugins/publish/validate_no_colons_in_name.py
@@ -19,7 +19,6 @@ class ValidateNoColonsInName(pyblish.api.InstancePlugin):
     order = ValidateContentsOrder
     hosts = ["blender"]
     families = ["model", "rig"]
-    version = (0, 1, 0)
     label = "No Colons in names"
     actions = [openpype.hosts.blender.api.action.SelectInvalidAction]
 

--- a/openpype/hosts/blender/plugins/publish/validate_transform_zero.py
+++ b/openpype/hosts/blender/plugins/publish/validate_transform_zero.py
@@ -21,7 +21,6 @@ class ValidateTransformZero(pyblish.api.InstancePlugin):
     order = ValidateContentsOrder
     hosts = ["blender"]
     families = ["model"]
-    version = (0, 1, 0)
     label = "Transform Zero"
     actions = [openpype.hosts.blender.api.action.SelectInvalidAction]
 

--- a/openpype/hosts/maya/plugins/publish/collect_maya_workspace.py
+++ b/openpype/hosts/maya/plugins/publish/collect_maya_workspace.py
@@ -12,7 +12,6 @@ class CollectMayaWorkspace(pyblish.api.ContextPlugin):
     label = "Maya Workspace"
 
     hosts = ['maya']
-    version = (0, 1, 0)
 
     def process(self, context):
         workspace = cmds.workspace(rootDirectory=True, query=True)

--- a/openpype/hosts/maya/plugins/publish/validate_color_sets.py
+++ b/openpype/hosts/maya/plugins/publish/validate_color_sets.py
@@ -19,7 +19,6 @@ class ValidateColorSets(pyblish.api.Validator):
     order = ValidateMeshOrder
     hosts = ['maya']
     families = ['model']
-    category = 'geometry'
     label = 'Mesh ColorSets'
     actions = [openpype.hosts.maya.api.action.SelectInvalidAction,
                RepairAction]

--- a/openpype/hosts/maya/plugins/publish/validate_mesh_arnold_attributes.py
+++ b/openpype/hosts/maya/plugins/publish/validate_mesh_arnold_attributes.py
@@ -19,7 +19,6 @@ class ValidateMeshArnoldAttributes(pyblish.api.InstancePlugin):
     order = ValidateMeshOrder
     hosts = ["maya"]
     families = ["model"]
-    category = "geometry"
     label = "Mesh Arnold Attributes"
     actions = [
         openpype.hosts.maya.api.action.SelectInvalidAction,

--- a/openpype/hosts/maya/plugins/publish/validate_mesh_has_uv.py
+++ b/openpype/hosts/maya/plugins/publish/validate_mesh_has_uv.py
@@ -48,7 +48,6 @@ class ValidateMeshHasUVs(pyblish.api.InstancePlugin):
     order = ValidateMeshOrder
     hosts = ['maya']
     families = ['model']
-    category = 'geometry'
     label = 'Mesh Has UVs'
     actions = [openpype.hosts.maya.api.action.SelectInvalidAction]
     optional = True

--- a/openpype/hosts/maya/plugins/publish/validate_mesh_lamina_faces.py
+++ b/openpype/hosts/maya/plugins/publish/validate_mesh_lamina_faces.py
@@ -16,7 +16,6 @@ class ValidateMeshLaminaFaces(pyblish.api.InstancePlugin):
     hosts = ['maya']
     families = ['model']
     category = 'geometry'
-    version = (0, 1, 0)
     label = 'Mesh Lamina Faces'
     actions = [openpype.hosts.maya.api.action.SelectInvalidAction]
 

--- a/openpype/hosts/maya/plugins/publish/validate_mesh_lamina_faces.py
+++ b/openpype/hosts/maya/plugins/publish/validate_mesh_lamina_faces.py
@@ -15,7 +15,6 @@ class ValidateMeshLaminaFaces(pyblish.api.InstancePlugin):
     order = ValidateMeshOrder
     hosts = ['maya']
     families = ['model']
-    category = 'geometry'
     label = 'Mesh Lamina Faces'
     actions = [openpype.hosts.maya.api.action.SelectInvalidAction]
 

--- a/openpype/hosts/maya/plugins/publish/validate_mesh_non_zero_edge.py
+++ b/openpype/hosts/maya/plugins/publish/validate_mesh_non_zero_edge.py
@@ -20,7 +20,6 @@ class ValidateMeshNonZeroEdgeLength(pyblish.api.InstancePlugin):
     families = ['model']
     hosts = ['maya']
     category = 'geometry'
-    version = (0, 1, 0)
     label = 'Mesh Edge Length Non Zero'
     actions = [openpype.hosts.maya.api.action.SelectInvalidAction]
     optional = True

--- a/openpype/hosts/maya/plugins/publish/validate_mesh_non_zero_edge.py
+++ b/openpype/hosts/maya/plugins/publish/validate_mesh_non_zero_edge.py
@@ -19,7 +19,6 @@ class ValidateMeshNonZeroEdgeLength(pyblish.api.InstancePlugin):
     order = ValidateMeshOrder
     families = ['model']
     hosts = ['maya']
-    category = 'geometry'
     label = 'Mesh Edge Length Non Zero'
     actions = [openpype.hosts.maya.api.action.SelectInvalidAction]
     optional = True

--- a/openpype/hosts/maya/plugins/publish/validate_mesh_normals_unlocked.py
+++ b/openpype/hosts/maya/plugins/publish/validate_mesh_normals_unlocked.py
@@ -21,7 +21,6 @@ class ValidateMeshNormalsUnlocked(pyblish.api.Validator):
     hosts = ['maya']
     families = ['model']
     category = 'geometry'
-    version = (0, 1, 0)
     label = 'Mesh Normals Unlocked'
     actions = [openpype.hosts.maya.api.action.SelectInvalidAction,
                RepairAction]

--- a/openpype/hosts/maya/plugins/publish/validate_mesh_normals_unlocked.py
+++ b/openpype/hosts/maya/plugins/publish/validate_mesh_normals_unlocked.py
@@ -20,7 +20,6 @@ class ValidateMeshNormalsUnlocked(pyblish.api.Validator):
     order = ValidateMeshOrder
     hosts = ['maya']
     families = ['model']
-    category = 'geometry'
     label = 'Mesh Normals Unlocked'
     actions = [openpype.hosts.maya.api.action.SelectInvalidAction,
                RepairAction]

--- a/openpype/hosts/maya/plugins/publish/validate_mesh_overlapping_uvs.py
+++ b/openpype/hosts/maya/plugins/publish/validate_mesh_overlapping_uvs.py
@@ -235,7 +235,6 @@ class ValidateMeshHasOverlappingUVs(pyblish.api.InstancePlugin):
     order = ValidateMeshOrder
     hosts = ['maya']
     families = ['model']
-    category = 'geometry'
     label = 'Mesh Has Overlapping UVs'
     actions = [openpype.hosts.maya.api.action.SelectInvalidAction]
     optional = True

--- a/openpype/hosts/maya/plugins/publish/validate_mesh_single_uv_set.py
+++ b/openpype/hosts/maya/plugins/publish/validate_mesh_single_uv_set.py
@@ -21,7 +21,6 @@ class ValidateMeshSingleUVSet(pyblish.api.InstancePlugin):
     order = ValidateMeshOrder
     hosts = ['maya']
     families = ['model', 'pointcache']
-    category = 'uv'
     optional = True
     label = "Mesh Single UV Set"
     actions = [openpype.hosts.maya.api.action.SelectInvalidAction,

--- a/openpype/hosts/maya/plugins/publish/validate_mesh_single_uv_set.py
+++ b/openpype/hosts/maya/plugins/publish/validate_mesh_single_uv_set.py
@@ -23,7 +23,6 @@ class ValidateMeshSingleUVSet(pyblish.api.InstancePlugin):
     families = ['model', 'pointcache']
     category = 'uv'
     optional = True
-    version = (0, 1, 0)
     label = "Mesh Single UV Set"
     actions = [openpype.hosts.maya.api.action.SelectInvalidAction,
                RepairAction]

--- a/openpype/hosts/maya/plugins/publish/validate_mesh_vertices_have_edges.py
+++ b/openpype/hosts/maya/plugins/publish/validate_mesh_vertices_have_edges.py
@@ -63,7 +63,6 @@ class ValidateMeshVerticesHaveEdges(pyblish.api.InstancePlugin):
     order = ValidateMeshOrder
     hosts = ['maya']
     families = ['model']
-    category = 'geometry'
     label = 'Mesh Vertices Have Edges'
     actions = [openpype.hosts.maya.api.action.SelectInvalidAction,
                RepairAction]

--- a/openpype/hosts/maya/plugins/publish/validate_no_default_camera.py
+++ b/openpype/hosts/maya/plugins/publish/validate_no_default_camera.py
@@ -16,7 +16,6 @@ class ValidateNoDefaultCameras(pyblish.api.InstancePlugin):
     order = ValidateContentsOrder
     hosts = ['maya']
     families = ['camera']
-    version = (0, 1, 0)
     label = "No Default Cameras"
     actions = [openpype.hosts.maya.api.action.SelectInvalidAction]
 

--- a/openpype/hosts/maya/plugins/publish/validate_no_namespace.py
+++ b/openpype/hosts/maya/plugins/publish/validate_no_namespace.py
@@ -24,7 +24,6 @@ class ValidateNoNamespace(pyblish.api.InstancePlugin):
     hosts = ['maya']
     families = ['model']
     category = 'cleanup'
-    version = (0, 1, 0)
     label = 'No Namespaces'
     actions = [openpype.hosts.maya.api.action.SelectInvalidAction,
                RepairAction]

--- a/openpype/hosts/maya/plugins/publish/validate_no_namespace.py
+++ b/openpype/hosts/maya/plugins/publish/validate_no_namespace.py
@@ -23,7 +23,6 @@ class ValidateNoNamespace(pyblish.api.InstancePlugin):
     order = ValidateContentsOrder
     hosts = ['maya']
     families = ['model']
-    category = 'cleanup'
     label = 'No Namespaces'
     actions = [openpype.hosts.maya.api.action.SelectInvalidAction,
                RepairAction]

--- a/openpype/hosts/maya/plugins/publish/validate_no_null_transforms.py
+++ b/openpype/hosts/maya/plugins/publish/validate_no_null_transforms.py
@@ -44,7 +44,6 @@ class ValidateNoNullTransforms(pyblish.api.InstancePlugin):
     hosts = ['maya']
     families = ['model']
     category = 'cleanup'
-    version = (0, 1, 0)
     label = 'No Empty/Null Transforms'
     actions = [RepairAction,
                openpype.hosts.maya.api.action.SelectInvalidAction]

--- a/openpype/hosts/maya/plugins/publish/validate_no_null_transforms.py
+++ b/openpype/hosts/maya/plugins/publish/validate_no_null_transforms.py
@@ -43,7 +43,6 @@ class ValidateNoNullTransforms(pyblish.api.InstancePlugin):
     order = ValidateContentsOrder
     hosts = ['maya']
     families = ['model']
-    category = 'cleanup'
     label = 'No Empty/Null Transforms'
     actions = [RepairAction,
                openpype.hosts.maya.api.action.SelectInvalidAction]

--- a/openpype/hosts/maya/plugins/publish/validate_rig_joints_hidden.py
+++ b/openpype/hosts/maya/plugins/publish/validate_rig_joints_hidden.py
@@ -24,7 +24,6 @@ class ValidateRigJointsHidden(pyblish.api.InstancePlugin):
     order = ValidateContentsOrder
     hosts = ['maya']
     families = ['rig']
-    version = (0, 1, 0)
     label = "Joints Hidden"
     actions = [openpype.hosts.maya.api.action.SelectInvalidAction,
                RepairAction]

--- a/openpype/hosts/maya/plugins/publish/validate_scene_set_workspace.py
+++ b/openpype/hosts/maya/plugins/publish/validate_scene_set_workspace.py
@@ -32,7 +32,6 @@ class ValidateSceneSetWorkspace(pyblish.api.ContextPlugin):
     order = ValidatePipelineOrder
     hosts = ['maya']
     category = 'scene'
-    version = (0, 1, 0)
     label = 'Maya Workspace Set'
 
     def process(self, context):

--- a/openpype/hosts/maya/plugins/publish/validate_scene_set_workspace.py
+++ b/openpype/hosts/maya/plugins/publish/validate_scene_set_workspace.py
@@ -31,7 +31,6 @@ class ValidateSceneSetWorkspace(pyblish.api.ContextPlugin):
 
     order = ValidatePipelineOrder
     hosts = ['maya']
-    category = 'scene'
     label = 'Maya Workspace Set'
 
     def process(self, context):

--- a/openpype/hosts/maya/plugins/publish/validate_shape_default_names.py
+++ b/openpype/hosts/maya/plugins/publish/validate_shape_default_names.py
@@ -38,7 +38,6 @@ class ValidateShapeDefaultNames(pyblish.api.InstancePlugin):
     order = ValidateContentsOrder
     hosts = ['maya']
     families = ['model']
-    category = 'cleanup'
     optional = True
     label = "Shape Default Naming"
     actions = [openpype.hosts.maya.api.action.SelectInvalidAction,

--- a/openpype/hosts/maya/plugins/publish/validate_shape_default_names.py
+++ b/openpype/hosts/maya/plugins/publish/validate_shape_default_names.py
@@ -40,7 +40,6 @@ class ValidateShapeDefaultNames(pyblish.api.InstancePlugin):
     families = ['model']
     category = 'cleanup'
     optional = True
-    version = (0, 1, 0)
     label = "Shape Default Naming"
     actions = [openpype.hosts.maya.api.action.SelectInvalidAction,
                RepairAction]

--- a/openpype/hosts/maya/plugins/publish/validate_transform_naming_suffix.py
+++ b/openpype/hosts/maya/plugins/publish/validate_transform_naming_suffix.py
@@ -32,7 +32,6 @@ class ValidateTransformNamingSuffix(pyblish.api.InstancePlugin):
     order = ValidateContentsOrder
     hosts = ['maya']
     families = ['model']
-    category = 'cleanup'
     optional = True
     label = 'Suffix Naming Conventions'
     actions = [openpype.hosts.maya.api.action.SelectInvalidAction]

--- a/openpype/hosts/maya/plugins/publish/validate_transform_naming_suffix.py
+++ b/openpype/hosts/maya/plugins/publish/validate_transform_naming_suffix.py
@@ -34,7 +34,6 @@ class ValidateTransformNamingSuffix(pyblish.api.InstancePlugin):
     families = ['model']
     category = 'cleanup'
     optional = True
-    version = (0, 1, 0)
     label = 'Suffix Naming Conventions'
     actions = [openpype.hosts.maya.api.action.SelectInvalidAction]
     SUFFIX_NAMING_TABLE = {"mesh": ["_GEO", "_GES", "_GEP", "_OSD"],

--- a/openpype/hosts/maya/plugins/publish/validate_transform_zero.py
+++ b/openpype/hosts/maya/plugins/publish/validate_transform_zero.py
@@ -19,7 +19,6 @@ class ValidateTransformZero(pyblish.api.Validator):
     hosts = ["maya"]
     families = ["model"]
     category = "geometry"
-    version = (0, 1, 0)
     label = "Transform Zero (Freeze)"
     actions = [openpype.hosts.maya.api.action.SelectInvalidAction]
 

--- a/openpype/hosts/maya/plugins/publish/validate_transform_zero.py
+++ b/openpype/hosts/maya/plugins/publish/validate_transform_zero.py
@@ -18,7 +18,6 @@ class ValidateTransformZero(pyblish.api.Validator):
     order = ValidateContentsOrder
     hosts = ["maya"]
     families = ["model"]
-    category = "geometry"
     label = "Transform Zero (Freeze)"
     actions = [openpype.hosts.maya.api.action.SelectInvalidAction]
 

--- a/openpype/hosts/maya/plugins/publish/validate_unreal_mesh_triangulated.py
+++ b/openpype/hosts/maya/plugins/publish/validate_unreal_mesh_triangulated.py
@@ -13,7 +13,6 @@ class ValidateUnrealMeshTriangulated(pyblish.api.InstancePlugin):
     order = ValidateMeshOrder
     hosts = ["maya"]
     families = ["staticMesh"]
-    category = "geometry"
     label = "Mesh is Triangulated"
     actions = [openpype.hosts.maya.api.action.SelectInvalidAction]
     active = False


### PR DESCRIPTION
## Brief description

Once upon a time in a land far far away there lived a few plug-ins who felt like they didn't belong in generic boxes and felt they needed to be versioned well above others. They tried, but with no success.

## Description

Even though they now lived in a universe with elaborate `version` and `category` attributes embedded into their tiny little plug-in DNA this particular deviation has been greatly unused. There is nothing special about the version, nothing special about the category.

It does nothing.

## Additional info

Having these attributes on these plug-ins just meant other developers would join in thinking _"hell yeah baby!"_ producing their own special plug-in babies with `category` and `version` attributes of their own. Well, they were fooled.

Their time spent on adding these precious attributes meant more lines of code that ended up doing nothing - except clutter and increase memory usage of machines across the world!

It's time to say, no more! This is where it stops.

Unless someone has a good use for these.

## Testing notes:

1. Test blender + maya publishing with these plug-ins, but they should remain unaffected.