### PR TITLE
Kitsu: Fix task itteration in update-op-with-zou

### DIFF
--- a/openpype/modules/kitsu/utils/update_op_with_zou.py
+++ b/openpype/modules/kitsu/utils/update_op_with_zou.py
@@ -95,7 +95,8 @@ def update_op_assets(
             op_asset = create_op_asset(item)
             insert_result = dbcon.insert_one(op_asset)
             item_doc = get_asset_by_id(
-                project_name, insert_result.inserted_id)
+                project_name, insert_result.inserted_id
+            )
 
         # Update asset
         item_data = deepcopy(item_doc["data"])
@@ -133,39 +134,47 @@ def update_op_assets(
         try:
             fps = float(item_data.get("fps"))
         except (TypeError, ValueError):
-            fps = float(gazu_project.get(
-                "fps", project_doc["data"].get("fps", 25)))
+            fps = float(
+                gazu_project.get("fps", project_doc["data"].get("fps", 25))
+            )
         item_data["fps"] = fps
         # Resolution, fall back to project default
         match_res = re.match(
             r"(\d+)x(\d+)",
-            item_data.get("resolution", gazu_project.get("resolution"))
+            item_data.get("resolution", gazu_project.get("resolution")),
         )
         if match_res:
             item_data["resolutionWidth"] = int(match_res.group(1))
             item_data["resolutionHeight"] = int(match_res.group(2))
         else:
             item_data["resolutionWidth"] = project_doc["data"].get(
-                "resolutionWidth")
+                "resolutionWidth"
+            )
             item_data["resolutionHeight"] = project_doc["data"].get(
-                "resolutionHeight")
+                "resolutionHeight"
+            )
         # Properties that doesn't fully exist in Kitsu.
         # Guessing those property names below:
         # Pixel Aspect Ratio
         item_data["pixelAspect"] = item_data.get(
-            "pixel_aspect", project_doc["data"].get("pixelAspect"))
+            "pixel_aspect", project_doc["data"].get("pixelAspect")
+        )
         # Handle Start
         item_data["handleStart"] = item_data.get(
-            "handle_start", project_doc["data"].get("handleStart"))
+            "handle_start", project_doc["data"].get("handleStart")
+        )
         # Handle End
         item_data["handleEnd"] = item_data.get(
-            "handle_end", project_doc["data"].get("handleEnd"))
+            "handle_end", project_doc["data"].get("handleEnd")
+        )
         # Clip In
         item_data["clipIn"] = item_data.get(
-            "clip_in", project_doc["data"].get("clipIn"))
+            "clip_in", project_doc["data"].get("clipIn")
+        )
         # Clip Out
         item_data["clipOut"] = item_data.get(
-            "clip_out", project_doc["data"].get("clipOut"))
+            "clip_out", project_doc["data"].get("clipOut")
+        )
 
         # Tasks
         tasks_list = []
@@ -175,11 +184,9 @@ def update_op_assets(
         elif item_type == "Shot":
             tasks_list = gazu.task.all_tasks_for_shot(item)
         item_data["tasks"] = {
-            item_data["tasks"] = {
-                t["task_type_name"]: {
-                    "type": t["task_type_name"],
-                    "zou": gazu.task.get_task(t["id"]),
-                }
+            t["task_type_name"]: {
+                "type": t["task_type_name"],
+                "zou": gazu.task.get_task(t["id"]),
             }
             for t in tasks_list
         }
@@ -218,7 +225,9 @@ def update_op_assets(
             if parent_zou_id_dict is not None:
                 visual_parent_doc_id = (
                     parent_zou_id_dict.get("_id")
-                    if parent_zou_id_dict else None)
+                    if parent_zou_id_dict
+                    else None
+                )
 
         if visual_parent_doc_id is None:
             # Find root folder doc ("Assets" or "Shots")
@@ -345,7 +354,8 @@ def write_project_to_op(project: dict, dbcon: AvalonMongoDB) -> UpdateOne:
 
 
 def sync_all_projects(
-        login: str, password: str, ignore_projects: list = None):
+    login: str, password: str, ignore_projects: list = None
+):
     """Update all OP projects in DB with Zou data.
 
     Args:
@@ -390,7 +400,7 @@ def sync_project_from_kitsu(dbcon: AvalonMongoDB, project: dict):
     if not project:
         project = gazu.project.get_project_by_name(project["name"])
 
-    log.info("Synchronizing {}...".format(project['name']))
+    log.info("Synchronizing {}...".format(project["name"]))
 
     # Get all assets from zou
     all_assets = gazu.asset.all_assets_for_project(project)
@@ -473,8 +483,11 @@ def sync_project_from_kitsu(dbcon: AvalonMongoDB, project: dict):
         [
             UpdateOne({"_id": id}, update)
             for id, update in update_op_assets(
-                dbcon, project, project_dict,
-                all_entities, zou_ids_and_asset_docs
+                dbcon,
+                project,
+                project_dict,
+                all_entities,
+                zou_ids_and_asset_docs,
             )
         ]
     )


### PR DESCRIPTION
From the last PR (https://github.com/ynput/OpenPype/pull/4425) a comment-commit last second messed up the code and resulted in two lines being the same, crashing the script. This PR fixes that.