### PR TITLE
Maya: Change namespace for references

### DIFF
--- a/openpype/hosts/maya/api/plugin.py
+++ b/openpype/hosts/maya/api/plugin.py
@@ -148,7 +148,7 @@ class ReferenceLoader(Loader):
         count = options.get("count") or 1
         for c in range(0, count):
             namespace = namespace or lib.unique_namespace(
-                "{}_{}_".format(asset["name"], context["subset"]["name"]),
+                "{}:{}_".format(asset["name"], context["subset"]["name"]),
                 prefix="_" if asset["name"][0].isdigit() else "",
                 suffix="_",
             )

--- a/openpype/hosts/maya/plugins/load/load_reference.py
+++ b/openpype/hosts/maya/plugins/load/load_reference.py
@@ -36,7 +36,7 @@ class ReferenceLoader(openpype.hosts.maya.api.plugin.ReferenceLoader):
     # Name of creator class that will be used to create animation instance
     animation_creator_name = "CreateAnimation"
 
-    def process_reference(self, context, name, namespace, options):
+    def process_reference(self, context, name, namespace, options, group_name=None):  # noqa
         import maya.cmds as cmds
         import pymel.core as pm
 
@@ -45,7 +45,8 @@ class ReferenceLoader(openpype.hosts.maya.api.plugin.ReferenceLoader):
         except ValueError:
             family = "model"
 
-        group_name = "{}_GRP".format(namespace)
+        if not group_name:
+            group_name = "{}:_GRP".format(namespace)
         # True by default to keep legacy behaviours
         attach_to_root = options.get("attach_to_root", True)
 

--- a/openpype/hosts/maya/plugins/load/load_reference.py
+++ b/openpype/hosts/maya/plugins/load/load_reference.py
@@ -45,7 +45,7 @@ class ReferenceLoader(openpype.hosts.maya.api.plugin.ReferenceLoader):
         except ValueError:
             family = "model"
 
-        group_name = "{}:_GRP".format(namespace)
+        group_name = "{}GRP".format(namespace)
         # True by default to keep legacy behaviours
         attach_to_root = options.get("attach_to_root", True)
 
@@ -53,6 +53,10 @@ class ReferenceLoader(openpype.hosts.maya.api.plugin.ReferenceLoader):
             cmds.loadPlugin("AbcImport.mll", quiet=True)
             file_url = self.prepare_root_value(self.fname,
                                                context["project"]["name"])
+
+            if not cmds.namespace(exists=namespace):
+                cmds.namespace(add=namespace)
+
             nodes = cmds.file(file_url,
                               namespace=namespace,
                               sharedReferenceFile=False,

--- a/openpype/hosts/maya/plugins/load/load_reference.py
+++ b/openpype/hosts/maya/plugins/load/load_reference.py
@@ -45,7 +45,7 @@ class ReferenceLoader(openpype.hosts.maya.api.plugin.ReferenceLoader):
         except ValueError:
             family = "model"
 
-        group_name = "{}GRP".format(namespace)
+        group_name = "{}_GRP".format(namespace)
         # True by default to keep legacy behaviours
         attach_to_root = options.get("attach_to_root", True)
 

--- a/openpype/settings/defaults/project_settings/maya.json
+++ b/openpype/settings/defaults/project_settings/maya.json
@@ -903,6 +903,9 @@
                 125,
                 255
             ]
+        },
+        "reference_loader": {
+            "naming": ""
         }
     },
     "workfile_build": {

--- a/openpype/settings/entities/schemas/projects_schema/schemas/schema_maya_load.json
+++ b/openpype/settings/entities/schemas/projects_schema/schemas/schema_maya_load.json
@@ -91,6 +91,23 @@
                     "key": "yetiRig"
                 }
             ]
+        },
+        {
+            "type": "dict",
+            "collapsible": true,
+            "key": "reference_loader",
+            "label": "Reference Loader",
+            "children": [
+                {
+                    "type": "text",
+                    "label": "Naming",
+                    "key": "naming"
+                },
+                {
+                    "type": "label",
+                    "label": "Here's a link to the doc where you can find explanations about customing the naming of referenced assets: https://openpype.io/docs/admin_hosts_maya#load-plugins"
+                }
+            ]
         }
     ]
 }

--- a/website/docs/admin_hosts_maya.md
+++ b/website/docs/admin_hosts_maya.md
@@ -6,7 +6,7 @@ sidebar_label: Maya
 
 ## Publish Plugins
 
-### Render Settings Validator 
+### Render Settings Validator
 
 `ValidateRenderSettings`
 
@@ -51,7 +51,7 @@ just one instance of this node type but if that is not so, validator will go thr
 instances and check the value there. Node type for **VRay** settings is `VRaySettingsNode`, for **Renderman**
 it is `rmanGlobals`, for **Redshift** it is `RedshiftOptions`.
 
-### Model Name Validator 
+### Model Name Validator
 
 `ValidateRenderSettings`
 
@@ -95,7 +95,7 @@ You can set various aspects of scene submission to farm with per-project setting
 
  - **Optional** will mark sumission plugin optional
  - **Active** will enable/disable plugin
- - **Tile Assembler Plugin** will set what should be used to assemble tiles on Deadline. Either **Open Image IO** will be used 
+ - **Tile Assembler Plugin** will set what should be used to assemble tiles on Deadline. Either **Open Image IO** will be used
 or Deadlines **Draft Tile Assembler**.
  - **Use Published scene** enable to render from published scene instead of scene in work area. Rendering from published files is much safer.
  - **Use Asset dependencies** will mark job pending on farm until asset dependencies are fulfilled - for example Deadline will wait for scene file to be synced to cloud, etc.
@@ -106,6 +106,18 @@ or Deadlines **Draft Tile Assembler**.
  - **Scene patches** - configure mechanism to add additional lines to published Maya Ascii scene files before they are used for rendering.
 This is useful to fix some specific renderer glitches and advanced hacking of Maya Scene files. `Patch name` is label for patch for easier orientation.
 `Patch regex` is regex used to find line in file, after `Patch line` string is inserted. Note that you need to add line ending.
+
+## Load Plugins
+
+### Reference Loader > Namespace
+Here you can create your own custom naming for the reference loader. <br>
+The custom naming is split into two parts separated by a ":" symbol. The first half is the namespace and the second half is the group name of the reference. If you don't set the namespace or the group name (or both), the default namespace and group name will be applied.
+Here's the different variables you can use: <br>
+Asset name: {asset[name]} <br>
+Asset type: {asset[type]} <br>
+Subset name: {subset[name]} <br>
+Subset family: {subset[data][family]} <br>
+Example: {asset[name]}_{subset[name]}:GRP
 
 ## Custom Menu
 You can add your custom tools menu into Maya by extending definitions in **Maya -> Scripts Menu Definition**.


### PR DESCRIPTION
## Brief description
Change namespace for references in Maya for a better readability. Proposed format: {asset}:{subset}_GRP