### PR TITLE
Fix: Loader doesn't filter asset list recursively

### DIFF
--- a/openpype/tools/utils/models.py
+++ b/openpype/tools/utils/models.py
@@ -240,7 +240,6 @@ class RecursiveSortFilterProxyModel(QtCore.QSortFilterProxyModel):
         )
 
 
-
 class ProjectModel(QtGui.QStandardItemModel):
     def __init__(
         self, dbcon=None, only_active=True, add_default_project=False,

--- a/openpype/tools/utils/models.py
+++ b/openpype/tools/utils/models.py
@@ -202,6 +202,11 @@ class RecursiveSortFilterProxyModel(QtCore.QSortFilterProxyModel):
     Use case: Filtering by string - parent won't be filtered if does not match
         the filter string but first checks if any children does.
     """
+    def __init__(self, *args, **kwargs):
+        super(RecursiveSortFilterProxyModel, self).__init__(*args, **kwargs)
+        if hasattr(self, "setRecursiveFilteringEnabled"):
+            self.setRecursiveFilteringEnabled(True)
+
     def filterAcceptsRow(self, row, parent_index):
         if hasattr(self, "filterRegularExpression"):
             regex = self.filterRegularExpression()
@@ -233,6 +238,7 @@ class RecursiveSortFilterProxyModel(QtCore.QSortFilterProxyModel):
         return super(RecursiveSortFilterProxyModel, self).filterAcceptsRow(
             row, parent_index
         )
+
 
 
 class ProjectModel(QtGui.QStandardItemModel):


### PR DESCRIPTION
## Changelog Description
Since OP 3.15.0 Loader doesn't filter asset list recursively

## Testing notes:
1. Open Loader
2. Try to filter by typing words
