### PR TITLE
Ftrack: Upload reviewables with original name

### DIFF
--- a/openpype/modules/ftrack/plugins/publish/integrate_ftrack_instances.py
+++ b/openpype/modules/ftrack/plugins/publish/integrate_ftrack_instances.py
@@ -56,6 +56,7 @@ class IntegrateFtrackInstance(pyblish.api.InstancePlugin):
         "reference": "reference"
     }
     keep_first_subset_name_for_review = True
+    upload_reviewable_with_origin_name = False
     asset_versions_status_profiles = []
     additional_metadata_keys = []
 
@@ -294,6 +295,13 @@ class IntegrateFtrackInstance(pyblish.api.InstancePlugin):
             )
             # Add item to component list
             component_list.append(review_item)
+            if self.upload_reviewable_with_origin_name:
+                origin_name_component = copy.deepcopy(review_item)
+                filename = os.path.basename(repre_path)
+                origin_name_component["component_data"]["name"] = (
+                    os.path.splitext(filename)[0]
+                )
+                component_list.append(origin_name_component)
 
         # Duplicate thumbnail component for all not first reviews
         if first_thumbnail_component is not None:

--- a/openpype/settings/defaults/project_settings/ftrack.json
+++ b/openpype/settings/defaults/project_settings/ftrack.json
@@ -488,7 +488,8 @@
             },
             "keep_first_subset_name_for_review": true,
             "asset_versions_status_profiles": [],
-            "additional_metadata_keys": []
+            "additional_metadata_keys": [],
+            "upload_reviewable_with_origin_name": false
         },
         "IntegrateFtrackFarmStatus": {
             "farm_status_profiles": []

--- a/openpype/settings/entities/schemas/projects_schema/schema_project_ftrack.json
+++ b/openpype/settings/entities/schemas/projects_schema/schema_project_ftrack.json
@@ -1037,6 +1037,21 @@
                                 {"fps": "FPS"},
                                 {"code": "Codec"}
                             ]
+                        },
+                        {
+                            "type": "separator"
+                        },
+                        {
+                            "type": "boolean",
+                            "key": "upload_reviewable_with_origin_name",
+                            "label": "Upload reviewable with origin name"
+                        },
+                        {
+                            "type": "label",
+                            "label": "<b>Note:</b> Reviewable will be uploaded twice into ftrack when enabled. One with original name and second with required 'ftrackreview-mp4'. That may cause dramatic increase of ftrack storage usage."
+                        },
+                        {
+                            "type": "separator"
                         }
                     ]
                 },


### PR DESCRIPTION
## Brief description
Ftrack can integrate reviewables with original filenames.

## Description
As ftrack have restrictions about names of components the only way how to achieve the result was to upload the same file twice, one with required name and one with origin name.

## Additional info
~~We could try "reuse" the same container id from the required file so the file does not have to uploaded twice.~~ I couldn't figura out how it could be possible.

## Testing notes:
Make sure you have enabled ftrack
1. Go to `project_settings/ftrack/publish/IntegrateFtrackInstance/upload_reviewable_with_origin_name` and enable it
2. Publish something with reviewable (e.g. trough tray publisher)
3. Check ftrack where should be on version `ftrackreview-mp4` component and component with original filename prepared to be downloaded 