### PR TITLE
AttrDefs: Fix type for PySide6

### DIFF
--- a/openpype/tools/attribute_defs/widgets.py
+++ b/openpype/tools/attribute_defs/widgets.py
@@ -186,7 +186,7 @@ class AttributeDefinitionsWidget(QtWidgets.QWidget):
 
 class _BaseAttrDefWidget(QtWidgets.QWidget):
     # Type 'object' may not work with older PySide versions
-    value_changed = QtCore.Signal(object, uuid.UUID)
+    value_changed = QtCore.Signal(object, str)
 
     def __init__(self, attr_def, parent):
         super(_BaseAttrDefWidget, self).__init__(parent)


### PR DESCRIPTION
## Brief description
Use right type in signal emit for value change of attribute definitions.

## Description
Changed `UUID` type to `str`. This is not an issue with PySide2 but it is with PySide6.

## Testing notes:
1. Run some UI using AttrDefs (e.g. Publisher) in process using PySide6
2. Change value of the attribute
3. The change should not cause crash