### PR TITLE
Publisher: Fix compatibility of QAction in Publisher

### DIFF
--- a/openpype/tools/publisher/widgets/widgets.py
+++ b/openpype/tools/publisher/widgets/widgets.py
@@ -250,21 +250,25 @@ class PublishReportBtn(PublishIconBtn):
         self._actions = []
 
     def add_action(self, label, identifier):
-        action = QtWidgets.QAction(label)
-        action.setData(identifier)
-        action.triggered.connect(
-            functools.partial(self._on_action_trigger, action)
+        self._actions.append(
+            (label, identifier)
         )
-        self._actions.append(action)
 
-    def _on_action_trigger(self, action):
-        identifier = action.data()
+    def _on_action_trigger(self, identifier):
         self.triggered.emit(identifier)
 
     def mouseReleaseEvent(self, event):
         super(PublishReportBtn, self).mouseReleaseEvent(event)
         menu = QtWidgets.QMenu(self)
-        menu.addActions(self._actions)
+        actions = []
+        for item in self._actions:
+            label, identifier = item
+            action = QtWidgets.QAction(label, menu)
+            action.triggered.connect(
+                functools.partial(self._on_action_trigger, identifier)
+            )
+            actions.append(action)
+        menu.addActions(actions)
         menu.exec_(event.globalPos())
 
 


### PR DESCRIPTION
## Brief description
Fix `QAction` for older version of Qt bindings where QAction requires a parent on initialization.

## Description
This bug was discovered in Nuke 11. Fixed by creating QAction when QMenu is already available and can be used as parent.

## Testing notes:
1. Open Publisher in Nuke 11
2. Should not crash