### PR TITLE
General: Ignore decode error of stdout/stderr in run_subprocess

### DIFF
--- a/openpype/hosts/harmony/plugins/publish/extract_render.py
+++ b/openpype/hosts/harmony/plugins/publish/extract_render.py
@@ -108,9 +108,9 @@ class ExtractRender(pyblish.api.InstancePlugin):
         output = process.communicate()[0]
 
         if process.returncode != 0:
-            raise ValueError(output.decode("utf-8"))
+            raise ValueError(output.decode("utf-8", errors="backslashreplace"))
 
-        self.log.debug(output.decode("utf-8"))
+        self.log.debug(output.decode("utf-8", errors="backslashreplace"))
 
         # Generate representations.
         extension = collection.tail[1:]

--- a/openpype/lib/execute.py
+++ b/openpype/lib/execute.py
@@ -117,12 +117,12 @@ def run_subprocess(*args, **kwargs):
     full_output = ""
     _stdout, _stderr = proc.communicate()
     if _stdout:
-        _stdout = _stdout.decode("utf-8")
+        _stdout = _stdout.decode("utf-8", errors="backslashreplace")
         full_output += _stdout
         logger.debug(_stdout)
 
     if _stderr:
-        _stderr = _stderr.decode("utf-8")
+        _stderr = _stderr.decode("utf-8", errors="backslashreplace")
         # Add additional line break if output already contains stdout
         if full_output:
             full_output += "\n"

--- a/openpype/modules/deadline/repository/custom/plugins/OpenPypeTileAssembler/OpenPypeTileAssembler.py
+++ b/openpype/modules/deadline/repository/custom/plugins/OpenPypeTileAssembler/OpenPypeTileAssembler.py
@@ -204,10 +204,10 @@ def info_about_input(oiiotool_path, filepath):
     _stdout, _stderr = popen.communicate()
     output = ""
     if _stdout:
-        output += _stdout.decode("utf-8")
+        output += _stdout.decode("utf-8", errors="backslashreplace")
 
     if _stderr:
-        output += _stderr.decode("utf-8")
+        output += _stderr.decode("utf-8", errors="backslashreplace")
 
     output = output.replace("\r\n", "\n")
     xml_started = False

--- a/openpype/scripts/otio_burnin.py
+++ b/openpype/scripts/otio_burnin.py
@@ -340,13 +340,11 @@ class ModifiedBurnins(ffmpeg_burnins.Burnins):
 
         _stdout, _stderr = proc.communicate()
         if _stdout:
-            for line in _stdout.split(b"\r\n"):
-                print(line.decode("utf-8"))
+            print(_stdout.decode("utf-8", errors="backslashreplace"))
 
         # This will probably never happen as ffmpeg use stdout
         if _stderr:
-            for line in _stderr.split(b"\r\n"):
-                print(line.decode("utf-8"))
+            print(_stderr.decode("utf-8", errors="backslashreplace"))
 
         if proc.returncode != 0:
             raise RuntimeError(


### PR DESCRIPTION
## Brief description
Ignore decode errors and replace invalid character (byte) with escaped byte character.

## Description
Calling of `run_subprocess` may cause crashes if output contains some unicode character which (for example Polish name of encoder handler).

## Testing notes:
Issue was discovered by a client so testing notes are related to the case.
1. Open TrayPublisher
2. Select family (e.g. Render)
3. Drop video from client to both (source and reveiw) input fields
4. Publish
5. Publishing should went smoothly without issues in ExtractReview plugin