### PR TITLE
Maya: Validate missing instance attributes

### DIFF
--- a/openpype/hosts/maya/plugins/publish/collect_instances.py
+++ b/openpype/hosts/maya/plugins/publish/collect_instances.py
@@ -137,6 +137,7 @@ class CollectInstances(pyblish.api.ContextPlugin):
             # Create the instance
             instance = context.create_instance(objset)
             instance[:] = members_hierarchy
+            instance.data["objset"] = objset
 
             # Store the exact members of the object set
             instance.data["setMembers"] = members

--- a/openpype/hosts/maya/plugins/publish/validate_instance_attributes.py
+++ b/openpype/hosts/maya/plugins/publish/validate_instance_attributes.py
@@ -9,7 +9,12 @@ from openpype.hosts.maya.api.lib import imprint
 
 
 class ValidateInstanceAttributes(pyblish.api.InstancePlugin):
-    """Validate Instance Attributes."""
+    """Validate Instance Attributes.
+
+    New attributes can be introduced as new features come in. Old instances
+    will need to be updated with these attributes for the documentation to make
+    sense, and users do not have to recreate the instances.
+    """
 
     order = ValidateContentsOrder
     hosts = ["maya"]

--- a/openpype/hosts/maya/plugins/publish/validate_instance_attributes.py
+++ b/openpype/hosts/maya/plugins/publish/validate_instance_attributes.py
@@ -1,0 +1,55 @@
+from maya import cmds
+
+import pyblish.api
+from openpype.pipeline.publish import (
+    ValidateContentsOrder, PublishValidationError, RepairAction
+)
+from openpype.pipeline import discover_legacy_creator_plugins
+from openpype.hosts.maya.api.lib import imprint
+
+
+class ValidateInstanceAttributes(pyblish.api.InstancePlugin):
+    """Validate Instance Attributes."""
+
+    order = ValidateContentsOrder
+    hosts = ["maya"]
+    families = ["*"]
+    label = "Instance Attributes"
+    plugins_by_family = {
+        p.family: p for p in discover_legacy_creator_plugins()
+    }
+    actions = [RepairAction]
+
+    @classmethod
+    def get_missing_attributes(self, instance):
+        plugin = self.plugins_by_family[instance.data["family"]]
+        subset = instance.data["subset"]
+        asset = instance.data["asset"]
+        objset = instance.data["objset"]
+
+        missing_attributes = {}
+        for key, value in plugin(subset, asset).data.items():
+            if not cmds.objExists("{}.{}".format(objset, key)):
+                missing_attributes[key] = value
+
+        return missing_attributes
+
+    def process(self, instance):
+        objset = instance.data.get("objset")
+        if objset is None:
+            self.log.debug(
+                "Skipping {} because no objectset found.".format(instance)
+            )
+            return
+
+        missing_attributes = self.get_missing_attributes(instance)
+        if missing_attributes:
+            raise PublishValidationError(
+                "Missing attributes on {}:\n{}".format(
+                    objset, missing_attributes
+                )
+            )
+
+    @classmethod
+    def repair(cls, instance):
+        imprint(instance.data["objset"], cls.get_missing_attributes(instance))


### PR DESCRIPTION
## Brief description
Validate missing instance attributes.

## Description
New attributes can be introduced as new features come in. Old instances will need to be updated with these attributes for the documentation to make sense, and users do not have to recreate the instances.

## Testing notes:
1. Make an instance in Maya.
2. Delete an attribute from the instance's objectset.
3. Publish.