### PR TITLE
Nuke: Add option to use new creating system in workfile template builder

### DIFF
--- a/openpype/hosts/maya/api/workfile_template_builder.py
+++ b/openpype/hosts/maya/api/workfile_template_builder.py
@@ -22,6 +22,8 @@ PLACEHOLDER_SET = "PLACEHOLDERS_SET"
 class MayaTemplateBuilder(AbstractTemplateBuilder):
     """Concrete implementation of AbstractTemplateBuilder for maya"""
 
+    use_legacy_creators = True
+
     def import_template(self, path):
         """Import template into current scene.
         Block if a template is already loaded.

--- a/openpype/hosts/nuke/api/plugin.py
+++ b/openpype/hosts/nuke/api/plugin.py
@@ -239,7 +239,11 @@ class NukeCreator(NewCreator):
 
     def get_pre_create_attr_defs(self):
         return [
-            BoolDef("use_selection", label="Use selection")
+            BoolDef(
+                "use_selection",
+                default=not self.create_context.headless,
+                label="Use selection"
+            )
         ]
 
     def get_creator_settings(self, project_settings, settings_key=None):

--- a/openpype/hosts/nuke/plugins/create/create_write_image.py
+++ b/openpype/hosts/nuke/plugins/create/create_write_image.py
@@ -35,7 +35,7 @@ class CreateWriteImage(napi.NukeWriteCreator):
         attr_defs = [
             BoolDef(
                 "use_selection",
-                default=True,
+                default=not self.create_context.headless,
                 label="Use selection"
             ),
             self._get_render_target_enum(),

--- a/openpype/hosts/nuke/plugins/create/create_write_prerender.py
+++ b/openpype/hosts/nuke/plugins/create/create_write_prerender.py
@@ -37,7 +37,7 @@ class CreateWritePrerender(napi.NukeWriteCreator):
         attr_defs = [
             BoolDef(
                 "use_selection",
-                default=True,
+                default=not self.create_context.headless,
                 label="Use selection"
             ),
             self._get_render_target_enum()

--- a/openpype/hosts/nuke/plugins/create/create_write_render.py
+++ b/openpype/hosts/nuke/plugins/create/create_write_render.py
@@ -34,7 +34,7 @@ class CreateWriteRender(napi.NukeWriteCreator):
         attr_defs = [
             BoolDef(
                 "use_selection",
-                default=True,
+                default=not self.create_context.headless,
                 label="Use selection"
             ),
             self._get_render_target_enum()

--- a/openpype/pipeline/workfile/workfile_template_builder.py
+++ b/openpype/pipeline/workfile/workfile_template_builder.py
@@ -1653,7 +1653,7 @@ class PlaceholderCreateMixin(object):
                     asset_name
                 ).process()
             else:
-                creator_instance =  creator_plugin.create(
+                creator_instance = creator_plugin.create(
                     subset_name,
                     {
                         "asset": asset_doc["name"],

--- a/openpype/pipeline/workfile/workfile_template_builder.py
+++ b/openpype/pipeline/workfile/workfile_template_builder.py
@@ -43,7 +43,8 @@ from openpype.pipeline.load import (
     load_with_repre_context,
 )
 from openpype.pipeline.create import (
-    discover_legacy_creator_plugins
+    discover_legacy_creator_plugins,
+    CreateContext,
 )
 
 
@@ -91,6 +92,7 @@ class AbstractTemplateBuilder(object):
     """
 
     _log = None
+    use_legacy_creators = False
 
     def __init__(self, host):
         # Get host name
@@ -110,6 +112,7 @@ class AbstractTemplateBuilder(object):
         self._placeholder_plugins = None
         self._loaders_by_name = None
         self._creators_by_name = None
+        self._create_context = None
 
         self._system_settings = None
         self._project_settings = None
@@ -170,6 +173,14 @@ class AbstractTemplateBuilder(object):
             .get(self.current_task_name, {})
             .get("type")
         )
+
+    @property
+    def create_context(self):
+        if self._create_context is None:
+            self._create_context = CreateContext(
+                self.host, discover_publish_plugins=False
+            )
+        return self._create_context
 
     def get_placeholder_plugin_classes(self):
         """Get placeholder plugin classes that can be used to build template.
@@ -235,18 +246,29 @@ class AbstractTemplateBuilder(object):
             self._loaders_by_name = get_loaders_by_name()
         return self._loaders_by_name
 
+    def _collect_legacy_creators(self):
+        creators_by_name = {}
+        for creator in discover_legacy_creator_plugins():
+            if not creator.enabled:
+                continue
+            creator_name = creator.__name__
+            if creator_name in creators_by_name:
+                raise KeyError(
+                    "Duplicated creator name {} !".format(creator_name)
+                )
+            creators_by_name[creator_name] = creator
+        self._creators_by_name = creators_by_name
+
+    def _collect_creators(self):
+        self._creators_by_name = dict(self.create_context.creators)
+
     def get_creators_by_name(self):
         if self._creators_by_name is None:
-            self._creators_by_name = {}
-            for creator in discover_legacy_creator_plugins():
-                if not creator.enabled:
-                    continue
-                creator_name = creator.__name__
-                if creator_name in self._creators_by_name:
-                    raise KeyError(
-                        "Duplicated creator name {} !".format(creator_name)
-                    )
-                self._creators_by_name[creator_name] = creator
+            if self.use_legacy_creators:
+                self._collect_legacy_creators()
+            else:
+                self._collect_creators()
+
         return self._creators_by_name
 
     def get_shared_data(self, key):
@@ -1579,6 +1601,8 @@ class PlaceholderCreateMixin(object):
             placeholder (PlaceholderItem): Placeholder item with information
                 about requested publishable instance.
         """
