### PR TITLE
add up to 3 decimals precision to the frame rate settings

### DIFF
--- a/openpype/settings/entities/schemas/projects_schema/schemas/schema_anatomy_attributes.json
+++ b/openpype/settings/entities/schemas/projects_schema/schemas/schema_anatomy_attributes.json
@@ -10,7 +10,7 @@
             "type": "number",
             "key": "fps",
             "label": "Frame Rate",
-            "decimal": 2,
+            "decimal": 3,
             "minimum": 0
         },
         {

--- a/openpype/tools/project_manager/project_manager/delegates.py
+++ b/openpype/tools/project_manager/project_manager/delegates.py
@@ -83,15 +83,18 @@ class NumberDelegate(QtWidgets.QStyledItemDelegate):
         decimals(int): How many decimal points can be used. Float will be used
             as value if is higher than 0.
     """
-    def __init__(self, minimum, maximum, decimals, *args, **kwargs):
+    def __init__(self, minimum, maximum, decimals, step, *args, **kwargs):
         super(NumberDelegate, self).__init__(*args, **kwargs)
         self.minimum = minimum
         self.maximum = maximum
         self.decimals = decimals
+        self.step = step
 
     def createEditor(self, parent, option, index):
         if self.decimals > 0:
             editor = DoubleSpinBoxScrollFixed(parent)
+            editor.setSingleStep(self.step)
+            editor.setDecimals(self.decimals)
         else:
             editor = SpinBoxScrollFixed(parent)
 

--- a/openpype/tools/project_manager/project_manager/view.py
+++ b/openpype/tools/project_manager/project_manager/view.py
@@ -26,10 +26,11 @@ class NameDef:
 
 
 class NumberDef:
-    def __init__(self, minimum=None, maximum=None, decimals=None):
+    def __init__(self, minimum=None, maximum=None, decimals=None, step=None):
         self.minimum = 0 if minimum is None else minimum
         self.maximum = 999999999 if maximum is None else maximum
         self.decimals = 0 if decimals is None else decimals
+        self.step = 1 if decimals is None else step
 
 
 class TypeDef:
@@ -73,14 +74,14 @@ class HierarchyView(QtWidgets.QTreeView):
         "type": TypeDef(),
         "frameStart": NumberDef(1),
         "frameEnd": NumberDef(1),
-        "fps": NumberDef(1, decimals=2),
+        "fps": NumberDef(1, decimals=3, step=0.01),
         "resolutionWidth": NumberDef(0),
         "resolutionHeight": NumberDef(0),
         "handleStart": NumberDef(0),
         "handleEnd": NumberDef(0),
         "clipIn": NumberDef(1),
         "clipOut": NumberDef(1),
-        "pixelAspect": NumberDef(0, decimals=2),
+        "pixelAspect": NumberDef(0, decimals=2, step=0.1),
         "tools_env": ToolsDef()
     }
 
@@ -95,6 +96,10 @@ class HierarchyView(QtWidgets.QTreeView):
         "type": {
             "stretch": QtWidgets.QHeaderView.Interactive,
             "width": 140
+        },
+        "fps": {
+            "stretch": QtWidgets.QHeaderView.Interactive,
+            "width": 65
         },
         "tools_env": {
             "stretch": QtWidgets.QHeaderView.Interactive,
@@ -148,7 +153,8 @@ class HierarchyView(QtWidgets.QTreeView):
                 delegate = NumberDelegate(
                     item_type.minimum,
                     item_type.maximum,
-                    item_type.decimals
+                    item_type.decimals,
+                    item_type.step
                 )
 
             elif isinstance(item_type, TypeDef):

--- a/openpype/tools/project_manager/project_manager/view.py
+++ b/openpype/tools/project_manager/project_manager/view.py
@@ -74,14 +74,14 @@ class HierarchyView(QtWidgets.QTreeView):
         "type": TypeDef(),
         "frameStart": NumberDef(1),
         "frameEnd": NumberDef(1),
-        "fps": NumberDef(1, decimals=3, step=0.01),
+        "fps": NumberDef(1, decimals=3, step=1),
         "resolutionWidth": NumberDef(0),
         "resolutionHeight": NumberDef(0),
         "handleStart": NumberDef(0),
         "handleEnd": NumberDef(0),
         "clipIn": NumberDef(1),
         "clipOut": NumberDef(1),
-        "pixelAspect": NumberDef(0, decimals=2, step=0.1),
+        "pixelAspect": NumberDef(0, decimals=2, step=0.01),
         "tools_env": ToolsDef()
     }
 


### PR DESCRIPTION
## Brief description
Allows input 23.976 to the FPS settings both in Project Manager and the Project Anatomy.
Adds `setSingleStep` to the DoubleSpinBox editor with decimals.
Makes the FPS column in the Project Manager adjustable.

## Description
Based on this issue: https://github.com/ynput/OpenPype/issues/4479

## Testing notes:

* Go to Project Manager
* Click on asset
* Try to set fps to 23,976 with `,` as decimals separator.
* Select FPS cell and scroll the mouse, the value will be adjusted with 1 frame precision.
* Select Pixel Aspect cell and scroll the mouse, the value will be adjusted with 0.01 precision.
* Open Studio settings and check Project -> Anatomy -> Attributes. The Frame Rate field now have three decimals precision.

![image](https://user-images.githubusercontent.com/11698866/222926364-fbd6ea42-7d32-4929-b18d-8a9fd380f738.png)
![image](https://user-images.githubusercontent.com/11698866/222926411-2177a353-d5cd-404a-af0f-927a2bb1e161.png)
