### PR TITLE
Default Ftrack Family on RenderLayer

### DIFF
--- a/openpype/settings/defaults/project_settings/ftrack.json
+++ b/openpype/settings/defaults/project_settings/ftrack.json
@@ -324,7 +324,8 @@
                         "animation",
                         "look",
                         "rig",
-                        "camera"
+                        "camera",
+                        "renderlayer"
                     ],
                     "task_types": [],
                     "tasks": [],

--- a/openpype/settings/defaults/project_settings/ftrack.json
+++ b/openpype/settings/defaults/project_settings/ftrack.json
@@ -324,8 +324,7 @@
                         "animation",
                         "look",
                         "rig",
-                        "camera",
-                        "renderlayer"
+                        "camera"
                     ],
                     "task_types": [],
                     "tasks": [],


### PR DESCRIPTION
## Brief description
With default settings, renderlayers in Maya were not being tagged with the Ftrack family leading to confusion when doing reviews.

## Testing notes:
1. Start a new pipeline/project with default settings.
2. Create render in Maya and Publish.