### PR TITLE
Color Transcoding: store target_colorspace as new colorspace

### DIFF
--- a/openpype/plugins/publish/extract_color_transcode.py
+++ b/openpype/plugins/publish/extract_color_transcode.py
@@ -129,11 +129,14 @@ class ExtractOIIOTranscode(publish.Extractor):
                                colorspace_data.get("display"))
 
                 # both could be already collected by DCC,
-                # but could be overwritten
+                # but could be overwritten when transcoding
                 if view:
                     new_repre["colorspaceData"]["view"] = view
                 if display:
                     new_repre["colorspaceData"]["display"] = display
+                if target_colorspace:
+                    new_repre["colorspaceData"]["colorspace"] = \
+                        target_colorspace
 
                 additional_command_args = (output_def["oiiotool_args"]
                                            ["additional_command_args"])


### PR DESCRIPTION
## Brief description
When transcoding into new colorspace, representation must carry this information instead original color space.


## Testing notes:
1. publish workfile where color transcoding should happen
2. check final transcoded representation in DB if it contains colorspace which should be transcoded into