### PR TITLE
Maya: Replace last usages of Qt module

### DIFF
--- a/openpype/hosts/maya/plugins/inventory/connect_geometry.py
+++ b/openpype/hosts/maya/plugins/inventory/connect_geometry.py
@@ -134,7 +134,7 @@ class ConnectGeometry(InventoryAction):
             bool
         """
 
-        from Qt import QtWidgets
+        from qtpy import QtWidgets
 
         accept = QtWidgets.QMessageBox.Ok
         if show_cancel:

--- a/openpype/hosts/maya/plugins/inventory/connect_xgen.py
+++ b/openpype/hosts/maya/plugins/inventory/connect_xgen.py
@@ -149,7 +149,7 @@ class ConnectXgen(InventoryAction):
             bool
         """
 
-        from Qt import QtWidgets
+        from qtpy import QtWidgets
 
         accept = QtWidgets.QMessageBox.Ok
         if show_cancel:

--- a/openpype/hosts/maya/plugins/load/load_xgen.py
+++ b/openpype/hosts/maya/plugins/load/load_xgen.py
@@ -3,7 +3,7 @@ import os
 import maya.cmds as cmds
 import xgenm
 
-from Qt import QtWidgets
+from qtpy import QtWidgets
 
 import openpype.hosts.maya.api.plugin
 from openpype.hosts.maya.api.lib import (


### PR DESCRIPTION
## Changelog Description
Replace last usage of `Qt` module with `qtpy`. This change is needed for `PySide6` support. All changes happened in Maya loader plugins.

## Testing notes:
1. Open Maya
2. Open Loader
3. Use `Load XGen`
4. Open Scene Inventory
5. Use `Connect Geometry` action
6. Use `Connect XGen` action

Resolves https://github.com/ynput/OpenPype/issues/3987