### PR TITLE
Start script: Fix possible issues with destination drive path

### DIFF
--- a/start.py
+++ b/start.py
@@ -348,8 +348,15 @@ def run_disk_mapping_commands(settings):
 
     mappings = disk_mapping.get(low_platform) or []
     for source, destination in mappings:
-        destination = destination.rstrip('/')
-        source = source.rstrip('/')
+        if low_platform == "windows":
+            destination = destination.replace("/", "\\").rstrip("\\")
+            source = source.replace("/", "\\").rstrip("\\")
+            # Add slash after ':' ('G:' -> 'G:\')
+            if destination.endswith(":"):
+                destination += "\\"
+        else:
+            destination = destination.rstrip("/")
+            source = source.rstrip("/")
 
         if low_platform == "darwin":
             scr = f'do shell script "ln -s {source} {destination}" with administrator privileges'  # noqa


### PR DESCRIPTION
## Brief description
Drive paths for windows are fixing possibly missing slash at the end of destination path.

## Description
Windows `subst` command require to have destination path with slash if it's a drive (it should be `G:\` not `G:`).

## Testing notes:
1. Set mapping e.g. `C:/` -> `D:/` in general settings for windows
2. Run tray
3. The mapping should happen