### PR TITLE
Shotgrid: Fix how representation paths are received during publishing

### DIFF
--- a/openpype/modules/ftrack/plugins/publish/integrate_ftrack_instances.py
+++ b/openpype/modules/ftrack/plugins/publish/integrate_ftrack_instances.py
@@ -3,6 +3,7 @@ import json
 import copy
 import pyblish.api
 
+from openpype.pipeline.publish import get_publish_repre_path
 from openpype.lib.openpype_version import get_openpype_version
 from openpype.lib.transcoding import (
     get_ffprobe_streams,
@@ -10,7 +11,6 @@ from openpype.lib.transcoding import (
 )
 from openpype.lib.profiles_filtering import filter_profiles
 from openpype.lib.transcoding import VIDEO_EXTENSIONS
-from openpype.plugins.publish.integrate import get_representation_path
 
 
 class IntegrateFtrackInstance(pyblish.api.InstancePlugin):
@@ -154,7 +154,7 @@ class IntegrateFtrackInstance(pyblish.api.InstancePlugin):
 
         if not review_representations or has_movie_review:
             for repre in thumbnail_representations:
-                repre_path = get_representation_path(instance, repre, False)
+                repre_path = get_publish_repre_path(instance, repre, False)
                 if not repre_path:
                     self.log.warning(
                         "Published path is not set and source was removed."
@@ -211,7 +211,7 @@ class IntegrateFtrackInstance(pyblish.api.InstancePlugin):
                                "from {}".format(repre))
                 continue
 
-            repre_path = get_representation_path(instance, repre, False)
+            repre_path = get_publish_repre_path(instance, repre, False)
             if not repre_path:
                 self.log.warning(
                     "Published path is not set and source was removed."
@@ -325,7 +325,7 @@ class IntegrateFtrackInstance(pyblish.api.InstancePlugin):
 
         # Add others representations as component
         for repre in other_representations:
-            published_path = get_representation_path(instance, repre, True)
+            published_path = get_publish_repre_path(instance, repre, True)
             if not published_path:
                 continue
             # Create copy of base comp item and append it

--- a/openpype/modules/ftrack/plugins/publish/integrate_ftrack_instances.py
+++ b/openpype/modules/ftrack/plugins/publish/integrate_ftrack_instances.py
@@ -10,6 +10,7 @@ from openpype.lib.transcoding import (
 )
 from openpype.lib.profiles_filtering import filter_profiles
 from openpype.lib.transcoding import VIDEO_EXTENSIONS
+from openpype.plugins.publish.integrate import get_representation_path
 
 
 class IntegrateFtrackInstance(pyblish.api.InstancePlugin):
@@ -153,7 +154,7 @@ class IntegrateFtrackInstance(pyblish.api.InstancePlugin):
 
         if not review_representations or has_movie_review:
             for repre in thumbnail_representations:
-                repre_path = self._get_repre_path(instance, repre, False)
+                repre_path = get_representation_path(instance, repre, False)
                 if not repre_path:
                     self.log.warning(
                         "Published path is not set and source was removed."
@@ -210,7 +211,7 @@ class IntegrateFtrackInstance(pyblish.api.InstancePlugin):
                                "from {}".format(repre))
                 continue
 
-            repre_path = self._get_repre_path(instance, repre, False)
+            repre_path = get_representation_path(instance, repre, False)
             if not repre_path:
                 self.log.warning(
                     "Published path is not set and source was removed."
@@ -324,7 +325,7 @@ class IntegrateFtrackInstance(pyblish.api.InstancePlugin):
 
         # Add others representations as component
         for repre in other_representations:
-            published_path = self._get_repre_path(instance, repre, True)
+            published_path = get_representation_path(instance, repre, True)
             if not published_path:
                 continue
             # Create copy of base comp item and append it
@@ -363,51 +364,6 @@ class IntegrateFtrackInstance(pyblish.api.InstancePlugin):
 
     def _collect_additional_metadata(self, streams):
         pass
-
-    def _get_repre_path(self, instance, repre, only_published):
-        """Get representation path that can be used for integration.
-
-        When 'only_published' is set to true the validation of path is not
-        relevant. In that case we just need what is set in 'published_path'
-        as "reference". The reference is not used to get or upload the file but
-        for reference where the file was published.
-
-        Args:
-            instance (pyblish.Instance): Processed instance object. Used
-                for source of staging dir if representation does not have
-                filled it.
-            repre (dict): Representation on instance which could be and
-                could not be integrated with main integrator.
-            only_published (bool): Care only about published paths and
-                ignore if filepath is not existing anymore.
-
-        Returns:
-            str: Path to representation file.
-            None: Path is not filled or does not exists.
-        """
-
-        published_path = repre.get("published_path")
-        if published_path:
-            published_path = os.path.normpath(published_path)
-            if os.path.exists(published_path):
-                return published_path
-
-        if only_published:
-            return published_path
-
-        comp_files = repre["files"]
-        if isinstance(comp_files, (tuple, list, set)):
-            filename = comp_files[0]
-        else:
-            filename = comp_files
-
-        staging_dir = repre.get("stagingDir")
-        if not staging_dir:
-            staging_dir = instance.data["stagingDir"]
-        src_path = os.path.normpath(os.path.join(staging_dir, filename))
-        if os.path.exists(src_path):
-            return src_path
-        return None
 
     def _get_asset_version_status_name(self, instance):
         if not self.asset_versions_status_profiles:

--- a/openpype/modules/shotgrid/plugins/publish/integrate_shotgrid_publish.py
+++ b/openpype/modules/shotgrid/plugins/publish/integrate_shotgrid_publish.py
@@ -24,7 +24,9 @@ class IntegrateShotgridPublish(pyblish.api.InstancePlugin):
 
         for representation in instance.data.get("representations", []):
 
-            local_path = get_representation_path(instance, representation, False)
+            local_path = get_representation_path(
+                instance, representation, False
+            )
             code = os.path.basename(local_path)
 
             if representation.get("tags", []):

--- a/openpype/modules/shotgrid/plugins/publish/integrate_shotgrid_publish.py
+++ b/openpype/modules/shotgrid/plugins/publish/integrate_shotgrid_publish.py
@@ -1,6 +1,8 @@
 import os
 import pyblish.api
 
+from openpype.plugins.publish.integrate import get_representation_path
+
 
 class IntegrateShotgridPublish(pyblish.api.InstancePlugin):
     """
@@ -22,7 +24,7 @@ class IntegrateShotgridPublish(pyblish.api.InstancePlugin):
 
         for representation in instance.data.get("representations", []):
 
-            local_path = representation.get("published_path")
+            local_path = get_representation_path(instance, representation, False)
             code = os.path.basename(local_path)
 
             if representation.get("tags", []):

--- a/openpype/modules/shotgrid/plugins/publish/integrate_shotgrid_publish.py
+++ b/openpype/modules/shotgrid/plugins/publish/integrate_shotgrid_publish.py
@@ -1,7 +1,7 @@
 import os
 import pyblish.api
 
-from openpype.plugins.publish.integrate import get_representation_path
+from openpype.pipeline.publish import get_publish_repre_path
 
 
 class IntegrateShotgridPublish(pyblish.api.InstancePlugin):
@@ -24,7 +24,7 @@ class IntegrateShotgridPublish(pyblish.api.InstancePlugin):
 
         for representation in instance.data.get("representations", []):
 
-            local_path = get_representation_path(
+            local_path = get_publish_repre_path(
                 instance, representation, False
             )
             code = os.path.basename(local_path)

--- a/openpype/modules/shotgrid/plugins/publish/integrate_shotgrid_version.py
+++ b/openpype/modules/shotgrid/plugins/publish/integrate_shotgrid_version.py
@@ -1,6 +1,6 @@
 import pyblish.api
 
-from openpype.plugins.publish.integrate import get_representation_path
+from openpype.pipeline.publish import get_publish_repre_path
 
 
 class IntegrateShotgridVersion(pyblish.api.InstancePlugin):
@@ -42,7 +42,7 @@ class IntegrateShotgridVersion(pyblish.api.InstancePlugin):
             data_to_update["sg_status_list"] = status
 
         for representation in instance.data.get("representations", []):
-            local_path = get_representation_path(
+            local_path = get_publish_repre_path(
                 instance, representation, False
             )
 

--- a/openpype/modules/shotgrid/plugins/publish/integrate_shotgrid_version.py
+++ b/openpype/modules/shotgrid/plugins/publish/integrate_shotgrid_version.py
@@ -18,37 +18,15 @@ class IntegrateShotgridVersion(pyblish.api.InstancePlugin):
 
         # TODO: Use path template solver to build version code from settings
         anatomy = instance.data.get("anatomyData", {})
-        ### Starts Alkemy-X Override ###
-        # code = "_".join(
-        #     [
-        #         anatomy["project"]["code"],
-        #         anatomy["parent"],
-        #         anatomy["asset"],
-        #         anatomy["task"]["name"],
-        #         "v{:03}".format(int(anatomy["version"])),
-        #     ]
-        # )
-        # Initial editorial Shotgrid versions don't need task in name
-        if anatomy["app"] == "hiero":
-            code = "_".join(
-                [
-                    anatomy["project"]["code"],
-                    anatomy["parent"],
-                    anatomy["asset"],
-                    "v{:03}".format(int(anatomy["version"])),
-                ]
-            )
-        else:
-            code = "_".join(
-                [
-                    anatomy["project"]["code"],
-                    anatomy["parent"],
-                    anatomy["asset"],
-                    anatomy["task"]["name"],
-                    "v{:03}".format(int(anatomy["version"])),
-                ]
-            )
-        ### Ends Alkemy-X Override ###
+        code = "_".join(
+            [
+                anatomy["project"]["code"],
+                anatomy["parent"],
+                anatomy["asset"],
+                anatomy["task"]["name"],
+                "v{:03}".format(int(anatomy["version"])),
+            ]
+        )
 
         version = self._find_existing_version(code, context)
 
@@ -64,9 +42,9 @@ class IntegrateShotgridVersion(pyblish.api.InstancePlugin):
             data_to_update["sg_status_list"] = status
 
         for representation in instance.data.get("representations", []):
-            # Get representation path from published_path or create it from stagingDir if not existent
-            local_path = get_representation_path(instance, representation, False)
-            self.log.info("Local path: %s", local_path)
+            local_path = get_representation_path(
+                instance, representation, False
+            )
 
             if "shotgridreview" in representation.get("tags", []):
 

--- a/openpype/modules/slack/plugins/publish/integrate_slack_api.py
+++ b/openpype/modules/slack/plugins/publish/integrate_slack_api.py
@@ -8,8 +8,8 @@ from abc import ABCMeta, abstractmethod
 import time
 
 from openpype.client import OpenPypeMongoConnection
+from openpype.pipeline.publish import get_publish_repre_path
 from openpype.lib.plugin_tools import prepare_template_data
-from openpype.plugins.publish.integrate import get_representation_path
 
 
 class IntegrateSlackAPI(pyblish.api.InstancePlugin):
@@ -168,7 +168,7 @@ class IntegrateSlackAPI(pyblish.api.InstancePlugin):
         thumbnail_path = None
         for repre in instance.data.get("representations", []):
             if repre.get('thumbnail') or "thumbnail" in repre.get('tags', []):
-                repre_thumbnail_path = get_representation_path(
+                repre_thumbnail_path = get_publish_repre_path(
                     instance, repre, False
                 )
                 if os.path.exists(repre_thumbnail_path):
@@ -184,7 +184,7 @@ class IntegrateSlackAPI(pyblish.api.InstancePlugin):
             if (repre.get("review")
                     or "review" in tags
                     or "burnin" in tags):
-                repre_review_path = get_representation_path(
+                repre_review_path = get_publish_repre_path(
                     instance, repre, False
                 )
                 if os.path.exists(repre_review_path):

--- a/openpype/modules/slack/plugins/publish/integrate_slack_api.py
+++ b/openpype/modules/slack/plugins/publish/integrate_slack_api.py
@@ -168,7 +168,9 @@ class IntegrateSlackAPI(pyblish.api.InstancePlugin):
         thumbnail_path = None
         for repre in instance.data.get("representations", []):
             if repre.get('thumbnail') or "thumbnail" in repre.get('tags', []):
-                repre_thumbnail_path = get_representation_path(instance, repre, False)
+                repre_thumbnail_path = get_representation_path(
+                    instance, repre, False
+                )
                 if os.path.exists(repre_thumbnail_path):
                     thumbnail_path = repre_thumbnail_path
                 break
@@ -182,7 +184,9 @@ class IntegrateSlackAPI(pyblish.api.InstancePlugin):
             if (repre.get("review")
                     or "review" in tags
                     or "burnin" in tags):
-                repre_review_path = get_representation_path(instance, repre, False)
+                repre_review_path = get_representation_path(
+                    instance, repre, False
+                )
                 if os.path.exists(repre_review_path):
                     review_path = repre_review_path
                 if "burnin" in tags:  # burnin has precedence if exists

--- a/openpype/modules/slack/plugins/publish/integrate_slack_api.py
+++ b/openpype/modules/slack/plugins/publish/integrate_slack_api.py
@@ -9,6 +9,7 @@ import time
 
 from openpype.client import OpenPypeMongoConnection
 from openpype.lib.plugin_tools import prepare_template_data
+from openpype.plugins.publish.integrate import get_representation_path
 
 
 class IntegrateSlackAPI(pyblish.api.InstancePlugin):
@@ -167,10 +168,7 @@ class IntegrateSlackAPI(pyblish.api.InstancePlugin):
         thumbnail_path = None
         for repre in instance.data.get("representations", []):
             if repre.get('thumbnail') or "thumbnail" in repre.get('tags', []):
-                repre_thumbnail_path = (
-                    repre.get("published_path") or
-                    os.path.join(repre["stagingDir"], repre["files"])
-                )
+                repre_thumbnail_path = get_representation_path(instance, repre, False)
                 if os.path.exists(repre_thumbnail_path):
                     thumbnail_path = repre_thumbnail_path
                 break
@@ -184,10 +182,7 @@ class IntegrateSlackAPI(pyblish.api.InstancePlugin):
             if (repre.get("review")
                     or "review" in tags
                     or "burnin" in tags):
-                repre_review_path = (
-                    repre.get("published_path") or
-                    os.path.join(repre["stagingDir"], repre["files"])
-                )
+                repre_review_path = get_representation_path(instance, repre, False)
                 if os.path.exists(repre_review_path):
                     review_path = repre_review_path
                 if "burnin" in tags:  # burnin has precedence if exists

--- a/openpype/pipeline/publish/__init__.py
+++ b/openpype/pipeline/publish/__init__.py
@@ -36,6 +36,7 @@ from .lib import (
     filter_instances_for_context_plugin,
     context_plugin_should_run,
     get_instance_staging_dir,
+    get_publish_repre_path,
 )
 
 from .abstract_expected_files import ExpectedFiles
@@ -79,6 +80,7 @@ __all__ = (
     "filter_instances_for_context_plugin",
     "context_plugin_should_run",
     "get_instance_staging_dir",
+    "get_publish_repre_path",
 
     "ExpectedFiles",
 

--- a/openpype/pipeline/publish/lib.py
+++ b/openpype/pipeline/publish/lib.py
@@ -632,3 +632,49 @@ def get_instance_staging_dir(instance):
         instance.data["stagingDir"] = staging_dir
 
     return staging_dir
+
+
+def get_publish_repre_path(instance, repre, only_published):
+    """Get representation path that can be used for integration.
+
+    When 'only_published' is set to true the validation of path is not
+    relevant. In that case we just need what is set in 'published_path'
+    as "reference". The reference is not used to get or upload the file but
+    for reference where the file was published.
+
+    Args:
+        instance (pyblish.Instance): Processed instance object. Used
+            for source of staging dir if representation does not have
+            filled it.
+        repre (dict): Representation on instance which could be and
+            could not be integrated with main integrator.
+        only_published (bool): Care only about published paths and
+            ignore if filepath is not existing anymore.
+
+    Returns:
+        str: Path to representation file.
+        None: Path is not filled or does not exists.
+    """
+
+    published_path = repre.get("published_path")
+    if published_path:
+        published_path = os.path.normpath(published_path)
+        if os.path.exists(published_path):
+            return published_path
+
+    if only_published:
+        return published_path
+
+    comp_files = repre["files"]
+    if isinstance(comp_files, (tuple, list, set)):
+        filename = comp_files[0]
+    else:
+        filename = comp_files
+
+    staging_dir = repre.get("stagingDir")
+    if not staging_dir:
+        staging_dir = get_instance_staging_dir(instance)
+    src_path = os.path.normpath(os.path.join(staging_dir, filename))
+    if os.path.exists(src_path):
+        return src_path
+    return None

--- a/openpype/pipeline/publish/lib.py
+++ b/openpype/pipeline/publish/lib.py
@@ -634,7 +634,7 @@ def get_instance_staging_dir(instance):
     return staging_dir
 
 
-def get_publish_repre_path(instance, repre, only_published):
+def get_publish_repre_path(instance, repre, only_published=False):
     """Get representation path that can be used for integration.
 
     When 'only_published' is set to true the validation of path is not

--- a/openpype/plugins/publish/integrate.py
+++ b/openpype/plugins/publish/integrate.py
@@ -53,52 +53,6 @@ def get_frame_padded(frame, padding):
     return "{frame:0{padding}d}".format(padding=padding, frame=frame)
 
 
-def get_representation_path(instance, repre, only_published):
-    """Get representation path that can be used for integration.
-
-    When 'only_published' is set to true the validation of path is not
-    relevant. In that case we just need what is set in 'published_path'
-    as "reference". The reference is not used to get or upload the file but
-    for reference where the file was published.
-
-    Args:
-        instance (pyblish.Instance): Processed instance object. Used
-            for source of staging dir if representation does not have
-            filled it.
-        repre (dict): Representation on instance which could be and
-            could not be integrated with main integrator.
-        only_published (bool): Care only about published paths and
-            ignore if filepath is not existing anymore.
-
-    Returns:
-        str: Path to representation file.
-        None: Path is not filled or does not exists.
-    """
-
-    published_path = repre.get("published_path")
-    if published_path:
-        published_path = os.path.normpath(published_path)
-        if os.path.exists(published_path):
-            return published_path
-
-    if only_published:
-        return published_path
-
-    comp_files = repre["files"]
-    if isinstance(comp_files, (tuple, list, set)):
-        filename = comp_files[0]
-    else:
-        filename = comp_files
-
-    staging_dir = repre.get("stagingDir")
-    if not staging_dir:
-        staging_dir = instance.data["stagingDir"]
-    src_path = os.path.normpath(os.path.join(staging_dir, filename))
-    if os.path.exists(src_path):
-        return src_path
-    return None
-
-
 class IntegrateAsset(pyblish.api.InstancePlugin):
     """Register publish in the database and transfer files to destinations.
 

--- a/openpype/plugins/publish/integrate.py
+++ b/openpype/plugins/publish/integrate.py
@@ -53,6 +53,52 @@ def get_frame_padded(frame, padding):
     return "{frame:0{padding}d}".format(padding=padding, frame=frame)
 
 
+def get_representation_path(instance, repre, only_published):
+    """Get representation path that can be used for integration.
+
+    When 'only_published' is set to true the validation of path is not
+    relevant. In that case we just need what is set in 'published_path'
+    as "reference". The reference is not used to get or upload the file but
+    for reference where the file was published.
+
+    Args:
+        instance (pyblish.Instance): Processed instance object. Used
+            for source of staging dir if representation does not have
+            filled it.
+        repre (dict): Representation on instance which could be and
+            could not be integrated with main integrator.
+        only_published (bool): Care only about published paths and
+            ignore if filepath is not existing anymore.
+
+    Returns:
+        str: Path to representation file.
+        None: Path is not filled or does not exists.
+    """
+
+    published_path = repre.get("published_path")
+    if published_path:
+        published_path = os.path.normpath(published_path)
+        if os.path.exists(published_path):
+            return published_path
+
+    if only_published:
+        return published_path
+
+    comp_files = repre["files"]
+    if isinstance(comp_files, (tuple, list, set)):
+        filename = comp_files[0]
+    else:
+        filename = comp_files
+
+    staging_dir = repre.get("stagingDir")
+    if not staging_dir:
+        staging_dir = instance.data["stagingDir"]
+    src_path = os.path.normpath(os.path.join(staging_dir, filename))
+    if os.path.exists(src_path):
+        return src_path
+    return None
+
+
 class IntegrateAsset(pyblish.api.InstancePlugin):
     """Register publish in the database and transfer files to destinations.
 


### PR DESCRIPTION
## Brief description
Representation instances don't have a "published_path" attribute when submitting remotely so the Shotgrid integrator plugins were failing expecting it. This PR abstracts the function that the ftrack integrator plugins used into a common module and uses it on the Shotgrid plugins to fix the bug.

## Description
Rendering remotely in the farm we were hitting this bug where "published_data" attribute didn't exist on the representation instances:
```
INFO: Create Shotgrid version: {'id': 290916, 'project': {'id': 2917, 'name': 'zzz', 'type': 'Project'}, 'sg_task': None, 'entity': {'id': 53397, 'name': 'cloud1_10_10', 'type': 'Shot'}, 'code': 'zzz_Shots_cloud1_10_10_DummyTask_v045', 'type': 'Version'}
Traceback (most recent call last):
  File "/usr/openpype/exe.linux-x86_64-3.9/dependencies/pyblish/plugin.py", line 522, in __explicit_process
    runner(*args)
  File "/usr/openpype/exe.linux-x86_64-3.9/openpype/modules/shotgrid/plugins/publish/integrate_shotgrid_version.py", line 67, in process
  File "/sw/nuke/14.0v2/lib/python3.9/posixpath.py", line 142, in basename
    p = os.fspath(p)
TypeError: expected str, bytes or os.PathLike object, not NoneType
```
I checked how the ftrack integrators dealt with it and found this function `_get_repre_path` which accounts for this case so if "published_data" doesn't exist it creates a path of the `stagingDir` attribute instead. I have abstracted that function and placed it under `plugins/integrate.py` (maybe there's a better place for it?) and replaced it on the few cases I saw where plugins relied on the `published_path` (except on the Kitsu integration plugin)

## Testing notes:
1. Create a write render on Nuke
2. Set it to render in the farm
3. Click publish