### PR TITLE
General: Don't use mongo call in load utils

### DIFF
--- a/openpype/pipeline/load/utils.py
+++ b/openpype/pipeline/load/utils.py
@@ -28,7 +28,6 @@ from openpype.lib import (
     TemplateUnsolved,
 )
 from openpype.pipeline import (
-    schema,
     legacy_io,
     Anatomy,
 )
@@ -643,7 +642,10 @@ def get_representation_path(representation, root=None, dbcon=None):
 
     def path_from_config():
         try:
-            version_, subset, asset, project = dbcon.parenthood(representation)
+            project_name = dbcon.active_project()
+            version_, subset, asset, project = get_representation_parents(
+                project_name, representation
+            )
         except ValueError:
             log.debug(
                 "Representation %s wasn't found in database, "


### PR DESCRIPTION
## Brief description
Replaced forgotten usage of `dbcon.parenthood` with function `get_representation_parents`.

## Testing notes:
Don't know if there is a way how to test this change. Technically it should never get to that point if the files from representation are available on the machine.