### PR TITLE
AttrDefs: Enhancements of AttrDefs widgets

### DIFF
--- a/openpype/tools/attribute_defs/widgets.py
+++ b/openpype/tools/attribute_defs/widgets.py
@@ -146,6 +146,9 @@ class AttributeDefinitionsWidget(QtWidgets.QWidget):
 
             if attr_def.label:
                 label_widget = QtWidgets.QLabel(attr_def.label, self)
+                tooltip = attr_def.tooltip
+                if tooltip:
+                    label_widget.setToolTip(tooltip)
                 layout.addWidget(
                     label_widget, row, 0, 1, expand_cols
                 )

--- a/openpype/tools/attribute_defs/widgets.py
+++ b/openpype/tools/attribute_defs/widgets.py
@@ -16,7 +16,11 @@ from openpype.lib.attribute_definitions import (
     UISeparatorDef,
     UILabelDef
 )
-from openpype.tools.utils import CustomTextComboBox
+from openpype.tools.utils import (
+    CustomTextComboBox,
+    FocusSpinBox,
+    FocusDoubleSpinBox,
+)
 from openpype.widgets.nice_checkbox import NiceCheckbox
 
 from .files_widget import FilesWidget
@@ -243,10 +247,10 @@ class NumberAttrWidget(_BaseAttrDefWidget):
     def _ui_init(self):
         decimals = self.attr_def.decimals
         if decimals > 0:
-            input_widget = QtWidgets.QDoubleSpinBox(self)
+            input_widget = FocusDoubleSpinBox(self)
             input_widget.setDecimals(decimals)
         else:
-            input_widget = QtWidgets.QSpinBox(self)
+            input_widget = FocusSpinBox(self)
 
         if self.attr_def.tooltip:
             input_widget.setToolTip(self.attr_def.tooltip)

--- a/openpype/tools/utils/__init__.py
+++ b/openpype/tools/utils/__init__.py
@@ -1,4 +1,6 @@
 from .widgets import (
+    FocusSpinBox,
+    FocusDoubleSpinBox,
     CustomTextComboBox,
     PlaceholderLineEdit,
     BaseClickableFrame,
@@ -34,6 +36,8 @@ from .overlay_messages import (
 
 
 __all__ = (
+    "FocusSpinBox",
+    "FocusDoubleSpinBox",
     "CustomTextComboBox",
     "PlaceholderLineEdit",
     "BaseClickableFrame",

--- a/openpype/tools/utils/widgets.py
+++ b/openpype/tools/utils/widgets.py
@@ -13,6 +13,34 @@ from openpype.lib.attribute_definitions import AbstractAttrDef
 log = logging.getLogger(__name__)
 
 
+class FocusSpinBox(QtWidgets.QSpinBox):
+    """QSpinBox which allow scroll wheel changes only in active state."""
+
+    def __init__(self, *args, **kwargs):
+        super(FocusSpinBox, self).__init__(*args, **kwargs)
+        self.setFocusPolicy(QtCore.Qt.StrongFocus)
+
+    def wheelEvent(self, event):
+        if not self.hasFocus():
+            event.ignore()
+        else:
+            super(FocusSpinBox, self).wheelEvent(event)
+
+
+class FocusDoubleSpinBox(QtWidgets.QDoubleSpinBox):
+    """QDoubleSpinBox which allow scroll wheel changes only in active state."""
+
+    def __init__(self, *args, **kwargs):
+        super(FocusDoubleSpinBox, self).__init__(*args, **kwargs)
+        self.setFocusPolicy(QtCore.Qt.StrongFocus)
+
+    def wheelEvent(self, event):
+        if not self.hasFocus():
+            event.ignore()
+        else:
+            super(FocusDoubleSpinBox, self).wheelEvent(event)
+
+
 class CustomTextComboBox(QtWidgets.QComboBox):
     """Combobox which can have different text showed."""
 


### PR DESCRIPTION
## Brief description
Scroll of mouse wheel should not affect number inputs unless thay are clicked in. Label widgets of attribute definitions also have tooltips.

## Testing notes:
1. Labels should have same tooltips as input fields
2. Make sure you have NumberDef in UI
3. Make sure the widget of NumberDef is not active (click elsewhere)
4. Scroll mouse over number input
5. Value should not change
6. Make the widget active (click in)
7. Scroll mouse over number input
8. Value should change
