### PR TITLE
Kitsu fixes

### DIFF
--- a/openpype/modules/kitsu/actions/launcher_show_in_kitsu.py
+++ b/openpype/modules/kitsu/actions/launcher_show_in_kitsu.py
@@ -100,7 +100,7 @@ class ShowInKitsu(LauncherAction):
             kitsu_url = kitsu_url[:-len("/api")]
 
         sub_url = f"/productions/{project_id}"
-        asset_type_url = "Shots" if asset_type in shots_url else "Assets"
+        asset_type_url = "shots" if asset_type in shots_url else "assets"
 
         if task_id:
             # Go to task page

--- a/openpype/modules/kitsu/plugins/publish/collect_kitsu_entities.py
+++ b/openpype/modules/kitsu/plugins/publish/collect_kitsu_entities.py
@@ -4,6 +4,11 @@ import os
 import gazu
 import pyblish.api
 
+from openpype.client import (
+    get_projects,
+    get_project,
+    get_assets,
+)
 
 class CollectKitsuEntities(pyblish.api.ContextPlugin):
     """Collect Kitsu entities according to the current context"""
@@ -12,19 +17,33 @@ class CollectKitsuEntities(pyblish.api.ContextPlugin):
     label = "Kitsu entities"
 
     def process(self, context):
+        
+        # Get all needed names
+        project_name = context.data.get("projectName")
+        asset_name = context.data.get("asset")
+        task_name = context.data.get("task")
+        # If asset and task name doesn't exist in context, look in instance
+        for instance in context:
+            if not asset_name:
+                asset_name = instance.data.get("asset")
+            if not task_name:
+                task_name = instance.data.get("task")
 
-        asset_data = context.data["assetEntity"]["data"]
-        zou_asset_data = asset_data.get("zou")
+        # Get all assets of the local project
+        asset_docs = {
+            asset_doc["name"]: asset_doc
+            for asset_doc in get_assets(project_name)
+        }
+
+        # Get asset object
+        asset = asset_docs.get(asset_name)
+        if not asset:
+            raise AssertionError("{} not found in DB".format(asset_name))
+
+        zou_asset_data = asset["data"].get("zou")
         if not zou_asset_data:
             raise AssertionError("Zou asset data not found in OpenPype!")
         self.log.debug("Collected zou asset data: {}".format(zou_asset_data))
-
-        zou_task_data = asset_data["tasks"][os.environ["AVALON_TASK"]].get(
-            "zou"
-        )
-        if not zou_task_data:
-            self.log.warning("Zou task data not found in OpenPype!")
-        self.log.debug("Collected zou task data: {}".format(zou_task_data))
 
         kitsu_project = gazu.project.get_project(zou_asset_data["project_id"])
         if not kitsu_project:
@@ -37,37 +56,33 @@ class CollectKitsuEntities(pyblish.api.ContextPlugin):
             kitsu_entity = gazu.shot.get_shot(zou_asset_data["id"])
         else:
             kitsu_entity = gazu.asset.get_asset(zou_asset_data["id"])
-
         if not kitsu_entity:
             raise AssertionError("{} not found in kitsu!".format(entity_type))
-
         context.data["kitsu_entity"] = kitsu_entity
         self.log.debug(
             "Collect kitsu {}: {}".format(entity_type, kitsu_entity)
         )
 
