### PR TITLE
Publisher: Report also crashed creators and convertors

### DIFF
--- a/openpype/pipeline/create/context.py
+++ b/openpype/pipeline/create/context.py
@@ -21,6 +21,7 @@ from openpype.lib.attribute_definitions import (
 )
 from openpype.host import IPublishHost
 from openpype.pipeline import legacy_io
+from openpype.pipeline.plugin_discover import DiscoverResult
 
 from .creator_plugins import (
     Creator,
@@ -1620,8 +1621,7 @@ class CreateContext:
 
         from openpype.pipeline import OpenPypePyblishPluginMixin
         from openpype.pipeline.publish import (
-            publish_plugins_discover,
-            DiscoverResult
+            publish_plugins_discover
         )
 
         # Reset publish plugins

--- a/openpype/pipeline/create/context.py
+++ b/openpype/pipeline/create/context.py
@@ -1379,6 +1379,8 @@ class CreateContext:
         # Instances by their ID
         self._instances_by_id = {}
 
+        self.creator_discover_result = None
+        self.convertor_discover_result = None
         # Discovered creators
         self.creators = {}
         # Prepare categories of creators
@@ -1666,7 +1668,9 @@ class CreateContext:
         creators = {}
         autocreators = {}
         manual_creators = {}
-        for creator_class in discover_creator_plugins():
+        report = discover_creator_plugins(return_report=True)
+        self.creator_discover_result = report
+        for creator_class in report.plugins:
             if inspect.isabstract(creator_class):
                 self.log.info(
                     "Skipping abstract Creator {}".format(str(creator_class))
@@ -1711,7 +1715,9 @@ class CreateContext:
 
     def _reset_convertor_plugins(self):
         convertors_plugins = {}
-        for convertor_class in discover_convertor_plugins():
+        report = discover_convertor_plugins(return_report=True)
+        self.convertor_discover_result = report
+        for convertor_class in report.plugins:
             if inspect.isabstract(convertor_class):
                 self.log.info(
                     "Skipping abstract Creator {}".format(str(convertor_class))

--- a/openpype/pipeline/create/context.py
+++ b/openpype/pipeline/create/context.py
@@ -8,6 +8,9 @@ import inspect
 from uuid import uuid4
 from contextlib import contextmanager
 
+import pyblish.logic
+import pyblish.api
+
 from openpype.client import get_assets, get_asset_by_name
 from openpype.settings import (
     get_system_settings,
@@ -1619,8 +1622,6 @@ class CreateContext:
         self._reset_convertor_plugins()
 
     def _reset_publish_plugins(self, discover_publish_plugins):
-        import pyblish.logic
-
         from openpype.pipeline import OpenPypePyblishPluginMixin
         from openpype.pipeline.publish import (
             publish_plugins_discover
@@ -1629,7 +1630,7 @@ class CreateContext:
         # Reset publish plugins
         self._attr_plugins_by_family = {}
 
-        discover_result = DiscoverResult()
+        discover_result = DiscoverResult(pyblish.api.Plugin)
         plugins_with_defs = []
         plugins_by_targets = []
         plugins_mismatch_targets = []

--- a/openpype/pipeline/create/creator_plugins.py
+++ b/openpype/pipeline/create/creator_plugins.py
@@ -153,6 +153,12 @@ class BaseCreator:
     Single object should be used for multiple instances instead of single
     instance per one creator object. Do not store temp data or mid-process data
     to `self` if it's not Plugin specific.
+
+    Args:
+        project_settings (Dict[str, Any]): Project settings.
+        system_settings (Dict[str, Any]): System settings.
+        create_context (CreateContext): Context which initialized creator.
+        headless (bool): Running in headless mode.
     """
 
     # Label shown in UI

--- a/openpype/pipeline/create/creator_plugins.py
+++ b/openpype/pipeline/create/creator_plugins.py
@@ -605,12 +605,12 @@ class AutoCreator(BaseCreator):
         pass
 
 
-def discover_creator_plugins():
-    return discover(BaseCreator)
+def discover_creator_plugins(*args, **kwargs):
+    return discover(BaseCreator, *args, **kwargs)
 
 
-def discover_convertor_plugins():
-    return discover(SubsetConvertorPlugin)
+def discover_convertor_plugins(*args, **kwargs):
+    return discover(SubsetConvertorPlugin, *args, **kwargs)
 
 
 def discover_legacy_creator_plugins():

--- a/openpype/pipeline/plugin_discover.py
+++ b/openpype/pipeline/plugin_discover.py
@@ -135,11 +135,12 @@ class PluginDiscoverContext(object):
             allow_duplicates (bool): Validate class name duplications.
             ignore_classes (list): List of classes that will be ignored
                 and not added to result.
+            return_report (bool): Output will be full report if set to 'True'.
 
         Returns:
-            DiscoverResult: Object holding succesfully discovered plugins,
-                ignored plugins, plugins with missing abstract implementation
-                and duplicated plugin.
+            Union[DiscoverResult, list[Any]]: Object holding successfully
+                discovered plugins, ignored plugins, plugins with missing
+                abstract implementation and duplicated plugin.
         """
 
         if not ignore_classes:
@@ -268,9 +269,34 @@ class _GlobalDiscover:
         return cls._context
 
 
-def discover(superclass, allow_duplicates=True):
+def discover(
+    superclass,
+    allow_duplicates=True,
+    ignore_classes=None,
+    return_report=False
+):
+    """Find and return subclasses of `superclass`
+
+    Args:
+        superclass (type): Class which determines discovered subclasses.
+        allow_duplicates (bool): Validate class name duplications.
+        ignore_classes (list): List of classes that will be ignored
+            and not added to result.
+        return_report (bool): Output will be full report if set to 'True'.
+
+    Returns:
+        Union[DiscoverResult, list[Any]]: Object holding successfully
+            discovered plugins, ignored plugins, plugins with missing
+            abstract implementation and duplicated plugin.
+    """
+
     context = _GlobalDiscover.get_context()
-    return context.discover(superclass, allow_duplicates)
+    return context.discover(
+        superclass,
+        allow_duplicates,
+        ignore_classes,
+        return_report
+    )
 
 
 def get_last_discovered_plugins(superclass):

--- a/openpype/pipeline/publish/__init__.py
+++ b/openpype/pipeline/publish/__init__.py
@@ -25,7 +25,6 @@ from .publish_plugins import (
 from .lib import (
     get_publish_template_name,
 
-    DiscoverResult,
     publish_plugins_discover,
     load_help_content_from_plugin,
     load_help_content_from_filepath,
@@ -68,7 +67,6 @@ __all__ = (
 
     "get_publish_template_name",
 
-    "DiscoverResult",
     "publish_plugins_discover",
     "load_help_content_from_plugin",
     "load_help_content_from_filepath",

--- a/openpype/pipeline/publish/lib.py
+++ b/openpype/pipeline/publish/lib.py
@@ -270,7 +270,7 @@ def publish_plugins_discover(paths=None):
     """
 
     # The only difference with `pyblish.api.discover`
-    result = DiscoverResult()
+    result = DiscoverResult(pyblish.api.Plugin)
 
     plugins = dict()
     plugin_names = []

--- a/openpype/pipeline/publish/lib.py
+++ b/openpype/pipeline/publish/lib.py
@@ -21,6 +21,7 @@ from openpype.settings import (
 from openpype.pipeline import (
     tempdir
 )
+from openpype.pipeline.plugin_discover import DiscoverResult
 
 from .contants import (
     DEFAULT_PUBLISH_TEMPLATE,
@@ -200,28 +201,6 @@ def get_publish_template_name(
     if profile:
         template = profile["template_name"]
     return template or default_template
-
-
-class DiscoverResult:
-    """Hold result of publish plugins discovery.
-
-    Stores discovered plugins duplicated plugins and file paths which
-    crashed on execution of file.
-    """
-    def __init__(self):
-        self.plugins = []
-        self.crashed_file_paths = {}
-        self.duplicated_plugins = []
-
-    def __iter__(self):
-        for plugin in self.plugins:
-            yield plugin
-
-    def __getitem__(self, item):
-        return self.plugins[item]
-
-    def __setitem__(self, item, value):
-        self.plugins[item] = value
 
 
 class HelpContent:

--- a/openpype/tools/publisher/control.py
+++ b/openpype/tools/publisher/control.py
@@ -169,6 +169,8 @@ class PublishReport:
 
     def __init__(self, controller):
         self.controller = controller
+        self._create_discover_result = None
+        self._convert_discover_result = None
         self._publish_discover_result = None
         self._plugin_data = []
         self._plugin_data_with_plugin = []
@@ -181,6 +183,10 @@ class PublishReport:
     def reset(self, context, create_context):
         """Reset report and clear all data."""
 
+        self._create_discover_result = create_context.creator_discover_result
+        self._convert_discover_result = (
+            create_context.convertor_discover_result
+        )
         self._publish_discover_result = create_context.publish_discover_result
         self._plugin_data = []
         self._plugin_data_with_plugin = []
@@ -293,9 +299,19 @@ class PublishReport:
                 if plugin not in self._stored_plugins:
                     plugins_data.append(self._create_plugin_data_item(plugin))
 
-        crashed_file_paths = {}
+        reports = []
+        if self._create_discover_result is not None:
+            reports.append(self._create_discover_result)
+
+        if self._convert_discover_result is not None:
+            reports.append(self._convert_discover_result)
+
         if self._publish_discover_result is not None:
-            items = self._publish_discover_result.crashed_file_paths.items()
+            reports.append(self._publish_discover_result)
+
+        crashed_file_paths = {}
+        for report in reports:
+            items = report.crashed_file_paths.items()
             for filepath, exc_info in items:
                 crashed_file_paths[filepath] = "".join(
                     traceback.format_exception(*exc_info)

--- a/openpype/tools/publisher/widgets/create_widget.py
+++ b/openpype/tools/publisher/widgets/create_widget.py
@@ -457,13 +457,14 @@ class CreateWidget(QtWidgets.QWidget):
             # TODO add details about creator
             new_creators.add(identifier)
             if identifier in existing_items:
+                is_new = False
                 item = existing_items[identifier]
             else:
+                is_new = True
                 item = QtGui.QStandardItem()
                 item.setFlags(
                     QtCore.Qt.ItemIsEnabled | QtCore.Qt.ItemIsSelectable
                 )
-                self._creators_model.appendRow(item)
 
             item.setData(creator_item.label, QtCore.Qt.DisplayRole)
             item.setData(creator_item.show_order, CREATOR_SORT_ROLE)
@@ -473,6 +474,8 @@ class CreateWidget(QtWidgets.QWidget):
                 CREATOR_THUMBNAIL_ENABLED_ROLE
             )
             item.setData(creator_item.family, FAMILY_ROLE)
+            if is_new:
+                self._creators_model.appendRow(item)
 
         # Remove families that are no more available
         for identifier in (old_creators - new_creators):


### PR DESCRIPTION
## Brief description
Added crashes of creators and convertos discovery (lazy solution).

## Description
Report in Publisher also contains information about crashed files caused during creator plugin discovery and convertor plugin discovery. They're not separated into categroies and there is no other information in the report about them, but this helps a lot during development. This change does not need to change format/schema of the report nor UI logic.

## Testing notes:
1. Cause a crash in Creator plugin on import (e.g. add `import foobar` to file)
2. Open Publisher
3. Go to 'Report' tab
4. Go to crashed plugins information
5. The crashed file with creator should be there