### PR TITLE
Update tests and documentation for  `ColormanagedPyblishPluginMixin`

### DIFF
--- a/tests/unit/openpype/pipeline/publish/test_publish_plugins.py
+++ b/tests/unit/openpype/pipeline/publish/test_publish_plugins.py
@@ -135,7 +135,7 @@ class TestPipelinePublishPlugins(TestPipeline):
         }
 
         # load plugin function for testing
-        plugin = publish_plugins.ExtractorColormanaged()
+        plugin = publish_plugins.ColormanagedPyblishPluginMixin()
         plugin.log = log
         config_data, file_rules = plugin.get_colorspace_settings(context)
 
@@ -175,14 +175,14 @@ class TestPipelinePublishPlugins(TestPipeline):
         }
 
         # load plugin function for testing
-        plugin = publish_plugins.ExtractorColormanaged()
+        plugin = publish_plugins.ColormanagedPyblishPluginMixin()
         plugin.log = log
         plugin.set_representation_colorspace(
             representation_nuke, context,
             colorspace_settings=(config_data_nuke, file_rules_nuke)
         )
         # load plugin function for testing
-        plugin = publish_plugins.ExtractorColormanaged()
+        plugin = publish_plugins.ColormanagedPyblishPluginMixin()
         plugin.log = log
         plugin.set_representation_colorspace(
             representation_hiero, context,

--- a/website/docs/dev_colorspace.md
+++ b/website/docs/dev_colorspace.md
@@ -63,7 +63,7 @@ It's up to the Loaders to read these values and apply the correct expected color
 	- set the `OCIO` environment variable before launching the host via a prelaunch hook
 	- or (if the host allows) to set the workfile OCIO config path using the host's API
 
-3. Each Extractor exporting pixel data (e.g. image or video) has to use parent class `openpype.pipeline.publish.publish_plugins.ExtractorColormanaged` and use `self.set_representation_colorspace` on the representations to be integrated.
+3. Each Extractor exporting pixel data (e.g. image or video) has to inherit from the mixin class `openpype.pipeline.publish.publish_plugins.ColormanagedPyblishPluginMixin` and use `self.set_representation_colorspace` on the representations to be integrated.
 
 The **set_representation_colorspace** method adds `colorspaceData` to the representation. If the `colorspace` passed is not `None` then it is added directly to the representation with resolved config path otherwise a color space is assumed using the configured file rules. If no file rule matches the `colorspaceData` is **not** added to the representation.
 


### PR DESCRIPTION
## Changelog Description

Refactor `ExtractorColormanaged` to `ColormanagedPyblishPluginMixin` in tests and documentation.

## Additional info

The PR https://github.com/ynput/OpenPype/pull/4556 refactored  `ExtractorColormanaged` to `ColormanagedPyblishPluginMixin` but the tests and documentation still referred to the old name.

## Testing notes:

1. Run tests
