### PR TITLE
Ftrack: Fix methods called on thread objects

### DIFF
--- a/openpype/modules/ftrack/ftrack_server/event_server_cli.py
+++ b/openpype/modules/ftrack/ftrack_server/event_server_cli.py
@@ -316,7 +316,7 @@ def main_loop(ftrack_url):
                 statuser_failed_count = 0
 
         # If thread failed test Ftrack and Mongo connection
-        elif not statuser_thread.isAlive():
+        elif not statuser_thread.is_alive():
             statuser_thread.join()
             statuser_thread = None
             ftrack_accessible = False
@@ -359,7 +359,7 @@ def main_loop(ftrack_url):
                 storer_failed_count = 0
 
         # If thread failed test Ftrack and Mongo connection
-        elif not storer_thread.isAlive():
+        elif not storer_thread.is_alive():
             if storer_thread.mongo_error:
                 raise MongoPermissionsError()
             storer_thread.join()
@@ -396,7 +396,7 @@ def main_loop(ftrack_url):
                 processor_failed_count = 0
 
         # If thread failed test Ftrack and Mongo connection
-        elif not processor_thread.isAlive():
+        elif not processor_thread.is_alive():
             if processor_thread.mongo_error:
                 raise Exception(
                     "Exiting because have issue with acces to MongoDB"

--- a/openpype/modules/ftrack/tray/login_dialog.py
+++ b/openpype/modules/ftrack/tray/login_dialog.py
@@ -259,7 +259,7 @@ class CredentialsDialog(QtWidgets.QDialog):
 
         # If there is an existing server thread running we need to stop it.
         if self._login_server_thread:
-            if self._login_server_thread.isAlive():
+            if self._login_server_thread.is_alive():
                 self._login_server_thread.stop()
             self._login_server_thread.join()
             self._login_server_thread = None


### PR DESCRIPTION
## Brief description
Use `is_alive` method instead of `isAlive` which is not compatible with Python 3.9.*.

## Testing notes:
1. Ftrack statuser on ftrack event server should work