### PR TITLE
Maya: Unify menu labels for "Set Frame Range" and "Set Resolution"

### DIFF
--- a/openpype/hosts/blender/api/ops.py
+++ b/openpype/hosts/blender/api/ops.py
@@ -382,8 +382,8 @@ class TOPBAR_MT_avalon(bpy.types.Menu):
         layout.operator(LaunchLibrary.bl_idname, text="Library...")
         layout.separator()
         layout.operator(LaunchWorkFiles.bl_idname, text="Work Files...")
-        # TODO (jasper): maybe add 'Reload Pipeline', 'Reset Frame Range' and
-        #                'Reset Resolution'?
+        # TODO (jasper): maybe add 'Reload Pipeline', 'Set Frame Range' and
+        #                'Set Resolution'?
 
 
 def draw_avalon_menu(self, context):

--- a/openpype/hosts/houdini/startup/MainMenuCommon.xml
+++ b/openpype/hosts/houdini/startup/MainMenuCommon.xml
@@ -66,7 +66,7 @@ host_tools.show_workfiles(parent)
 ]]></scriptCode>
             </scriptItem>
 
-            <scriptItem id="reset_frame_range">
+            <scriptItem id="set_frame_range">
                 <label>Set Frame Range</label>
                 <scriptCode><![CDATA[
 import openpype.hosts.houdini.api.lib

--- a/openpype/hosts/houdini/startup/MainMenuCommon.xml
+++ b/openpype/hosts/houdini/startup/MainMenuCommon.xml
@@ -67,7 +67,7 @@ host_tools.show_workfiles(parent)
             </scriptItem>
 
             <scriptItem id="reset_frame_range">
-                <label>Reset Frame Range</label>
+                <label>Set Frame Range</label>
                 <scriptCode><![CDATA[
 import openpype.hosts.houdini.api.lib
 openpype.hosts.houdini.api.lib.reset_framerange()

--- a/openpype/hosts/maya/api/menu.py
+++ b/openpype/hosts/maya/api/menu.py
@@ -111,12 +111,12 @@ def install():
         )
 
         cmds.menuItem(
-            "Reset Frame Range",
+            "Set Frame Range",
             command=lambda *args: lib.reset_frame_range()
         )
 
         cmds.menuItem(
-            "Reset Resolution",
+            "Set Resolution",
             command=lambda *args: lib.reset_scene_resolution()
         )
 

--- a/openpype/hosts/resolve/api/menu.py
+++ b/openpype/hosts/resolve/api/menu.py
@@ -69,7 +69,7 @@ class OpenPypeMenu(QtWidgets.QWidget):
         #     "Set colorspace from presets", self
         # )
         # reset_resolution_btn = QtWidgets.QPushButton(
-        #     "Reset Resolution from peresets", self
+        #     "Set Resolution from presets", self
         # )
 
         layout = QtWidgets.QVBoxLayout(self)
@@ -108,7 +108,7 @@ class OpenPypeMenu(QtWidgets.QWidget):
         libload_btn.clicked.connect(self.on_libload_clicked)
         # rename_btn.clicked.connect(self.on_rename_clicked)
         # set_colorspace_btn.clicked.connect(self.on_set_colorspace_clicked)
-        # reset_resolution_btn.clicked.connect(self.on_reset_resolution_clicked)
+        # reset_resolution_btn.clicked.connect(self.on_set_resolution_clicked)
         experimental_btn.clicked.connect(self.on_experimental_clicked)
 
     def on_workfile_clicked(self):
@@ -145,8 +145,8 @@ class OpenPypeMenu(QtWidgets.QWidget):
     def on_set_colorspace_clicked(self):
         print("Clicked Set Colorspace")
 
-    def on_reset_resolution_clicked(self):
-        print("Clicked Reset Resolution")
+    def on_set_resolution_clicked(self):
+        print("Clicked Set Resolution")
 
     def on_experimental_clicked(self):
         host_tools.show_experimental_tools_dialog()

--- a/website/docs/artist_hosts_maya.md
+++ b/website/docs/artist_hosts_maya.md
@@ -230,8 +230,8 @@ Maya settings concerning framerate, resolution and frame range are handled by
 OpenPype. If set correctly in Ftrack, Maya will validate you have correct fps on
 scene save and publishing offering way to fix it for you.
 
-For resolution and frame range, use **OpenPype → Reset Frame Range** and
-**OpenPype → Reset Resolution**
+For resolution and frame range, use **OpenPype → Set Frame Range** and
+**OpenPype → Set Resolution**
 
 
 ## Creating rigs with OpenPype
@@ -386,7 +386,7 @@ Lets start with empty scene. First I'll pull in my favorite Buddha model.
 there just click on **Reference (abc)**.
 
 Next, I want to be sure that I have same frame range as is set on shot I am working
-on. To do this just **OpenPype → Reset Frame Range**. This should set Maya timeline to same
+on. To do this just **OpenPype → Set Frame Range**. This should set Maya timeline to same
 values as they are set on shot in *Ftrack* for example.
 
 I have my time set, so lets create some animation. We'll turn Buddha model around for
@@ -500,7 +500,7 @@ and for vray:
 maya/<Layer>/<Layer>
 ```
 
-Doing **OpenPype → Reset Resolution** will set correct resolution on camera.
+Doing **OpenPype → Set Resolution** will set correct resolution on camera.
 
 Scene is now ready for submission and should publish without errors.
 


### PR DESCRIPTION
## Changelog Description

Fix #4109: Unify menu labels for "Set Frame Range" and "Set Resolution"
This also tweaks it in Houdini from Reset Frame Range to Set Frame Range.

## Additional info

Whether we prefer **set** over **reset** or not I'll let for others to decide. It's good to note currently that the functions in the code base are mostly called `reset_x` instead of `set_x` (from a coding perspective somewhat from an obvious perspective since `set_x` looks like you need to pass it the value.

## Testing notes:

1. Start Maya and Houdini
2. It should look super-unified.
