### PR TITLE
Deadline: Allow disabling strict error check in Maya submissions

### DIFF
--- a/openpype/hosts/maya/plugins/create/create_render.py
+++ b/openpype/hosts/maya/plugins/create/create_render.py
@@ -54,6 +54,7 @@ class CreateRender(plugin.Creator):
         tileRendering (bool): Instance is set to tile rendering mode. We
             won't submit actual render, but we'll make publish job to wait
             for Tile Assembly job done and then publish.
+        strict_error_checking (bool): Enable/disable error checking on DL
 
     See Also:
         https://pype.club/docs/artist_hosts_maya#creating-basic-render-setup
@@ -271,6 +272,9 @@ class CreateRender(plugin.Creator):
             secondary_pool = pool_setting["secondary_pool"]
             self.data["secondaryPool"] = self._set_default_pool(pool_names,
                                                                 secondary_pool)
+            strict_error_checking = maya_submit_dl.get("strict_error_checking",
+                                                       True)
+            self.data["strict_error_checking"] = strict_error_checking
 
         if muster_enabled:
             self.log.info(">>> Loading Muster credentials ...")

--- a/openpype/hosts/maya/plugins/publish/collect_render.py
+++ b/openpype/hosts/maya/plugins/publish/collect_render.py
@@ -318,7 +318,9 @@ class CollectMayaRender(pyblish.api.ContextPlugin):
                 "aovSeparator": layer_render_products.layer_data.aov_separator,  # noqa: E501
                 "renderSetupIncludeLights": render_instance.data.get(
                     "renderSetupIncludeLights"
-                )
+                ),
+                "strict_error_checking": render_instance.data.get(
+                    "strict_error_checking")
             }
 
             # Collect Deadline url if Deadline module is enabled

--- a/openpype/modules/deadline/plugins/publish/submit_maya_deadline.py
+++ b/openpype/modules/deadline/plugins/publish/submit_maya_deadline.py
@@ -771,7 +771,8 @@ class MayaSubmitDeadline(abstract_submit_deadline.AbstractSubmitDeadline):
             "task_types": task_data.get("type"),
             "subsets": instance.data["subset"]
         }
