### PR TITLE
Start script: Change returncode on validate or list versions

### DIFF
--- a/start.py
+++ b/start.py
@@ -1032,7 +1032,7 @@ def boot():
 
     if "validate" in commands:
         _boot_validate_versions(use_version, local_version)
-        sys.exit(1)
+        sys.exit(0)
 
     if not openpype_path:
         _print("*** Cannot get OpenPype path from database.")
@@ -1042,7 +1042,7 @@ def boot():
 
     if "print_versions" in commands:
         _boot_print_versions(OPENPYPE_ROOT)
-        sys.exit(1)
+        sys.exit(0)
 
     # ------------------------------------------------------------------------
     # Find OpenPype versions


### PR DESCRIPTION
## Brief description
Change exit code from `1` to `0` when versions  are printed or when version is validated.

## Description
Return code `1` is indicating error but there didn't happen any error.

## Testing notes:
1. Run and check return code when you run `openpype_console --list-versions`