### PR TITLE
Maya: Create Arnold options on repair.

### DIFF
--- a/openpype/hosts/maya/plugins/publish/validate_ass_relative_paths.py
+++ b/openpype/hosts/maya/plugins/publish/validate_ass_relative_paths.py
@@ -2,6 +2,7 @@ import os
 import types
 
 import maya.cmds as cmds
+from mtoa.core import createOptions
 
 import pyblish.api
 from openpype.pipeline.publish import (
@@ -34,8 +35,7 @@ class ValidateAssRelativePaths(pyblish.api.InstancePlugin):
                 "defaultArnoldRenderOptions.pspath"
             )
         except ValueError:
-            assert False, ("Can not validate, render setting were not opened "
-                           "yet so Arnold setting cannot be validate")
+            assert False, ("Default Arnold options has not been created yet.")
 
         scene_dir, scene_basename = os.path.split(cmds.file(q=True, loc=True))
         scene_name, _ = os.path.splitext(scene_basename)
@@ -66,6 +66,8 @@ class ValidateAssRelativePaths(pyblish.api.InstancePlugin):
 
     @classmethod
     def repair(cls, instance):
+        createOptions()
+
         texture_path = cmds.getAttr("defaultArnoldRenderOptions.tspath")
         procedural_path = cmds.getAttr("defaultArnoldRenderOptions.pspath")
 

--- a/openpype/hosts/maya/plugins/publish/validate_ass_relative_paths.py
+++ b/openpype/hosts/maya/plugins/publish/validate_ass_relative_paths.py
@@ -8,6 +8,7 @@ import pyblish.api
 from openpype.pipeline.publish import (
     RepairAction,
     ValidateContentsOrder,
+    PublishValidationError
 )
 
 
@@ -35,7 +36,9 @@ class ValidateAssRelativePaths(pyblish.api.InstancePlugin):
                 "defaultArnoldRenderOptions.pspath"
             )
         except ValueError:
-            assert False, ("Default Arnold options has not been created yet.")
+            raise PublishValidationError(
+                "Default Arnold options has not been created yet."
+            )
 
         scene_dir, scene_basename = os.path.split(cmds.file(q=True, loc=True))
         scene_name, _ = os.path.splitext(scene_basename)


### PR DESCRIPTION
## Brief description
When validating/repairing we previously required users to open render settings to create the Arnold options. This is done through code now.

## Testing notes:
1. Launch Maya and setup lighting scene without opening render settings.
2. Publish.