### PR TITLE
3dsmax unable to delete loaded asset in the scene inventory

### DIFF
--- a/openpype/hosts/max/plugins/load/load_camera_fbx.py
+++ b/openpype/hosts/max/plugins/load/load_camera_fbx.py
@@ -49,9 +49,9 @@ importFile @"{filepath}" #noPrompt using:FBXIMP
         path = get_representation_path(representation)
         node = rt.getNodeByName(container["instance_node"])
 
-        alembic_objects = self.get_container_children(node, "AlembicObject")
-        for alembic_object in alembic_objects:
-            alembic_object.source = path
+        fbx_objects = self.get_container_children(node, "AlembicObject")
+        for fbx_object in fbx_objects:
+            fbx_object.source = path
 
         lib.imprint(container["instance_node"], {
             "representation": str(representation["_id"])

--- a/openpype/hosts/max/plugins/load/load_camera_fbx.py
+++ b/openpype/hosts/max/plugins/load/load_camera_fbx.py
@@ -49,7 +49,7 @@ importFile @"{filepath}" #noPrompt using:FBXIMP
         path = get_representation_path(representation)
         node = rt.getNodeByName(container["instance_node"])
 
-        fbx_objects = self.get_container_children(node, "AlembicObject")
+        fbx_objects = self.get_container_children(node)
         for fbx_object in fbx_objects:
             fbx_object.source = path
 

--- a/openpype/hosts/max/plugins/load/load_camera_fbx.py
+++ b/openpype/hosts/max/plugins/load/load_camera_fbx.py
@@ -1,7 +1,10 @@
 import os
 from openpype.pipeline import (
-    load
+    load,
+    get_representation_path
 )
+from openpype.hosts.max.api.pipeline import containerise
+from openpype.hosts.max.api import lib
 
 
 class FbxLoader(load.LoaderPlugin):
@@ -36,14 +39,26 @@ importFile @"{filepath}" #noPrompt using:FBXIMP
         container_name = f"{name}_CON"
 
         asset = rt.getNodeByName(f"{name}")
-        # rename the container with "_CON"
-        container = rt.container(name=container_name)
-        asset.Parent = container
 
-        return container
+        return containerise(
+            name, [asset], context, loader=self.__class__.__name__)
+
+    def update(self, container, representation):
+        from pymxs import runtime as rt
+
+        path = get_representation_path(representation)
+        node = rt.getNodeByName(container["instance_node"])
+
+        alembic_objects = self.get_container_children(node, "AlembicObject")
+        for alembic_object in alembic_objects:
+            alembic_object.source = path
+
+        lib.imprint(container["instance_node"], {
+            "representation": str(representation["_id"])
+        })
 
     def remove(self, container):
         from pymxs import runtime as rt
 
-        node = container["node"]
+        node = rt.getNodeByName(container["instance_node"])
         rt.delete(node)

--- a/openpype/hosts/max/plugins/load/load_max_scene.py
+++ b/openpype/hosts/max/plugins/load/load_max_scene.py
@@ -1,7 +1,9 @@
 import os
 from openpype.pipeline import (
-    load
+    load, get_representation_path
 )
+from openpype.hosts.max.api.pipeline import containerise
+from openpype.hosts.max.api import lib
 
 
 class MaxSceneLoader(load.LoaderPlugin):
@@ -35,16 +37,26 @@ class MaxSceneLoader(load.LoaderPlugin):
             self.log.error("Something failed when loading.")
 
         max_container = max_containers.pop()
-        container_name = f"{name}_CON"
-        # rename the container with "_CON"
-        # get the original container
-        container = rt.container(name=container_name)
-        max_container.Parent = container
 
-        return container
+        return containerise(
+            name, [max_container], context, loader=self.__class__.__name__)
+
+    def update(self, container, representation):
+        from pymxs import runtime as rt
+
+        path = get_representation_path(representation)
+        node = rt.getNodeByName(container["instance_node"])
+
+        alembic_objects = self.get_container_children(node, "AlembicObject")
+        for alembic_object in alembic_objects:
+            alembic_object.source = path
+
+        lib.imprint(container["instance_node"], {
+            "representation": str(representation["_id"])
+        })
 
     def remove(self, container):
         from pymxs import runtime as rt
 
-        node = container["node"]
+        node = rt.getNodeByName(container["instance_node"])
         rt.delete(node)

--- a/openpype/hosts/max/plugins/load/load_max_scene.py
+++ b/openpype/hosts/max/plugins/load/load_max_scene.py
@@ -47,9 +47,9 @@ class MaxSceneLoader(load.LoaderPlugin):
         path = get_representation_path(representation)
         node = rt.getNodeByName(container["instance_node"])
 
-        alembic_objects = self.get_container_children(node, "AlembicObject")
-        for alembic_object in alembic_objects:
-            alembic_object.source = path
+        max_objects = self.get_container_children(node, "AlembicObject")
+        for max_object in max_objects:
+            max_object.source = path
 
         lib.imprint(container["instance_node"], {
             "representation": str(representation["_id"])

--- a/openpype/hosts/max/plugins/load/load_max_scene.py
+++ b/openpype/hosts/max/plugins/load/load_max_scene.py
@@ -47,7 +47,7 @@ class MaxSceneLoader(load.LoaderPlugin):
         path = get_representation_path(representation)
         node = rt.getNodeByName(container["instance_node"])
 
-        max_objects = self.get_container_children(node, "AlembicObject")
+        max_objects = self.get_container_children(node)
         for max_object in max_objects:
             max_object.source = path
 

--- a/openpype/hosts/max/plugins/load/load_pointcache.py
+++ b/openpype/hosts/max/plugins/load/load_pointcache.py
@@ -80,7 +80,7 @@ importFile @"{file_path}" #noPrompt
     def remove(self, container):
         from pymxs import runtime as rt
 
-        node = container["node"]
+        node = rt.getNodeByName(container["instance_node"])
         rt.delete(node)
 
     @staticmethod


### PR DESCRIPTION
## Brief description
Fix the bug of being unable to delete loaded asset in the Scene Inventory

## Description
Fix the bug of being unable to delete loaded asset in the Scene Inventory

## Testing notes:
1. launch 3dsmax through Openpype
2. go to Openpype -> load
3. load the assets from any families
4. go to Openpype -> Manage
5.  RMB -> Removeitems
![image](https://user-images.githubusercontent.com/64118225/220659678-6fedf340-77c5-4cd4-915e-916141133250.png)
