### PR TITLE
Fusion: Fix files collection and small bug-fixes

### DIFF
--- a/openpype/hosts/fusion/api/lib.py
+++ b/openpype/hosts/fusion/api/lib.py
@@ -68,8 +68,8 @@ def set_asset_framerange():
     asset_doc = get_current_project_asset()
     start = asset_doc["data"]["frameStart"]
     end = asset_doc["data"]["frameEnd"]
-    handle_start = asset_doc["data"]["handleStart"]
-    handle_end = asset_doc["data"]["handleEnd"]
+    handle_start = asset_doc["data"].get("handleStart")
+    handle_end = asset_doc["data"].get("handleEnd")
     update_frame_range(start, end, set_render_range=True,
                        handle_start=handle_start,
                        handle_end=handle_end)

--- a/openpype/hosts/fusion/api/lib.py
+++ b/openpype/hosts/fusion/api/lib.py
@@ -68,8 +68,8 @@ def set_asset_framerange():
     asset_doc = get_current_project_asset()
     start = asset_doc["data"]["frameStart"]
     end = asset_doc["data"]["frameEnd"]
-    handle_start = asset_doc["data"].get("handleStart")
-    handle_end = asset_doc["data"].get("handleEnd")
+    handle_start = asset_doc["data"]["handleStart"]
+    handle_end = asset_doc["data"]["handleEnd"]
     update_frame_range(start, end, set_render_range=True,
                        handle_start=handle_start,
                        handle_end=handle_end)

