### PR TITLE
Global: fixing python2 incompatibility 

### DIFF
--- a/openpype/pipeline/tempdir.py
+++ b/openpype/pipeline/tempdir.py
@@ -54,6 +54,6 @@ def create_custom_tempdir(project_name, anatomy=None):
             os.makedirs(custom_tempdir)
         except IOError as error:
             raise IOError(
-                "Path couldn't be created: {}".format(error)) from error
+                "Path couldn't be created: {}".format(error))
 
     return custom_tempdir


### PR DESCRIPTION
## Brief description
Fixing python2 incompatibility

## Description
Python 3 only compatible code had slipped into codebase.


Resolves https://github.com/ynput/OpenPype/issues/4475