### PR TITLE
General: Add project code to anatomy

### DIFF
--- a/openpype/pipeline/anatomy.py
+++ b/openpype/pipeline/anatomy.py
@@ -60,6 +60,7 @@ class BaseAnatomy(object):
     def __init__(self, project_doc, local_settings, site_name):
         project_name = project_doc["name"]
         self.project_name = project_name
+        self.project_code = project_doc["data"]["code"]
 
         if (site_name and
                 site_name not in ["studio", "local", get_local_site_id()]):


### PR DESCRIPTION
## Brief description
Added attribute `project_code` to `Anatomy` object.

## Description
Anatomy already have access to almost all attributes from project anatomy except project code. This PR changing it. Technically `Anatomy` is everything what would be needed to get fill data of project.
```
{
    "project": {
        "name": anatomy.project_name,
        "code": anatomy.project_code
    }
}
```

## Testing notes:
Nothing has changed for user.