### PR TITLE
Harmony: missing set of frame range when opening scene

### DIFF
--- a/openpype/hosts/harmony/api/pipeline.py
+++ b/openpype/hosts/harmony/api/pipeline.py
@@ -126,10 +126,6 @@ def check_inventory():
 
 def application_launch(event):
     """Event that is executed after Harmony is launched."""
-    # FIXME: This is breaking server <-> client communication.
-    # It is now moved so it it manually called.
-    # ensure_scene_settings()
-    # check_inventory()
     # fills OPENPYPE_HARMONY_JS
     pype_harmony_path = Path(__file__).parent.parent / "js" / "PypeHarmony.js"
     pype_harmony_js = pype_harmony_path.read_text()
@@ -145,6 +141,9 @@ def application_launch(event):
     harmony.send({"script": pype_harmony_js})
     harmony.send({"script": script})
     inject_avalon_js()
+
+    ensure_scene_settings()
+    check_inventory()
 
 
 def export_template(backdrops, nodes, filepath):


### PR DESCRIPTION
## Brief description
Frame range gets set from DB everytime scene is opened.

## Description
Added also check for not up-to-date loaded containers.

## Testing notes:
1. open scene in Harmony and check if frame duration matches to DB (Harmony starts from 1, so only duration is set
2. load older version of published asset