### PR TITLE
Workfiles tool: Add PySide 6 support

### DIFF
--- a/openpype/tools/workfiles/files_widget.py
+++ b/openpype/tools/workfiles/files_widget.py
@@ -621,7 +621,7 @@ class FilesWidget(QtWidgets.QWidget):
             "caption": "Work Files",
             "filter": ext_filter
         }
-        if qtpy.API in ("pyside", "pyside2"):
+        if qtpy.API in ("pyside", "pyside2", "pyside6"):
             kwargs["dir"] = self._workfiles_root
         else:
             kwargs["directory"] = self._workfiles_root


### PR DESCRIPTION
## Brief description
Browse button works with PySide 6 binding too.

## Description
Added one more option to choose which kwargs is filled for QFileDialog.

## Testing notes:
1. Build OpenPype with PySide6
2. Launch a host DCC which is using OpenPype process for UIs (AE, Photoshop, Harmony, TVPaint,...)
3. Open workfiles tool
4. Click on `Browse`
5. A dilog should pop up