### PR TITLE
Maya: V-Ray Proxy - Update to latest fails - OP-2008

### DIFF
--- a/openpype/hosts/maya/plugins/load/load_vrayproxy.py
+++ b/openpype/hosts/maya/plugins/load/load_vrayproxy.py
@@ -81,10 +81,11 @@ class VRayProxyLoader(load.LoaderPlugin):
         c = colors.get(family)
         if c is not None:
             cmds.setAttr("{0}.useOutlinerColor".format(group_node), 1)
-            cmds.setAttr("{0}.outlinerColor".format(group_node),
-                (float(c[0])/255),
-                (float(c[1])/255),
-                (float(c[2])/255)
+            cmds.setAttr(
+                "{0}.outlinerColor".format(group_node),
+                (float(c[0]) / 255),
+                (float(c[1]) / 255),
+                (float(c[2]) / 255)
             )
 
         return containerise(
@@ -101,7 +102,7 @@ class VRayProxyLoader(load.LoaderPlugin):
         assert cmds.objExists(node), "Missing container"
 
         members = cmds.sets(node, query=True) or []
-        vraymeshes = cmds.ls(members, type="VRayMesh")
+        vraymeshes = cmds.ls(members, type="VRayProxy")
         assert vraymeshes, "Cannot find VRayMesh in container"
 
         #  get all representations for this version

--- a/openpype/hosts/maya/plugins/publish/validate_vray.py
+++ b/openpype/hosts/maya/plugins/publish/validate_vray.py
@@ -1,0 +1,18 @@
+from maya import cmds
+
+import pyblish.api
+from openpype.pipeline import PublishValidationError
+
+
+class ValidateVray(pyblish.api.InstancePlugin):
+    """Validate general Vray setup."""
+
+    order = pyblish.api.ValidatorOrder
+    label = 'VRay'
+    hosts = ["maya"]
+    families = ["vrayproxy"]
+
+    def process(self, instance):
+        # Validate vray plugin is loaded.
+        if not cmds.pluginInfo("vrayformaya", query=True, loaded=True):
+            raise PublishValidationError("Vray plugin is not loaded.")


### PR DESCRIPTION
## Brief description
Updating the Vray proxy would fail.

Also added validator to ensure vray plugin is enabled since publishing could go past validation without needing vray and fail at extraction.

## Testing notes:
1. Create Vray Proxy in Maya.
2. Publish.
3. Load into Maya.
4. Publish a new version and update.