### PR TITLE
3dsmax: startup fixes

### DIFF
--- a/openpype/hosts/max/addon.py
+++ b/openpype/hosts/max/addon.py
@@ -12,6 +12,11 @@ class MaxAddon(OpenPypeModule, IHostAddon):
     def initialize(self, module_settings):
         self.enabled = True
 
+    def add_implementation_envs(self, env, _app):
+        # Remove auto screen scale factor for Qt
+        # - let 3dsmax decide it's value
+        env.pop("QT_AUTO_SCREEN_SCALE_FACTOR", None)
+
     def get_workfile_extensions(self):
         return [".max"]
 

--- a/openpype/hosts/max/startup/startup.py
+++ b/openpype/hosts/max/startup/startup.py
@@ -4,17 +4,12 @@ import sys
 
 # this might happen in some 3dsmax version where PYTHONPATH isn't added
 # to sys.path automatically
-try:
-    from openpype.hosts.max.api import MaxHost
-    from openpype.pipeline import install_host
-except (ImportError, ModuleNotFoundError):
+for path in os.environ["PYTHONPATH"].split(os.pathsep):
+    if path and path not in sys.path:
+        sys.path.append(path)
 
-    for path in os.environ["PYTHONPATH"].split(os.pathsep):
-        if path and path not in sys.path:
-            sys.path.append(path)
-
-    from openpype.hosts.max.api import MaxHost
-    from openpype.pipeline import install_host
+from openpype.hosts.max.api import MaxHost
+from openpype.pipeline import install_host
 
 host = MaxHost()
 install_host(host)

--- a/openpype/hosts/max/startup/startup.py
+++ b/openpype/hosts/max/startup/startup.py
@@ -1,6 +1,20 @@
 # -*- coding: utf-8 -*-
-from openpype.hosts.max.api import MaxHost
-from openpype.pipeline import install_host
+import os
+import sys
+
+# this might happen in some 3dsmax version where PYTHONPATH isn't added
+# to sys.path automatically
+try:
+    from openpype.hosts.max.api import MaxHost
+    from openpype.pipeline import install_host
+except (ImportError, ModuleNotFoundError):
+
+    for path in os.environ["PYTHONPATH"].split(os.pathsep):
+        if path and path not in sys.path:
+            sys.path.append(path)
+
+    from openpype.hosts.max.api import MaxHost
+    from openpype.pipeline import install_host
 
 host = MaxHost()
 install_host(host)


### PR DESCRIPTION
## Brief description
This is fixing various issues that can occur on some of the 3dsmax versions.

## Description
On displays with +4K resolution UI was broken, some 3dsmax versions couldn't process `PYTHONPATH` correctly. This PR is forcing `sys.path` and disabling `QT_AUTO_SCREEN_SCALE_FACTOR`

## Testing notes:
1. 3dsmax with OpenPype should start as expected
2. No UI issues on high resolution displays