### PR TITLE
TVPaint: Ignore transparency in Render Pass

### DIFF
--- a/openpype/hosts/tvpaint/plugins/create/create_render.py
+++ b/openpype/hosts/tvpaint/plugins/create/create_render.py
@@ -660,7 +660,6 @@ class TVPaintAutoDetectRenderCreator(TVPaintCreator):
             ["create"]
             ["auto_detect_render"]
         )
-        self.enabled = plugin_settings["enabled"]
         self.allow_group_rename = plugin_settings["allow_group_rename"]
         self.group_name_template = plugin_settings["group_name_template"]
         self.group_idx_offset = plugin_settings["group_idx_offset"]

--- a/openpype/hosts/tvpaint/plugins/publish/collect_render_instances.py
+++ b/openpype/hosts/tvpaint/plugins/publish/collect_render_instances.py
@@ -9,6 +9,8 @@ class CollectRenderInstances(pyblish.api.InstancePlugin):
     hosts = ["tvpaint"]
     families = ["render", "review"]
 
+    ignore_render_pass_transparency = False
+
     def process(self, instance):
         context = instance.context
         creator_identifier = instance.data["creator_identifier"]
@@ -63,6 +65,9 @@ class CollectRenderInstances(pyblish.api.InstancePlugin):
             for layer in layers_data
             if layer["name"] in layer_names
         ]
+        instance.data["ignoreLayersTransparency"] = (
+            self.ignore_render_pass_transparency
+        )
 
         render_layer_data = None
         render_layer_id = creator_attributes["render_layer_instance_id"]

--- a/openpype/hosts/tvpaint/plugins/publish/extract_sequence.py
+++ b/openpype/hosts/tvpaint/plugins/publish/extract_sequence.py
@@ -59,6 +59,10 @@ class ExtractSequence(pyblish.api.Extractor):
             )
         )
 
+        ignore_layers_transparency = instance.data.get(
+            "ignoreLayersTransparency", False
+        )
+
         family_lowered = instance.data["family"].lower()
         mark_in = instance.context.data["sceneMarkIn"]
         mark_out = instance.context.data["sceneMarkOut"]
@@ -114,7 +118,11 @@ class ExtractSequence(pyblish.api.Extractor):
         else:
             # Render output
             result = self.render(
-                output_dir, mark_in, mark_out, filtered_layers
+                output_dir,
+                mark_in,
+                mark_out,
+                filtered_layers,
+                ignore_layers_transparency
             )
 
         output_filepaths_by_frame_idx, thumbnail_fullpath = result
@@ -274,7 +282,9 @@ class ExtractSequence(pyblish.api.Extractor):
 
         return output_filepaths_by_frame_idx, thumbnail_filepath
 
-    def render(self, output_dir, mark_in, mark_out, layers):
+    def render(
+        self, output_dir, mark_in, mark_out, layers, ignore_layer_opacity
+    ):
         """ Export images from TVPaint.
 
         Args:
@@ -282,6 +292,7 @@ class ExtractSequence(pyblish.api.Extractor):
             mark_in (int): Starting frame index from which export will begin.
             mark_out (int): On which frame index export will end.
             layers (list): List of layers to be exported.
+            ignore_layer_opacity (bool): Layer's opacity will be ignored.
 
         Returns:
             tuple: With 2 items first is list of filenames second is path to
@@ -323,7 +334,7 @@ class ExtractSequence(pyblish.api.Extractor):
         for layer_id, render_data in extraction_data_by_layer_id.items():
             layer = layers_by_id[layer_id]
             filepaths_by_layer_id[layer_id] = self._render_layer(
-                render_data, layer, output_dir
+                render_data, layer, output_dir, ignore_layer_opacity
             )
 
         # Prepare final filepaths where compositing should store result
@@ -380,7 +391,9 @@ class ExtractSequence(pyblish.api.Extractor):
                 red, green, blue = self.review_bg
         return (red, green, blue)
 
-    def _render_layer(self, render_data, layer, output_dir):
+    def _render_layer(
+        self, render_data, layer, output_dir, ignore_layer_opacity
+    ):
         frame_references = render_data["frame_references"]
         filenames_by_frame_index = render_data["filenames_by_frame_index"]
 
@@ -389,6 +402,12 @@ class ExtractSequence(pyblish.api.Extractor):
             "tv_layerset {}".format(layer_id),
             "tv_SaveMode \"PNG\""
         ]
+        # Set density to 100 and store previous opacity
+        if ignore_layer_opacity:
+            george_script_lines.extend([
+                "tv_layerdensity 100",
+                "orig_opacity = result",
+            ])
 
         filepaths_by_frame = {}
         frames_to_render = []
@@ -408,6 +427,10 @@ class ExtractSequence(pyblish.api.Extractor):
             george_script_lines.append("tv_layerImage {}".format(frame_idx))
             # Store image to output
             george_script_lines.append("tv_saveimage \"{}\"".format(dst_path))
+
+        # Set density back to origin opacity
+        if ignore_layer_opacity:
+            george_script_lines.append("tv_layerdensity orig_opacity")
 
         self.log.debug("Rendering Exposure frames {} of layer {} ({})".format(
             ",".join(frames_to_render), layer_id, layer["name"]

--- a/openpype/settings/defaults/project_settings/tvpaint.json
+++ b/openpype/settings/defaults/project_settings/tvpaint.json
@@ -49,6 +49,9 @@
         }
     },
     "publish": {
+        "CollectRenderInstances": {
+            "ignore_render_pass_transparency": true
+        },
         "ExtractSequence": {
             "review_bg": [
                 255,

--- a/openpype/settings/defaults/project_settings/tvpaint.json
+++ b/openpype/settings/defaults/project_settings/tvpaint.json
@@ -50,7 +50,7 @@
     },
     "publish": {
         "CollectRenderInstances": {
-            "ignore_render_pass_transparency": true
+            "ignore_render_pass_transparency": false
         },
         "ExtractSequence": {
             "review_bg": [

--- a/openpype/settings/entities/schemas/projects_schema/schema_project_tvpaint.json
+++ b/openpype/settings/entities/schemas/projects_schema/schema_project_tvpaint.json
@@ -244,6 +244,20 @@
                 {
                     "type": "dict",
                     "collapsible": true,
+                    "key": "CollectRenderInstances",
+                    "label": "Collect Render Instances",
+                    "is_group": true,
+                    "children": [
+                        {
+                            "type": "boolean",
+                            "key": "ignore_render_pass_transparency",
+                            "label": "Ignore Render Pass opacity"
+                        }
+                    ]
+                },
+                {
+                    "type": "dict",
+                    "collapsible": true,
                     "key": "ExtractSequence",
                     "label": "ExtractSequence",
                     "is_group": true,


### PR DESCRIPTION
## Brief description
It is possible to ignore layers transparency during Render Pass extraction.

## Description
Render pass extraction does not respect opacity of TVPaint layers set in scene during extraction. It can be enabled/disabled in settings.

## Additional info
I found out that `opacity` received using `tv_layerinfo` is always `0` which caused a troubles but `tv_layerdensity` does return previous value on change so I've used that option to change it to `100` and then back to previous value.

![image](https://user-images.githubusercontent.com/43494761/220591918-9e76526c-ca1e-4fb3-a561-12c08f3e5792.png)

## Testing notes:
1. Enable `project_settings/tvpaint/publish/CollectRenderInstances/ignore_render_pass_transparency`
2. Open TVPaint scene
3. Create Render Layer
4. Create Render Pass on TVPaint layer
5. Change opacity of the layer (e.g. to 50%)
6. Publish
7. Output of Render Pass should have 100%