### PR TITLE
Maya: Fix changed location of reset_frame_range

### DIFF
--- a/openpype/hosts/maya/api/commands.py
+++ b/openpype/hosts/maya/api/commands.py
@@ -4,7 +4,6 @@ from maya import cmds
 
 from openpype.client import get_asset_by_name, get_project
 from openpype.pipeline import legacy_io
-from . import lib
 
 
 class ToolWindows:
@@ -56,54 +55,6 @@ def edit_shader_definitions():
             window = ShaderDefinitionsEditor(parent=main_window)
             ToolWindows.set_window("shader_definition_editor", window)
         window.show()
-
-
-def reset_frame_range():
-    """Set frame range to current asset"""
-
-    fps = lib.convert_to_maya_fps(
-        float(legacy_io.Session.get("AVALON_FPS", 25))
-    )
-    lib.set_scene_fps(fps)
-
-    # Set frame start/end
-    project_name = legacy_io.active_project()
-    asset_name = legacy_io.Session["AVALON_ASSET"]
-    asset = get_asset_by_name(project_name, asset_name)
-
-    frame_start = asset["data"].get("frameStart")
-    frame_end = asset["data"].get("frameEnd")
-    # Backwards compatibility
-    if frame_start is None or frame_end is None:
-        frame_start = asset["data"].get("edit_in")
-        frame_end = asset["data"].get("edit_out")
-
-    if frame_start is None or frame_end is None:
-        cmds.warning("No edit information found for %s" % asset_name)
-        return
-
-    handles = asset["data"].get("handles") or 0
-    handle_start = asset["data"].get("handleStart")
-    if handle_start is None:
-        handle_start = handles
-
-    handle_end = asset["data"].get("handleEnd")
-    if handle_end is None:
-        handle_end = handles
-
-    frame_start -= int(handle_start)
-    frame_end += int(handle_end)
-
-    cmds.playbackOptions(minTime=frame_start)
-    cmds.playbackOptions(maxTime=frame_end)
-    cmds.playbackOptions(animationStartTime=frame_start)
-    cmds.playbackOptions(animationEndTime=frame_end)
-    cmds.playbackOptions(minTime=frame_start)
-    cmds.playbackOptions(maxTime=frame_end)
-    cmds.currentTime(frame_start)
-
-    cmds.setAttr("defaultRenderGlobals.startFrame", frame_start)
-    cmds.setAttr("defaultRenderGlobals.endFrame", frame_end)
 
 
 def _resolution_from_document(doc):

--- a/openpype/hosts/maya/api/lib_rendersettings.py
+++ b/openpype/hosts/maya/api/lib_rendersettings.py
@@ -14,7 +14,7 @@ from openpype.settings import (
 from openpype.pipeline import legacy_io
 from openpype.pipeline import CreatorError
 from openpype.pipeline.context_tools import get_current_project_asset
-from openpype.hosts.maya.api.commands import reset_frame_range
+from openpype.hosts.maya.api.lib import reset_frame_range
 
 
 class RenderSettings(object):

--- a/openpype/hosts/maya/api/menu.py
+++ b/openpype/hosts/maya/api/menu.py
@@ -12,7 +12,6 @@ from openpype.pipeline.workfile import BuildWorkfile
 from openpype.tools.utils import host_tools
 from openpype.hosts.maya.api import lib, lib_rendersettings
 from .lib import get_main_window, IS_HEADLESS
-from .commands import reset_frame_range
 
 from .workfile_template_builder import (
     create_placeholder,
@@ -113,7 +112,7 @@ def install():
 
         cmds.menuItem(
             "Reset Frame Range",
-            command=lambda *args: reset_frame_range()
+            command=lambda *args: lib.reset_frame_range()
         )
 
         cmds.menuItem(


### PR DESCRIPTION
## Brief description
Location in commands caused cyclic import

## Additional info
Failure occurred in automatic testing in Maya 2020.

![2023-02-20 18_12_20-Testing Platform PC - AnyDesk](https://user-images.githubusercontent.com/4457962/220170893-38c5829c-25c0-4404-898d-3319bb99dd1c.png)

## Testing notes:
1.open Maya (2020)
