### PR TITLE
Blender: fix import workfile all families

### DIFF
--- a/openpype/hosts/blender/plugins/load/import_workfile.py
+++ b/openpype/hosts/blender/plugins/load/import_workfile.py
@@ -44,7 +44,7 @@ class AppendBlendLoader(plugin.AssetLoader):
     """
 
     representations = ["blend"]
-    families = ["*"]
+    families = ["workfile"]
 
     label = "Append Workfile"
     order = 9
@@ -68,7 +68,7 @@ class ImportBlendLoader(plugin.AssetLoader):
     """
 
     representations = ["blend"]
-    families = ["*"]
+    families = ["workfile"]
 
     label = "Import Workfile"
     order = 9


### PR DESCRIPTION
## Brief description
Having this feature related to workfile available for any family is absurd.
