### PR TITLE
Unreal: Added settings for rendering

### DIFF
--- a/openpype/hosts/unreal/api/rendering.py
+++ b/openpype/hosts/unreal/api/rendering.py
@@ -2,6 +2,7 @@ import os
 
 import unreal
 
+from openpype.settings import get_project_settings
 from openpype.pipeline import Anatomy
 from openpype.hosts.unreal.api import pipeline
 
@@ -66,6 +67,13 @@ def start_rendering():
 
     ar = unreal.AssetRegistryHelpers.get_asset_registry()
 
+    data = get_project_settings(project)
+    config = None
+    config_path = str(data.get("unreal").get("render_config_path"))
+    if config_path and unreal.EditorAssetLibrary.does_asset_exist(config_path):
+        unreal.log("Found saved render configuration")
+        config = ar.get_asset_by_object_path(config_path).get_asset()
+
     for i in inst_data:
         sequence = ar.get_asset_by_object_path(i["sequence"]).get_asset()
 
@@ -81,47 +89,50 @@ def start_rendering():
         # Get all the sequences to render. If there are subsequences,
         # add them and their frame ranges to the render list. We also
         # use the names for the output paths.
-        for s in sequences:
-            subscenes = pipeline.get_subsequences(s.get('sequence'))
+        for seq in sequences:
+            subscenes = pipeline.get_subsequences(seq.get('sequence'))
 
             if subscenes:
-                for ss in subscenes:
+                for sub_seq in subscenes:
                     sequences.append({
-                        "sequence": ss.get_sequence(),
-                        "output": (f"{s.get('output')}/"
-                                   f"{ss.get_sequence().get_name()}"),
+                        "sequence": sub_seq.get_sequence(),
+                        "output": (f"{seq.get('output')}/"
+                                   f"{sub_seq.get_sequence().get_name()}"),
                         "frame_range": (
-                            ss.get_start_frame(), ss.get_end_frame())
+                            sub_seq.get_start_frame(), sub_seq.get_end_frame())
                     })
             else:
                 # Avoid rendering camera sequences
-                if "_camera" not in s.get('sequence').get_name():
-                    render_list.append(s)
+                if "_camera" not in seq.get('sequence').get_name():
+                    render_list.append(seq)
 
         # Create the rendering jobs and add them to the queue.
-        for r in render_list:
+        for render_setting in render_list:
             job = queue.allocate_new_job(unreal.MoviePipelineExecutorJob)
             job.sequence = unreal.SoftObjectPath(i["master_sequence"])
             job.map = unreal.SoftObjectPath(i["master_level"])
             job.author = "OpenPype"
+
+            # If we have a saved configuration, copy it to the job.
+            if config:
+                job.get_configuration().copy_from(config)
 
             # User data could be used to pass data to the job, that can be
             # read in the job's OnJobFinished callback. We could,
             # for instance, pass the AvalonPublishInstance's path to the job.
             # job.user_data = ""
 
+            output_dir = render_setting.get('output')
+            shot_name = render_setting.get('sequence').get_name()
+
             settings = job.get_configuration().find_or_add_setting_by_class(
                 unreal.MoviePipelineOutputSetting)
             settings.output_resolution = unreal.IntPoint(1920, 1080)
-            settings.custom_start_frame = r.get("frame_range")[0]
-            settings.custom_end_frame = r.get("frame_range")[1]
+            settings.custom_start_frame = render_setting.get("frame_range")[0]
+            settings.custom_end_frame = render_setting.get("frame_range")[1]
             settings.use_custom_playback_range = True
-            settings.file_name_format = "{sequence_name}.{frame_number}"
-            settings.output_directory.path = f"{render_dir}/{r.get('output')}"
-
-            renderPass = job.get_configuration().find_or_add_setting_by_class(
-                unreal.MoviePipelineDeferredPassBase)
-            renderPass.disable_multisample_effects = True
+            settings.file_name_format = f"{shot_name}" + ".{frame_number}"
+            settings.output_directory.path = f"{render_dir}/{output_dir}"
 
             job.get_configuration().find_or_add_setting_by_class(
                 unreal.MoviePipelineImageSequenceOutput_PNG)
@@ -130,6 +141,13 @@ def start_rendering():
     if queue.get_jobs():
         global executor
         executor = unreal.MoviePipelinePIEExecutor()
+
+        preroll_frames = data.get("unreal").get("preroll_frames", 0)
+
+        settings = unreal.MoviePipelinePIEExecutorSettings()
+        settings.set_editor_property(
+            "initial_delay_frame_count", preroll_frames)
+
         executor.on_executor_finished_delegate.add_callable_unique(
             _queue_finish_callback)
         executor.on_individual_job_finished_delegate.add_callable_unique(

--- a/openpype/settings/defaults/project_settings/unreal.json
+++ b/openpype/settings/defaults/project_settings/unreal.json
@@ -11,6 +11,8 @@
     },
     "level_sequences_for_layouts": false,
     "delete_unmatched_assets": false,
+    "render_config_path": "",
+    "preroll_frames": 0,
     "project_setup": {
         "dev_mode": true
     }

--- a/openpype/settings/entities/schemas/projects_schema/schema_project_unreal.json
+++ b/openpype/settings/entities/schemas/projects_schema/schema_project_unreal.json
@@ -33,6 +33,16 @@
             "label": "Delete assets that are not matched"
         },
         {
+            "type": "text",
+            "key": "render_config_path",
+            "label": "Render Config Path"
+        },
+        {
+            "type": "number",
+            "key": "preroll_frames",
+            "label": "Pre-roll frames"
+        },
+        {
             "type": "dict",
             "collapsible": true,
             "key": "project_setup",


### PR DESCRIPTION
## Brief description
Added settings for rendering in Unreal Engine.

## Description
Two settings has been added:
- Pre roll frames, to set how many frames are used to load the scene before starting the actual rendering.
- Configuration path, to allow to save a preset of settings from Unreal, and use it for rendering.

## Testing notes:
A layout will need to be loaded from Maya or Blender to be able to render the shot.
To render:
1. Create a render instance for a sequence.
2. Select the render instance and select `Render` from the OpenPype menu.

You can set the settings from the `Studio Settings/Project/Unreal Engine`.
For the `Pre-roll frames`, you can just set any number of frames. 
For the `Render Config Path`, it should work both with an empty setting (and in that case it will use some default settings), or by setting a path with the Unreal format (e.g. `/Game/Settings/Config.Config`).