### PR TITLE
Maya: Options for VrayProxy output - OP-2010

### DIFF
--- a/openpype/hosts/maya/plugins/create/create_vrayproxy.py
+++ b/openpype/hosts/maya/plugins/create/create_vrayproxy.py
@@ -9,6 +9,9 @@ class CreateVrayProxy(plugin.Creator):
     family = "vrayproxy"
     icon = "gears"
 
+    vrmesh = True
+    alembic = True
+
     def __init__(self, *args, **kwargs):
         super(CreateVrayProxy, self).__init__(*args, **kwargs)
 
@@ -18,3 +21,6 @@ class CreateVrayProxy(plugin.Creator):
 
         # Write vertex colors
         self.data["vertexColors"] = False
+
+        self.data["vrmesh"] = self.vrmesh
+        self.data["alembic"] = self.alembic

--- a/openpype/hosts/maya/plugins/publish/collect_vrayproxy.py
+++ b/openpype/hosts/maya/plugins/publish/collect_vrayproxy.py
@@ -9,10 +9,16 @@ class CollectVrayProxy(pyblish.api.InstancePlugin):
     Add `pointcache` family for it.
     """
     order = pyblish.api.CollectorOrder + 0.01
-    label = 'Collect Vray Proxy'
+    label = "Collect Vray Proxy"
     families = ["vrayproxy"]
 
     def process(self, instance):
         """Collector entry point."""
         if not instance.data.get('families'):
             instance.data["families"] = []
+
+        if instance.data.get("vrmesh"):
+            instance.data["families"].append("vrayproxy.vrmesh")
+
+        if instance.data.get("alembic"):
+            instance.data["families"].append("vrayproxy.alembic")

--- a/openpype/hosts/maya/plugins/publish/extract_pointcache.py
+++ b/openpype/hosts/maya/plugins/publish/extract_pointcache.py
@@ -25,7 +25,7 @@ class ExtractAlembic(publish.Extractor):
 
     label = "Extract Pointcache (Alembic)"
     hosts = ["maya"]
-    families = ["pointcache", "model", "vrayproxy"]
+    families = ["pointcache", "model", "vrayproxy.alembic"]
     targets = ["local", "remote"]
 
     def process(self, instance):

--- a/openpype/hosts/maya/plugins/publish/extract_vrayproxy.py
+++ b/openpype/hosts/maya/plugins/publish/extract_vrayproxy.py
@@ -16,7 +16,7 @@ class ExtractVRayProxy(publish.Extractor):
 
     label = "VRay Proxy (.vrmesh)"
     hosts = ["maya"]
-    families = ["vrayproxy"]
+    families = ["vrayproxy.vrmesh"]
 
     def process(self, instance):
 

--- a/openpype/hosts/maya/plugins/publish/validate_vrayproxy.py
+++ b/openpype/hosts/maya/plugins/publish/validate_vrayproxy.py
@@ -12,8 +12,6 @@ class ValidateVrayProxy(pyblish.api.InstancePlugin):
 
     def process(self, instance):
         data = instance.data
-        self.log.info(data["family"])
-        self.log.info(data["families"])
 
         if not data["setMembers"]:
             raise KnownPublishError(

--- a/openpype/hosts/maya/plugins/publish/validate_vrayproxy.py
+++ b/openpype/hosts/maya/plugins/publish/validate_vrayproxy.py
@@ -1,27 +1,33 @@
 import pyblish.api
 
+from openpype.pipeline import KnownPublishError
+
 
 class ValidateVrayProxy(pyblish.api.InstancePlugin):
 
     order = pyblish.api.ValidatorOrder
-    label = 'VRay Proxy Settings'
-    hosts = ['maya']
-    families = ['studio.vrayproxy']
+    label = "VRay Proxy Settings"
+    hosts = ["maya"]
+    families = ["vrayproxy"]
 
     def process(self, instance):
-
-        invalid = self.get_invalid(instance)
-        if invalid:
-            raise RuntimeError("'%s' has invalid settings for VRay Proxy "
-                               "export!" % instance.name)
-
-    @classmethod
-    def get_invalid(cls, instance):
         data = instance.data
+        self.log.info(data["family"])
+        self.log.info(data["families"])
 
         if not data["setMembers"]:
-            cls.log.error("'%s' is empty! This is a bug" % instance.name)
+            raise KnownPublishError(
+                "'%s' is empty! This is a bug" % instance.name
+            )
 
         if data["animation"]:
             if data["frameEnd"] < data["frameStart"]:
-                cls.log.error("End frame is smaller than start frame")
+                raise KnownPublishError(
+                    "End frame is smaller than start frame"
+                )
+
+        if not data["vrmesh"] and not data["alembic"]:
+            raise KnownPublishError(
+                "Both vrmesh and alembic are off. Needs at least one to"
+                " publish."
+            )

--- a/openpype/settings/defaults/project_settings/maya.json
+++ b/openpype/settings/defaults/project_settings/maya.json
@@ -197,6 +197,14 @@
             "maskColor_manager": false,
             "maskOperator": false
         },
+        "CreateVrayProxy": {
+            "enabled": true,
+            "vrmesh": true,
+            "alembic": true,
+            "defaults": [
+                "Main"
+            ]
+        },
         "CreateMultiverseUsd": {
             "enabled": true,
             "defaults": [
@@ -264,12 +272,6 @@
             "defaults": [
                 "Main",
                 "Anim"
-            ]
-        },
-        "CreateVrayProxy": {
-            "enabled": true,
-            "defaults": [
-                "Main"
             ]
         },
         "CreateVRayScene": {
@@ -674,7 +676,7 @@
             "families": [
                 "pointcache",
                 "model",
-                "vrayproxy"
+                "vrayproxy.alembic"
             ]
         },
         "ExtractObj": {

--- a/openpype/settings/entities/schemas/projects_schema/schemas/schema_maya_create.json
+++ b/openpype/settings/entities/schemas/projects_schema/schemas/schema_maya_create.json
@@ -323,6 +323,36 @@
             ]
         },
         {
+            "type": "dict",
+            "collapsible": true,
+            "key": "CreateVrayProxy",
+            "label": "Create VRay Proxy",
+            "checkbox_key": "enabled",
+            "children": [
+                {
+                    "type": "boolean",
+                    "key": "enabled",
+                    "label": "Enabled"
+                },
+                {
+                    "type": "boolean",
+                    "key": "vrmesh",
+                    "label": "VrMesh"
+                },
+                {
+                    "type": "boolean",
+                    "key": "alembic",
+                    "label": "Alembic"
+                },
+                {
+                    "type": "list",
+                    "key": "defaults",
+                    "label": "Default Subsets",
+                    "object_type": "text"
+                }
+            ]
+        },
+        {
             "type": "schema_template",
             "name": "template_create_plugin",
             "template_data": [
@@ -369,10 +399,6 @@
                 {
                     "key": "CreateSetDress",
                     "label": "Create Set Dress"
-                },
-                {
-                    "key": "CreateVrayProxy",
-                    "label": "Create VRay Proxy"
                 },
                 {
                     "key": "CreateVRayScene",


### PR DESCRIPTION
## Brief description
Options for output of VrayProxy.

## Description
Client requested more granular control of output from VrayProxy instance. Exposed options on the instance and settings for vrmesh and alembic.

## Testing notes:
1. Create VrayProxy in Maya.
2. Enable/Disable attributes `vrmesh` and `alembic`, on the instance.
3. Enable/Disable `project_settings/maya/create/CreateVrayProxy/vrmesh` and/or `project_settings/maya/create/CreateVrayProxy/alembic` and create VrayProxy instance to validate settings are propagated to instance.