### PR TITLE
Hiero/Nuke: originalBasename editorial publishing and loading

### DIFF
--- a/openpype/hosts/nuke/plugins/load/load_clip.py
+++ b/openpype/hosts/nuke/plugins/load/load_clip.py
@@ -222,13 +222,12 @@ class LoadClip(plugin.NukeLoader):
         representation = deepcopy(representation)
         context = representation["context"]
         template = representation["data"]["template"]
-        frame = context["frame"]
-        hashed_frame = "#" * len(str(frame))
-
         if (
             "{originalBasename}" in template
             and "frame" in context
         ):
+            frame = context["frame"]
+            hashed_frame = "#" * len(str(frame))
             origin_basename = context["originalBasename"]
             context["originalBasename"] = origin_basename.replace(
                 frame, hashed_frame

--- a/openpype/hosts/nuke/plugins/load/load_clip.py
+++ b/openpype/hosts/nuke/plugins/load/load_clip.py
@@ -220,8 +220,21 @@ class LoadClip(plugin.NukeLoader):
             dict: altered representation data
         """
         representation = deepcopy(representation)
-        frame = representation["context"]["frame"]
-        representation["context"]["frame"] = "#" * len(str(frame))
+        context = representation["context"]
+        template = representation["data"]["template"]
+        frame = context["frame"]
+        hashed_frame = "#" * len(str(frame))
+
+        if (
+            "{originalBasename}" in template
+            and "frame" in context
+        ):
+            origin_basename = context["originalBasename"]
+            context["originalBasename"] = origin_basename.replace(
+                frame, hashed_frame
+            )
+
+        representation["context"]["frame"] = hashed_frame
         return representation
 
     def update(self, container, representation):

--- a/openpype/plugins/publish/collect_otio_subset_resources.py
+++ b/openpype/plugins/publish/collect_otio_subset_resources.py
@@ -26,28 +26,6 @@ class CollectOtioSubsetResources(pyblish.api.InstancePlugin):
     families = ["clip"]
     hosts = ["resolve", "hiero", "flame"]
 
-    def get_template_name(self, instance):
-        """Return anatomy template name to use for integration"""
-
-        # Anatomy data is pre-filled by Collectors
-        context = instance.context
-        project_name = context.data["projectName"]
-
-        # Task can be optional in anatomy data
-        host_name = context.data["hostName"]
-        family = instance.data["family"]
-        anatomy_data = instance.context.data["anatomyData"]
-        task_info = anatomy_data.get("task") or {}
-
-        return get_publish_template_name(
-            project_name,
-            host_name,
-            family,
-            task_name=task_info.get("name"),
-            task_type=task_info.get("type"),
-            project_settings=context.data["project_settings"],
-            logger=self.log
-        )
 
     def process(self, instance):
 
@@ -116,6 +94,7 @@ class CollectOtioSubsetResources(pyblish.api.InstancePlugin):
         frame_start = instance.data["frameStart"]
         frame_end = frame_start + (media_out - media_in)
 
+        # Fit start /end frame to media in /out
         if "{originalDirname}" in template:
             frame_start = media_in
             frame_end = media_out
@@ -258,3 +237,26 @@ class CollectOtioSubsetResources(pyblish.api.InstancePlugin):
         if kwargs.get("trim") is True:
             representation_data["tags"] = ["trim"]
         return representation_data
+
+    def get_template_name(self, instance):
+        """Return anatomy template name to use for integration"""
+
+        # Anatomy data is pre-filled by Collectors
+        context = instance.context
+        project_name = context.data["projectName"]
+
+        # Task can be optional in anatomy data
+        host_name = context.data["hostName"]
+        family = instance.data["family"]
+        anatomy_data = instance.context.data["anatomyData"]
+        task_info = anatomy_data.get("task") or {}
+
+        return get_publish_template_name(
+            project_name,
+            host_name,
+            family,
+            task_name=task_info.get("name"),
+            task_type=task_info.get("type"),
+            project_settings=context.data["project_settings"],
+            logger=self.log
+        )

--- a/openpype/plugins/publish/collect_otio_subset_resources.py
+++ b/openpype/plugins/publish/collect_otio_subset_resources.py
@@ -95,7 +95,7 @@ class CollectOtioSubsetResources(pyblish.api.InstancePlugin):
         frame_end = frame_start + (media_out - media_in)
 
         # Fit start /end frame to media in /out
-        if "{originalDirname}" in template:
+        if "{originalBasename}" in template:
             frame_start = media_in
             frame_end = media_out
 

--- a/openpype/plugins/publish/collect_otio_subset_resources.py
+++ b/openpype/plugins/publish/collect_otio_subset_resources.py
@@ -22,7 +22,7 @@ class CollectOtioSubsetResources(pyblish.api.InstancePlugin):
     """Get Resources for a subset version"""
 
     label = "Collect OTIO Subset Resources"
-    order = pyblish.api.CollectorOrder + 0.0021
+    order = pyblish.api.CollectorOrder + 0.491
     families = ["clip"]
     hosts = ["resolve", "hiero", "flame"]
 
@@ -50,9 +50,9 @@ class CollectOtioSubsetResources(pyblish.api.InstancePlugin):
 
         # get basic variables
         otio_clip = instance.data["otioClip"]
-        otio_avalable_range = otio_clip.available_range()
-        media_fps = otio_avalable_range.start_time.rate
-        available_duration = otio_avalable_range.duration.value
+        otio_available_range = otio_clip.available_range()
+        media_fps = otio_available_range.start_time.rate
+        available_duration = otio_available_range.duration.value
 
         # get available range trimmed with processed retimes
         retimed_attributes = get_media_range_with_retimes(
@@ -248,7 +248,7 @@ class CollectOtioSubsetResources(pyblish.api.InstancePlugin):
         # Task can be optional in anatomy data
         host_name = context.data["hostName"]
         family = instance.data["family"]
-        anatomy_data = instance.context.data["anatomyData"]
+        anatomy_data = instance.data["anatomyData"]
         task_info = anatomy_data.get("task") or {}
 
         return get_publish_template_name(


### PR DESCRIPTION
## Brief description
Publishing and loading `originalBasename` is working as expected

## Description
Frame-ranges on version document is now correctly defined to fit original media frame range which is published. It means loading is now correctly identifying frame start and end on clip loader in Nuke.  

## Additional info
Loading is only fixed for Nuke but other DCC's should also be treated. Perhaps some abstracted implementation in wider scale should be done.

## Testing notes:
1. Set to use the template for your use case. `plate` family with `source` template.
![Animation](https://user-images.githubusercontent.com/40640033/218154057-55676948-886b-4bd5-8f07-ec50c094bd0f.gif)
2. Open Hiero and add a clip, create to publishable and publish 
3. Open Nuke Load published clip and all should play as it suppose to