### PR TITLE
Scene Inventory: Avoid using ObjectId

### DIFF
--- a/openpype/tools/sceneinventory/switch_dialog.py
+++ b/openpype/tools/sceneinventory/switch_dialog.py
@@ -2,7 +2,6 @@ import collections
 import logging
 from qtpy import QtWidgets, QtCore
 import qtawesome
-from bson.objectid import ObjectId
 
 from openpype.client import (
     get_asset_by_name,
@@ -161,7 +160,7 @@ class SwitchAssetDialog(QtWidgets.QDialog):
         repre_ids = set()
         content_loaders = set()
         for item in self._items:
-            repre_ids.add(ObjectId(item["representation"]))
+            repre_ids.add(str(item["representation"]))
             content_loaders.add(item["loader"])
 
         project_name = self.active_project()
@@ -170,7 +169,7 @@ class SwitchAssetDialog(QtWidgets.QDialog):
             representation_ids=repre_ids,
             archived=True
         ))
-        repres_by_id = {repre["_id"]: repre for repre in repres}
+        repres_by_id = {str(repre["_id"]): repre for repre in repres}
 
         # stash context values, works only for single representation
         if len(repres) == 1:
@@ -181,18 +180,18 @@ class SwitchAssetDialog(QtWidgets.QDialog):
         content_repres = {}
         archived_repres = []
         missing_repres = []
-        version_ids = []
+        version_ids = set()
         for repre_id in repre_ids:
             if repre_id not in repres_by_id:
                 missing_repres.append(repre_id)
             elif repres_by_id[repre_id]["type"] == "archived_representation":
                 repre = repres_by_id[repre_id]
                 archived_repres.append(repre)
-                version_ids.append(repre["parent"])
+                version_ids.add(repre["parent"])
             else:
                 repre = repres_by_id[repre_id]
                 content_repres[repre_id] = repres_by_id[repre_id]
-                version_ids.append(repre["parent"])
+                version_ids.add(repre["parent"])
 
         versions = get_versions(
             project_name,
@@ -1249,7 +1248,7 @@ class SwitchAssetDialog(QtWidgets.QDialog):
             repre_docs_by_parent_id_by_name[parent_id][name] = repre_doc
 
         for container in self._items:
-            container_repre_id = ObjectId(container["representation"])
+            container_repre_id = container["representation"]
             container_repre = self.content_repres[container_repre_id]
             container_repre_name = container_repre["name"]
 

--- a/openpype/tools/sceneinventory/view.py
+++ b/openpype/tools/sceneinventory/view.py
@@ -4,7 +4,6 @@ from functools import partial
 
 from qtpy import QtWidgets, QtCore
 import qtawesome
-from bson.objectid import ObjectId
 
 from openpype.client import (
     get_version_by_id,
@@ -84,22 +83,20 @@ class SceneInventoryView(QtWidgets.QTreeView):
         if not items:
             return
 
-        repre_ids = []
-        for item in items:
-            item_id = ObjectId(item["representation"])
-            if item_id not in repre_ids:
-                repre_ids.append(item_id)
+        repre_ids = {
+            item["representation"]
+            for item in items
+        }
 
         project_name = legacy_io.active_project()
         repre_docs = get_representations(
             project_name, representation_ids=repre_ids, fields=["parent"]
         )
 
-        version_ids = []
-        for repre_doc in repre_docs:
-            version_id = repre_doc["parent"]
-            if version_id not in version_ids:
-                version_ids.append(version_id)
+        version_ids = {
+            repre_doc["parent"]
+            for repre_doc in repre_docs
+        }
 
         loaded_versions = get_versions(
             project_name, version_ids=version_ids, hero=True
@@ -107,18 +104,17 @@ class SceneInventoryView(QtWidgets.QTreeView):
 
         loaded_hero_versions = []
         versions_by_parent_id = collections.defaultdict(list)
-        version_parents = []
+        subset_ids = set()
         for version in loaded_versions:
             if version["type"] == "hero_version":
                 loaded_hero_versions.append(version)
             else:
                 parent_id = version["parent"]
                 versions_by_parent_id[parent_id].append(version)
-                if parent_id not in version_parents:
-                    version_parents.append(parent_id)
+                subset_ids.add(parent_id)
 
         all_versions = get_versions(
-            project_name, subset_ids=version_parents, hero=True
+            project_name, subset_ids=subset_ids, hero=True
         )
         hero_versions = []
         versions = []
@@ -146,11 +142,11 @@ class SceneInventoryView(QtWidgets.QTreeView):
         switch_to_versioned = None
         if has_loaded_hero_versions:
             def _on_switch_to_versioned(items):
-                repre_ids = []
+                repre_ids = set()
                 for item in items:
-                    item_id = ObjectId(item["representation"])
+                    item_id = item["representation"]
                     if item_id not in repre_ids:
-                        repre_ids.append(item_id)
+                        repre_ids.add(item_id)
 
                 repre_docs = get_representations(
                     project_name,
@@ -158,13 +154,13 @@ class SceneInventoryView(QtWidgets.QTreeView):
                     fields=["parent"]
                 )
 
-                version_ids = []
+                version_ids = set()
                 version_id_by_repre_id = {}
                 for repre_doc in repre_docs:
                     version_id = repre_doc["parent"]
-                    version_id_by_repre_id[repre_doc["_id"]] = version_id
-                    if version_id not in version_ids:
-                        version_ids.append(version_id)
+                    repre_id = str(repre_doc["_id"])
+                    version_id_by_repre_id[repre_id] = version_id
+                    version_ids.add(version_id)
 
                 hero_versions = get_hero_versions(
                     project_name,
@@ -194,7 +190,7 @@ class SceneInventoryView(QtWidgets.QTreeView):
                         version_doc["name"]
 
                 for item in items:
-                    repre_id = ObjectId(item["representation"])
+                    repre_id = item["representation"]
                     version_id = version_id_by_repre_id.get(repre_id)
                     version_name = version_name_by_id.get(version_id)
                     if version_name is not None:


### PR DESCRIPTION
## Brief description
Avoid using conversion to ObjectId type in scene inventory tool.

## Description
Preparation for AYON compatibility where ObjectId won't be used for ids. Representation ids from loaded containers are not converted to ObjectId but kept as strings which also required some changes when working with representation documents.

## Testing notes:
1. Open DCC where is host integration with references
2. Reference (load) something into the scene
3. Open scene manager
4. You should see all loaded containers there
5. All actions on them should work
6. Try run Switch action
7. Switch dialog should show valid possible changes as before this PR