### PR TITLE
SiteSync: host dirmap is not working properly

### DIFF
--- a/openpype/host/dirmap.py
+++ b/openpype/host/dirmap.py
@@ -16,7 +16,6 @@ from openpype.lib import Logger
 from openpype.modules import ModulesManager
 from openpype.settings import get_project_settings
 from openpype.settings.lib import get_site_local_overrides
-from openpype.pipeline import Anatomy
 
 
 @six.add_metaclass(ABCMeta)

--- a/openpype/hosts/nuke/api/lib.py
+++ b/openpype/hosts/nuke/api/lib.py
@@ -2850,10 +2850,10 @@ class NukeDirmap(HostDirmap):
         pass
 
     def dirmap_routine(self, source_path, destination_path):
-        log.debug("{}: {}->{}".format(self.file_name,
-                                      source_path, destination_path))
         source_path = source_path.lower().replace(os.sep, '/')
         destination_path = destination_path.lower().replace(os.sep, '/')
+        log.debug("Map: {} with: {}->{}".format(self.file_name,
+                                                source_path, destination_path))
         if platform.system().lower() == "windows":
             self.file_name = self.file_name.lower().replace(
                 source_path, destination_path)
@@ -2867,6 +2867,7 @@ class DirmapCache:
     _project_name = None
     _project_settings = None
     _sync_module = None
+    _mapping = None
 
     @classmethod
     def project_name(cls):
@@ -2885,6 +2886,36 @@ class DirmapCache:
         if cls._sync_module is None:
             cls._sync_module = ModulesManager().modules_by_name["sync_server"]
         return cls._sync_module
+
+    @classmethod
+    def mapping(cls):
+        return cls._mapping
+
+    @classmethod
+    def set_mapping(cls, mapping):
+        cls._mapping = mapping
+
+
+def dirmap_file_name_filter(file_name):
+    """Nuke callback function with single full path argument.
+
+        Checks project settings for potential mapping from source to dest.
+    """
+
+    dirmap_processor = NukeDirmap(
+        file_name,
+        "nuke",
+        DirmapCache.project_name(),
+        DirmapCache.project_settings(),
+        DirmapCache.sync_module(),
+    )
+    if not DirmapCache.mapping():
+        DirmapCache.set_mapping(dirmap_processor.get_mappings())
+
+    dirmap_processor.process_dirmap(DirmapCache.mapping())
+    if os.path.exists(dirmap_processor.file_name):
+        return dirmap_processor.file_name
+    return file_name
 
 
 @contextlib.contextmanager
@@ -2929,25 +2960,6 @@ def duplicate_node(node):
     reset_selection()
 
     return dupli_node
-
-
-def dirmap_file_name_filter(file_name):
-    """Nuke callback function with single full path argument.
-
-        Checks project settings for potential mapping from source to dest.
-    """
-
-    dirmap_processor = NukeDirmap(
-        file_name,
-        "nuke",
-        DirmapCache.project_name(),
-        DirmapCache.project_settings(),
-        DirmapCache.sync_module(),
-    )
-    dirmap_processor.process_dirmap()
-    if os.path.exists(dirmap_processor.file_name):
-        return dirmap_processor.file_name
-    return file_name
 
 
 def get_group_io_nodes(nodes):

--- a/openpype/modules/sync_server/sync_server_module.py
+++ b/openpype/modules/sync_server/sync_server_module.py
@@ -1472,13 +1472,15 @@ class SyncServerModule(OpenPypeModule, ITrayModule):
 
         return sync_settings
 
-    def get_all_site_configs(self, project_name=None):
+    def get_all_site_configs(self, project_name=None,
+                             local_editable_only=False):
         """
             Returns (dict) with all sites configured system wide.
 
             Args:
                 project_name (str)(optional): if present, check if not disabled
-
+                local_editable_only (bool)(opt): if True return only Local
+                    Setting configurable (for LS UI)
             Returns:
                 (dict): {'studio': {'provider':'local_drive'...},
                          'MY_LOCAL': {'provider':....}}
@@ -1499,9 +1501,21 @@ class SyncServerModule(OpenPypeModule, ITrayModule):
                     if site_settings:
                         detail.update(site_settings)
                 system_sites[site] = detail
-
         system_sites.update(self._get_default_site_configs(sync_enabled,
                                                            project_name))
+        if local_editable_only:
+            local_schema = SyncServerModule.get_local_settings_schema()
+            editable_keys = {}
+            for provider_code, editables in local_schema.items():
+                editable_keys[provider_code] = ["enabled", "provider"]
+                for editable_item in editables:
+                    editable_keys[provider_code].append(editable_item["key"])
+
+            for site_name, site in system_sites.items():
+                provider = site["provider"]
+                for site_config_key in list(site.keys()):
+                    if site_config_key not in editable_keys[provider]:
+                        site.pop(site_config_key, None)
 
         return system_sites
 

--- a/openpype/modules/sync_server/sync_server_module.py
+++ b/openpype/modules/sync_server/sync_server_module.py
@@ -1511,7 +1511,7 @@ class SyncServerModule(OpenPypeModule, ITrayModule):
                 for editable_item in editables:
                     editable_keys[provider_code].append(editable_item["key"])
 
-            for site_name, site in system_sites.items():
+            for _, site in system_sites.items():
                 provider = site["provider"]
                 for site_config_key in list(site.keys()):
                     if site_config_key not in editable_keys[provider]:

--- a/openpype/tools/settings/local_settings/projects_widget.py
+++ b/openpype/tools/settings/local_settings/projects_widget.py
@@ -272,7 +272,7 @@ class SitesWidget(QtWidgets.QWidget):
         )
 
         site_configs = sync_server_module.get_all_site_configs(
-            self._project_name)
+            self._project_name, local_editable_only=True)
 
         roots_entity = (
             self.project_settings[PROJECT_ANATOMY_KEY][LOCAL_ROOTS_KEY]


### PR DESCRIPTION
## Brief description
If artists uses SiteSync with real remote (gdrive, dropbox, sftp) drive, Local Settings were throwing error `string indices must be integers`.

## Description
Logic was reworked to provide only `local_drive` values to be overrriden by Local Settings. If remote site is `gdrive` etc. mapping to `studio` is provided as it is expected that workfiles will have imported from `studio` location and not from `gdrive` folder.

Also Nuke dirmap was reworked to be less verbose and much faster.

## Additional Info
This should be gone from Nuke logs:
![2023-03-03 13_03_58-Window](https://user-images.githubusercontent.com/4457962/222715930-1c62ccf1-bce8-46f5-8d91-2a81bd689b62.png)



## Testing notes:
1. Set SiteSync to be enabled on project
2. Set gdrive/dropbox/sftp remote site in Local Settings (might not be actually working)
3. Check in LS that no error is throwns
4. Download some Maya or Nuke workile from remote site, open it and check if dirmap doesn't fail.