### PR TITLE
Maya: Fix extract look colorspace detection

### DIFF
--- a/openpype/hosts/maya/plugins/publish/extract_look.py
+++ b/openpype/hosts/maya/plugins/publish/extract_look.py
@@ -24,7 +24,7 @@ HARDLINK = 2
 def _has_arnold():
     """Return whether the arnold package is available and can be imported."""
     try:
-        import arnold
+        import arnold  # noqa: F401
         return True
     except (ImportError, ModuleNotFoundError):
         return False

--- a/openpype/hosts/maya/plugins/publish/extract_look.py
+++ b/openpype/hosts/maya/plugins/publish/extract_look.py
@@ -21,6 +21,15 @@ COPY = 1
 HARDLINK = 2
 
 
+def _has_arnold():
+    """Return whether the arnold package is available and can be imported."""
+    try:
+        import arnold
+        return True
+    except (ImportError, ModuleNotFoundError):
+        return False
+
+
 def escape_space(path):
     """Ensure path is enclosed by quotes to allow paths with spaces"""
     return '"{}"'.format(path) if " " in path else path
@@ -546,7 +555,7 @@ class ExtractLook(publish.Extractor):
                         color_space = cmds.getAttr(color_space_attr)
                     except ValueError:
                         # node doesn't have color space attribute
-                        if cmds.loadPlugin("mtoa", quiet=True):
+                        if _has_arnold():
                             img_info = image_info(filepath)
                             color_space = guess_colorspace(img_info)
                         else:
@@ -558,7 +567,7 @@ class ExtractLook(publish.Extractor):
                                             render_colorspace])
                 else:
 
-                    if cmds.loadPlugin("mtoa", quiet=True):
+                    if _has_arnold():
                         img_info = image_info(filepath)
                         color_space = guess_colorspace(img_info)
                         if color_space == "sRGB":

--- a/openpype/hosts/maya/plugins/publish/extract_look.py
+++ b/openpype/hosts/maya/plugins/publish/extract_look.py
@@ -1,12 +1,10 @@
 # -*- coding: utf-8 -*-
 """Maya look extractor."""
 import os
-import sys
 import json
 import tempfile
 import platform
 import contextlib
-import subprocess
 from collections import OrderedDict
 
 from maya import cmds  # noqa


### PR DESCRIPTION
## Changelog Description

Fix the logic which guesses the colorspace using `arnold` python library.

- Previously it'd error if `mtoa` was not available on path so it still required `mtoa` to be available.
- The guessing colorspace logic doesn't actually require `mtoa` to be loaded, but just the `arnold` python library to be available. This changes the logic so it doesn't require the `mtoa` plugin to get loaded to guess the colorspace.
- The if/else branch was likely not doing what was intended `cmds.loadPlugin("mtoa", quiet=True)` returns None if the plug-in was already loaded. So this would only ever be true if it ends up loading the `mtoa` plugin the first time.

```python
# Tested in Maya 2022.1
print(cmds.loadPlugin("mtoa", quiet=True))
# ['mtoa']
print(cmds.loadPlugin("mtoa", quiet=True))
# None
```

## Additional info

Originally implemented in PR https://github.com/ynput/OpenPype/pull/4276

## Testing notes:

1. Start Maya without Arnold and `mtoa` plug-in available - it should extract look just fine.
2. Start Maya with Arnold available but `mtoa` plug-in unloaded - it should not require loading `mtoa` but still be able to guess the colorspace
3. Start Maya with Arnold available and with `mtoa` plug-in loaded - it should still be able to guess the colorspace
