### PR TITLE
General: Input representation ids are not ObjectIds

### DIFF
--- a/openpype/hosts/fusion/plugins/publish/collect_inputs.py
+++ b/openpype/hosts/fusion/plugins/publish/collect_inputs.py
@@ -106,6 +106,6 @@ class CollectUpstreamInputs(pyblish.api.InstancePlugin):
         # Collect containers for the given set of nodes
         containers = collect_input_containers(nodes)
 
-        inputs = {c["representation"] for c in containers}
+        inputs = [c["representation"] for c in containers]
         instance.data["inputRepresentations"] = inputs
         self.log.info("Collected inputs: %s" % inputs)

--- a/openpype/hosts/fusion/plugins/publish/collect_inputs.py
+++ b/openpype/hosts/fusion/plugins/publish/collect_inputs.py
@@ -1,5 +1,3 @@
-from bson.objectid import ObjectId
-
 import pyblish.api
 
 from openpype.pipeline import registered_host
@@ -108,7 +106,6 @@ class CollectUpstreamInputs(pyblish.api.InstancePlugin):
         # Collect containers for the given set of nodes
         containers = collect_input_containers(nodes)
 
-        inputs = [ObjectId(c["representation"]) for c in containers]
+        inputs = {c["representation"] for c in containers}
         instance.data["inputRepresentations"] = inputs
-
         self.log.info("Collected inputs: %s" % inputs)

--- a/openpype/hosts/houdini/plugins/publish/collect_inputs.py
+++ b/openpype/hosts/houdini/plugins/publish/collect_inputs.py
@@ -115,6 +115,6 @@ class CollectUpstreamInputs(pyblish.api.InstancePlugin):
         # Collect containers for the given set of nodes
         containers = collect_input_containers(nodes)
 
-        inputs = {c["representation"] for c in containers}
+        inputs = [c["representation"] for c in containers]
         instance.data["inputRepresentations"] = inputs
         self.log.info("Collected inputs: %s" % inputs)

--- a/openpype/hosts/houdini/plugins/publish/collect_inputs.py
+++ b/openpype/hosts/houdini/plugins/publish/collect_inputs.py
@@ -1,5 +1,3 @@
-from bson.objectid import ObjectId
-
 import pyblish.api
 
 from openpype.pipeline import registered_host
@@ -117,7 +115,6 @@ class CollectUpstreamInputs(pyblish.api.InstancePlugin):
         # Collect containers for the given set of nodes
         containers = collect_input_containers(nodes)
 
-        inputs = [ObjectId(c["representation"]) for c in containers]
+        inputs = {c["representation"] for c in containers}
         instance.data["inputRepresentations"] = inputs
-
         self.log.info("Collected inputs: %s" % inputs)

--- a/openpype/hosts/maya/plugins/publish/collect_inputs.py
+++ b/openpype/hosts/maya/plugins/publish/collect_inputs.py
@@ -164,7 +164,7 @@ class CollectUpstreamInputs(pyblish.api.InstancePlugin):
             containers = collect_input_containers(scene_containers,
                                                   nodes)
 
-        inputs = {c["representation"] for c in containers}
+        inputs = [c["representation"] for c in containers]
         instance.data["inputRepresentations"] = inputs
         self.log.info("Collected inputs: %s" % inputs)
 

--- a/openpype/hosts/maya/plugins/publish/collect_inputs.py
+++ b/openpype/hosts/maya/plugins/publish/collect_inputs.py
@@ -1,5 +1,4 @@
 import copy
-from bson.objectid import ObjectId
 
 from maya import cmds
 import maya.api.OpenMaya as om
@@ -165,9 +164,8 @@ class CollectUpstreamInputs(pyblish.api.InstancePlugin):
             containers = collect_input_containers(scene_containers,
                                                   nodes)
 
-        inputs = [ObjectId(c["representation"]) for c in containers]
+        inputs = {c["representation"] for c in containers}
         instance.data["inputRepresentations"] = inputs
-
         self.log.info("Collected inputs: %s" % inputs)
 
     def _collect_renderlayer_inputs(self, scene_containers, instance):

--- a/openpype/plugins/publish/collect_input_representations_to_versions.py
+++ b/openpype/plugins/publish/collect_input_representations_to_versions.py
@@ -22,8 +22,9 @@ class CollectInputRepresentationsToVersions(pyblish.api.ContextPlugin):
         # Query all version ids for representation ids from the database once
         representations = set()
         for instance in context:
