### PR TITLE
Nuke: multiple reformat in baking review profiles

### DIFF
--- a/openpype/hosts/nuke/api/lib.py
+++ b/openpype/hosts/nuke/api/lib.py
@@ -214,7 +214,6 @@ def update_node_data(node, knobname, data):
     knob.setValue(knob_value)
 
 
-@deprecated
 class Knobby(object):
     """[DEPRECATED] For creating knob which it's type isn't
                     mapped in `create_knobs`
@@ -249,9 +248,8 @@ class Knobby(object):
         return " ".join(words)
 
 
-@deprecated
 def create_knobs(data, tab=None):
-    """[DEPRECATED] Create knobs by data
+    """Create knobs by data
 
     Depending on the type of each dict value and creates the correct Knob.
 
@@ -344,9 +342,8 @@ def create_knobs(data, tab=None):
     return knobs
 
 
-@deprecated
 def imprint(node, data, tab=None):
-    """[DEPRECATED] Store attributes with value on node
+    """Store attributes with value on node
 
     Parse user data into Node knobs.
     Use `collections.OrderedDict` to ensure knob order.
@@ -1249,7 +1246,7 @@ def create_write_node(
             nodes to be created before write with dependency
         review (bool)[optional]: adding review knob
         farm (bool)[optional]: rendering workflow target
-        kwargs (dict)[optional]: additional key arguments for formating
+        kwargs (dict)[optional]: additional key arguments for formatting
 
     Example:
         prenodes = {

--- a/openpype/hosts/nuke/api/lib.py
+++ b/openpype/hosts/nuke/api/lib.py
@@ -214,8 +214,9 @@ def update_node_data(node, knobname, data):
     knob.setValue(knob_value)
 
 
+@deprecated
 class Knobby(object):
-    """[DEPRICATED] For creating knob which it's type isn't
+    """[DEPRECATED] For creating knob which it's type isn't
                     mapped in `create_knobs`
 
     Args:
@@ -248,8 +249,9 @@ class Knobby(object):
         return " ".join(words)
 
 
+@deprecated
 def create_knobs(data, tab=None):
-    """[DEPRICATED] Create knobs by data
+    """[DEPRECATED] Create knobs by data
 
     Depending on the type of each dict value and creates the correct Knob.
 
@@ -342,8 +344,9 @@ def create_knobs(data, tab=None):
     return knobs
 
 
+@deprecated
 def imprint(node, data, tab=None):
-    """[DEPRICATED] Store attributes with value on node
+    """[DEPRECATED] Store attributes with value on node
 
     Parse user data into Node knobs.
     Use `collections.OrderedDict` to ensure knob order.
@@ -398,8 +401,9 @@ def imprint(node, data, tab=None):
         node.addKnob(knob)
 
 
+@deprecated
 def add_publish_knob(node):
-    """[DEPRICATED] Add Publish knob to node
+    """[DEPRECATED] Add Publish knob to node
 
     Arguments:
         node (nuke.Node): nuke node to be processed
@@ -416,8 +420,9 @@ def add_publish_knob(node):
     return node
 
 
+@deprecated
 def set_avalon_knob_data(node, data=None, prefix="avalon:"):
-    """[DEPRICATED] Sets data into nodes's avalon knob
+    """[DEPRECATED] Sets data into nodes's avalon knob
 
     Arguments:
         node (nuke.Node): Nuke node to imprint with data,
@@ -478,8 +483,9 @@ def set_avalon_knob_data(node, data=None, prefix="avalon:"):
     return node
 
 
+@deprecated
 def get_avalon_knob_data(node, prefix="avalon:", create=True):
-    """[DEPRICATED]  Gets a data from nodes's avalon knob
+    """[DEPRECATED]  Gets a data from nodes's avalon knob
 
     Arguments:
         node (obj): Nuke node to search for data,
@@ -521,8 +527,9 @@ def get_avalon_knob_data(node, prefix="avalon:", create=True):
     return data
 
 
+@deprecated
 def fix_data_for_node_create(data):
-    """[DEPRICATED] Fixing data to be used for nuke knobs
+    """[DEPRECATED] Fixing data to be used for nuke knobs
     """
     for k, v in data.items():
         if isinstance(v, six.text_type):
@@ -532,8 +539,9 @@ def fix_data_for_node_create(data):
     return data
 
 