--- a/openpype/hosts/fusion/api/lib.py
+++ b/openpype/hosts/fusion/api/lib.py
@@ -210,7 +210,7 @@ def switch_item(container,
     if any(not x for x in [asset_name, subset_name, representation_name]):
         repre_id = container["representation"]
         representation = get_representation_by_id(project_name, repre_id)
-        repre_parent_docs = get_representation_parents(representation)
+        repre_parent_docs = get_representation_parents(project_name, representation)
         if repre_parent_docs:
             version, subset, asset, _ = repre_parent_docs
         else:

--- a/openpype/hosts/fusion/api/lib.py
+++ b/openpype/hosts/fusion/api/lib.py
@@ -210,7 +210,8 @@ def switch_item(container,
     if any(not x for x in [asset_name, subset_name, representation_name]):
         repre_id = container["representation"]
         representation = get_representation_by_id(project_name, repre_id)
-        repre_parent_docs = get_representation_parents(project_name, representation)
+        repre_parent_docs = get_representation_parents(
+            project_name, representation)
         if repre_parent_docs:
             version, subset, asset, _ = repre_parent_docs
         else:

--- a/openpype/hosts/fusion/hooks/pre_fusion_setup.py
+++ b/openpype/hosts/fusion/hooks/pre_fusion_setup.py
@@ -36,7 +36,7 @@ class FusionPrelaunch(PreLaunchHook):
                 "Make sure the environment in fusion settings has "
                 "'FUSION_PYTHON3_HOME' set correctly and make sure "
                 "Python 3 is installed in the given path."
-                f"\n\nPYTHON36: {fusion_python3_home}"
+                f"\n\nPYTHON PATH: {fusion_python3_home}"
             )
 
         self.log.info(f"Setting {py3_var}: '{py3_dir}'...")

--- a/openpype/hosts/fusion/plugins/publish/collect_instances.py
+++ b/openpype/hosts/fusion/plugins/publish/collect_instances.py
@@ -80,6 +80,7 @@ class CollectInstances(pyblish.api.ContextPlugin):
                 "outputDir": os.path.dirname(path),
                 "ext": ext,  # todo: should be redundant
                 "label": label,
+                "task": context.data["task"],
                 "frameStart": context.data["frameStart"],
                 "frameEnd": context.data["frameEnd"],
                 "frameStartHandle": context.data["frameStartHandle"],

--- a/openpype/hosts/fusion/plugins/publish/render_local.py
+++ b/openpype/hosts/fusion/plugins/publish/render_local.py
@@ -37,7 +37,8 @@ class Fusionlocal(pyblish.api.InstancePlugin):
         basename = os.path.basename(path)
         head, ext = os.path.splitext(basename)
         files = [
-            f"{head}{str(frame).zfill(4)}{ext}" for frame in range(frame_start, frame_end + 1)
+            f"{head}{str(frame).zfill(4)}{ext}"
+            for frame in range(frame_start, frame_end + 1)
         ]
         repre = {
             'name': ext[1:],

--- a/openpype/hosts/fusion/plugins/publish/render_local.py
+++ b/openpype/hosts/fusion/plugins/publish/render_local.py
@@ -1,6 +1,4 @@
 import os
-import copy
-
 import pyblish.api
 from openpype.hosts.fusion.api import comp_lock_and_undo_chunk
 
@@ -19,7 +17,7 @@ class Fusionlocal(pyblish.api.InstancePlugin):
     families = ["render.local"]
 
     def process(self, instance):
-        
+
         # This plug-in runs only once and thus assumes all instances
         # currently will render the same frame range
         context = instance.context
@@ -33,12 +31,12 @@ class Fusionlocal(pyblish.api.InstancePlugin):
         basename = os.path.basename(path)
         head, ext = os.path.splitext(basename)
         files = [
-            f"{head}{str(frame).zfill(4)}{ext}" for frame in range(frame_start, frame_end+1)
+            f"{head}{str(frame).zfill(4)}{ext}" for frame in range(frame_start, frame_end + 1)
         ]
         repre = {
             'name': ext[1:],
             'ext': ext[1:],
-            'frameStart': "%0{}d".format(len(str(frame_end))) % frame_start,
+            'frameStart': f"%0{len(str(frame_end))}d" % frame_start,
             'files': files,
             "stagingDir": output_dir,
         }
@@ -56,19 +54,19 @@ class Fusionlocal(pyblish.api.InstancePlugin):
     def render_once(self, context):
         """Render context comp only once, even with more render instances"""
 
-        key = "__hasRun{}".format(self.__class__.__name__)
+        key = f'__hasRun{self.__class__.__name__}'
         if context.data.get(key, False):
             return
-        else:
-            context.data[key] = True
+
+        context.data[key] = True
 
         current_comp = context.data["currentComp"]
         frame_start = context.data["frameStartHandle"]
         frame_end = context.data["frameEndHandle"]
 
         self.log.info("Starting render")
-        self.log.info("Start frame: {}".format(frame_start))
-        self.log.info("End frame: {}".format(frame_end))
+        self.log.info(f"Start frame: {frame_start}")
+        self.log.info(f"End frame: {frame_end}")
 
         with comp_lock_and_undo_chunk(current_comp):
             result = current_comp.Render({

--- a/openpype/hosts/fusion/plugins/publish/render_local.py
+++ b/openpype/hosts/fusion/plugins/publish/render_local.py
@@ -55,7 +55,7 @@ class Fusionlocal(pyblish.api.InstancePlugin):
         # review representation
         repre_preview = repre.copy()
         repre_preview["name"] = repre_preview["ext"] = "mp4"
-        repre_preview["tags"] = ["review",  "ftrackreview", "delete"]
+        repre_preview["tags"] = ["review", "ftrackreview", "delete"]
         instance.data["representations"].append(repre_preview)
 
     def render_once(self, context):

--- a/openpype/hosts/fusion/plugins/publish/render_local.py
+++ b/openpype/hosts/fusion/plugins/publish/render_local.py
@@ -33,7 +33,7 @@ class Fusionlocal(pyblish.api.InstancePlugin):
         basename = os.path.basename(path)
         head, ext = os.path.splitext(basename)
         files = [
-            f"{head}{frame}{ext}" for frame in range(frame_start, frame_end+1)
+            f"{head}{str(frame).zfill(4)}{ext}" for frame in range(frame_start, frame_end+1)
         ]
         repre = {
             'name': ext[1:],

--- a/openpype/hosts/fusion/plugins/publish/render_local.py
+++ b/openpype/hosts/fusion/plugins/publish/render_local.py
@@ -21,6 +21,12 @@ class Fusionlocal(pyblish.api.InstancePlugin):
         # This plug-in runs only once and thus assumes all instances
         # currently will render the same frame range
         context = instance.context
+        key = f"__hasRun{self.__class__.__name__}"
+        if context.data.get(key, False):
+            return
+
+        context.data[key] = True
+
         self.render_once(context)
 
         frame_start = context.data["frameStartHandle"]
@@ -53,12 +59,6 @@ class Fusionlocal(pyblish.api.InstancePlugin):
 
     def render_once(self, context):
         """Render context comp only once, even with more render instances"""
-
-        key = f'__hasRun{self.__class__.__name__}'
-        if context.data.get(key, False):
-            return
-
-        context.data[key] = True
 
         current_comp = context.data["currentComp"]
         frame_start = context.data["frameStartHandle"]


### PR DESCRIPTION
## Brief description
Fixed Fusion review-representation and small bug-fixes

## Description
This fixes the problem with review-file generation that stopped the publishing on second publish before the fix.
The problem was that Fusion simply looked at all the files in the render-folder instead of only gathering the needed frames for the review.

Also includes a fix to get the handle start/end that before throw an error if the data didn't exist (like from a kitsu sync).
