### PR TITLE
Nuke: Fix workfile template placeholder creation

### DIFF
--- a/openpype/hosts/nuke/api/__init__.py
+++ b/openpype/hosts/nuke/api/__init__.py
@@ -30,7 +30,6 @@ from .pipeline import (
     parse_container,
     update_container,
 
-    get_workfile_build_placeholder_plugins,
 )
 from .lib import (
     INSTANCE_DATA_KNOB,
@@ -78,8 +77,6 @@ __all__ = (
     "containerise",
     "parse_container",
     "update_container",
-
-    "get_workfile_build_placeholder_plugins",
 
     "INSTANCE_DATA_KNOB",
     "ROOT_DATA_KNOB",

--- a/openpype/hosts/nuke/api/pipeline.py
+++ b/openpype/hosts/nuke/api/pipeline.py
@@ -101,6 +101,12 @@ class NukeHost(
     def get_workfile_extensions(self):
         return file_extensions()
 
+    def get_workfile_build_placeholder_plugins(self):
+        return [
+            NukePlaceholderLoadPlugin,
+            NukePlaceholderCreatePlugin
+        ]
+
     def get_containers(self):
         return ls()
 
@@ -198,13 +204,6 @@ def _show_workfiles():
     #   avoid issues with reopening
     # - it is possible to explicitly change on top flag of the tool
     host_tools.show_workfiles(parent=None, on_top=False)
-
-
-def get_workfile_build_placeholder_plugins():
-    return [
-        NukePlaceholderLoadPlugin,
-        NukePlaceholderCreatePlugin
-    ]
 
 
 def _install_menu():


### PR DESCRIPTION
## Brief description
Template placeholder creation was erroring out in Nuke due to the Workfile template builder not being able to find any of the plugins for the Nuke host.

## Description
Move `get_workfile_build_placeholder_plugins` function to NukeHost class as workfile template builder expects.

## Testing notes:
1. Start Nuke
2. Create a Placeholder from the template builder