### PR TITLE
Maya: Fix setting scene fps with float input

### DIFF
--- a/openpype/hosts/maya/api/lib.py
+++ b/openpype/hosts/maya/api/lib.py
@@ -1998,7 +1998,7 @@ def set_scene_fps(fps, update=True):
         '48000': '48000fps'
     }
 
-    unit = fps_mapping.get(str(fps), None)
+    unit = fps_mapping.get(str(convert_to_maya_fps(fps)), None)
     if unit is None:
         raise ValueError("Unsupported FPS value: `%s`" % fps)
 
@@ -3407,11 +3407,11 @@ def convert_to_maya_fps(fps):
     # If input fps is a whole number we'll return.
     if float(fps).is_integer():
         # Validate fps is part of Maya's fps selection.
-        if fps not in int_framerates:
+        if int(fps) not in int_framerates:
             raise ValueError(
                 "Framerate \"{}\" is not supported in Maya".format(fps)
             )
-        return fps
+        return int(fps)
     else:
         # Differences to supported float frame rates.
         differences = []

--- a/openpype/hosts/maya/plugins/publish/validate_maya_units.py
+++ b/openpype/hosts/maya/plugins/publish/validate_maya_units.py
@@ -4,7 +4,6 @@ import pyblish.api
 
 import openpype.hosts.maya.api.lib as mayalib
 from openpype.pipeline.context_tools import get_current_project_asset
-from math import ceil
 from openpype.pipeline.publish import (
     RepairContextAction,
     ValidateSceneOrder,


### PR DESCRIPTION
## Brief description
Returned value of float fps on integer values would return float.

## Description
This PR fixes the case when switching between integer fps values for example 24 > 25. Issue was when setting the scene fps, the original float value was used which makes it unpredictable whether the value is float or integer when mapping the fps values.

## Testing notes:
1. Set `project_anatomy/attributes/fps` to 24.
2. Launch Maya and save the workfile as 24 fps.
3. Set `project_anatomy/attributes/fps` to 25.
4. Publish or relaunch the workfile, and fix the fps validation.