### PR TITLE
Maya: Ignore workfile lock in Untitled scene

### DIFF
--- a/openpype/hosts/maya/api/pipeline.py
+++ b/openpype/hosts/maya/api/pipeline.py
@@ -683,10 +683,12 @@ def before_workfile_save(event):
 
 def after_workfile_save(event):
     workfile_name = event["filename"]
-    if handle_workfile_locks():
-        if workfile_name:
-            if not is_workfile_locked(workfile_name):
-                create_workfile_lock(workfile_name)
+    if (
+        handle_workfile_locks()
+        and workfile_name
+        and not is_workfile_locked(workfile_name)
+    ):
+        create_workfile_lock(workfile_name)
 
 
 class MayaDirmap(HostDirmap):

--- a/openpype/hosts/maya/api/pipeline.py
+++ b/openpype/hosts/maya/api/pipeline.py
@@ -514,6 +514,9 @@ def check_lock_on_current_file():
 
     # add the lock file when opening the file
     filepath = current_file()
+    # Skip if current file is 'untitled'
+    if not filepath:
+        return
 
     if is_workfile_locked(filepath):
         # add lockfile dialog


### PR DESCRIPTION
## Brief description
Skip workfile lock check if current scene is 'Untitled'.

## Testing notes:
1. If Maya is opened in Untitled scene it should not crash on lock workfile check