### PR TITLE
hiero: fix effect item node class

### DIFF
--- a/openpype/hosts/hiero/plugins/publish/collect_clip_effects.py
+++ b/openpype/hosts/hiero/plugins/publish/collect_clip_effects.py
@@ -120,13 +120,10 @@ class CollectClipEffects(pyblish.api.InstancePlugin):
         track = sitem.parentTrack().name()
         # node serialization
         node = sitem.node()
-        node_serialized = self.node_serialisation(node)
+        node_serialized = self.node_serialization(node)
         node_name = sitem.name()
+        node_class = node.Class()
 
-        if "_" in node_name:
-            node_class = re.sub(r"(?:_)[_0-9]+", "", node_name)  # more numbers
-        else:
-            node_class = re.sub(r"\d+", "", node_name)  # one number
 
         # collect timelineIn/Out
         effect_t_in = int(sitem.timelineIn())
@@ -148,7 +145,7 @@ class CollectClipEffects(pyblish.api.InstancePlugin):
             "node": node_serialized
         }}
 
-    def node_serialisation(self, node):
+    def node_serialization(self, node):
         node_serialized = {}
 
         # adding ignoring knob keys

--- a/openpype/hosts/hiero/plugins/publish/collect_clip_effects.py
+++ b/openpype/hosts/hiero/plugins/publish/collect_clip_effects.py
@@ -124,7 +124,6 @@ class CollectClipEffects(pyblish.api.InstancePlugin):
         node_name = sitem.name()
         node_class = node.Class()
 
-
         # collect timelineIn/Out
         effect_t_in = int(sitem.timelineIn())
         effect_t_out = int(sitem.timelineOut())


### PR DESCRIPTION
## Brief description
Collected effect name after renaming is saving correct class name.

## Testing notes:
1. Go to a Hiero timeline.
2. Drag in a clip and create soft effects. Tested with `OCIOCDLTransform`.
3. Rename soft effects with something other than default node name.
4. Publsih clip with its effects.
5. Check published effects json, it will have wrong class name.

Resolves https://github.com/ynput/OpenPype/issues/4326