### PR TITLE
Fusion: Load sequence fix filepath resolving from representation

### DIFF
--- a/openpype/hosts/fusion/plugins/load/load_sequence.py
+++ b/openpype/hosts/fusion/plugins/load/load_sequence.py
@@ -1,11 +1,9 @@
-import os
 import contextlib
 
-from openpype.client import get_version_by_id
-from openpype.pipeline import (
-    load,
-    legacy_io,
-    get_representation_path,
+import openpype.pipeline.load as load
+from openpype.pipeline.load import (
+    get_representation_context,
+    get_representation_path_from_context
 )
 from openpype.hosts.fusion.api import (
     imprint_container,
@@ -141,7 +139,7 @@ class FusionLoadSequence(load.LoaderPlugin):
             namespace = context['asset']['name']
 
         # Use the first file for now
-        path = self._get_first_image(os.path.dirname(self.fname))
+        path = get_representation_path_from_context(context)
 
         # Create the Loader with the filename path set
         comp = get_current_comp()
@@ -210,13 +208,11 @@ class FusionLoadSequence(load.LoaderPlugin):
         assert tool.ID == "Loader", "Must be Loader"
         comp = tool.Comp()
 
-        root = os.path.dirname(get_representation_path(representation))
-        path = self._get_first_image(root)
+        context = get_representation_context(representation)
+        path = get_representation_path_from_context(context)
 
         # Get start frame from version data
-        project_name = legacy_io.active_project()
-        version = get_version_by_id(project_name, representation["parent"])
-        start = self._get_start(version, tool)
+        start = self._get_start(context["version"], tool)
 
         with comp_lock_and_undo_chunk(comp, "Update Loader"):
 
@@ -248,11 +244,6 @@ class FusionLoadSequence(load.LoaderPlugin):
 
         with comp_lock_and_undo_chunk(comp, "Remove Loader"):
             tool.Delete()
-
-    def _get_first_image(self, root):
-        """Get first file in representation root"""
-        files = sorted(os.listdir(root))
-        return os.path.join(root, files[0])
 
     def _get_start(self, version_doc, tool):
         """Return real start frame of published files (incl. handles)"""


### PR DESCRIPTION
## Brief description

[Resolves issue mentioned on discord](https://discord.com/channels/517362899170230292/563751989075378201/1082272423212224593) by @movalex:
> I launch openpype menu, choose Load - plateMain - right click - load sequence (mov) and instead of the plate the thumbnail file appears in the created loader. 
> there's two files in the publish folder.
> One is the plate, second is the thumbnail.

The loader was incorrectly trying to find the file in the publish folder which resulted in just picking 'any first file'.

## Description

This gets the filepath from representation instead of taking the first file from listing files from publish folder.

## Testing notes:
1. Load an image sequence (or video file)
2. Make sure to test a case where the publish folder also contains other files than the image sequence (or video file), like e.g. a thumbnail representation or a review file.