### PR TITLE
Strict Error Checking Default

### DIFF
--- a/openpype/hosts/maya/plugins/publish/collect_render.py
+++ b/openpype/hosts/maya/plugins/publish/collect_render.py
@@ -319,7 +319,7 @@ class CollectMayaRender(pyblish.api.ContextPlugin):
                     "renderSetupIncludeLights"
                 ),
                 "strict_error_checking": render_instance.data.get(
-                    "strict_error_checking", False
+                    "strict_error_checking", True
                 )
             }
 

--- a/openpype/hosts/maya/plugins/publish/collect_render.py
+++ b/openpype/hosts/maya/plugins/publish/collect_render.py
@@ -42,7 +42,6 @@ Provides:
 import re
 import os
 import platform
-import json
 
 from maya import cmds
 import maya.app.renderSetup.model.renderSetup as renderSetup

--- a/openpype/hosts/maya/plugins/publish/collect_render.py
+++ b/openpype/hosts/maya/plugins/publish/collect_render.py
@@ -320,7 +320,8 @@ class CollectMayaRender(pyblish.api.ContextPlugin):
                     "renderSetupIncludeLights"
                 ),
                 "strict_error_checking": render_instance.data.get(
-                    "strict_error_checking")
+                    "strict_error_checking", False
+                )
             }
 
             # Collect Deadline url if Deadline module is enabled


### PR DESCRIPTION
## Brief description
Provide default of strict error checking for instances created prior to PR.

## Testing notes:
1. Create a render instance.
2. Delete the strict error checking attribute to simulate having an instance from before the PR was made.
3. Publish.