### PR TITLE
Maya: SkeletalMesh family loadable as reference

### DIFF
--- a/openpype/hosts/maya/plugins/load/load_reference.py
+++ b/openpype/hosts/maya/plugins/load/load_reference.py
@@ -26,6 +26,7 @@ class ReferenceLoader(openpype.hosts.maya.api.plugin.ReferenceLoader):
                 "rig",
                 "camerarig",
                 "staticMesh",
+                "skeletalMesh",
                 "mvLook"]
 
     representations = ["ma", "abc", "fbx", "mb"]


### PR DESCRIPTION
## Brief description
In Maya, fix the SkeletalMesh family not loadable as reference.

## Testing notes:
1. Have a rig published as SkeletalMesh.
2. Load that rig in the scene as reference.