### PR TITLE
Slack: added missed scopes for Slack bot

### DIFF
--- a/openpype/modules/slack/manifest.yml
+++ b/openpype/modules/slack/manifest.yml
@@ -19,6 +19,8 @@ oauth_config:
       - chat:write.public
       - files:write
       - channels:read
+      - users:read
+      - usergroups:read
 settings:
   org_deploy_enabled: false
   socket_mode_enabled: false


### PR DESCRIPTION
## Brief description
Added missed additional scopes for Slack bot

## Description
Must be added with Slack admin for a organization. Slack app must be restarted (but token stays the same).

## Additional info
Slack user notificaton was added here https://github.com/ynput/OpenPype/pull/4265
