### PR TITLE
Photosohp: context is not changed in publisher

### DIFF
--- a/openpype/hosts/photoshop/api/launch_logic.py
+++ b/openpype/hosts/photoshop/api/launch_logic.py
@@ -10,8 +10,16 @@ from wsrpc_aiohttp import (
 
 from qtpy import QtCore
 
-from openpype.lib import Logger
-from openpype.pipeline import legacy_io
+from openpype.lib import Logger, StringTemplate
+from openpype.pipeline import (
+    registered_host,
+    Anatomy,
+)
+from openpype.pipeline.workfile import (
+    get_workfile_template_key_from_context,
+    get_last_workfile,
+)
+from openpype.pipeline.template_data import get_template_data_with_names
 from openpype.tools.utils import host_tools
 from openpype.tools.adobe_webserver.app import WebServerTool
 from openpype.pipeline.context_tools import change_current_context
@@ -312,18 +320,28 @@ class PhotoshopRoute(WebSocketRoute):
     # client functions
     async def set_context(self, project, asset, task):
         """
-            Sets 'project' and 'asset' to envs, eg. setting context
+            Sets 'project' and 'asset' to envs, eg. setting context.
 
-            Args:
-                project (str)
-                asset (str)
-                task (str
+        Opens last workile from that context if exists.
+
+        Args:
+            project (str)
+            asset (str)
+            task (str
         """
         log.info("Setting context change")
         log.info(f"project {project} asset {asset} task {task}")
 
         asset_doc = get_asset_by_name(project, asset)
         change_current_context(asset_doc, task)
+
+        last_workfile_path = self._get_last_workfile_path(project,
+                                                          asset,
+                                                          task)
+        if last_workfile_path and os.path.exists(last_workfile_path):
+            ProcessLauncher.execute_in_main_thread(
+                lambda:  stub().open(last_workfile_path))
+
 
     async def read(self):
         log.debug("photoshop.read client calls server server calls "
@@ -353,3 +371,36 @@ class PhotoshopRoute(WebSocketRoute):
 
         # Required return statement.
         return "nothing"
+
+    def _get_last_workfile_path(self, project_name, asset_name, task_name):
+        """Returns last workfile path if exists"""
+        host = registered_host()
+        host_name = "photoshop"
+        template_key = get_workfile_template_key_from_context(
+            asset_name,
+            task_name,
+            host_name,
+            project_name=project_name
+        )
+        anatomy = Anatomy(project_name)
+
+        data = get_template_data_with_names(
+            project_name, asset_name, task_name, host_name
+        )
+        data["root"] = anatomy.roots
+
+        file_template = anatomy.templates[template_key]["file"]
+
+        # Define saving file extension
+        extensions = host.get_workfile_extensions()
+        data["ext"] = extensions[0]
+
+        folder_template = anatomy.templates[template_key]["folder"]
+        work_root = StringTemplate.format_strict_template(
+            folder_template, data
+        )
+        last_workfile_path = get_last_workfile(
+            work_root, file_template, data, extensions, True
+        )
+
+        return last_workfile_path

--- a/openpype/hosts/photoshop/api/launch_logic.py
+++ b/openpype/hosts/photoshop/api/launch_logic.py
@@ -14,6 +14,8 @@ from openpype.lib import Logger
 from openpype.pipeline import legacy_io
 from openpype.tools.utils import host_tools
 from openpype.tools.adobe_webserver.app import WebServerTool
+from openpype.pipeline.context_tools import change_current_context
+from openpype.client import get_asset_by_name
 
 from .ws_stub import PhotoshopServerStub
 
@@ -315,18 +317,13 @@ class PhotoshopRoute(WebSocketRoute):
             Args:
                 project (str)
                 asset (str)
+                task (str
         """
         log.info("Setting context change")
-        log.info("project {} asset {} ".format(project, asset))
-        if project:
-            legacy_io.Session["AVALON_PROJECT"] = project
-            os.environ["AVALON_PROJECT"] = project
-        if asset:
-            legacy_io.Session["AVALON_ASSET"] = asset
-            os.environ["AVALON_ASSET"] = asset
-        if task:
-            legacy_io.Session["AVALON_TASK"] = task
-            os.environ["AVALON_TASK"] = task
+        log.info(f"project {project} asset {asset} task {task}")
+
+        asset_doc = get_asset_by_name(project, asset)
+        change_current_context(asset_doc, task)
 
     async def read(self):
         log.debug("photoshop.read client calls server server calls "


### PR DESCRIPTION
## Brief description
When PS is already open and artists launch new task, it should keep only opened PS open, but change context.

## Description
Problem were occurring in Workfile app where under new task files from old task were shown. This fixes this and adds opening of last workfile for new context if workfile exists.

## Additional info
This was most problematic on MacOS where for some unknown reason PS is not closing after clicking on Close (X) button. (AE closes fine.)


## Testing notes:
1. Open first workfile in PS
2. Dont close PS, open second task
3. Check in Workfiles that files under both tasks look ok
4. Try to Create new instance if context is correct