### PR TITLE
Publisher: Fix reopen bug

### DIFF
--- a/openpype/tools/publisher/window.py
+++ b/openpype/tools/publisher/window.py
@@ -366,7 +366,7 @@ class PublisherWindow(QtWidgets.QDialog):
 
     def make_sure_is_visible(self):
         if self._window_is_visible:
-            self.setWindowState(QtCore.Qt.ActiveWindow)
+            self.setWindowState(QtCore.Qt.WindowActive)
 
         else:
             self.show()


### PR DESCRIPTION
## Brief description
Use right name of constant 'ActiveWindow' -> 'WindowActive'.

## Testing notes:
1. Start a host with Publisher
2. Open Publisher
3. Keep it opened and try open it again
4. Nothing should crash

Crash is described in https://github.com/ynput/OpenPype/issues/4462

Resolves https://github.com/ynput/OpenPype/issues/4462