### PR TITLE
Fusion: Avoid error in "Scene has outdated content" pop-up in PySide6+

### DIFF
--- a/openpype/widgets/popup.py
+++ b/openpype/widgets/popup.py
@@ -99,7 +99,7 @@ class Popup(QtWidgets.QDialog):
         height = max(height, window.sizeHint().height())
 
         try:
-            screen = QtWidgets.QApplication.primaryScreen()
+            screen = window.screen()
             desktop_geometry = screen.availableGeometry()
         except AttributeError:
             # Backwards compatibility for older Qt versions

--- a/openpype/widgets/popup.py
+++ b/openpype/widgets/popup.py
@@ -98,15 +98,22 @@ class Popup(QtWidgets.QDialog):
         height = window.height()
         height = max(height, window.sizeHint().height())
 
-        desktop_geometry = QtWidgets.QDesktopWidget().availableGeometry()
-        screen_geometry = window.geometry()
+        try:
+            screen = QtWidgets.QApplication.primaryScreen()
+            desktop_geometry = screen.availableGeometry()
+        except AttributeError:
+            # Backwards compatibility for older Qt versions
+            # PySide6 removed QDesktopWidget
+            desktop_geometry = QtWidgets.QDesktopWidget().availableGeometry()
 
-        screen_width = screen_geometry.width()
-        screen_height = screen_geometry.height()
+        window_geometry = window.geometry()
+
+        screen_width = window_geometry.width()
+        screen_height = window_geometry.height()
 
         # Calculate width and height of system tray
-        systray_width = screen_geometry.width() - desktop_geometry.width()
-        systray_height = screen_geometry.height() - desktop_geometry.height()
+        systray_width = window_geometry.width() - desktop_geometry.width()
+        systray_height = window_geometry.height() - desktop_geometry.height()
 
         padding = 10
 


### PR DESCRIPTION
## Brief description

This fixes an error for applications showing the "Scene has outdated content" pop-ups which use PySide6+ 
This is currently noticable only in Fusion as far as I know since it's the only application using the pop-up widget which allows a custom Python version with a PySide version of your choice.

## Description

Note that the pop-up widget is used in Houdini, Maya and Fusion so it's likely good to test across the different applications to ensure it still works as expected.

## Additional info

This is the reported error:

> [after clicking _Repair_ I've got an AttributeError (reported by @movalex on Discord)](https://discord.com/channels/517362899170230292/517382145552154634/1081869316074516560):
![image](https://user-images.githubusercontent.com/2439881/223378482-784280b5-b059-474e-8f80-5225bc0589f4.png)

## Testing notes:
1. [x] Test pop-up in Fusion (tested in Fusion 18, Py3.7, PySide6
1. [x] Test pop-up in Maya (tested in Maya 2022.1, Py3.7.7, PySide2)
1. [ ] Test pop-up in Houdini