### PR TITLE
Update Asset field of creator Instances in Maya Template Builder

### DIFF
--- a/openpype/hosts/maya/api/workfile_template_builder.py
+++ b/openpype/hosts/maya/api/workfile_template_builder.py
@@ -50,6 +50,7 @@ class MayaTemplateBuilder(AbstractTemplateBuilder):
             return True
 
         # update imported sets information
+        asset_name = get_current_asset_name()
         for node in imported_sets:
             if not cmds.attributeQuery("id", node=node, exists=True):
                 continue
@@ -57,9 +58,9 @@ class MayaTemplateBuilder(AbstractTemplateBuilder):
                 continue
             if not cmds.attributeQuery("asset", node=node, exists=True):
                 continue
-            asset = legacy_io.Session["AVALON_ASSET"]
 
-            cmds.setAttr("{}.asset".format(node), asset, type="string")
+            cmds.setAttr(
+                "{}.asset".format(node), asset_name, type="string")
 
         return True
 

--- a/openpype/hosts/maya/api/workfile_template_builder.py
+++ b/openpype/hosts/maya/api/workfile_template_builder.py
@@ -2,7 +2,7 @@ import json
 
 from maya import cmds
 
-from openpype.pipeline import registered_host, legacy_io
+from openpype.pipeline import registered_host, get_current_asset_name
 from openpype.pipeline.workfile.workfile_template_builder import (
     TemplateAlreadyImported,
     AbstractTemplateBuilder,


### PR DESCRIPTION
## Brief description
When we build a template with Maya Template Builder, it will update the asset field of the sets (creator instances) that are imported from the template. 

## Description
When building a template, we also want to define the publishable content in advance: create an instance of a model, or look, etc., to speed up the workflow and reduce the number of questions we are asked. After building a work file from a saved template that contains pre-created instances, the template builder should update the asset field to the current asset.

## Additional info
As an aside, for some instances that contain CbId, I didn't know if we should update the ID or not. 

## Testing notes:
1. Create a template base on the documentation.
2. Make sure that your template contains a creator instance. 
3. In a new asset, build workfile from template.
4. You should see that asset field is updated to the current one. 

![image](https://user-images.githubusercontent.com/68907585/219065104-bd117405-9f5b-4968-94a6-9be2c32a4ec2.png)
