### PR TITLE
Publisher: Prevent access to create tab after publish start

### DIFF
--- a/openpype/tools/publisher/widgets/overview_widget.py
+++ b/openpype/tools/publisher/widgets/overview_widget.py
@@ -146,6 +146,7 @@ class OverviewWidget(QtWidgets.QFrame):
         self._subset_list_view = subset_list_view
         self._subset_views_layout = subset_views_layout
 
+        self._create_btn = create_btn
         self._delete_btn = delete_btn
 
         self._subset_attributes_widget = subset_attributes_widget
@@ -388,11 +389,13 @@ class OverviewWidget(QtWidgets.QFrame):
     def _on_publish_start(self):
         """Publish started."""
 
+        self._create_btn.setEnabled(False)
         self._subset_attributes_wrap.setEnabled(False)
 
     def _on_publish_reset(self):
         """Context in controller has been refreshed."""
 
+        self._create_btn.setEnabled(True)
         self._subset_attributes_wrap.setEnabled(True)
         self._subset_content_widget.setEnabled(self._controller.host_is_valid)
 

--- a/openpype/tools/publisher/window.py
+++ b/openpype/tools/publisher/window.py
@@ -561,7 +561,8 @@ class PublisherWindow(QtWidgets.QDialog):
         return self._tabs_widget.is_current_tab(identifier)
 
     def _go_to_create_tab(self):
-        self._set_current_tab("create")
+        if self._create_tab.isEnabled():
+            self._set_current_tab("create")
 
     def _go_to_publish_tab(self):
         self._set_current_tab("publish")


### PR DESCRIPTION
## Brief description
Prevent access to create tab after publish start.

## Description
Disable create button in instance view on publish start and enable it again on reset. Even with that make sure that it is not possible to go to create tab if the tab is disabled.

## Testing notes:
1. Open Publisher tool
2. Hit validate (you must have at least 1 created instance to be able do that)
3. Go to Publish tab
4. Minimize bottom overlay
5. `+` button in instance view should be disabled

Resolves https://github.com/ynput/OpenPype/issues/4316