### PR TITLE
General: hardcode Poetry to 1.3.2 temporarily

### DIFF
--- a/tools/create_env.ps1
+++ b/tools/create_env.ps1
@@ -68,7 +68,7 @@ function Install-Poetry() {
     }
 
     $env:POETRY_HOME="$openpype_root\.poetry"
-    # $env:POETRY_VERSION="1.1.15"
+    $env:POETRY_VERSION="1.3.2"
     (Invoke-WebRequest -Uri https://install.python-poetry.org/ -UseBasicParsing).Content | & $($python) -
 }
 

--- a/tools/create_env.sh
+++ b/tools/create_env.sh
@@ -109,7 +109,7 @@ detect_python () {
 install_poetry () {
   echo -e "${BIGreen}>>>${RST} Installing Poetry ..."
   export POETRY_HOME="$openpype_root/.poetry"
-  # export POETRY_VERSION="1.1.15"
+  export POETRY_VERSION="1.3.2"
   command -v curl >/dev/null 2>&1 || { echo -e "${BIRed}!!!${RST}${BIYellow} Missing ${RST}${BIBlue}curl${BIYellow} command.${RST}"; return 1; }
   curl -sSL https://install.python-poetry.org/ | python -
 }


### PR DESCRIPTION
## Brief description
New 1.4.0 breaks `sphinxcontrib-applehelp`. Change in `poetry.lock` would need new minor version.

## Description
`poetry.lock` will be redone for next release, so that should fix it for newer version of Poetry

## Additional info
This will help new users to build OP, I encountered issue with failures of `atomicwrites`.
![2023-02-28 15_12_35-Testing Platform PC - AnyDesk](https://user-images.githubusercontent.com/4457962/221893901-27a5d634-ca7b-4b4f-9119-2d927367cc14.png)

The solution was to purge poetry pypi cache. I used in OP root:
```
poetry cache clear pypi --all
``` 

Or you could manually delete `c:\Users\YOUR_USER\AppData\Local\pypoetry\`
