### PR TITLE
Deadline: Added support for multiple install dirs in Deadline

### DIFF
--- a/openpype/modules/deadline/repository/custom/plugins/GlobalJobPreLoad.py
+++ b/openpype/modules/deadline/repository/custom/plugins/GlobalJobPreLoad.py
@@ -196,19 +196,21 @@ def get_openpype_versions(dir_list):
     print(">>> Getting OpenPype executable ...")
     openpype_versions = []
 
-    install_dir = DirectoryUtils.SearchDirectoryList(dir_list)
-    if install_dir:
-        print("--- Looking for OpenPype at: {}".format(install_dir))
-        sub_dirs = [
-            f.path for f in os.scandir(install_dir)
-            if f.is_dir()
-        ]
-        for subdir in sub_dirs:
-            version = get_openpype_version_from_path(subdir)
-            if not version:
-                continue
-            print("  - found: {} - {}".format(version, subdir))
-            openpype_versions.append((version, subdir))
+    # special case of multiple install dirs
+    for dir_list in dir_list.split(","):
+        install_dir = DirectoryUtils.SearchDirectoryList(dir_list)
+        if install_dir:
+            print("--- Looking for OpenPype at: {}".format(install_dir))
+            sub_dirs = [
+                f.path for f in os.scandir(install_dir)
+                if f.is_dir()
+            ]
+            for subdir in sub_dirs:
+                version = get_openpype_version_from_path(subdir)
+                if not version:
+                    continue
+                print("  - found: {} - {}".format(version, subdir))
+                openpype_versions.append((version, subdir))
     return openpype_versions
 
 

--- a/openpype/modules/deadline/repository/custom/plugins/OpenPype/OpenPype.py
+++ b/openpype/modules/deadline/repository/custom/plugins/OpenPype/OpenPype.py
@@ -107,17 +107,18 @@ class OpenPypeDeadlinePlugin(DeadlinePlugin):
                 "Scanning for compatible requested "
                 f"version {requested_version}"))
             dir_list = self.GetConfigEntry("OpenPypeInstallationDirs")
-            install_dir = DirectoryUtils.SearchDirectoryList(dir_list)
-            if dir:
-                sub_dirs = [
-                    f.path for f in os.scandir(install_dir)
-                    if f.is_dir()
-                ]
-                for subdir in sub_dirs:
-                    version = self.get_openpype_version_from_path(subdir)
-                    if not version:
-                        continue
-                    openpype_versions.append((version, subdir))
+            for dir_list in dir_list.split(","):
+                install_dir = DirectoryUtils.SearchDirectoryList(dir_list)
+                if install_dir:
+                    sub_dirs = [
+                        f.path for f in os.scandir(install_dir)
+                        if f.is_dir()
+                    ]
+                    for subdir in sub_dirs:
+                        version = self.get_openpype_version_from_path(subdir)
+                        if not version:
+                            continue
+                        openpype_versions.append((version, subdir))
 
         exe_list = self.GetConfigEntry("OpenPypeExecutable")
         exe = FileUtils.SearchFileList(exe_list)


### PR DESCRIPTION
## Brief description
SearchDirectoryList returns FIRST existing so if you would have multiple OP install dirs, it won't search for appropriate version in later ones.

## Additional info
Not sure if this is widely used use case, I need it for automatic tests (2 installations - one for daily, one for PRs), without this it is probably impossible to achieve that.
But I could imagine this would be helpful for using "staging" and "production" isntallation of  OP.


## Testing notes:
1. update DL custom folder
2. try publish to DL without any change (to check that this is not breaking anything)