### PR TITLE
Kitsu: fix  extra frame with frameEnd calcul using frames duration

### DIFF
--- a/openpype/modules/kitsu/utils/update_op_with_zou.py
+++ b/openpype/modules/kitsu/utils/update_op_with_zou.py
@@ -113,17 +113,17 @@ def update_op_assets(
         except (TypeError, ValueError):
             frame_in = 1001
         item_data["frameStart"] = frame_in
-        # Frames duration, fallback on 0
+        # Frames duration, fallback on 1
         try:
             # NOTE nb_frames is stored directly in item
             # because of zou's legacy design
-            frames_duration = int(item.get("nb_frames", 0))
+            frames_duration = int(item.get("nb_frames", 1))
         except (TypeError, ValueError):
-            frames_duration = 0
+            frames_duration = 1
         # Frame out, fallback on frame_in + duration or project's value or 1001
         frame_out = item_data.pop("frame_out", None)
         if not frame_out:
-            frame_out = frame_in + frames_duration
+            frame_out = frame_in + frames_duration - 1
         try:
             frame_out = int(frame_out)
         except (TypeError, ValueError):

--- a/openpype/modules/kitsu/utils/update_zou_with_op.py
+++ b/openpype/modules/kitsu/utils/update_zou_with_op.py
@@ -174,7 +174,9 @@ def sync_zou_from_op_project(
                 doc["name"],
                 frame_in=doc["data"]["frameStart"],
                 frame_out=doc["data"]["frameEnd"],
-                nb_frames=doc["data"]["frameEnd"] - doc["data"]["frameStart"],
+                nb_frames=(
+                    doc["data"]["frameEnd"] - doc["data"]["frameStart"] + 1
+                ),
             )
 
         elif match.group(2):  # Sequence
@@ -229,7 +231,7 @@ def sync_zou_from_op_project(
                             "frame_in": frame_in,
                             "frame_out": frame_out,
                         },
-                        "nb_frames": frame_out - frame_in,
+                        "nb_frames": frame_out - frame_in + 1,
                     }
                 )
             entity = gazu.raw.update("entities", zou_id, entity_data)


### PR DESCRIPTION
## Brief description
Updating OpenPype shot data `frameEnd` using Kitsu frames duration data add an extra frame with the frame range.

## Description
Because frameEnd is include in shot frame range, to avoid extra frame, we should have :
`frameEnd = frameStart + frames_duration - 1`
`frames_duration = frameEnd - frameStart + 1`
with
`frameStart >= frameEnd `
`frames_duration > 0`