### PR TITLE
Scene inventory: Fix code errors when "not found" entries are found

### DIFF
--- a/openpype/tools/sceneinventory/model.py
+++ b/openpype/tools/sceneinventory/model.py
@@ -327,7 +327,7 @@ class InventoryModel(TreeModel):
                 project_name, repre_id
             )
             if not representation:
-                not_found["representation"].append(group_items)
+                not_found["representation"].extend(group_items)
                 not_found_ids.append(repre_id)
                 continue
 
@@ -335,7 +335,7 @@ class InventoryModel(TreeModel):
                 project_name, representation["parent"]
             )
             if not version:
-                not_found["version"].append(group_items)
+                not_found["version"].extend(group_items)
                 not_found_ids.append(repre_id)
                 continue
 
@@ -348,13 +348,13 @@ class InventoryModel(TreeModel):
 
             subset = get_subset_by_id(project_name, version["parent"])
             if not subset:
-                not_found["subset"].append(group_items)
+                not_found["subset"].extend(group_items)
                 not_found_ids.append(repre_id)
                 continue
 
             asset = get_asset_by_id(project_name, subset["parent"])
             if not asset:
-                not_found["asset"].append(group_items)
+                not_found["asset"].extend(group_items)
                 not_found_ids.append(repre_id)
                 continue
 
@@ -380,11 +380,10 @@ class InventoryModel(TreeModel):
 
             self.add_child(group_node, parent=parent)
 
-            for _group_items in group_items:
+            for item in group_items:
                 item_node = Item()
-                item_node["Name"] = ", ".join(
-                    [item["objectName"] for item in _group_items]
-                )
+                item_node.update(item)
+                item_node["Name"] = item.get("objectName", "NO NAME")
                 self.add_child(item_node, parent=group_node)
 
         for repre_id, group_dict in sorted(grouped.items()):

--- a/openpype/tools/sceneinventory/model.py
+++ b/openpype/tools/sceneinventory/model.py
@@ -384,6 +384,7 @@ class InventoryModel(TreeModel):
                 item_node = Item()
                 item_node.update(item)
                 item_node["Name"] = item.get("objectName", "NO NAME")
+                item_node["isNotFound"] = True
                 self.add_child(item_node, parent=group_node)
 
         for repre_id, group_dict in sorted(grouped.items()):

--- a/openpype/tools/sceneinventory/view.py
+++ b/openpype/tools/sceneinventory/view.py
@@ -80,15 +80,19 @@ class SceneInventoryView(QtWidgets.QTreeView):
         self.setStyleSheet("QTreeView {}")
 
     def _build_item_menu_for_selection(self, items, menu):
+
+        # Exclude items that are "NOT FOUND" since setting versions, updating
+        # and removal won't work for those items.
+        items = [item for item in items if not item.get("isNotFound")]
+
         if not items:
             return
 
         # An item might not have a representation, for example when an item
         # is listed as "NOT FOUND"
         repre_ids = {
-            item.get("representation")
+            item["representation"]
             for item in items
-            if "representation" in item
         }
 
         project_name = legacy_io.active_project()

--- a/openpype/tools/sceneinventory/view.py
+++ b/openpype/tools/sceneinventory/view.py
@@ -83,9 +83,12 @@ class SceneInventoryView(QtWidgets.QTreeView):
         if not items:
             return
 
+        # An item might not have a representation, for example when an item
+        # is listed as "NOT FOUND"
         repre_ids = {
-            item["representation"]
+            item.get("representation")
             for item in items
+            if "representation" in item
         }
 
         project_name = legacy_io.active_project()

--- a/openpype/tools/utils/delegates.py
+++ b/openpype/tools/utils/delegates.py
@@ -30,9 +30,11 @@ class VersionDelegate(QtWidgets.QStyledItemDelegate):
     def displayText(self, value, locale):
         if isinstance(value, HeroVersionType):
             return lib.format_version(value, True)
-        assert isinstance(value, numbers.Integral), (
-            "Version is not integer. \"{}\" {}".format(value, str(type(value)))
-        )
+        if not isinstance(value, numbers.Integral):
+            # For cases where no version is resolved like NOT FOUND cases
+            # where a representation might not exist in current database
+            return
+
         return lib.format_version(value)
 
     def paint(self, painter, option, index):


### PR DESCRIPTION
## Changelog Description

Whenever a "NOT FOUND" entry is present a lot of errors happened in the Scene Inventory:

- It started spamming a lot of errors for the VersionDelegate since it had no numeric version (no version at all). 

[Error reported on Discord](https://discord.com/channels/517362899170230292/563751989075378201/1082727536523489341):
```python
Traceback (most recent call last):
  File "C:\Users\videopro\Documents\github\OpenPype\openpype\tools\utils\delegates.py", line 65, in paint
    text = self.displayText(
  File "C:\Users\videopro\Documents\github\OpenPype\openpype\tools\utils\delegates.py", line 33, in displayText
    assert isinstance(value, numbers.Integral), (
AssertionError: Version is not integer. "None" <class 'NoneType'>
```

- Right click menu would error on NOT FOUND entries, and thus not show. With this PR it will now _disregard_ not found items for "Set version" and "Remove" but still allow actions.

This PR resolves those.

## Additional info

I'd love for "remove" to still be possible for not found entries since the Loader logic for remove is just `Loader.remove(container)` and we do have a container so should be able to call that logic. However due to `Loader.__init__` currently requiring a full context that is not possible. 

[Also reported on Discord.](https://discord.com/channels/517362899170230292/563751989075378201/1082987059725221888)

## Testing notes:

1. Tweak the representation value on a container so it's broken
2. Use the scene inventory - it should now behave better.
