### PR TITLE
Global | Nuke: fixing farm publishing workflow

### DIFF
--- a/openpype/hosts/nuke/plugins/publish/extract_review_data.py
+++ b/openpype/hosts/nuke/plugins/publish/extract_review_data.py
@@ -25,7 +25,7 @@ class ExtractReviewData(publish.Extractor):
         # review can be removed since `ProcessSubmittedJobOnFarm` will create
         # reviewable representation if needed
         if (
-            "render.farm" in instance.data["families"]
+            instance.data.get("farm")
             and "review" in instance.data["families"]
         ):
             instance.data["families"].remove("review")

--- a/openpype/hosts/nuke/plugins/publish/extract_review_data_lut.py
+++ b/openpype/hosts/nuke/plugins/publish/extract_review_data_lut.py
@@ -49,7 +49,12 @@ class ExtractReviewDataLut(publish.Extractor):
                 exporter.stagingDir, exporter.file).replace("\\", "/")
             instance.data["representations"] += data["representations"]
 
-        if "render.farm" in families:
+        # review can be removed since `ProcessSubmittedJobOnFarm` will create
+        # reviewable representation if needed
+        if (
+            instance.data.get("farm")
+            and "review" in instance.data["families"]
+        ):
             instance.data["families"].remove("review")
 
         self.log.debug(

--- a/openpype/hosts/nuke/plugins/publish/extract_review_data_mov.py
+++ b/openpype/hosts/nuke/plugins/publish/extract_review_data_mov.py
@@ -105,10 +105,7 @@ class ExtractReviewDataMov(publish.Extractor):
                     self, instance, o_name, o_data["extension"],
                     multiple_presets)
 
-                if (
-                    "render.farm" in families or
-                    "prerender.farm" in families
-                ):
+                if instance.data.get("farm"):
                     if "review" in instance.data["families"]:
                         instance.data["families"].remove("review")
 

--- a/openpype/hosts/nuke/plugins/publish/extract_thumbnail.py
+++ b/openpype/hosts/nuke/plugins/publish/extract_thumbnail.py
@@ -31,7 +31,7 @@ class ExtractThumbnail(publish.Extractor):
 
 
     def process(self, instance):
-        if "render.farm" in instance.data["families"]:
+        if instance.data.get("farm"):
             return
 
         with napi.maintained_selection():

