### PR TITLE
Maya: V-Ray Set Image Format from settings

### DIFF
--- a/openpype/hosts/maya/api/lib_rendersettings.py
+++ b/openpype/hosts/maya/api/lib_rendersettings.py
@@ -336,7 +336,8 @@ class RenderSettings(object):
         )
 
         # Set render file format to exr
-        cmds.setAttr("{}.imageFormatStr".format(node), "exr", type="string")
+        ext = vray_render_presets["image_format"]
+        cmds.setAttr("{}.imageFormatStr".format(node), ext, type="string")
 
         # animType
         cmds.setAttr("{}.animType".format(node), 1)


### PR DESCRIPTION
## Brief description

Resolves #4565

## Description

Set V-Ray Image Format using settings.

## Testing notes:

1. apply different image format in settings
2. apply render settings for v-ray in maya