+@deprecated
 def add_write_node_legacy(name, **kwarg):
-    """[DEPRICATED] Adding nuke write node
+    """[DEPRECATED] Adding nuke write node
     Arguments:
         name (str): nuke node name
         kwarg (attrs): data for nuke knobs
@@ -697,7 +705,7 @@ def get_nuke_imageio_settings():
 
 @deprecated("openpype.hosts.nuke.api.lib.get_nuke_imageio_settings")
 def get_created_node_imageio_setting_legacy(nodeclass, creator, subset):
-    '''[DEPRICATED]  Get preset data for dataflow (fileType, compression, bitDepth)
+    '''[DEPRECATED]  Get preset data for dataflow (fileType, compression, bitDepth)
     '''
 
     assert any([creator, nodeclass]), nuke.message(

--- a/openpype/hosts/nuke/api/plugin.py
+++ b/openpype/hosts/nuke/api/plugin.py
@@ -558,9 +558,7 @@ class ExporterReview(object):
         self.path_in = self.instance.data.get("path", None)
         self.staging_dir = self.instance.data["stagingDir"]
         self.collection = self.instance.data.get("collection", None)
-        self.data = dict({
-            "representations": list()
-        })
+        self.data = {"representations": []}
 
     def get_file_info(self):
         if self.collection:
@@ -626,7 +624,7 @@ class ExporterReview(object):
         nuke_imageio = opnlib.get_nuke_imageio_settings()
 
         # TODO: this is only securing backward compatibility lets remove
-        # this once all projects's anotomy are updated to newer config
+        # this once all projects's anatomy are updated to newer config
         if "baking" in nuke_imageio.keys():
             return nuke_imageio["baking"]["viewerProcess"]
         else:
@@ -823,8 +821,41 @@ class ExporterReviewMov(ExporterReview):
         add_tags = []
         self.publish_on_farm = farm
         read_raw = kwargs["read_raw"]
+
+        # TODO: remove this when `reformat_nodes_config`
+        # is changed in settings
         reformat_node_add = kwargs["reformat_node_add"]
         reformat_node_config = kwargs["reformat_node_config"]
+
+        # TODO: make this required in future
+        reformat_nodes_config = kwargs.get("reformat_nodes_config", {})
+
+        # TODO: remove this once deprecated is removed
+        # make sure only reformat_nodes_config is used in future
+        if reformat_node_add and reformat_nodes_config.get("enabled"):
+            self.log.warning(
+                "`reformat_node_add` is deprecated. "
+                "Please use only `reformat_nodes_config` instead.")
+            reformat_nodes_config = None
+
+        # TODO: reformat code when backward compatibility is not needed
+        # warning if reformat_nodes_config is not set
+        if not reformat_nodes_config:
+            self.log.warning(
+                "Please set `reformat_nodes_config` in settings.")
+            self.log.warning(
+                "Using `reformat_node_config` instead.")
+            reformat_nodes_config = {
+                "enabled": reformat_node_add,
+                "reposition_nodes": [
+                    {
+                        "node_class": "Reformat",
+                        "knobs": reformat_node_config
+                    }
+                ]
+            }
+
+
         bake_viewer_process = kwargs["bake_viewer_process"]
         bake_viewer_input_process_node = kwargs[
             "bake_viewer_input_process"]
@@ -846,7 +877,6 @@ class ExporterReviewMov(ExporterReview):
 
         subset = self.instance.data["subset"]
         self._temp_nodes[subset] = []
-        # ---------- start nodes creation
 
         # Read node
         r_node = nuke.createNode("Read")
@@ -860,25 +890,24 @@ class ExporterReviewMov(ExporterReview):
         if read_raw:
             r_node["raw"].setValue(1)
 
-        # connect
-        self._temp_nodes[subset].append(r_node)
-        self.previous_node = r_node
-        self.log.debug("Read...   `{}`".format(self._temp_nodes[subset]))
+        # connect to Read node
+        self._shift_to_previous_node_and_temp(subset, r_node, "Read...   `{}`")
 
         # add reformat node
-        if reformat_node_add:
+        if reformat_nodes_config["enabled"]:
+            reposition_nodes = reformat_nodes_config["reposition_nodes"]
+            for reposition_node in reposition_nodes:
+                node_class = reposition_node["node_class"]
+                knobs = reposition_node["knobs"]
+                node = nuke.createNode(node_class)
+                set_node_knobs_from_settings(node, knobs)
+
+                # connect in order
+                self._connect_to_above_nodes(
+                    node, subset, "Reposition node...   `{}`"
+                )
             # append reformated tag
             add_tags.append("reformated")
-
-            rf_node = nuke.createNode("Reformat")
-            set_node_knobs_from_settings(rf_node, reformat_node_config)
-
-            # connect
-            rf_node.setInput(0, self.previous_node)
-            self._temp_nodes[subset].append(rf_node)
-            self.previous_node = rf_node
-            self.log.debug(
-                "Reformat...   `{}`".format(self._temp_nodes[subset]))
 
         # only create colorspace baking if toggled on
         if bake_viewer_process:
@@ -886,18 +915,14 @@ class ExporterReviewMov(ExporterReview):
                 # View Process node
                 ipn = get_view_process_node()
                 if ipn is not None:
-                    # connect
-                    ipn.setInput(0, self.previous_node)
-                    self._temp_nodes[subset].append(ipn)
-                    self.previous_node = ipn
-                    self.log.debug(
-                        "ViewProcess...   `{}`".format(
-                            self._temp_nodes[subset]))
+                    # connect to ViewProcess node
+                    self._connect_to_above_nodes(ipn, subset, "ViewProcess...   `{}`")
 
             if not self.viewer_lut_raw:
                 # OCIODisplay
                 dag_node = nuke.createNode("OCIODisplay")
 
+                # assign display
                 display, viewer = get_viewer_config_from_string(
                     str(baking_view_profile)
                 )
@@ -907,13 +932,7 @@ class ExporterReviewMov(ExporterReview):
                 # assign viewer
                 dag_node["view"].setValue(viewer)
 
-                # connect
-                dag_node.setInput(0, self.previous_node)
-                self._temp_nodes[subset].append(dag_node)
-                self.previous_node = dag_node
-                self.log.debug("OCIODisplay...   `{}`".format(
-                    self._temp_nodes[subset]))
-
+                self._connect_to_above_nodes(dag_node, subset, "OCIODisplay...   `{}`")
         # Write node
         write_node = nuke.createNode("Write")
         self.log.debug("Path: {}".format(self.path))
@@ -966,6 +985,15 @@ class ExporterReviewMov(ExporterReview):
         nuke.scriptSave()
 
         return self.data
+
+    def _shift_to_previous_node_and_temp(self, subset, node, message):
+        self._temp_nodes[subset].append(node)
+        self.previous_node = node
+        self.log.debug(message.format(self._temp_nodes[subset]))
+
+    def _connect_to_above_nodes(self, node, subset, message):
+        node.setInput(0, self.previous_node)
+        self._shift_to_previous_node_and_temp(subset, node, message)
 
 
 @deprecated("openpype.hosts.nuke.api.plugin.NukeWriteCreator")

--- a/openpype/hosts/nuke/api/plugin.py
+++ b/openpype/hosts/nuke/api/plugin.py
@@ -842,9 +842,9 @@ class ExporterReviewMov(ExporterReview):
         # warning if reformat_nodes_config is not set
         if not reformat_nodes_config:
             self.log.warning(
-                "Please set `reformat_nodes_config` in settings.")
-            self.log.warning(
-                "Using `reformat_node_config` instead.")
+                "Please set `reformat_nodes_config` in settings. "
+                "Using `reformat_node_config` instead."
+            )
             reformat_nodes_config = {
                 "enabled": reformat_node_add,
                 "reposition_nodes": [

--- a/openpype/settings/defaults/project_settings/nuke.json
+++ b/openpype/settings/defaults/project_settings/nuke.json
@@ -446,6 +446,41 @@
                             "value": false
                         }
                     ],
+                    "reformat_nodes_config": {
+                        "enabled": false,
+                        "reposition_nodes": [
+                            {
+                                "node_class": "Reformat",
+                                "knobs": [
+                                    {
+                                        "type": "text",
+                                        "name": "type",
+                                        "value": "to format"
+                                    },
+                                    {
+                                        "type": "text",
+                                        "name": "format",
+                                        "value": "HD_1080"
+                                    },
+                                    {
+                                        "type": "text",
+                                        "name": "filter",
+                                        "value": "Lanczos6"
+                                    },
+                                    {
+                                        "type": "bool",
+                                        "name": "black_outside",
+                                        "value": true
+                                    },
+                                    {
+                                        "type": "bool",
+                                        "name": "pbb",
+                                        "value": false
+                                    }
+                                ]
+                            }
+                        ]
+                    },
                     "extension": "mov",
                     "add_custom_tags": []
                 }

--- a/openpype/settings/entities/schemas/projects_schema/schemas/schema_nuke_publish.json
+++ b/openpype/settings/entities/schemas/projects_schema/schemas/schema_nuke_publish.json
@@ -272,6 +272,10 @@
                                 "type": "separator"
                             },
                             {
+                                "type": "label",
+                                "label": "Currently we are supporting also multiple reposition nodes. <br/>Older single reformat node is still supported <br/>and if it is activated then preference will <br/>be on it. If you want to use multiple reformat <br/>nodes then you need to disable single reformat <br/>node and enable multiple <b>Reformat nodes</b> <a href=\"settings://project_settings/nuke/publish/ExtractReviewDataMov/outputs/baking/reformat_nodes_config/enabled\"><b>here</b></a>."
+                            },
+                            {
                                 "type": "boolean",
                                 "key": "reformat_node_add",
                                 "label": "Add Reformat Node",
@@ -284,6 +288,49 @@
                                     {
                                         "label": "Reformat Node Knobs",
                                         "key": "reformat_node_config"
+                                    }
+                                ]
+                            },
+                            {
+                                "key": "reformat_nodes_config",
+                                "type": "dict",
+                                "label": "Reformat Nodes",
+                                "collapsible": true,
+                                "checkbox_key": "enabled",
+                                "children": [
+                                    {
+                                        "type": "boolean",
+                                        "key": "enabled",
+                                        "label": "Enabled"
+                                    },
+                                    {
+                                        "type": "label",
+                                        "label": "Reposition knobs supported only.<br/>You can add multiple reformat nodes <br/>and set their knobs. Order of reformat <br/>nodes is important. First reformat node <br/>will be applied first and last reformat <br/>node will be applied last."
+                                    },
+                                    {
+                                        "key": "reposition_nodes",
+                                        "type": "list",
+                                        "label": "Reposition nodes",
+                                        "object_type": {
+                                            "type": "dict",
+                                            "children": [
+                                                {
+                                                    "key": "node_class",
+                                                    "label": "Node class",
+                                                    "type": "text"
+                                                },
+                                                {
+                                                    "type": "schema_template",
+                                                    "name": "template_nuke_knob_inputs",
+                                                    "template_data": [
+                                                        {
+                                                            "label": "Node knobs",
+                                                            "key": "knobs"
+                                                        }
+                                                    ]
+                                                }
+                                            ]
+                                        }
                                     }
                                 ]
                             },


### PR DESCRIPTION
## Brief description
Added support for multiple reformat nodes in baking profiles.

## Description
Old settings for single reformat node is supported and prioritised just in case studios are using it and backward compatibility is needed. Warnings in Nuke terminal are notifying users to switch settings to new workflow. Settings are also explaining the migration way. 

## Testing notes:
1. Go to settings at your testing project
2. Go to settings `project_settings/nuke/publish/ExtractReviewDataMov/outputs/baking/reformat_node_add` and disable
3. Go to settings `project_settings/nuke/publish/ExtractReviewDataMov/outputs/baking/reformat_nodes_config/enabled` and disable
![nuke_bake_reformat_activate](https://user-images.githubusercontent.com/40640033/220883976-31af74ff-124d-4c53-8eb8-769eade0ab28.png)

4. Go to `project_settings/nuke/publish/ExtractReviewDataMov/outputs/baking/reformat_nodes_config/reposition_nodes` copy contenst of .zip file and paste it to `reposition_nodes`
[bake_multipleReformat__reposition_nodes.zip](https://github.com/ynput/OpenPype/files/10812695/bake_multipleReformat__reposition_nodes.zip)

Here is how it suppose to look after you apply the settins
![nuke_bake_reformat_two](https://user-images.githubusercontent.com/40640033/220886042-44a0bc53-adbb-4fba-9f50-5064293899b7.png)

5. go to your testing nuke workfile and publish with review notice that during publising, there will be two reformats created
![nuke_bake_reformat_two_graph](https://user-images.githubusercontent.com/40640033/220886463-6c73bc29-8c37-43b5-aa9c-51ed8758a632.png)

