### PR TITLE
Ftrack: Don't force ftrackapp endpoint

### DIFF
--- a/openpype/modules/ftrack/ftrack_module.py
+++ b/openpype/modules/ftrack/ftrack_module.py
@@ -510,7 +510,10 @@ def resolve_ftrack_url(url, logger=None):
         url = "https://" + url
 
     ftrack_url = None
-    if not url.endswith("ftrackapp.com"):
+    if url and _check_ftrack_url(url):
+        ftrack_url = url
+
+    if not ftrack_url and not url.endswith("ftrackapp.com"):
         ftrackapp_url = url + ".ftrackapp.com"
         if _check_ftrack_url(ftrackapp_url):
             ftrack_url = ftrackapp_url

--- a/openpype/modules/ftrack/ftrack_module.py
+++ b/openpype/modules/ftrack/ftrack_module.py
@@ -73,8 +73,19 @@ class FtrackModule(
 
     ftrack_url = property(get_ftrack_url)
 
+    @property
+    def settings_ftrack_url(self):
+        """Ftrack url from settings in a format as it is.
+
+        Returns:
+            str: Ftrack url from settings.
+        """
+
+        return self._settings_ftrack_url
+
     def get_global_environments(self):
         """Ftrack's global environments."""
+
         return {
             "FTRACK_SERVER": self.ftrack_url
         }

--- a/openpype/modules/ftrack/ftrack_module.py
+++ b/openpype/modules/ftrack/ftrack_module.py
@@ -64,6 +64,16 @@ class FtrackModule(
         self._timers_manager_module = None
 
     def get_ftrack_url(self):
+        """Resolved ftrack url.
+
+        Resolving is trying to fill missing information in url and tried to
+        connect to the server.
+
+        Returns:
+            Union[str, None]: Final variant of url or None if url could not be
+                reached.
+        """
+
         if self._ftrack_url is _URL_NOT_SET:
             self._ftrack_url = resolve_ftrack_url(
                 self._settings_ftrack_url,

--- a/openpype/modules/ftrack/tray/login_dialog.py
+++ b/openpype/modules/ftrack/tray/login_dialog.py
@@ -139,8 +139,7 @@ class CredentialsDialog(QtWidgets.QDialog):
         self.fill_ftrack_url()
 
     def fill_ftrack_url(self):
-        url = os.getenv("FTRACK_SERVER")
-        checked_url = self.check_url(url)
+        checked_url = self.check_url()
         if checked_url == self.ftsite_input.text():
             return
 
@@ -154,7 +153,7 @@ class CredentialsDialog(QtWidgets.QDialog):
         self.api_input.setEnabled(enabled)
         self.user_input.setEnabled(enabled)
 
-        if not url:
+        if not checked_url:
             self.btn_advanced.hide()
             self.btn_simple.hide()
             self.btn_ftrack_login.hide()
@@ -254,7 +253,7 @@ class CredentialsDialog(QtWidgets.QDialog):
             )
 
     def _on_ftrack_login_clicked(self):
-        url = self.check_url(self.ftsite_input.text())
+        url = self.check_url()
         if not url:
             return
 
@@ -302,21 +301,21 @@ class CredentialsDialog(QtWidgets.QDialog):
         if is_logged is not None:
             self.set_is_logged(is_logged)
 
-    def check_url(self, url):
-        if url is not None:
-            url = url.strip("/ ")
-
-        if not url:
+    def check_url(self):
+        settings_url = self._module.settings_ftrack_url
+        url = self._module.ftrack_url
+        if not settings_url:
             self.set_error(
                 "Ftrack URL is not defined in settings!"
             )
             return
 
-        if "http" not in url:
-            if url.endswith("ftrackapp.com"):
-                url = "https://" + url
-            else:
-                url = "https://{}.ftrackapp.com".format(url)
+        if url is None:
+            self.set_error(
+                "Specified URL does not lead to a valid Ftrack server."
+            )
+            return
+
         try:
             result = requests.get(
                 url,


### PR DESCRIPTION
## Brief description
Auto-fill of ftrack url don't break custom urls. Custom urls couldn't be used as `ftrackapp.com` is added if is not in the url.

## Description
The code was changed in a way that auto-fill is still supported but before `ftrackapp` is added it will try to use url as is. If the connection works as is it is used.

## Additional info
Can't test it as I wasn't able run ftrack server locally and couldn't run redirect proxy either.

## Testing notes:
1. Have ftrack server without `ftrackapp` in url
2. Set it in settings to be connected there
3. Run Tray and log in
4. Publish at least from one DCC