### PR TITLE
Unreal: fix loaders because of missing AssetContainer

### DIFF
--- a/openpype/hosts/unreal/integration/UE_5.0/OpenPype/Source/OpenPype/Private/AssetContainer.cpp
+++ b/openpype/hosts/unreal/integration/UE_5.0/OpenPype/Source/OpenPype/Private/AssetContainer.cpp
@@ -1,0 +1,114 @@
+// Fill out your copyright notice in the Description page of Project Settings.
+
+#include "AssetContainer.h"
+#include "AssetRegistry/AssetRegistryModule.h"
+#include "Misc/PackageName.h"
+#include "Engine.h"
+#include "Containers/UnrealString.h"
+
+UAssetContainer::UAssetContainer(const FObjectInitializer& ObjectInitializer)
+: UAssetUserData(ObjectInitializer)
+{
+	FAssetRegistryModule& AssetRegistryModule = FModuleManager::LoadModuleChecked<FAssetRegistryModule>("AssetRegistry");
+	FString path = UAssetContainer::GetPathName();
+	UE_LOG(LogTemp, Warning, TEXT("UAssetContainer %s"), *path);
+	FARFilter Filter;
+	Filter.PackagePaths.Add(FName(*path));
+
+	AssetRegistryModule.Get().OnAssetAdded().AddUObject(this, &UAssetContainer::OnAssetAdded);
+	AssetRegistryModule.Get().OnAssetRemoved().AddUObject(this, &UAssetContainer::OnAssetRemoved);
+	AssetRegistryModule.Get().OnAssetRenamed().AddUObject(this, &UAssetContainer::OnAssetRenamed);
+}
+
+void UAssetContainer::OnAssetAdded(const FAssetData& AssetData)
+{
+	TArray<FString> split;
+
+	// get directory of current container
+	FString selfFullPath = UAssetContainer::GetPathName();
+	FString selfDir = FPackageName::GetLongPackagePath(*selfFullPath);
+
+	// get asset path and class
+	FString assetPath = AssetData.GetFullName();
+	FString assetFName = AssetData.AssetClassPath.ToString();
+	UE_LOG(LogTemp, Log, TEXT("asset name %s"), *assetFName);
+	// split path
+	assetPath.ParseIntoArray(split, TEXT(" "), true);
+
+	FString assetDir = FPackageName::GetLongPackagePath(*split[1]);
+
+	// take interest only in paths starting with path of current container
+	if (assetDir.StartsWith(*selfDir))
+	{
+		// exclude self
+		if (assetFName != "AssetContainer")
+		{
+			assets.Add(assetPath);
+			assetsData.Add(AssetData);
+			UE_LOG(LogTemp, Log, TEXT("%s: asset added to %s"), *selfFullPath, *selfDir);
+		}
+	}
+}
+
+void UAssetContainer::OnAssetRemoved(const FAssetData& AssetData)
+{
+	TArray<FString> split;
+
+	// get directory of current container
+	FString selfFullPath = UAssetContainer::GetPathName();
+	FString selfDir = FPackageName::GetLongPackagePath(*selfFullPath);
+
+	// get asset path and class
+	FString assetPath = AssetData.GetFullName();
+	FString assetFName = AssetData.AssetClassPath.ToString();
+
+	// split path
+	assetPath.ParseIntoArray(split, TEXT(" "), true);
+
+	FString assetDir = FPackageName::GetLongPackagePath(*split[1]);
+
+	// take interest only in paths starting with path of current container
+	FString path = UAssetContainer::GetPathName();
+	FString lpp = FPackageName::GetLongPackagePath(*path);
+
+	if (assetDir.StartsWith(*selfDir))
+	{
+		// exclude self
+		if (assetFName != "AssetContainer")
+		{
+			// UE_LOG(LogTemp, Warning, TEXT("%s: asset removed"), *lpp);
+			assets.Remove(assetPath);
+			assetsData.Remove(AssetData);
+		}
+	}
+}
+
+void UAssetContainer::OnAssetRenamed(const FAssetData& AssetData, const FString& str)
+{
+	TArray<FString> split;
+
+	// get directory of current container
+	FString selfFullPath = UAssetContainer::GetPathName();
+	FString selfDir = FPackageName::GetLongPackagePath(*selfFullPath);
+
+	// get asset path and class
+	FString assetPath = AssetData.GetFullName();
+	FString assetFName = AssetData.AssetClassPath.ToString();
+
+	// split path
+	assetPath.ParseIntoArray(split, TEXT(" "), true);
+
+	FString assetDir = FPackageName::GetLongPackagePath(*split[1]);
+	if (assetDir.StartsWith(*selfDir))
+	{
+		// exclude self
+		if (assetFName != "AssetContainer")
+		{
+
+			assets.Remove(str);
+			assets.Add(assetPath);
+			assetsData.Remove(AssetData);
+			// UE_LOG(LogTemp, Warning, TEXT("%s: asset renamed %s"), *lpp, *str);
+		}
+	}
+}