-            inst_repre = instance.data.get("inputRepresentations", [])
-            representations.update(inst_repre)
+            inst_repre = instance.data.get("inputRepresentations")
+            if inst_repre:
+                representations.update(inst_repre)
 
         representations_docs = get_representations(
             project_name=context.data["projectEntity"]["name"],
@@ -31,17 +32,20 @@ class CollectInputRepresentationsToVersions(pyblish.api.ContextPlugin):
             fields=["_id", "parent"])
 
         representation_id_to_version_id = {
-            repre["_id"]: repre["parent"] for repre in representations_docs
+            str(repre["_id"]): repre["parent"]
+            for repre in representations_docs
         }
 
         for instance in context:
-            inst_repre = instance.data.get("inputRepresentations", [])
+            inst_repre = instance.data.get("inputRepresentations")
             if not inst_repre:
                 continue
 
-            input_versions = instance.data.get("inputVersions", [])
+            if "inputVersions" not in instance.data:
+                instance.data["inputVersions"] = set()
+            input_versions = instance.data["inputVersions"]
             for repre_id in inst_repre:
-                repre_id = ObjectId(repre_id)
-                version_id = representation_id_to_version_id[repre_id]
-                input_versions.append(version_id)
+                version_id = representation_id_to_version_id.get(repre_id)
+                if version_id:
+                    input_versions.add(version_id)
             instance.data["inputVersions"] = input_versions

--- a/openpype/plugins/publish/collect_input_representations_to_versions.py
+++ b/openpype/plugins/publish/collect_input_representations_to_versions.py
@@ -37,7 +37,7 @@ class CollectInputRepresentationsToVersions(pyblish.api.ContextPlugin):
         }
 
         for instance in context:
-            inst_repre = instance.data.get("inputRepresentations")
+            inst_repre = instance.data.get("inputRepresentations", [])
             if not inst_repre:
                 continue
 

--- a/openpype/plugins/publish/collect_input_representations_to_versions.py
+++ b/openpype/plugins/publish/collect_input_representations_to_versions.py
@@ -41,11 +41,9 @@ class CollectInputRepresentationsToVersions(pyblish.api.ContextPlugin):
             if not inst_repre:
                 continue
 
-            if "inputVersions" not in instance.data:
-                instance.data["inputVersions"] = []
+            instance.data.setdefault("inputVersions", [])
             input_versions = instance.data["inputVersions"]
             for repre_id in inst_repre:
                 version_id = representation_id_to_version_id.get(repre_id)
                 if version_id:
                     input_versions.append(version_id)
-            instance.data["inputVersions"] = input_versions

--- a/openpype/plugins/publish/collect_input_representations_to_versions.py
+++ b/openpype/plugins/publish/collect_input_representations_to_versions.py
@@ -42,10 +42,10 @@ class CollectInputRepresentationsToVersions(pyblish.api.ContextPlugin):
                 continue
 
             if "inputVersions" not in instance.data:
-                instance.data["inputVersions"] = set()
+                instance.data["inputVersions"] = []
             input_versions = instance.data["inputVersions"]
             for repre_id in inst_repre:
                 version_id = representation_id_to_version_id.get(repre_id)
                 if version_id:
-                    input_versions.add(version_id)
+                    input_versions.append(version_id)
             instance.data["inputVersions"] = input_versions

--- a/openpype/plugins/publish/collect_input_representations_to_versions.py
+++ b/openpype/plugins/publish/collect_input_representations_to_versions.py
@@ -41,8 +41,7 @@ class CollectInputRepresentationsToVersions(pyblish.api.ContextPlugin):
             if not inst_repre:
                 continue
 
-            instance.data.setdefault("inputVersions", [])
-            input_versions = instance.data["inputVersions"]
+            input_versions = instance.data.setdefault("inputVersions", [])
             for repre_id in inst_repre:
                 version_id = representation_id_to_version_id.get(repre_id)
                 if version_id:

--- a/openpype/plugins/publish/collect_input_representations_to_versions.py
+++ b/openpype/plugins/publish/collect_input_representations_to_versions.py
@@ -22,7 +22,7 @@ class CollectInputRepresentationsToVersions(pyblish.api.ContextPlugin):
         # Query all version ids for representation ids from the database once
         representations = set()
         for instance in context:
-            inst_repre = instance.data.get("inputRepresentations")
+            inst_repre = instance.data.get("inputRepresentations", [])
             if inst_repre:
                 representations.update(inst_repre)
 


### PR DESCRIPTION
## Brief description
Don't use `ObjectId` as representation ids during publishing.

## Description
Representation ids are kept as strings during publishing instead of converting them to `ObjectId`. This change is pre-requirement for AYON connection.
Inputs are used for integration of links and for farm publishing (or at least it looks like).

## Testing notes:
### Links integration
1. Load (Reference) something into scene (fusion, houdini, maya)
2. Publish the scene
3. There should be integrated links in workfile version

### Farm publishing
1. Load (Reference) something into scene (fusion, houdini, maya)
2. Create a farm job
3. Input versions should be filled as expected