### PR TITLE
SiteSync: fix dirmap

### DIFF
--- a/openpype/host/dirmap.py
+++ b/openpype/host/dirmap.py
@@ -8,6 +8,7 @@ exists is used.
 
 import os
 from abc import ABCMeta, abstractmethod
+import platform
 
 import six
 
@@ -187,11 +188,19 @@ class HostDirmap(object):
 
             self.log.debug("local overrides {}".format(active_overrides))
             self.log.debug("remote overrides {}".format(remote_overrides))
+            current_platform = platform.system().lower()
             for root_name, active_site_dir in active_overrides.items():
                 remote_site_dir = (
                     remote_overrides.get(root_name)
                     or sync_settings["sites"][remote_site]["root"][root_name]
                 )
+
+                if isinstance(remote_site_dir, dict):
+                    remote_site_dir = remote_site_dir.get(current_platform)
+
+                if not remote_site_dir:
+                    continue
+
                 if os.path.isdir(active_site_dir):
                     if "destination-path" not in mapping:
                         mapping["destination-path"] = []


### PR DESCRIPTION
## Brief description
Fixed issue in dirmap in Maya and Nuke

## Description
Loads of error were thrown in Nuke console about dictionary value.
`AttributeError: 'dict' object has no attribute 'lower'`

## Additional info
`remote_site_dir` started to return platform dict instead of str value

## Documentation (add _"type: documentation"_ label)
[feature_documentation](future_url_after_it_will_be_merged)

## Testing notes:
1. enable SiteSync on a project,
2. set local site to local, remote to Studio
3. start Nuke or Maya - observe console