### PR TITLE
Publisher: Creators sorting

### DIFF
--- a/openpype/hosts/traypublisher/plugins/create/create_movie_batch.py
+++ b/openpype/hosts/traypublisher/plugins/create/create_movie_batch.py
@@ -33,6 +33,8 @@ class BatchMovieCreator(TrayPublishCreator):
 
     create_allow_context_change = False
     version_regex = re.compile(r"^(.+)_v([0-9]+)$")
+    # Position batch creator after simple creators
+    order = 110
 
     def __init__(self, project_settings, *args, **kwargs):
         super(BatchMovieCreator, self).__init__(project_settings,

--- a/openpype/pipeline/create/context.py
+++ b/openpype/pipeline/create/context.py
@@ -1935,6 +1935,12 @@ class CreateContext:
             identifier = instance.creator_identifier
             instances_by_identifier[identifier].append(instance)
 
+        # Just remove instances from context if creator is not available
+        missing_creators = set(instances_by_identifier) - set(self.creators)
+        for identifier in missing_creators:
+            for instance in instances_by_identifier[identifier]:
+                self._remove_instance(instance)
+
         error_message = "Instances removement of creator \"{}\" failed. {}"
         failed_info = []
         # Remove instances by creator plugin order
@@ -2046,7 +2052,7 @@ class CreateContext:
             convertor.convert()
 
     def run_convertors(self, convertor_identifiers):
-        """Run convertor plugins by idenfitifiers.
+        """Run convertor plugins by identifiers.
 
         Conversion is skipped if convertor is not available. It is recommended
         to trigger reset after conversion to reload instances.

--- a/openpype/pipeline/create/context.py
+++ b/openpype/pipeline/create/context.py
@@ -1237,6 +1237,37 @@ class CreateContext:
         """Access to global publish attributes."""
         return self._publish_attributes
 
+    def get_sorted_creators(self, identifiers=None):
+        """Sorted creators by 'order' attribute.
+
+        Returns:
+            List[BaseCreator]: Sorted creator plugins by 'order' value.
+        """
+
+        if identifiers is not None:
+            identifiers = set(identifiers)
+            creators = [
+                creator
+                for identifier, creator in self.creators.items()
+                if identifier in identifiers
+            ]
+        else:
+            creators = self.creators.values()
+
+        return sorted(
+            creators, key=lambda creator: creator.order
+        )
+
+    @property
+    def sorted_creators(self):
+        return self.get_sorted_creators()
+
+    @property
+    def sorted_autocreators(self):
+        return sorted(
+            self.autocreators.values(), key=lambda creator: creator.order
+        )
+
     @classmethod
     def get_host_misssing_methods(cls, host):
         """Collect missing methods from host.

--- a/openpype/pipeline/create/context.py
+++ b/openpype/pipeline/create/context.py
@@ -1630,6 +1630,9 @@ class CreateContext:
                 )
             ])
 
+    def _remove_instance(self, instance):
+        self._instances_by_id.pop(instance.id, None)
+
     def creator_removed_instance(self, instance):
         """When creator removes instance context should be acknowledged.
 
@@ -1641,7 +1644,7 @@ class CreateContext:
                 from scene metadata.
         """
 
-        self._instances_by_id.pop(instance.id, None)
+        self._remove_instance(instance)
 
     def add_convertor_item(self, convertor_identifier, label):
         self.convertor_items_by_id[convertor_identifier] = ConvertorItem(

--- a/openpype/pipeline/create/creator_plugins.py
+++ b/openpype/pipeline/create/creator_plugins.py
@@ -497,6 +497,17 @@ class Creator(BaseCreator):
     # - similar to instance attribute definitions
     pre_create_attr_defs = []
 
+    @property
+    def show_order(self):
+        """Order in which is creator shown in UI.
+
+        Returns:
+            int: Order in which is creator shown (less == earlier). By default
+                is using Creator's 'order' or processing.
+        """
+
+        return self.order
+
     @abstractmethod
     def create(self, subset_name, instance_data, pre_create_data):
         """Create new instance and store it.

--- a/openpype/pipeline/create/creator_plugins.py
+++ b/openpype/pipeline/create/creator_plugins.py
@@ -107,7 +107,11 @@ class SubsetConvertorPlugin(object):
 
     @property
     def create_context(self):
-        """Quick access to create context."""
+        """Quick access to create context.
+
+        Returns:
+            CreateContext: Context which initialized the plugin.
+        """
 
         return self._create_context
 
@@ -156,6 +160,10 @@ class BaseCreator:
     group_label = None
     # Cached group label after first call 'get_group_label'
     _cached_group_label = None
+
+    # Order in which will be plugin executed (collect & update instances)
+    #   less == earlier -> Order '90' will be processed before '100'
+    order = 100
 
     # Variable to store logger
     _log = None

--- a/openpype/tools/publisher/constants.py
+++ b/openpype/tools/publisher/constants.py
@@ -24,6 +24,7 @@ CREATOR_THUMBNAIL_ENABLED_ROLE = QtCore.Qt.UserRole + 5
 FAMILY_ROLE = QtCore.Qt.UserRole + 6
 GROUP_ROLE = QtCore.Qt.UserRole + 7
 CONVERTER_IDENTIFIER_ROLE = QtCore.Qt.UserRole + 8
+CREATOR_SORT_ROLE = QtCore.Qt.UserRole + 9
 
 
 __all__ = (
@@ -36,6 +37,7 @@ __all__ = (
     "IS_GROUP_ROLE",
     "CREATOR_IDENTIFIER_ROLE",
     "CREATOR_THUMBNAIL_ENABLED_ROLE",
+    "CREATOR_SORT_ROLE",
     "FAMILY_ROLE",
     "GROUP_ROLE",
     "CONVERTER_IDENTIFIER_ROLE",

--- a/openpype/tools/publisher/control.py
+++ b/openpype/tools/publisher/control.py
@@ -1508,9 +1508,6 @@ class BasePublisherController(AbstractPublisherController):
     def _reset_attributes(self):
         """Reset most of attributes that can be reset."""
 
-        # Reset creator items
-        self._creator_items = None
-
         self.publish_is_running = False
         self.publish_has_validated = False
         self.publish_has_crashed = False
@@ -1766,6 +1763,8 @@ class PublisherController(BasePublisherController):
         self._resetting_plugins = True
 
         self._create_context.reset_plugins()
+        # Reset creator items
+        self._creator_items = None
 
         self._resetting_plugins = False
 

--- a/openpype/tools/publisher/control.py
+++ b/openpype/tools/publisher/control.py
@@ -832,7 +832,8 @@ class CreatorItem:
         default_variants,
         create_allow_context_change,
         create_allow_thumbnail,
-        pre_create_attributes_defs
+        show_order,
+        pre_create_attributes_defs,
     ):
         self.identifier = identifier
         self.creator_type = creator_type
@@ -846,6 +847,7 @@ class CreatorItem:
         self.default_variants = default_variants
         self.create_allow_context_change = create_allow_context_change
         self.create_allow_thumbnail = create_allow_thumbnail
+        self.show_order = show_order
         self.pre_create_attributes_defs = pre_create_attributes_defs
 
     def get_group_label(self):
@@ -869,6 +871,7 @@ class CreatorItem:
         pre_create_attr_defs = None
         create_allow_context_change = None
         create_allow_thumbnail = None
+        show_order = creator.order
         if creator_type is CreatorTypes.artist:
             description = creator.get_description()
             detail_description = creator.get_detail_description()
@@ -877,6 +880,7 @@ class CreatorItem:
             pre_create_attr_defs = creator.get_pre_create_attr_defs()
             create_allow_context_change = creator.create_allow_context_change
             create_allow_thumbnail = creator.create_allow_thumbnail
+            show_order = creator.show_order
 
         identifier = creator.identifier
         return cls(
@@ -892,7 +896,8 @@ class CreatorItem:
             default_variants,
             create_allow_context_change,
             create_allow_thumbnail,
-            pre_create_attr_defs
+            show_order,
+            pre_create_attr_defs,
         )
 
     def to_data(self):
@@ -915,6 +920,7 @@ class CreatorItem:
             "default_variants": self.default_variants,
             "create_allow_context_change": self.create_allow_context_change,
             "create_allow_thumbnail": self.create_allow_thumbnail,
+            "show_order": self.show_order,
             "pre_create_attributes_defs": pre_create_attributes_defs,
         }
 

--- a/openpype/tools/publisher/widgets/create_widget.py
+++ b/openpype/tools/publisher/widgets/create_widget.py
@@ -91,6 +91,15 @@ class CreatorShortDescWidget(QtWidgets.QWidget):
         self._description_label.setText(description)
 
 
+class CreatorsProxyModel(QtCore.QSortFilterProxyModel):
+    def lessThan(self, left, right):
+        l_show_order = left.data(CREATOR_SORT_ROLE)
+        r_show_order = right.data(CREATOR_SORT_ROLE)
+        if l_show_order == r_show_order:
+            return super(CreatorsProxyModel, self).lessThan(left, right)
+        return l_show_order < r_show_order
+
+
 class CreateWidget(QtWidgets.QWidget):
     def __init__(self, controller, parent=None):
         super(CreateWidget, self).__init__(parent)
@@ -142,7 +151,7 @@ class CreateWidget(QtWidgets.QWidget):
 
         creators_view = QtWidgets.QListView(creators_view_widget)
         creators_model = QtGui.QStandardItemModel()
-        creators_sort_model = QtCore.QSortFilterProxyModel()
+        creators_sort_model = CreatorsProxyModel()
         creators_sort_model.setSourceModel(creators_model)
         creators_view.setModel(creators_sort_model)
 

--- a/openpype/tools/publisher/widgets/create_widget.py
+++ b/openpype/tools/publisher/widgets/create_widget.py
@@ -104,8 +104,6 @@ class CreateWidget(QtWidgets.QWidget):
     def __init__(self, controller, parent=None):
         super(CreateWidget, self).__init__(parent)
 
-        self.setWindowTitle("Create new instance")
-
         self._controller = controller
 
         self._asset_name = None

--- a/openpype/tools/publisher/widgets/create_widget.py
+++ b/openpype/tools/publisher/widgets/create_widget.py
@@ -18,9 +18,10 @@ from .tasks_widget import CreateWidgetTasksWidget
 from .precreate_widget import PreCreateWidget
 from ..constants import (
     VARIANT_TOOLTIP,
-    CREATOR_IDENTIFIER_ROLE,
     FAMILY_ROLE,
+    CREATOR_IDENTIFIER_ROLE,
     CREATOR_THUMBNAIL_ENABLED_ROLE,
+    CREATOR_SORT_ROLE,
 )
 
 SEPARATORS = ("---separator---", "---")
@@ -441,7 +442,8 @@ class CreateWidget(QtWidgets.QWidget):
 
         # Add new families
         new_creators = set()
-        for identifier, creator_item in self._controller.creator_items.items():
+        creator_items_by_identifier = self._controller.creator_items
+        for identifier, creator_item in creator_items_by_identifier.items():
             if creator_item.creator_type != "artist":
                 continue
 
@@ -457,6 +459,7 @@ class CreateWidget(QtWidgets.QWidget):
                 self._creators_model.appendRow(item)
 
             item.setData(creator_item.label, QtCore.Qt.DisplayRole)
+            item.setData(creator_item.show_order, CREATOR_SORT_ROLE)
             item.setData(identifier, CREATOR_IDENTIFIER_ROLE)
             item.setData(
                 creator_item.create_allow_thumbnail,
@@ -482,8 +485,9 @@ class CreateWidget(QtWidgets.QWidget):
             index = indexes[0]
 
         identifier = index.data(CREATOR_IDENTIFIER_ROLE)
+        create_item = creator_items_by_identifier.get(identifier)
 
-        self._set_creator_by_identifier(identifier)
+        self._set_creator(create_item)
 
     def _on_plugins_refresh(self):
         # Trigger refresh only if is visible


### PR DESCRIPTION
## Brief description
Added sorting to creators.

## Description
Added sorting ability to creator. Not just for UI purposes but also for processing of creators. All creators have `order` attribute which define in which order are triggered for collection, update and remove of instances which may be needed in some cases when a creator is dependent on other creator (e.g. in TVPaint). Also added option to change order of creator in UI by addin `show_order` which is by default using `order` attribute. Default `order` value is `100`.

Changed order of batch creator in traypublisher to be after simple creators.

### Additional information
This is prerequirement for TVPaint implementation where render pass creator must be sure that render layer already did changes that should have be done.

## Testing notes:
1. Open TrayPublisher
2. Batch creator should not be at first place but after simple creators (probably at the end of creators list)