### PR TITLE
General: Use right environment variable for current task name

### DIFF
--- a/openpype/host/host.py
+++ b/openpype/host/host.py
@@ -123,7 +123,7 @@ class HostBase(object):
             Union[str, None]: Current task name.
         """
 
-        return os.environ.get("AVALON_ASSET")
+        return os.environ.get("AVALON_TASK")
 
     def get_current_context(self):
         """Get current context information.


### PR DESCRIPTION
## Brief description
Fix bug created in https://github.com/ynput/OpenPype/pull/4324 where for current task name is used `AVALON_ASSET` instead of `AVALON_TASK`.

## Description
Use `AVALON_TASK` instead of `AVALON_ASSET` in `get_current_task_name`.