### PR TITLE
Tools: Fix recursive filtering

### DIFF
--- a/openpype/tools/loader/widgets.py
+++ b/openpype/tools/loader/widgets.py
@@ -295,10 +295,10 @@ class SubsetWidget(QtWidgets.QWidget):
             self.model.set_grouping(state)
 
     def _subset_changed(self, text):
-        if hasattr(self.proxy, "setFilterRegularExpression"):
-            self.proxy.setFilterRegularExpression(text)
-        else:
+        if hasattr(self.proxy, "setFilterRegExp"):
             self.proxy.setFilterRegExp(text)
+        else:
+            self.proxy.setFilterRegularExpression(text)
         self.view.expandAll()
 
     def set_loading_state(self, loading, empty):

--- a/openpype/tools/sceneinventory/model.py
+++ b/openpype/tools/sceneinventory/model.py
@@ -482,10 +482,10 @@ class FilterProxyModel(QtCore.QSortFilterProxyModel):
             return True
 
         # Filter by regex
-        if hasattr(self, "filterRegularExpression"):
-            regex = self.filterRegularExpression()
-        else:
+        if hasattr(self, "filterRegExp"):
             regex = self.filterRegExp()
+        else:
+            regex = self.filterRegularExpression()
         pattern = regex.pattern()
         if pattern:
             pattern = re.escape(pattern)

--- a/openpype/tools/sceneinventory/window.py
+++ b/openpype/tools/sceneinventory/window.py
@@ -160,10 +160,10 @@ class SceneInventoryWindow(QtWidgets.QDialog):
         self._model.set_hierarchy_view(enabled)
 
     def _on_text_filter_change(self, text_filter):
-        if hasattr(self._proxy, "setFilterRegularExpression"):
-            self._proxy.setFilterRegularExpression(text_filter)
-        else:
+        if hasattr(self._proxy, "setFilterRegExp"):
             self._proxy.setFilterRegExp(text_filter)
+        else:
+            self._proxy.setFilterRegularExpression(text_filter)
 
     def _on_outdated_state_change(self):
         self._proxy.set_filter_outdated(

--- a/openpype/tools/settings/settings/search_dialog.py
+++ b/openpype/tools/settings/settings/search_dialog.py
@@ -27,10 +27,10 @@ class RecursiveSortFilterProxyModel(QtCore.QSortFilterProxyModel):
         if not parent.isValid():
             return False
 
-        if hasattr(self, "filterRegularExpression"):
-            regex = self.filterRegularExpression()
-        else:
+        if hasattr(self, "filterRegExp"):
             regex = self.filterRegExp()
+        else:
+            regex = self.filterRegularExpression()
 
         pattern = regex.pattern()
         if pattern and regex.isValid():
@@ -111,10 +111,10 @@ class SearchEntitiesDialog(QtWidgets.QDialog):
 
     def _on_filter_timer(self):
         text = self._filter_edit.text()
-        if hasattr(self._proxy, "setFilterRegularExpression"):
-            self._proxy.setFilterRegularExpression(text)
-        else:
+        if hasattr(self._proxy, "setFilterRegExp"):
             self._proxy.setFilterRegExp(text)
+        else:
+            self._proxy.setFilterRegularExpression(text)
 
         # WARNING This expanding and resizing is relatively slow.
         self._view.expandAll()

--- a/openpype/tools/standalonepublish/widgets/model_filter_proxy_recursive_sort.py
+++ b/openpype/tools/standalonepublish/widgets/model_filter_proxy_recursive_sort.py
@@ -5,10 +5,10 @@ from qtpy import QtCore
 class RecursiveSortFilterProxyModel(QtCore.QSortFilterProxyModel):
     """Filters to the regex if any of the children matches allow parent"""
     def filterAcceptsRow(self, row, parent):
-        if hasattr(self, "filterRegularExpression"):
-            regex = self.filterRegularExpression()
-        else:
+        if hasattr(self, "filterRegExp"):
             regex = self.filterRegExp()
+        else:
+            regex = self.filterRegularExpression()
         pattern = regex.pattern()
         if pattern:
             model = self.sourceModel()

--- a/openpype/tools/utils/models.py
+++ b/openpype/tools/utils/models.py
@@ -202,6 +202,15 @@ class RecursiveSortFilterProxyModel(QtCore.QSortFilterProxyModel):
     Use case: Filtering by string - parent won't be filtered if does not match
         the filter string but first checks if any children does.
     """
+
+    def __init__(self, *args, **kwargs):
+        super(RecursiveSortFilterProxyModel, self).__init__(*args, **kwargs)
+        recursive_enabled = False
+        if hasattr(self, "setRecursiveFilteringEnabled"):
+            self.setRecursiveFilteringEnabled(True)
+            recursive_enabled = True
+        self._recursive_enabled = recursive_enabled
+
     def filterAcceptsRow(self, row, parent_index):
         if hasattr(self, "filterRegExp"):
             regex = self.filterRegExp()
@@ -219,8 +228,9 @@ class RecursiveSortFilterProxyModel(QtCore.QSortFilterProxyModel):
 
                 # Check current index itself
                 value = model.data(source_index, self.filterRole())
-                if re.search(pattern, value, re.IGNORECASE):
-                    return True
+                matched = bool(re.search(pattern, value, re.IGNORECASE))
+                if matched or self._recursive_enabled:
+                    return matched
 
                 rows = model.rowCount(source_index)
                 for idx in range(rows):

--- a/openpype/tools/utils/models.py
+++ b/openpype/tools/utils/models.py
@@ -203,10 +203,10 @@ class RecursiveSortFilterProxyModel(QtCore.QSortFilterProxyModel):
         the filter string but first checks if any children does.
     """
     def filterAcceptsRow(self, row, parent_index):
-        if hasattr(self, "filterRegularExpression"):
-            regex = self.filterRegularExpression()
-        else:
+        if hasattr(self, "filterRegExp"):
             regex = self.filterRegExp()
+        else:
+            regex = self.filterRegularExpression()
 
         pattern = regex.pattern()
         if pattern:


### PR DESCRIPTION
## Changelog Description
Fix recursive filtering which is broken since PySide6 support was added.

## Additional info
Change order of available methods to check for legacy ones first to fix PySide2 support. Assets filtering if using Qt recursive filtering if is available.

## Testing notes:
The most changes can be visible in Loader, Scene Inventory and Settings tool.
### Loader
1. Open Loader
2. Try filter assets by nested asset name
3. The parents should stay visible
4. The same for Subsets

### Settings
1. Open settings
2. Press CTRL+F (or find shortcut of your OS)
3. Type some settings key nested in the search dialog
4. The filtering should not hide parents if they don't match the name but their children does

Enhanced [PR](https://github.com/ynput/OpenPype/pull/4595) which solved only one issue.
