### PR TITLE
Nuke: fix clip sequence loading

### DIFF
--- a/openpype/hosts/nuke/plugins/load/load_clip.py
+++ b/openpype/hosts/nuke/plugins/load/load_clip.py
@@ -222,18 +222,21 @@ class LoadClip(plugin.NukeLoader):
         """
         representation = deepcopy(representation)
         context = representation["context"]
-        template = representation["data"]["template"]
+
+        # Get the frame from the context and hash it
+        frame = context["frame"]
+        hashed_frame = "#" * len(str(frame))
+
+        # Replace the frame with the hash in the originalBasename
         if (
-            "{originalBasename}" in template
-            and "frame" in context
+            "{originalBasename}" in representation["data"]["template"]
         ):
-            frame = context["frame"]
-            hashed_frame = "#" * len(str(frame))
             origin_basename = context["originalBasename"]
             context["originalBasename"] = origin_basename.replace(
                 frame, hashed_frame
             )
 
+        # Replace the frame with the hash in the frame
         representation["context"]["frame"] = hashed_frame
         return representation
 


### PR DESCRIPTION
## Brief description
Nuke is loading correctly clip  from image sequence created without "{originalBasename}" token in anatomy template.


## Testing notes:
1. Open any testing workfile in Nuke
2. load any image sequence subset 
3. It should load without hiccups

# Resolving issue|
resolves https://github.com/ynput/OpenPype/issues/4553