### PR TITLE
Maya: extract Thumbnail "No active model panel found" - OP-3849

### DIFF
--- a/openpype/hosts/maya/plugins/publish/extract_playblast.py
+++ b/openpype/hosts/maya/plugins/publish/extract_playblast.py
@@ -131,8 +131,8 @@ class ExtractPlayblast(publish.Extractor):
 
             # Update preset with current panel setting
             # if override_viewport_options is turned off
-            if not override_viewport_options:
-                panel = cmds.getPanel(withFocus=True)
+            panel = cmds.getPanel(withFocus=True) or ""
+            if not override_viewport_options and "modelPanel" in panel:
                 panel_preset = capture.parse_active_view()
                 preset.update(panel_preset)
                 cmds.setFocus(panel)

--- a/openpype/hosts/maya/plugins/publish/extract_thumbnail.py
+++ b/openpype/hosts/maya/plugins/publish/extract_thumbnail.py
@@ -134,8 +134,8 @@ class ExtractThumbnail(publish.Extractor):
 
             # Update preset with current panel setting
             # if override_viewport_options is turned off
-            if not override_viewport_options:
-                panel = cmds.getPanel(withFocus=True)
+            panel = cmds.getPanel(withFocus=True) or ""
+            if not override_viewport_options and "modelPanel" in panel:
                 panel_preset = capture.parse_active_view()
                 preset.update(panel_preset)
                 cmds.setFocus(panel)


### PR DESCRIPTION
## Brief description
Error when extracting playblast with no model panel.

## Description
If `project_settings/maya/publish/ExtractPlayblast/capture_preset/Viewport Options/override_viewport_options` were off and publishing without showing any model panel, the extraction would fail.

## Testing notes:
1. Turn off `project_settings/maya/publish/ExtractPlayblast/capture_preset/Viewport Options/override_viewport_options`
2. Launch Maya and setup a review.
3. Dont show any model panels by choosing Outliner or similar.
4. Publish review.

Resolves #3754
Resolves #4104