--- a/openpype/modules/deadline/plugins/publish/submit_nuke_deadline.py
+++ b/openpype/modules/deadline/plugins/publish/submit_nuke_deadline.py
@@ -81,6 +81,7 @@ class NukeSubmitDeadline(pyblish.api.InstancePlugin,
 
     def process(self, instance):
         if not instance.data.get("farm"):
+            self.log.info("Skipping local instance.")
             return
 
         instance.data["attributeValues"] = self.get_attr_values_from_data(
@@ -171,10 +172,10 @@ class NukeSubmitDeadline(pyblish.api.InstancePlugin,
                     resp.json()["_id"])
 
         # redefinition of families
-        if "render" in family:
+        if "render" in instance.data["family"]:
             instance.data['family'] = 'write'
             families.insert(0, "render2d")
-        elif "prerender" in family:
+        elif "prerender" in instance.data["family"]:
             instance.data['family'] = 'write'
             families.insert(0, "prerender")
         instance.data["families"] = families

--- a/openpype/modules/deadline/plugins/publish/submit_nuke_deadline.py
+++ b/openpype/modules/deadline/plugins/publish/submit_nuke_deadline.py
@@ -32,7 +32,7 @@ class NukeSubmitDeadline(pyblish.api.InstancePlugin,
     label = "Submit Nuke to Deadline"
     order = pyblish.api.IntegratorOrder + 0.1
     hosts = ["nuke"]
-    families = ["render", "prerender.farm"]
+    families = ["render", "prerender"]
     optional = True
     targets = ["local"]
 
@@ -80,6 +80,9 @@ class NukeSubmitDeadline(pyblish.api.InstancePlugin,
         ]
 
     def process(self, instance):
+        if not instance.data.get("farm"):
+            return
+
         instance.data["attributeValues"] = self.get_attr_values_from_data(
             instance.data)
 
@@ -168,10 +171,10 @@ class NukeSubmitDeadline(pyblish.api.InstancePlugin,
                     resp.json()["_id"])
 
         # redefinition of families
-        if "render.farm" in families:
+        if "render" in family:
             instance.data['family'] = 'write'
             families.insert(0, "render2d")
-        elif "prerender.farm" in families:
+        elif "prerender" in family:
             instance.data['family'] = 'write'
             families.insert(0, "prerender")
         instance.data["families"] = families

--- a/openpype/modules/deadline/plugins/publish/submit_publish_job.py
+++ b/openpype/modules/deadline/plugins/publish/submit_publish_job.py
@@ -756,6 +756,10 @@ class ProcessSubmittedJobOnFarm(pyblish.api.InstancePlugin):
             instance (pyblish.api.Instance): Instance data.
 
         """
+        if not instance.data.get("farm"):
+            self.log.info("Skipping local instance.")
+            return
+
         data = instance.data.copy()
         context = instance.context
         self.context = context

--- a/openpype/modules/deadline/plugins/publish/validate_deadline_pools.py
+++ b/openpype/modules/deadline/plugins/publish/validate_deadline_pools.py
@@ -21,6 +21,10 @@ class ValidateDeadlinePools(OptionalPyblishPluginMixin,
     optional = True
 
     def process(self, instance):
+        if not instance.data.get("farm"):
+            self.log.info("Skipping local instance.")
+            return
+
         # get default deadline webservice url from deadline module
         deadline_url = instance.context.data["defaultDeadline"]
         self.log.info("deadline_url::{}".format(deadline_url))

--- a/tests/integration/hosts/nuke/test_deadline_publish_in_nuke.py
+++ b/tests/integration/hosts/nuke/test_deadline_publish_in_nuke.py
@@ -71,8 +71,26 @@ class TestDeadlinePublishInNuke(NukeDeadlinePublishTestClass):
         failures.append(
             DBAssert.count_of_types(dbcon, "representation", 4))
 
+        additional_args = {"context.subset": "workfileTest_task",
+                           "context.ext": "nk"}
+        failures.append(
+            DBAssert.count_of_types(dbcon, "representation", 1,
+                                    additional_args=additional_args))
+
         additional_args = {"context.subset": "renderTest_taskMain",
                            "context.ext": "exr"}
+        failures.append(
+            DBAssert.count_of_types(dbcon, "representation", 1,
+                                    additional_args=additional_args))
+
+        additional_args = {"context.subset": "renderTest_taskMain",
+                           "name": "thumbnail"}
+        failures.append(
+            DBAssert.count_of_types(dbcon, "representation", 1,
+                                    additional_args=additional_args))
+
+        additional_args = {"context.subset": "renderTest_taskMain",
+                           "name": "h264_mov"}
         failures.append(
             DBAssert.count_of_types(dbcon, "representation", 1,
                                     additional_args=additional_args))

--- a/tests/integration/hosts/nuke/test_publish_in_nuke.py
+++ b/tests/integration/hosts/nuke/test_publish_in_nuke.py
@@ -1,12 +1,12 @@
 import logging
 
 from tests.lib.assert_classes import DBAssert
-from tests.integration.hosts.nuke.lib import NukeDeadlinePublishTestClass
+from tests.integration.hosts.nuke.lib import NukeLocalPublishTestClass
 
 log = logging.getLogger("test_publish_in_nuke")
 
 
-class TestDeadlinePublishInNuke(NukeDeadlinePublishTestClass):
+class TestPublishInNuke(NukeLocalPublishTestClass):
     """Basic test case for publishing in Nuke
 
         Uses generic TestCase to prepare fixtures for test data, testing DBs,
@@ -36,13 +36,12 @@ class TestDeadlinePublishInNuke(NukeDeadlinePublishTestClass):
     """
     # https://drive.google.com/file/d/1SUurHj2aiQ21ZIMJfGVBI2KjR8kIjBGI/view?usp=sharing  # noqa: E501
     TEST_FILES = [
-        ("1SeWprClKhWMv2xVC9AcnekIJFExxnp_b",
-         "test_nuke_deadline_publish.zip", "")
+        ("1SUurHj2aiQ21ZIMJfGVBI2KjR8kIjBGI", "test_Nuke_publish.zip", "")
     ]
 
     APP_GROUP = "nuke"
 
-    TIMEOUT = 180  # publish timeout
+    TIMEOUT = 50  # publish timeout
 
     # could be overwritten by command line arguments
     # keep empty to locate latest installed variant or explicit
@@ -99,4 +98,4 @@ class TestDeadlinePublishInNuke(NukeDeadlinePublishTestClass):
 
 
 if __name__ == "__main__":
-    test_case = TestDeadlinePublishInNuke()
+    test_case = TestPublishInNuke()

--- a/tests/integration/hosts/nuke/test_publish_in_nuke.py
+++ b/tests/integration/hosts/nuke/test_publish_in_nuke.py
@@ -1,12 +1,12 @@
 import logging
 
 from tests.lib.assert_classes import DBAssert
-from tests.integration.hosts.nuke.lib import NukeLocalPublishTestClass
+from tests.integration.hosts.nuke.lib import NukeDeadlinePublishTestClass
 
 log = logging.getLogger("test_publish_in_nuke")
 
 
-class TestPublishInNuke(NukeLocalPublishTestClass):
+class TestDeadlinePublishInNuke(NukeDeadlinePublishTestClass):
     """Basic test case for publishing in Nuke
 
         Uses generic TestCase to prepare fixtures for test data, testing DBs,
@@ -15,7 +15,7 @@ class TestPublishInNuke(NukeLocalPublishTestClass):
         !!!
         It expects modified path in WriteNode,
         use '[python {nuke.script_directory()}]' instead of regular root
-        dir (eg. instead of `c:/projects/test_project/test_asset/test_task`).
+        dir (eg. instead of `c:/projects`).
         Access file path by selecting WriteNode group, CTRL+Enter, update file
         input
         !!!
@@ -36,12 +36,13 @@ class TestPublishInNuke(NukeLocalPublishTestClass):
     """
     # https://drive.google.com/file/d/1SUurHj2aiQ21ZIMJfGVBI2KjR8kIjBGI/view?usp=sharing  # noqa: E501
     TEST_FILES = [
-        ("1SUurHj2aiQ21ZIMJfGVBI2KjR8kIjBGI", "test_Nuke_publish.zip", "")
+        ("1SeWprClKhWMv2xVC9AcnekIJFExxnp_b",
+         "test_nuke_deadline_publish.zip", "")
     ]
 
     APP_GROUP = "nuke"
 
-    TIMEOUT = 50  # publish timeout
+    TIMEOUT = 180  # publish timeout
 
     # could be overwritten by command line arguments
     # keep empty to locate latest installed variant or explicit
@@ -70,8 +71,26 @@ class TestPublishInNuke(NukeLocalPublishTestClass):
         failures.append(
             DBAssert.count_of_types(dbcon, "representation", 4))
 
+        additional_args = {"context.subset": "workfileTest_task",
+                           "context.ext": "nk"}
+        failures.append(
+            DBAssert.count_of_types(dbcon, "representation", 1,
+                                    additional_args=additional_args))
+
         additional_args = {"context.subset": "renderTest_taskMain",
                            "context.ext": "exr"}
+        failures.append(
+            DBAssert.count_of_types(dbcon, "representation", 1,
+                                    additional_args=additional_args))
+
+        additional_args = {"context.subset": "renderTest_taskMain",
+                           "name": "thumbnail"}
+        failures.append(
+            DBAssert.count_of_types(dbcon, "representation", 1,
+                                    additional_args=additional_args))
+
+        additional_args = {"context.subset": "renderTest_taskMain",
+                           "name": "h264_mov"}
         failures.append(
             DBAssert.count_of_types(dbcon, "representation", 1,
                                     additional_args=additional_args))
@@ -80,4 +99,4 @@ class TestPublishInNuke(NukeLocalPublishTestClass):
 
 
 if __name__ == "__main__":
-    test_case = TestPublishInNuke()
+    test_case = TestDeadlinePublishInNuke()


### PR DESCRIPTION
## Changelog Description
After Nuke had adopted new publisher with new creators new issues were introduced. Those issues were addressed with this PR. Those are for example broken reviewable video files publishing if published via farm. Also fixed local publishing. 

## Additional info
Global plugins had to be addressed too so please test also other DCCs if those are still working - talking of AfterEffects, Maya mainly.

## Testing notes:
1. Open Nuke workfile and publish render family node to farm.
2. Ideally test also included slate workflow (you might need to add slate tag to your ExctractReview output preset)
3. After the publish is done check Ftrack if reviewable video (with slate) was published.
