### PR TITLE
Resolve missing OPENPYPE_MONGO in deadline global job preload 

### DIFF
--- a/openpype/modules/deadline/repository/custom/plugins/GlobalJobPreLoad.py
+++ b/openpype/modules/deadline/repository/custom/plugins/GlobalJobPreLoad.py
@@ -11,7 +11,6 @@ from Deadline.Scripting import (
     RepositoryUtils,
     FileUtils,
     DirectoryUtils,
-    ProcessUtils,
 )
 
 VERSION_REGEX = re.compile(
@@ -361,14 +360,14 @@ def inject_openpype_environment(deadlinePlugin):
         args_str = subprocess.list2cmdline(args)
         print(">>> Executing: {} {}".format(exe, args_str))
 
-        my_env = {**os.environ}
-        my_env["OPENPYPE_MONGO"] = job.GetJobEnvironmentKeyValue(
+        current_env = {**os.environ}
+        current_env["OPENPYPE_MONGO"] = job.GetJobEnvironmentKeyValue(
             'OPENPYPE_MONGO'
         )
 
-        process = subprocess.Popen([exe] + args, env=my_env)
+        process = subprocess.Popen([exe] + args, env=current_env)
+        process.communicate()
 
-        output = process.communicate()[0]
         if process.returncode != 0:
             raise RuntimeError(
                 "Failed to run OpenPype process to extract environments."


### PR DESCRIPTION
## Brief description
In the GlobalJobPreLoad plugin, we propose to replace the SpawnProcess by a sub-process and to pass the environment variables in the parameters, since the SpawnProcess under Centos Linux does not pass the environment variables.

## Description
In the GlobalJobPreLoad plugin, the Deadline SpawnProcess is used to start the OpenPype process. The problem is that the SpawnProcess does not pass environment variables, including OPENPYPE_MONGO, to the process when it is under Centos7 linux, and the process gets stuck. We propose to replace it by a subprocess and to pass the variable in the parameters.

## Additional info
Please note that I have not tested it on Windows. 

## Testing notes:
1. Run a deadline Job, under Linux, Centos 7, Deadline 10.1
2. Check if OPENPYPE_MONGO is in the os environment. 
3. Check if the spawned process can see the variable. 