### PR TITLE
AYON: Integrate Hero version is more specific about data

### DIFF
--- a/openpype/client/server/conversion_utils.py
+++ b/openpype/client/server/conversion_utils.py
@@ -838,22 +838,46 @@ def convert_create_version_to_v4(version, con):
 
 
 def convert_create_hero_version_to_v4(hero_version, project_name, con):
-    if "version_id" not in hero_version:
-        return None
+    if "version_id" in hero_version:
+        version_id = hero_version["version_id"]
+        version = con.get_version_by_id(project_name, version_id)
+        version["version"] = - version["version"]
 
-    version_id = hero_version["version_id"]
-    version = con.get_version_by_id(project_name, version_id)
-    version["version"] = - version["version"]
-    version["id"] = hero_version["_id"]
-    for auto_key in (
-        "name",
-        "createdAt",
-        "updatedAt",
-        "author",
-    ):
-        version.pop(auto_key, None)
+        for auto_key in (
+            "name",
+            "createdAt",
+            "updatedAt",
+            "author",
+        ):
+            version.pop(auto_key, None)
 
-    return version
+        return version
+
+    version_attributes = con.get_attributes_for_type("version")
+    converted_version = {
+        "version": hero_version["version"],
+        "subsetId": hero_version["parent"],
+    }
+    entity_id = hero_version.get("_id")
+    if entity_id:
+        converted_version["id"] = entity_id
+
+    version_data = hero_version["data"]
+    attribs = {}
+    data = {}
+    for key, value in version_data.items():
+        if key not in version_attributes:
+            data[key] = value
+        elif value is not None:
+            attribs[key] = value
+
+    if attribs:
+        converted_version["attrib"] = attribs
+
+    if data:
+        converted_version["data"] = attribs
+
+    return converted_version
 
 
 def convert_create_representation_to_v4(representation, con):

--- a/openpype/client/server/operations.py
+++ b/openpype/client/server/operations.py
@@ -185,14 +185,13 @@ def new_version_doc(version, subset_id, data=None, entity_id=None):
     }
 
 
-def new_hero_version_doc(version_id, subset_id, data=None, entity_id=None):
+def new_hero_version_doc(subset_id, data, version=None, entity_id=None):
     """Create skeleton data of hero version document.
 
     Args:
-        version_id (ObjectId): Is considered as unique identifier of version
-            under subset.
         subset_id (Union[str, ObjectId]): Id of parent subset.
         data (Dict[str, Any]): Version document data.
+        version (int): Version of source version.
         entity_id (Union[str, ObjectId]): Predefined id of document. New id is
             created if not passed.
 
@@ -200,14 +199,16 @@ def new_hero_version_doc(version_id, subset_id, data=None, entity_id=None):
         Dict[str, Any]: Skeleton of version document.
     """
 
-    if data is None:
-        data = {}
+    if version is None:
+        version = -1
+    elif version > 0:
+        version = -version
 
     return {
         "_id": _create_or_convert_to_id(entity_id),
         "schema": CURRENT_HERO_VERSION_SCHEMA,
         "type": "hero_version",
-        "version_id": _create_or_convert_to_id(version_id),
+        "version": version,
         "parent": _create_or_convert_to_id(subset_id),
         "data": data
     }
@@ -731,7 +732,7 @@ class OperationsSession(BaseOperationsSession):
                     ).format(
                         operation_id,
                         json.dumps(body_by_id[operation_id], indent=4),
-                        op_result["error"],
+                        op_result.get("error", "unknown"),
                     ))
 
     def create_entity(self, project_name, entity_type, data, nested_id=None):

--- a/openpype/plugins/publish/integrate_hero_version.py
+++ b/openpype/plugins/publish/integrate_hero_version.py
@@ -6,6 +6,7 @@ import shutil
 
 import pyblish.api
 
+from openpype import AYON_SERVER_ENABLED
 from openpype.client import (
     get_version_by_id,
     get_hero_version_by_subset_id,
@@ -195,11 +196,20 @@ class IntegrateHeroVersion(pyblish.api.InstancePlugin):
         entity_id = None
         if old_version:
             entity_id = old_version["_id"]
-        new_hero_version = new_hero_version_doc(
-            src_version_entity["_id"],
-            src_version_entity["parent"],
-            entity_id=entity_id
-        )
+
+        if AYON_SERVER_ENABLED:
+            new_hero_version = new_hero_version_doc(
+                src_version_entity["parent"],
+                copy.deepcopy(src_version_entity["data"]),
+                src_version_entity["name"],
+                entity_id=entity_id
+            )
+        else:
+            new_hero_version = new_hero_version_doc(
+                src_version_entity["_id"],
+                src_version_entity["parent"],
+                entity_id=entity_id
+            )
 
         if old_version:
             self.log.debug("Replacing old hero version.")


### PR DESCRIPTION
## Changelog Description
Hero versions integration is more specific about data integrated to ayon. The change was added to reduce time spent in requerying already known data. In AYON is hero version fully usable version without reference to source version entity (other than negative value of version).

## Additional info
During this process were discovered few bugs on server and python api. Some of bugfixes are in progress to be merged and released so it is possible that this PR won't work because of outdated versions (make sure you have run 'create_env' script).

## Testing notes:
1. Enabled Integrate Hero version on ayon server
2. Publish something (family must be in enabled families in settings)
3. Integration of hero version should be successful