+
+        legacy_create = self.builder.use_legacy_creators
         creator_name = placeholder.data["creator"]
         create_variant = placeholder.data["create_variant"]
 
@@ -1589,17 +1613,28 @@ class PlaceholderCreateMixin(object):
         task_name = legacy_io.Session["AVALON_TASK"]
         asset_name = legacy_io.Session["AVALON_ASSET"]
 
-        # get asset id
-        asset_doc = get_asset_by_name(project_name, asset_name, fields=["_id"])
-        assert asset_doc, "No current asset found in Session"
-        asset_id = asset_doc['_id']
+        if legacy_create:
+            asset_doc = get_asset_by_name(
+                project_name, asset_name, fields=["_id"]
+            )
+            assert asset_doc, "No current asset found in Session"
+            subset_name = creator_plugin.get_subset_name(
+                create_variant,
+                task_name,
+                asset_doc["_id"],
+                project_name
+            )
 
-        subset_name = creator_plugin.get_subset_name(
-            create_variant,
-            task_name,
-            asset_id,
-            project_name
-        )
+        else:
+            asset_doc = get_asset_by_name(project_name, asset_name)
+            assert asset_doc, "No current asset found in Session"
+            subset_name = creator_plugin.get_subset_name(
+                create_variant,
+                task_name,
+                asset_doc,
+                project_name,
+                self.builder.host_name
+            )
 
         creator_data = {
             "creator_name": creator_name,
@@ -1612,10 +1647,22 @@ class PlaceholderCreateMixin(object):
 
         # compile subset name from variant
         try:
-            creator_instance = creator_plugin(
-                subset_name,
-                asset_name
-            ).process()
+            if legacy_create:
+                creator_instance = creator_plugin(
+                    subset_name,
+                    asset_name
+                ).process()
+            else:
+                creator_instance =  creator_plugin.create(
+                    subset_name,
+                    {
+                        "asset": asset_doc["name"],
+                        "task": task_name,
+                        "family": creator_plugin.family,
+                        "variant": create_variant
+                    },
+                    {}
+                )
 
         except Exception:
             failed = True

--- a/openpype/pipeline/workfile/workfile_template_builder.py
+++ b/openpype/pipeline/workfile/workfile_template_builder.py
@@ -1662,7 +1662,7 @@ class PlaceholderCreateMixin(object):
                     task_name=task_name
                 )
 
-        except:
+        except: # noqa: E722
             failed = True
             self.create_failed(placeholder, creator_data)
 

--- a/openpype/pipeline/workfile/workfile_template_builder.py
+++ b/openpype/pipeline/workfile/workfile_template_builder.py
@@ -178,7 +178,9 @@ class AbstractTemplateBuilder(object):
     def create_context(self):
         if self._create_context is None:
             self._create_context = CreateContext(
-                self.host, discover_publish_plugins=False
+                self.host,
+                discover_publish_plugins=False,
+                headless=True
             )
         return self._create_context
 
@@ -1660,7 +1662,7 @@ class PlaceholderCreateMixin(object):
                     task_name=task_name
                 )
 
-        except Exception:
+        except:
             failed = True
             self.create_failed(placeholder, creator_data)
 

--- a/openpype/pipeline/workfile/workfile_template_builder.py
+++ b/openpype/pipeline/workfile/workfile_template_builder.py
@@ -1653,15 +1653,11 @@ class PlaceholderCreateMixin(object):
                     asset_name
                 ).process()
             else:
-                creator_instance = creator_plugin.create(
-                    subset_name,
-                    {
-                        "asset": asset_doc["name"],
-                        "task": task_name,
-                        "family": creator_plugin.family,
-                        "variant": create_variant
-                    },
-                    {}
+                creator_instance = self.create_context.create(
+                    creator_plugin.identifier,
+                    create_variant,
+                    asset_doc,
+                    task_name=task_name
                 )
 
         except Exception:

--- a/openpype/pipeline/workfile/workfile_template_builder.py
+++ b/openpype/pipeline/workfile/workfile_template_builder.py
@@ -1653,7 +1653,7 @@ class PlaceholderCreateMixin(object):
                     asset_name
                 ).process()
             else:
-                creator_instance = self.create_context.create(
+                creator_instance = self.builder.create_context.create(
                     creator_plugin.identifier,
                     create_variant,
                     asset_doc,

--- a/openpype/pipeline/workfile/workfile_template_builder.py
+++ b/openpype/pipeline/workfile/workfile_template_builder.py
@@ -1662,7 +1662,7 @@ class PlaceholderCreateMixin(object):
                     task_name=task_name
                 )
 
-        except: # noqa: E722
+        except:  # noqa: E722
             failed = True
             self.create_failed(placeholder, creator_data)
 


### PR DESCRIPTION
## Brief description
Nuke workfile template builder can use new creators instead of legacy creators.

## Description
Modified workfile template builder to have option to say if legacy creators should be used or new creators. Legacy creators are disabled by default, so Maya has changed the value.

## Testing notes:
- [x] Nuke template builder works with creator plugins
- [x] Maya template builder works with creator plugins