--- a/openpype/hosts/unreal/integration/UE_5.0/OpenPype/Source/OpenPype/Private/AssetContainerFactory.cpp
+++ b/openpype/hosts/unreal/integration/UE_5.0/OpenPype/Source/OpenPype/Private/AssetContainerFactory.cpp
@@ -1,0 +1,20 @@
+#include "AssetContainerFactory.h"
+#include "AssetContainer.h"
+
+UAssetContainerFactory::UAssetContainerFactory(const FObjectInitializer& ObjectInitializer)
+	: UFactory(ObjectInitializer)
+{
+	SupportedClass = UAssetContainer::StaticClass();
+	bCreateNew = false;
+	bEditorImport = true;
+}
+
+UObject* UAssetContainerFactory::FactoryCreateNew(UClass* Class, UObject* InParent, FName Name, EObjectFlags Flags, UObject* Context, FFeedbackContext* Warn)
+{
+	UAssetContainer* AssetContainer = NewObject<UAssetContainer>(InParent, Class, Name, Flags);
+	return AssetContainer;
+}
+
+bool UAssetContainerFactory::ShouldShowInNewMenu() const {
+	return false;
+}

--- a/openpype/hosts/unreal/integration/UE_5.0/OpenPype/Source/OpenPype/Public/AssetContainer.h
+++ b/openpype/hosts/unreal/integration/UE_5.0/OpenPype/Source/OpenPype/Public/AssetContainer.h
@@ -1,0 +1,37 @@
+// Fill out your copyright notice in the Description page of Project Settings.
+
+#pragma once
+
+#include "CoreMinimal.h"
+#include "UObject/NoExportTypes.h"
+#include "Engine/AssetUserData.h"
+#include "AssetRegistry/AssetData.h"
+#include "AssetContainer.generated.h"
+
+/**
+ *
+ */
+UCLASS(Blueprintable)
+class OPENPYPE_API UAssetContainer : public UAssetUserData
+{
+	GENERATED_BODY()
+
+public:
+
+	UAssetContainer(const FObjectInitializer& ObjectInitalizer);
+	// ~UAssetContainer();
+
+	UPROPERTY(EditAnywhere, BlueprintReadOnly, Category="Assets")
+		TArray<FString> assets;
+
+	// There seems to be no reflection option to expose array of FAssetData
+	/*
+	UPROPERTY(Transient, BlueprintReadOnly, Category = "Python", meta=(DisplayName="Assets Data"))
+		TArray<FAssetData> assetsData;
+	*/
+private:
+	TArray<FAssetData> assetsData;
+	void OnAssetAdded(const FAssetData& AssetData);
+	void OnAssetRemoved(const FAssetData& AssetData);
+	void OnAssetRenamed(const FAssetData& AssetData, const FString& str);
+};

--- a/openpype/hosts/unreal/integration/UE_5.0/OpenPype/Source/OpenPype/Public/AssetContainerFactory.h
+++ b/openpype/hosts/unreal/integration/UE_5.0/OpenPype/Source/OpenPype/Public/AssetContainerFactory.h
@@ -1,0 +1,21 @@
+// Fill out your copyright notice in the Description page of Project Settings.
+
+#pragma once
+
+#include "CoreMinimal.h"
+#include "Factories/Factory.h"
+#include "AssetContainerFactory.generated.h"
+
+/**
+ *
+ */
+UCLASS()
+class OPENPYPE_API UAssetContainerFactory : public UFactory
+{
+	GENERATED_BODY()
+
+public:
+	UAssetContainerFactory(const FObjectInitializer& ObjectInitializer);
+	virtual UObject* FactoryCreateNew(UClass* Class, UObject* InParent, FName Name, EObjectFlags Flags, UObject* Context, FFeedbackContext* Warn) override;
+	virtual bool ShouldShowInNewMenu() const override;
+};


### PR DESCRIPTION
## Brief description
Fixing Unreal loaders, where changes in OpenPype Unreal integration plugin deleted AssetContainer.

## Description
`AssetContainer` and `AssetContainerFactory` are still used to mark loaded instances. Because of optimizations in Integration plugin we've accidentally removed them but that broke loader.

## Testing notes:
1. Start Unreal with OP
2. try to load something

> **Note**
> you need to force engine to rebuild the plugin - delete `C:\Program Files\Epic Games\UE_5.1\Engine\Plugins\Marketplace\OpenPype` (or analogous)