### PR TITLE
General: Fix original basename frame issues

### DIFF
--- a/openpype/plugins/publish/integrate.py
+++ b/openpype/plugins/publish/integrate.py
@@ -701,7 +701,6 @@ class IntegrateAsset(pyblish.api.InstancePlugin):
             src_collections, remainders = clique.assemble(files)
 
             src_collection = src_collections[0]
-            template_data["originalBasename"] = src_collection.head[:-1]
             destination_indexes = list(src_collection.indexes)
             # Use last frame for minimum padding
             #   - that should cover both 'udim' and 'frame' minimum padding
@@ -723,11 +722,8 @@ class IntegrateAsset(pyblish.api.InstancePlugin):
                 # In case source are published in place we need to
                 # skip renumbering
                 repre_frame_start = repre.get("frameStart")
-                if (
-                    "originalBasename" not in template
-                    and repre_frame_start is not None
-                ):
-                    index_frame_start = int(repre["frameStart"])
+                if repre_frame_start is not None:
+                    index_frame_start = int(repre_frame_start)
                     # Shift destination sequence to the start frame
                     destination_indexes = [
                         index_frame_start + idx
@@ -783,7 +779,6 @@ class IntegrateAsset(pyblish.api.InstancePlugin):
 
         else:
             # Single file
-            template_data["originalBasename"], _ = os.path.splitext(fname)
             # Manage anatomy template data
             template_data.pop("frame", None)
             if is_udim:
@@ -795,7 +790,7 @@ class IntegrateAsset(pyblish.api.InstancePlugin):
             dst = os.path.normpath(template_filled)
 
             # Single file transfer
-            src = os.path.join(stagingdir, fname)
+            src = os.path.join(stagingdir, files)
             transfers = [(src, dst)]
 
         # todo: Are we sure the assumption each representation

--- a/openpype/plugins/publish/integrate.py
+++ b/openpype/plugins/publish/integrate.py
@@ -624,7 +624,7 @@ class IntegrateAsset(pyblish.api.InstancePlugin):
         is_udim = bool(repre.get("udim"))
 
         # handle publish in place
-        if "originalDirname" in template:
+        if "{originalDirname}" in template:
             # store as originalDirname only original value without project root
             # if instance collected originalDirname is present, it should be
             # used for all represe


### PR DESCRIPTION
## Brief description
Treat `{originalBasename}` in different way then standard files processing. In case template should use `{originalBasename}` the transfers will use them as they are without any changes or handling of frames.

## Description
Frames handling is problematic with original basename because their padding can't be defined to match padding in source filenames. Also it limits the usage of functionality to "must have frame at end of fiename". This is proposal how that could be solved by simply ignoring frame handling and using filenames as are on representation. First frame is still stored to representation context but is not used in formatting part. This way we don't have to care about padding of frames at all.

### Additional information
This is a proposal, I could miss some other issues related to the feature.

## Testing notes:
1. Add templates to use `{originalBasename}`
2. Set to use the template for your usecase (could be e.g. for `render` family in `traypublisher`)
3. Publish something which should use the template
   - single file
   - sequence - different paddings
4. Validate if the filenames are correct and did not change
5. Validate if something else did not break