### PR TITLE
Photoshop: fix missing legacy io for legacy instances

### DIFF
--- a/openpype/hosts/aftereffects/plugins/create/create_render.py
+++ b/openpype/hosts/aftereffects/plugins/create/create_render.py
@@ -6,8 +6,7 @@ from openpype.hosts.aftereffects import api
 from openpype.pipeline import (
     Creator,
     CreatedInstance,
-    CreatorError,
-    legacy_io,
+    CreatorError
 )
 from openpype.hosts.aftereffects.api.pipeline import cache_and_get_instances
 from openpype.lib import prepare_template_data
@@ -195,7 +194,7 @@ class RenderCreator(Creator):
             instance_data.pop("uuid")
 
         if not instance_data.get("task"):
-            instance_data["task"] = legacy_io.Session.get("AVALON_TASK")
+            instance_data["task"] = self.create_context.get_current_task_name()
 
         if not instance_data.get("creator_attributes"):
             is_old_farm = instance_data["family"] != "renderLocal"

--- a/openpype/hosts/aftereffects/plugins/create/create_render.py
+++ b/openpype/hosts/aftereffects/plugins/create/create_render.py
@@ -126,7 +126,7 @@ class RenderCreator(Creator):
             subset_change = _changes.get("subset")
             if subset_change:
                 api.get_stub().rename_item(created_inst.data["members"][0],
-                                           subset_change[1])
+                                           subset_change.new_value)
 
     def remove_instances(self, instances):
         for instance in instances:

--- a/openpype/hosts/aftereffects/plugins/create/workfile_creator.py
+++ b/openpype/hosts/aftereffects/plugins/create/workfile_creator.py
@@ -2,8 +2,7 @@ import openpype.hosts.aftereffects.api as api
 from openpype.client import get_asset_by_name
 from openpype.pipeline import (
     AutoCreator,
-    CreatedInstance,
-    legacy_io,
+    CreatedInstance
 )
 from openpype.hosts.aftereffects.api.pipeline import cache_and_get_instances
 
@@ -38,10 +37,11 @@ class AEWorkfileCreator(AutoCreator):
                 existing_instance = instance
                 break
 
-        project_name = legacy_io.Session["AVALON_PROJECT"]
-        asset_name = legacy_io.Session["AVALON_ASSET"]
-        task_name = legacy_io.Session["AVALON_TASK"]
-        host_name = legacy_io.Session["AVALON_APP"]
+        context = self.create_context
+        project_name = context.get_current_project_name()
+        asset_name = context.get_current_asset_name()
+        task_name = context.get_current_task_name()
+        host_name = context.host_name
 
         if existing_instance is None:
             asset_doc = get_asset_by_name(project_name, asset_name)

--- a/openpype/hosts/photoshop/plugins/create/create_image.py
+++ b/openpype/hosts/photoshop/plugins/create/create_image.py
@@ -193,7 +193,7 @@ class ImageCreator(Creator):
             instance_data.pop("uuid")
 
         if not instance_data.get("task"):
-            instance_data["task"] = legacy_io.Session.get("AVALON_TASK")
+            instance_data["task"] = self.create_context.get_current_task_name()
 
         if not instance_data.get("variant"):
             instance_data["variant"] = ''

--- a/openpype/hosts/photoshop/plugins/create/workfile_creator.py
+++ b/openpype/hosts/photoshop/plugins/create/workfile_creator.py
@@ -2,8 +2,7 @@ import openpype.hosts.photoshop.api as api
 from openpype.client import get_asset_by_name
 from openpype.pipeline import (
     AutoCreator,
-    CreatedInstance,
-    legacy_io
+    CreatedInstance
 )
 from openpype.hosts.photoshop.api.pipeline import cache_and_get_instances
 
@@ -38,10 +37,11 @@ class PSWorkfileCreator(AutoCreator):
                 existing_instance = instance
                 break
 
-        project_name = legacy_io.Session["AVALON_PROJECT"]
-        asset_name = legacy_io.Session["AVALON_ASSET"]
-        task_name = legacy_io.Session["AVALON_TASK"]
-        host_name = legacy_io.Session["AVALON_APP"]
+        context = self.create_context
+        project_name = context.get_current_project_name()
+        asset_name = context.get_current_asset_name()
+        task_name = context.get_current_task_name()
+        host_name = context.host_name
         if existing_instance is None:
             asset_doc = get_asset_by_name(project_name, asset_name)
             subset_name = self.get_subset_name(


### PR DESCRIPTION
## Brief description
`legacy_io` import was removed, but usage stayed. 

## Description
Usage of `legacy_io` should be eradicated, in creators it should be replaced by `self.create_context.get_current_project_name/asset_name/task_name`.

## Additional info
Source issue for this was found in automatic tests, it might be complicated to replicate it as it occurs in legacy instances without proper task.
It should be enough to try publishing to make sure it doesn't break regular process. (Automatic test will be fixed by this PR.)


## Testing notes:
1. Try to publish workflow - create new instance, publish in PS
1. Try to publish workflow - create new instance, publish in AE