### PR TITLE
Settings - first implementation of saving settings changes to DB

### DIFF
--- a/openpype/settings/handlers.py
+++ b/openpype/settings/handlers.py
@@ -238,7 +238,7 @@ class SettingsHandler(object):
     @abstractmethod
     def save_change_log(self, project_name, changes, settings_type):
         """Stores changes to settings to separate logging collection.
-        
+
         Args:
             project_name(str, null): Project name for which overrides are
                 or None for global settings.

--- a/openpype/settings/handlers.py
+++ b/openpype/settings/handlers.py
@@ -9,6 +9,7 @@ import six
 import openpype.version
 from openpype.client.mongo import OpenPypeMongoConnection
 from openpype.client.entities import get_project_connection, get_project
+from openpype.lib.pype_info import get_workstation_info
 
 from .constants import (
     GLOBAL_SETTINGS_KEY,
@@ -930,13 +931,17 @@ class MongoSettingsHandler(SettingsHandler):
         if not changes:
             return
 
-        from openpype.lib import get_local_site_id
-
         if settings_type == "project" and not project_name:
             project_name = "default"
 
+        host_info = get_workstation_info()
+
         document = {
-            "user": get_local_site_id(),
+            "local_id": host_info["local_id"],
+            "username": host_info["username"],
+            "hostname": host_info["hostname"],
+            "hostip": host_info["hostip"],
+            "system_name": host_info["system_name"],
             "date_created": datetime.datetime.now(),
             "project": project_name,
             "settings_type": settings_type,

--- a/openpype/settings/lib.py
+++ b/openpype/settings/lib.py
@@ -159,6 +159,7 @@ def save_studio_settings(data):
             except SaveWarningExc as exc:
                 warnings.extend(exc.warnings)
 
+    _SETTINGS_HANDLER.save_change_log(None, changes, "system")
     _SETTINGS_HANDLER.save_studio_settings(data)
     if warnings:
         raise SaveWarningExc(warnings)
@@ -218,7 +219,7 @@ def save_project_settings(project_name, overrides):
                 )
             except SaveWarningExc as exc:
                 warnings.extend(exc.warnings)
-
+    _SETTINGS_HANDLER.save_change_log(project_name, changes, "project")
     _SETTINGS_HANDLER.save_project_settings(project_name, overrides)
 
     if warnings:
@@ -280,6 +281,7 @@ def save_project_anatomy(project_name, anatomy_data):
             except SaveWarningExc as exc:
                 warnings.extend(exc.warnings)
 
+    _SETTINGS_HANDLER.save_change_log(project_name, changes, "anatomy")
     _SETTINGS_HANDLER.save_project_anatomy(project_name, anatomy_data)
 
     if warnings:


### PR DESCRIPTION
## Brief description
This logs all changes in Settings to separate collection ('setting_log') to help debug/trace changes. This functionality is pretty basic as it will be replaced by Ayon implementation in the future.

## Description
It saves only 'changes' (like diffs) not old values as resolution of that could get tricky (in complex dictionaries). 
No UI implemented, accessible only through Compass or other IDE.

## Additional info
It produces documents like this:
![2023-02-20 13_33_51-Window](https://user-images.githubusercontent.com/4457962/220109577-bd5de5bd-e9ff-4b9e-857c-e14216d9777d.png)

Changes to system/anatomy/project settings could be filtered by value in `settings_type`.

It would be theoretically possible to apply list of these changes on barebone Settings to create state at specific point in time. Not sure if we want to investigate this for v3 though.


## Testing notes:
1. Try to change something in settings, save, check `settings_log`