-        profile = filter_profiles(self.profiles, key_values,
+        profile = filter_profiles(self.disable_strict_check_profiles,
+                                  key_values,
                                   logger=self.log)
 
         if profile:

--- a/openpype/modules/deadline/plugins/publish/submit_maya_deadline.py
+++ b/openpype/modules/deadline/plugins/publish/submit_maya_deadline.py
@@ -35,7 +35,6 @@ from openpype.pipeline import legacy_io
 from openpype.hosts.maya.api.lib_rendersettings import RenderSettings
 from openpype.hosts.maya.api.lib import get_attr_in_layer
 
-from openpype.lib.profiles_filtering import filter_profiles
 from openpype_modules.deadline import abstract_submit_deadline
 from openpype_modules.deadline.abstract_submit_deadline import DeadlineJobInfo
 from openpype.tests.lib import is_in_tests

--- a/openpype/modules/deadline/plugins/publish/submit_maya_deadline.py
+++ b/openpype/modules/deadline/plugins/publish/submit_maya_deadline.py
@@ -753,7 +753,7 @@ class MayaSubmitDeadline(abstract_submit_deadline.AbstractSubmitDeadline):
             for file in exp:
                 yield file
 
-    def _get_strict_checking(self, plugin_info, instance):
+    def _get_strict_checking(self, instance):
         """Find profile to disable Strict Error Checking
 
         Args:

--- a/openpype/modules/deadline/plugins/publish/submit_maya_deadline.py
+++ b/openpype/modules/deadline/plugins/publish/submit_maya_deadline.py
@@ -776,6 +776,7 @@ class MayaSubmitDeadline(abstract_submit_deadline.AbstractSubmitDeadline):
                                   logger=self.log)
 
         if profile:
+            self.log.debug("Disabling Strict Error Checking")
             strict_checking = 0
 
         return strict_checking

--- a/openpype/settings/defaults/project_settings/deadline.json
+++ b/openpype/settings/defaults/project_settings/deadline.json
@@ -34,7 +34,7 @@
             "jobInfo": {},
             "pluginInfo": {},
             "scene_patches": [],
-            "disable_strict_check_profiles": []
+            "strict_error_checking": true
         },
         "NukeSubmitDeadline": {
             "enabled": true,

--- a/openpype/settings/defaults/project_settings/deadline.json
+++ b/openpype/settings/defaults/project_settings/deadline.json
@@ -33,7 +33,8 @@
             "limit": [],
             "jobInfo": {},
             "pluginInfo": {},
-            "scene_patches": []
+            "scene_patches": [],
+            "disable_strict_check_profiles": []
         },
         "NukeSubmitDeadline": {
             "enabled": true,

--- a/openpype/settings/entities/schemas/projects_schema/schema_project_deadline.json
+++ b/openpype/settings/entities/schemas/projects_schema/schema_project_deadline.json
@@ -197,34 +197,10 @@
                             }
                         },
                         {
-                            "type": "list",
-                            "collapsible": true,
-                            "key": "disable_strict_check_profiles",
-                            "label": "Disable Strict Error Check profiles",
-                            "use_label_wrap": true,
-                            "docstring": "Set profile for disabling 'Strict Error Checking'",
-                            "object_type": {
-                                "type": "dict",
-                                "children": [
-                                    {
-                                        "key": "task_types",
-                                        "label": "Task types",
-                                        "type": "task-types-enum"
-                                    },
-                                    {
-                                        "key": "task_names",
-                                        "label": "Task names",
-                                        "type": "list",
-                                        "object_type": "text"
-                                    },
-                                    {
-                                        "key": "subsets",
-                                        "label": "Subset names",
-                                        "type": "list",
-                                        "object_type": "text"
-                                    }
-                                ]
-                            }
+                            "type": "boolean",
+                            "key": "strict_error_checking",
+                            "label": "Strict Error Checking",
+                            "default": true
                         }
                     ]
                 },

--- a/openpype/settings/entities/schemas/projects_schema/schema_project_deadline.json
+++ b/openpype/settings/entities/schemas/projects_schema/schema_project_deadline.json
@@ -195,6 +195,36 @@
                                 ]
 
                             }
+                        },
+                        {
+                            "type": "list",
+                            "collapsible": true,
+                            "key": "disable_strict_check_profiles",
+                            "label": "Disable Strict Error Check profiles",
+                            "use_label_wrap": true,
+                            "docstring": "Set profile for disabling 'Strict Error Checking'",
+                            "object_type": {
+                                "type": "dict",
+                                "children": [
+                                    {
+                                        "key": "task_types",
+                                        "label": "Task types",
+                                        "type": "task-types-enum"
+                                    },
+                                    {
+                                        "key": "task_names",
+                                        "label": "Task names",
+                                        "type": "list",
+                                        "object_type": "text"
+                                    },
+                                    {
+                                        "key": "subsets",
+                                        "label": "Subset names",
+                                        "type": "list",
+                                        "object_type": "text"
+                                    }
+                                ]
+                            }
                         }
                     ]
                 },


### PR DESCRIPTION
## Brief description
DL by default has Strict error checking, but some errors are not fatal. 

## Description
This allows to set profile based on Task and Subset values to temporarily disable Strict Error Checks.

Subset and task names should support regular expressions. (not wildcard notation though).

## Testing notes:
1. Configure Settings in `project_settings/deadline/publish/MayaSubmitDeadline/strict_error_checking` - set to false
3. create new render instance, publish from Maya to DL, check `MayaBatch Settings` of job properties
![2023-02-02 18_42_10-Testing Platform PC - AnyDesk](https://user-images.githubusercontent.com/4457962/216402645-76a9f6c5-79c8-4dd0-b510-8a25a32cfb0a.png)