### PR TITLE
Nuke: adding nukeassist 

### DIFF
--- a/openpype/hosts/nuke/addon.py
+++ b/openpype/hosts/nuke/addon.py
@@ -63,5 +63,12 @@ class NukeAddon(OpenPypeModule, IHostAddon):
             path_paths.append(quick_time_path)
             env["PATH"] = os.pathsep.join(path_paths)
 
+    def get_launch_hook_paths(self, app):
+        if app.host_name != self.host_name:
+            return []
+        return [
+            os.path.join(NUKE_ROOT_DIR, "hooks")
+        ]
+
     def get_workfile_extensions(self):
         return [".nk"]

--- a/openpype/hosts/nuke/api/__init__.py
+++ b/openpype/hosts/nuke/api/__init__.py
@@ -1,3 +1,4 @@
+import os
 from .workio import (
     file_extensions,
     has_unsaved_changes,
@@ -51,6 +52,8 @@ from .utils import (
     get_colorspace_list
 )
 
+ASSIST = bool(os.getenv("NUKEASSIST"))
+
 __all__ = (
     "file_extensions",
     "has_unsaved_changes",
@@ -95,5 +98,7 @@ __all__ = (
     "create_write_node",
 
     "colorspace_exists_on_node",
-    "get_colorspace_list"
+    "get_colorspace_list",
+
+    "ASSIST"
 )

--- a/openpype/hosts/nuke/api/__init__.py
+++ b/openpype/hosts/nuke/api/__init__.py
@@ -1,4 +1,3 @@
-import os
 from .workio import (
     file_extensions,
     has_unsaved_changes,
@@ -52,8 +51,6 @@ from .utils import (
     get_colorspace_list
 )
 
-ASSIST = bool(os.getenv("NUKEASSIST"))
-
 __all__ = (
     "file_extensions",
     "has_unsaved_changes",
@@ -98,7 +95,5 @@ __all__ = (
     "create_write_node",
 
     "colorspace_exists_on_node",
-    "get_colorspace_list",
-
-    "ASSIST"
+    "get_colorspace_list"
 )

--- a/openpype/hosts/nuke/api/constants.py
+++ b/openpype/hosts/nuke/api/constants.py
@@ -1,0 +1,4 @@
+import os
+
+
+ASSIST = bool(os.getenv("NUKEASSIST"))

--- a/openpype/hosts/nuke/api/lib.py
+++ b/openpype/hosts/nuke/api/lib.py
@@ -2269,7 +2269,10 @@ class WorkfileSettings(object):
                 }
             )
         else:
-            log.warning("NukeAssist mode is not allowing updating custom knobs...")
+            log.warning(
+                "NukeAssist mode is not allowing "
+                "updating custom knobs..."
+            )
 
     def reset_resolution(self):
         """Set resolution to project resolution."""

--- a/openpype/hosts/nuke/api/lib.py
+++ b/openpype/hosts/nuke/api/lib.py
@@ -50,7 +50,7 @@ from openpype.pipeline.colorspace import (
 from openpype.pipeline.workfile import BuildWorkfile
 
 from . import gizmo_menu
-from .utils import ASSIST
+from .constants import ASSIST
 
 from .workio import (
     save_file,

--- a/openpype/hosts/nuke/api/lib.py
+++ b/openpype/hosts/nuke/api/lib.py
@@ -49,7 +49,7 @@ from openpype.pipeline.colorspace import (
 )
 from openpype.pipeline.workfile import BuildWorkfile
 
-from . import gizmo_menu
+from . import gizmo_menu, ASSIST
 
 from .workio import (
     save_file,
@@ -2258,14 +2258,17 @@ class WorkfileSettings(object):
             node['frame_range'].setValue(range)
             node['frame_range_lock'].setValue(True)
 
-        set_node_data(
-            self._root_node,
-            INSTANCE_DATA_KNOB,
-            {
-                "handleStart": int(handle_start),
-                "handleEnd": int(handle_end)
-            }
-        )
+        if not ASSIST:
+            set_node_data(
+                self._root_node,
+                INSTANCE_DATA_KNOB,
+                {
+                    "handleStart": int(handle_start),
+                    "handleEnd": int(handle_end)
+                }
+            )
+        else:
+            log.warning("NukeAssist mode is not allowing updating custom knobs...")
 
     def reset_resolution(self):
         """Set resolution to project resolution."""

--- a/openpype/hosts/nuke/api/lib.py
+++ b/openpype/hosts/nuke/api/lib.py
@@ -49,7 +49,8 @@ from openpype.pipeline.colorspace import (
 )
 from openpype.pipeline.workfile import BuildWorkfile
 
-from . import gizmo_menu, ASSIST
+from . import gizmo_menu
+from .utils import ASSIST
 
 from .workio import (
     save_file,

--- a/openpype/hosts/nuke/api/pipeline.py
+++ b/openpype/hosts/nuke/api/pipeline.py
@@ -60,7 +60,7 @@ from .workio import (
     work_root,
     current_file
 )
-from .utils import ASSIST
+from .constants import ASSIST
 
 log = Logger.get_logger(__name__)
 

--- a/openpype/hosts/nuke/api/pipeline.py
+++ b/openpype/hosts/nuke/api/pipeline.py
@@ -208,22 +208,25 @@ def get_workfile_build_placeholder_plugins():
 
 
 def _install_menu():
+    """Install Avalon menu into Nuke's main menu bar."""
 
     # uninstall original avalon menu
     main_window = get_main_window()
     menubar = nuke.menu("Nuke")
     menu = menubar.addMenu(MENU_LABEL)
 
-    label = "{0}, {1}".format(
-        os.environ["AVALON_ASSET"], os.environ["AVALON_TASK"]
-    )
-    Context.context_label = label
-    context_action = menu.addCommand(label)
 
     if not ASSIST:
+        label = "{0}, {1}".format(
+            os.environ["AVALON_ASSET"], os.environ["AVALON_TASK"]
+        )
+        Context.context_label = label
+        context_action = menu.addCommand(label)
         context_action.setEnabled(False)
 
-    menu.addSeparator()
+        # add separator after context label
+        menu.addSeparator()
+
     menu.addCommand(
         "Work Files...",
         _show_workfiles

--- a/openpype/hosts/nuke/api/pipeline.py
+++ b/openpype/hosts/nuke/api/pipeline.py
@@ -71,7 +71,7 @@ CREATE_PATH = os.path.join(PLUGINS_DIR, "create")
 INVENTORY_PATH = os.path.join(PLUGINS_DIR, "inventory")
 
 MENU_LABEL = os.environ["AVALON_LABEL"]
-
+ASSIST = bool(os.getenv("NUKEASSIST"))
 
 # registering pyblish gui regarding settings in presets
 if os.getenv("PYBLISH_GUI", None):
@@ -208,6 +208,7 @@ def get_workfile_build_placeholder_plugins():
 
 
 def _install_menu():
+
     # uninstall original avalon menu
     main_window = get_main_window()
     menubar = nuke.menu("Nuke")
@@ -218,7 +219,9 @@ def _install_menu():
     )
     Context.context_label = label
     context_action = menu.addCommand(label)
-    context_action.setEnabled(False)
+
+    if not ASSIST:
+        context_action.setEnabled(False)
 
     menu.addSeparator()
     menu.addCommand(
@@ -227,18 +230,20 @@ def _install_menu():
     )
 
     menu.addSeparator()
-    menu.addCommand(
-        "Create...",
-        lambda: host_tools.show_publisher(
-            tab="create"
+    if not ASSIST:
+        menu.addCommand(
+            "Create...",
+            lambda: host_tools.show_publisher(
+                tab="create"
+            )
         )
-    )
-    menu.addCommand(
-        "Publish...",
-        lambda: host_tools.show_publisher(
-            tab="publish"
+        menu.addCommand(
+            "Publish...",
+            lambda: host_tools.show_publisher(
+                tab="publish"
+            )
         )
-    )
+
     menu.addCommand(
         "Load...",
         lambda: host_tools.show_loader(
@@ -286,15 +291,18 @@ def _install_menu():
         "Build Workfile from template",
         lambda: build_workfile_template()
     )
-    menu_template.addSeparator()
-    menu_template.addCommand(
-        "Create Place Holder",
-        lambda: create_placeholder()
-    )
-    menu_template.addCommand(
-        "Update Place Holder",
-        lambda: update_placeholder()
-    )
+
+    if not ASSIST:
+        menu_template.addSeparator()
+        menu_template.addCommand(
+            "Create Place Holder",
+            lambda: create_placeholder()
+        )
+        menu_template.addCommand(
+            "Update Place Holder",
+            lambda: update_placeholder()
+        )
+
     menu.addSeparator()
     menu.addCommand(
         "Experimental tools...",

--- a/openpype/hosts/nuke/api/pipeline.py
+++ b/openpype/hosts/nuke/api/pipeline.py
@@ -60,6 +60,7 @@ from .workio import (
     work_root,
     current_file
 )
+from . import ASSIST
 
 log = Logger.get_logger(__name__)
 
@@ -71,7 +72,6 @@ CREATE_PATH = os.path.join(PLUGINS_DIR, "create")
 INVENTORY_PATH = os.path.join(PLUGINS_DIR, "inventory")
 
 MENU_LABEL = os.environ["AVALON_LABEL"]
-ASSIST = bool(os.getenv("NUKEASSIST"))
 
 # registering pyblish gui regarding settings in presets
 if os.getenv("PYBLISH_GUI", None):

--- a/openpype/hosts/nuke/api/pipeline.py
+++ b/openpype/hosts/nuke/api/pipeline.py
@@ -60,7 +60,7 @@ from .workio import (
     work_root,
     current_file
 )
-from . import ASSIST
+from .utils import ASSIST
 
 log = Logger.get_logger(__name__)
 

--- a/openpype/hosts/nuke/api/pipeline.py
+++ b/openpype/hosts/nuke/api/pipeline.py
@@ -215,7 +215,6 @@ def _install_menu():
     menubar = nuke.menu("Nuke")
     menu = menubar.addMenu(MENU_LABEL)
 
-
     if not ASSIST:
         label = "{0}, {1}".format(
             os.environ["AVALON_ASSET"], os.environ["AVALON_TASK"]

--- a/openpype/hosts/nuke/api/utils.py
+++ b/openpype/hosts/nuke/api/utils.py
@@ -4,6 +4,7 @@ import nuke
 from openpype import resources
 from .lib import maintained_selection
 
+ASSIST = bool(os.getenv("NUKEASSIST"))
 
 def set_context_favorites(favorites=None):
     """ Adding favorite folders to nuke's browser

--- a/openpype/hosts/nuke/api/utils.py
+++ b/openpype/hosts/nuke/api/utils.py
@@ -4,7 +4,6 @@ import nuke
 from openpype import resources
 from .lib import maintained_selection
 
-ASSIST = bool(os.getenv("NUKEASSIST"))
 
 def set_context_favorites(favorites=None):
     """ Adding favorite folders to nuke's browser

--- a/openpype/hosts/nuke/hooks/pre_nukeassist_setup.py
+++ b/openpype/hosts/nuke/hooks/pre_nukeassist_setup.py
@@ -8,3 +8,4 @@ class PrelaunchNukeAssistHook(PreLaunchHook):
 
     def execute(self):
         self.launch_context.env["NUKEASSIST"] = "1"
+

--- a/openpype/hosts/nuke/hooks/pre_nukeassist_setup.py
+++ b/openpype/hosts/nuke/hooks/pre_nukeassist_setup.py
@@ -8,4 +8,3 @@ class PrelaunchNukeAssistHook(PreLaunchHook):
 
     def execute(self):
         self.launch_context.env["NUKEASSIST"] = "1"
-

--- a/openpype/hosts/nuke/hooks/pre_nukeassist_setup.py
+++ b/openpype/hosts/nuke/hooks/pre_nukeassist_setup.py
@@ -1,0 +1,10 @@
+from openpype.lib import PreLaunchHook
+
+class PrelaunchNukeAssistHook(PreLaunchHook):
+    """
+    Adding flag when nukeassist
+    """
+    app_groups = ["nukeassist"]
+
+    def execute(self):
+        self.launch_context.env["NUKEASSIST"] = True

--- a/openpype/hosts/nuke/hooks/pre_nukeassist_setup.py
+++ b/openpype/hosts/nuke/hooks/pre_nukeassist_setup.py
@@ -1,5 +1,6 @@
 from openpype.lib import PreLaunchHook
 
+
 class PrelaunchNukeAssistHook(PreLaunchHook):
     """
     Adding flag when nukeassist

--- a/openpype/hosts/nuke/hooks/pre_nukeassist_setup.py
+++ b/openpype/hosts/nuke/hooks/pre_nukeassist_setup.py
@@ -7,4 +7,4 @@ class PrelaunchNukeAssistHook(PreLaunchHook):
     app_groups = ["nukeassist"]
 
     def execute(self):
-        self.launch_context.env["NUKEASSIST"] = True
+        self.launch_context.env["NUKEASSIST"] = "1"

--- a/openpype/settings/defaults/system_settings/applications.json
+++ b/openpype/settings/defaults/system_settings/applications.json
@@ -337,6 +337,134 @@
             }
         }
     },
+    "nukeassist": {
+        "enabled": true,
+        "label": "Nuke Assist",
+        "icon": "{}/app_icons/nuke.png",
+        "host_name": "nuke",
+        "environment": {
+            "NUKE_PATH": [
+                "{NUKE_PATH}",
+                "{OPENPYPE_STUDIO_PLUGINS}/nuke"
+            ]
+        },
+        "variants": {
+            "13-2": {
+                "use_python_2": false,
+                "executables": {
+                    "windows": [
+                        "C:\\Program Files\\Nuke13.2v1\\Nuke13.2.exe"
+                    ],
+                    "darwin": [],
+                    "linux": [
+                        "/usr/local/Nuke13.2v1/Nuke13.2"
+                    ]
+                },
+                "arguments": {
+                    "windows": ["--nukeassist"],
+                    "darwin": ["--nukeassist"],
+                    "linux": ["--nukeassist"]
+                },
+                "environment": {}
+            },
+            "13-0": {
+                "use_python_2": false,
+                "executables": {
+                    "windows": [
+                        "C:\\Program Files\\Nuke13.0v1\\Nuke13.0.exe"
+                    ],
+                    "darwin": [],
+                    "linux": [
+                        "/usr/local/Nuke13.0v1/Nuke13.0"
+                    ]
+                },
+                "arguments": {
+                    "windows": ["--nukeassist"],
+                    "darwin": ["--nukeassist"],
+                    "linux": ["--nukeassist"]
+                },
+                "environment": {}
+            },
+            "12-2": {
+                "use_python_2": true,
+                "executables": {
+                    "windows": [
+                        "C:\\Program Files\\Nuke12.2v3\\Nuke12.2.exe"
+                    ],
+                    "darwin": [],
+                    "linux": [
+                        "/usr/local/Nuke12.2v3Nuke12.2"
+                    ]
+                },
+                "arguments": {
+                    "windows": ["--nukeassist"],
+                    "darwin": ["--nukeassist"],
+                    "linux": ["--nukeassist"]
+                },
+                "environment": {}
+            },
+            "12-0": {
+                "use_python_2": true,
+                "executables": {
+                    "windows": [
+                        "C:\\Program Files\\Nuke12.0v1\\Nuke12.0.exe"
+                    ],
+                    "darwin": [],
+                    "linux": [
+                        "/usr/local/Nuke12.0v1/Nuke12.0"
+                    ]
+                },
+                "arguments": {
+                    "windows": ["--nukeassist"],
+                    "darwin": ["--nukeassist"],
+                    "linux": ["--nukeassist"]
+                },
+                "environment": {}
+            },
+            "11-3": {
+                "use_python_2": true,
+                "executables": {
+                    "windows": [
+                        "C:\\Program Files\\Nuke11.3v1\\Nuke11.3.exe"
+                    ],
+                    "darwin": [],
+                    "linux": [
+                        "/usr/local/Nuke11.3v5/Nuke11.3"
+                    ]
+                },
+                "arguments": {
+                    "windows": ["--nukeassist"],
+                    "darwin": ["--nukeassist"],
+                    "linux": ["--nukeassist"]
+                },
+                "environment": {}
+            },
+            "11-2": {
+                "use_python_2": true,
+                "executables": {
+                    "windows": [
+                        "C:\\Program Files\\Nuke11.2v2\\Nuke11.2.exe"
+                    ],
+                    "darwin": [],
+                    "linux": []
+                },
+                "arguments": {
+                    "windows": ["--nukeassist"],
+                    "darwin": ["--nukeassist"],
+                    "linux": ["--nukeassist"]
+                },
+                "environment": {}
+            },
+            "__dynamic_keys_labels__": {
+                "13-2": "13.2",
+                "13-0": "13.0",
+                "12-2": "12.2",
+                "12-0": "12.0",
+                "11-3": "11.3",
+                "11-2": "11.2"
+            }
+        }
+    },
     "nukex": {
         "enabled": true,
         "label": "Nuke X",

--- a/openpype/settings/entities/schemas/system_schema/schema_applications.json
+++ b/openpype/settings/entities/schemas/system_schema/schema_applications.json
@@ -29,6 +29,14 @@
       "type": "schema_template",
       "name": "template_nuke",
       "template_data": {
+        "nuke_type": "nukeassist",
+        "nuke_label": "Nuke Assist"
+      }
+    },
+    {
+      "type": "schema_template",
+      "name": "template_nuke",
+      "template_data": {
         "nuke_type": "nukex",
         "nuke_label": "Nuke X"
       }


### PR DESCRIPTION
## Brief description
Adding support for NukeAssist

## Description
For support of NukeAssist we had to limit some Nuke features since NukeAssist itself Nuke with limitations. We do not support Creator and Publisher. User can only Load versions with version control. User can also set Framerange and Colorspace.

## Testing notes:
1. Set NukeAssist to your project
2. Open NukeAssist on task and see the OpenPype menu items have are redefined.