### PR TITLE
Publisher: Less confusing tab changes

### DIFF
--- a/openpype/tools/publisher/window.py
+++ b/openpype/tools/publisher/window.py
@@ -647,10 +647,7 @@ class PublisherWindow(QtWidgets.QDialog):
         #   otherwise 'create' is used
         # - this happens only on first show
         if first_reset:
-            if self._overview_widget.has_items():
-                self._go_to_publish_tab()
-            else:
-                self._go_to_create_tab()
+            self._go_to_create_tab()
 
         elif (
             not self._is_on_create_tab()

--- a/openpype/tools/publisher/window.py
+++ b/openpype/tools/publisher/window.py
@@ -566,11 +566,11 @@ class PublisherWindow(QtWidgets.QDialog):
     def _go_to_publish_tab(self):
         self._set_current_tab("publish")
 
-    def _go_to_details_tab(self):
-        self._set_current_tab("details")
-
     def _go_to_report_tab(self):
         self._set_current_tab("report")
+
+    def _go_to_details_tab(self):
+        self._set_current_tab("details")
 
     def _is_on_create_tab(self):
         return self._is_current_tab("create")
@@ -578,11 +578,11 @@ class PublisherWindow(QtWidgets.QDialog):
     def _is_on_publish_tab(self):
         return self._is_current_tab("publish")
 
-    def _is_on_details_tab(self):
-        return self._is_current_tab("details")
-
     def _is_on_report_tab(self):
         return self._is_current_tab("report")
+
+    def _is_on_details_tab(self):
+        return self._is_current_tab("details")
 
     def _set_publish_overlay_visibility(self, visible):
         if visible:

--- a/openpype/tools/publisher/window.py
+++ b/openpype/tools/publisher/window.py
@@ -649,11 +649,8 @@ class PublisherWindow(QtWidgets.QDialog):
         if first_reset:
             self._go_to_create_tab()
 
-        elif (
-            not self._is_on_create_tab()
-            and not self._is_on_publish_tab()
-        ):
-            # If current tab is not 'Create' or 'Publish' go to 'Publish'
+        elif self._is_on_report_tab():
+            # Go to 'Publish' tab if is on 'Details' tab
             #   - this can happen when publishing started and was reset
             #       at that moment it doesn't make sense to stay at publish
             #       specific tabs.


### PR DESCRIPTION
## Brief description
A little bit less confusing automated tab changes in Publisher tool.

## Description
First reset of publisher won't trigger change of tab to anything else than 'Create' tab. Reset of publisher will change tab only if user is on Report tab -> Won't change tab if is on 'Details' tab.

## Testing notes:
Stay at `Create` tab on open
1. Open publisher in scene where is something already created
2. Publisher should stay at `Create` tab

Don't change tab on reset
1. Run publishing
2. When stopped hit reset
3. Only if you're on `Report` tab it should change tab to `Publish` but not in any other case