-        if zou_task_data:
-            kitsu_task = gazu.task.get_task(zou_task_data["id"])
-            if not kitsu_task:
-                raise AssertionError("Task not found in kitsu!")
-            context.data["kitsu_task"] = kitsu_task
-            self.log.debug("Collect kitsu task: {}".format(kitsu_task))
-
-        else:
-            kitsu_task_type = gazu.task.get_task_type_by_name(
-                os.environ["AVALON_TASK"]
-            )
-            if not kitsu_task_type:
-                raise AssertionError(
-                    "Task type {} not found in Kitsu!".format(
-                        os.environ["AVALON_TASK"]
+        if task_name:
+            zou_task_data = asset["data"]["tasks"][task_name].get("zou")
+            self.log.debug("Collected zou task data: {}".format(zou_task_data))
+            if zou_task_data:
+                kitsu_task = gazu.task.get_task(zou_task_data["id"])
+                if not kitsu_task:
+                    raise AssertionError("Task not found in kitsu!")
+                context.data["kitsu_task"] = kitsu_task
+                self.log.debug("Collect kitsu task: {}".format(kitsu_task))
+            else:
+                kitsu_task_type = gazu.task.get_task_type_by_name(task_name)
+                if not kitsu_task_type:
+                    raise AssertionError(
+                        "Task type {} not found in Kitsu!".format(task_name)
                     )
-                )
 
-            kitsu_task = gazu.task.get_task_by_name(
-                kitsu_entity, kitsu_task_type
-            )
-            if not kitsu_task:
-                raise AssertionError("Task not found in kitsu!")
-            context.data["kitsu_task"] = kitsu_task
-            self.log.debug("Collect kitsu task: {}".format(kitsu_task))
+                kitsu_task = gazu.task.get_task_by_name(
+                    kitsu_entity, kitsu_task_type
+                )
+                if not kitsu_task:
+                    raise AssertionError("Task not found in kitsu!")
+                context.data["kitsu_task"] = kitsu_task
+                self.log.debug("Collect kitsu task: {}".format(kitsu_task))

--- a/openpype/modules/kitsu/plugins/publish/integrate_kitsu_note.py
+++ b/openpype/modules/kitsu/plugins/publish/integrate_kitsu_note.py
@@ -8,7 +8,7 @@ class IntegrateKitsuNote(pyblish.api.ContextPlugin):
 
     order = pyblish.api.IntegratorOrder
     label = "Kitsu Note and Status"
-    # families = ["kitsu"]
+    families = ["render", "kitsu"]
     set_status_note = False
     note_status_shortname = "wfa"
 

--- a/openpype/modules/kitsu/plugins/publish/integrate_kitsu_review.py
+++ b/openpype/modules/kitsu/plugins/publish/integrate_kitsu_review.py
@@ -27,7 +27,7 @@ class IntegrateKitsuReview(pyblish.api.InstancePlugin):
         # Add review representations as preview of comment
         for representation in instance.data.get("representations", []):
             # Skip if not tagged as review
-            if "review" not in representation.get("tags", []):
+            if "kitsureview" not in representation.get("tags", []):
                 continue
 
             review_path = representation.get("published_path")

--- a/openpype/modules/kitsu/plugins/publish/integrate_kitsu_review.py
+++ b/openpype/modules/kitsu/plugins/publish/integrate_kitsu_review.py
@@ -8,7 +8,7 @@ class IntegrateKitsuReview(pyblish.api.InstancePlugin):
 
     order = pyblish.api.IntegratorOrder + 0.01
     label = "Kitsu Review"
-    # families = ["kitsu"]
+    families = ["render", "kitsu"]
     optional = True
 
     def process(self, instance):

--- a/openpype/modules/kitsu/utils/update_op_with_zou.py
+++ b/openpype/modules/kitsu/utils/update_op_with_zou.py
@@ -146,6 +146,14 @@ def update_op_assets(
         # Properties that doesn't fully exist in Kitsu. Guessing the property name
         # Pixel Aspect Ratio
         item_data["pixelAspect"] = item_data.get("pixel_aspect", project_doc["data"].get("pixelAspect"))
+        # Handle Start
+        item_data["handleStart"] = item_data.get("handle_start", project_doc["data"].get("handleStart"))
+        # Handle End
+        item_data["handleEnd"] = item_data.get("handle_end", project_doc["data"].get("handleEnd"))
+        # Clip In
+        item_data["clipIn"] = item_data.get("clip_in", project_doc["data"].get("clipIn"))
+        # Clip Out
+        item_data["clipOut"] = item_data.get("clip_out", project_doc["data"].get("clipOut"))
 
         # Tasks
         tasks_list = []

--- a/openpype/modules/kitsu/utils/update_op_with_zou.py
+++ b/openpype/modules/kitsu/utils/update_op_with_zou.py
@@ -401,6 +401,7 @@ def sync_project_from_kitsu(dbcon: AvalonMongoDB, project: dict):
                 "root_of": r,
                 "tasks": {},
                 "visualParent": None,
+                "parents": [],
             },
         }
         for r in ["Assets", "Shots"]

--- a/openpype/modules/kitsu/utils/update_op_with_zou.py
+++ b/openpype/modules/kitsu/utils/update_op_with_zou.py
@@ -135,6 +135,17 @@ def update_op_assets(
         except (TypeError, ValueError):
             fps = float(gazu_project.get("fps", project_doc["data"].get("fps", 25)))
         item_data["fps"] = fps
+        # Resolution, fall back to project default
+        match_res = re.match(r"(\d+)x(\d+)", item_data.get("resolution", gazu_project.get("resolution")))
+        if match_res:
+            item_data["resolutionWidth"] = int(match_res.group(1))
+            item_data["resolutionHeight"] = int(match_res.group(2))
+        else:
+            item_data["resolutionWidth"] = project_doc["data"].get("resolutionWidth")
+            item_data["resolutionHeight"] = project_doc["data"].get("resolutionHeight")
+        # Properties that doesn't fully exist in Kitsu. Guessing the property name
+        # Pixel Aspect Ratio
+        item_data["pixelAspect"] = item_data.get("pixel_aspect", project_doc["data"].get("pixelAspect"))
 
         # Tasks
         tasks_list = []

--- a/openpype/modules/kitsu/utils/update_op_with_zou.py
+++ b/openpype/modules/kitsu/utils/update_op_with_zou.py
@@ -389,6 +389,7 @@ def sync_project_from_kitsu(dbcon: AvalonMongoDB, project: dict):
             "data": {
                 "root_of": r,
                 "tasks": {},
+                "visualParent": None,
             },
         }
         for r in ["Assets", "Shots"]

--- a/openpype/settings/defaults/project_settings/global.json
+++ b/openpype/settings/defaults/project_settings/global.json
@@ -135,7 +135,8 @@
                             "ext": "mp4",
                             "tags": [
                                 "burnin",
-                                "ftrackreview"
+                                "ftrackreview",
+                                "kitsureview"
                             ],
                             "burnins": [],
                             "ffmpeg_args": {

--- a/openpype/settings/entities/schemas/projects_schema/schemas/schema_representation_tags.json
+++ b/openpype/settings/entities/schemas/projects_schema/schemas/schema_representation_tags.json
@@ -17,6 +17,9 @@
             "shotgridreview": "Add review to Shotgrid"
         },
         {
+            "kitsureview": "Add review to Kitsu"
+        },
+        {
             "delete": "Delete output"
         },
         {


### PR DESCRIPTION
## Brief description
Make Kitsu work with Tray Publisher, added kitsureview tag, fixed sync-problems.

## Description
This PR updates the way the module gather info for the current publish so it now works with Tray Publisher.
It fixes the data that gets synced from Kitsu to OP so all needed data gets registered even if it doesn't exist on Kitsus side.
It also adds the tag "Add review to Kitsu" and adds it to Burn In so previews gets generated by default to Kitsu.
