### PR TITLE
General: We should keep current subset version when we switch only the representation type

### DIFF
--- a/openpype/tools/sceneinventory/switch_dialog.py
+++ b/openpype/tools/sceneinventory/switch_dialog.py
@@ -1227,12 +1227,15 @@ class SwitchAssetDialog(QtWidgets.QDialog):
 
         version_ids = list()
 
-        version_docs_by_parent_id = {}
+        version_docs_by_parent_and_name = collections.defaultdict(dict)
+        last_version_docs_by_parent_id = {}
         for version_doc in version_docs:
             parent_id = version_doc["parent"]
-            if parent_id not in version_docs_by_parent_id:
-                version_ids.append(version_doc["_id"])
-                version_docs_by_parent_id[parent_id] = version_doc
+            version_ids.append(version_doc["_id"])
+            name = version_doc["name"]
+            version_docs_by_parent_and_name[parent_id][name] = version_doc
+            if parent_id not in last_version_docs_by_parent_id:
+                last_version_docs_by_parent_id[parent_id] = version_doc
 
         hero_version_docs_by_parent_id = {}
         for hero_version_doc in hero_version_docs:
@@ -1254,6 +1257,7 @@ class SwitchAssetDialog(QtWidgets.QDialog):
 
             container_version_id = container_repre["parent"]
             container_version = self.content_versions[container_version_id]
+            container_version_name = container_version["name"]
 
             container_subset_id = container_version["parent"]
             container_subset = self.content_subsets[container_subset_id]
@@ -1290,7 +1294,11 @@ class SwitchAssetDialog(QtWidgets.QDialog):
                         repre_doc = _repres.get(container_repre_name)
 
             if not repre_doc:
-                version_doc = version_docs_by_parent_id[subset_id]
+                version_by_name = version_docs_by_parent_and_name[subset_id]
+                if selected_asset or selected_subset:
+                    version_doc = last_version_docs_by_parent_id[subset_id]
+                else:
+                    version_doc = version_by_name[container_version_name]
                 version_id = version_doc["_id"]
                 repres_by_name = repre_docs_by_parent_id_by_name[version_id]
                 if selected_representation:

--- a/openpype/tools/sceneinventory/switch_dialog.py
+++ b/openpype/tools/sceneinventory/switch_dialog.py
@@ -1227,15 +1227,12 @@ class SwitchAssetDialog(QtWidgets.QDialog):
 
         version_ids = list()
 
-        version_docs_by_parent_and_name = collections.defaultdict(dict)
-        last_version_docs_by_parent_id = {}
+        version_docs_by_parent_id_and_name = collections.defaultdict(dict)
         for version_doc in version_docs:
             parent_id = version_doc["parent"]
             version_ids.append(version_doc["_id"])
             name = version_doc["name"]
-            version_docs_by_parent_and_name[parent_id][name] = version_doc
-            if parent_id not in last_version_docs_by_parent_id:
-                last_version_docs_by_parent_id[parent_id] = version_doc
+            version_docs_by_parent_id_and_name[parent_id][name] = version_doc
 
         hero_version_docs_by_parent_id = {}
         for hero_version_doc in hero_version_docs:
@@ -1294,17 +1291,32 @@ class SwitchAssetDialog(QtWidgets.QDialog):
                         repre_doc = _repres.get(container_repre_name)
 
             if not repre_doc:
-                version_by_name = version_docs_by_parent_and_name[subset_id]
+                version_by_name = version_docs_by_parent_id_and_name[subset_id]
+
+                # If asset or subset are selected for switching, we use latest
+                # version else we try to keep the current container version.
                 if selected_asset or selected_subset:
-                    version_doc = last_version_docs_by_parent_id[subset_id]
+                    version_name = max(version_by_name)
                 else:
-                    version_doc = version_by_name[container_version_name]
+                    version_name = container_version_name
+
+                version_doc = version_by_name[version_name]
                 version_id = version_doc["_id"]
                 repres_by_name = repre_docs_by_parent_id_by_name[version_id]
+
                 if selected_representation:
-                    repre_doc = repres_by_name[selected_representation]
+                    repres_name = selected_representation
                 else:
-                    repre_doc = repres_by_name[container_repre_name]
+                    repres_name = container_repre_name
+
+                # If selected representation is not available with container
+                # version, we use latest version.
+                if repres_name not in repres_by_name:
+                    repres_by_name = repre_docs_by_parent_id_by_name[
+                        version_by_name[max(version_by_name)]["_id"]
+                    ]
+
+                repre_doc = repres_by_name[repres_name]
 
             try:
                 switch_container(container, repre_doc, loader)

--- a/openpype/tools/sceneinventory/switch_dialog.py
+++ b/openpype/tools/sceneinventory/switch_dialog.py
@@ -1254,7 +1254,6 @@ class SwitchAssetDialog(QtWidgets.QDialog):
 
             container_version_id = container_repre["parent"]
             container_version = self.content_versions[container_version_id]
-            container_version_name = container_version["name"]
 
             container_subset_id = container_version["parent"]
             container_subset = self.content_subsets[container_subset_id]
@@ -1303,7 +1302,7 @@ class SwitchAssetDialog(QtWidgets.QDialog):
                 ):
                     version_name = max(version_docs_by_name)
                 else:
-                    version_name = container_version_name
+                    version_name = container_version["name"]
 
                 version_doc = version_docs_by_name[version_name]
                 version_id = version_doc["_id"]

--- a/openpype/tools/sceneinventory/switch_dialog.py
+++ b/openpype/tools/sceneinventory/switch_dialog.py
@@ -1291,32 +1291,29 @@ class SwitchAssetDialog(QtWidgets.QDialog):
                         repre_doc = _repres.get(container_repre_name)
 
             if not repre_doc:
-                version_by_name = version_docs_by_parent_id_and_name[subset_id]
+                version_docs_by_name = version_docs_by_parent_id_and_name[
+                    subset_id
+                ]
 
                 # If asset or subset are selected for switching, we use latest
                 # version else we try to keep the current container version.
                 if selected_asset or selected_subset:
-                    version_name = max(version_by_name)
+                    version_name = max(version_docs_by_name)
                 else:
                     version_name = container_version_name
 
-                version_doc = version_by_name[version_name]
+                version_doc = version_docs_by_name[version_name]
                 version_id = version_doc["_id"]
-                repres_by_name = repre_docs_by_parent_id_by_name[version_id]
+                repres_docs_by_name = repre_docs_by_parent_id_by_name[
+                    version_id
+                ]
 
                 if selected_representation:
                     repres_name = selected_representation
                 else:
                     repres_name = container_repre_name
 
-                # If selected representation is not available with container
-                # version, we use latest version.
-                if repres_name not in repres_by_name:
-                    repres_by_name = repre_docs_by_parent_id_by_name[
-                        version_by_name[max(version_by_name)]["_id"]
-                    ]
-
-                repre_doc = repres_by_name[repres_name]
+                repre_doc = repres_docs_by_name[repres_name]
 
             try:
                 switch_container(container, repre_doc, loader)

--- a/openpype/tools/sceneinventory/switch_dialog.py
+++ b/openpype/tools/sceneinventory/switch_dialog.py
@@ -1297,7 +1297,10 @@ class SwitchAssetDialog(QtWidgets.QDialog):
 
                 # If asset or subset are selected for switching, we use latest
                 # version else we try to keep the current container version.
-                if selected_asset or selected_subset:
+                if (
+                    selected_asset not in (None, container_asset_name)
+                    or selected_subset not in (None, container_subset_name)
+                ):
                     version_name = max(version_docs_by_name)
                 else:
                     version_name = container_version_name


### PR DESCRIPTION
## Changelog Description
When we switch only the representation type of subsets, we should not get the representation from the last version of the subset. 

## Testing notes:
1. Load a subset with several representation(any host)
2. Set version that is not the last existing version.
3. Switch the subset representation using the scene inventory.
4. Version should not change to the latest.

## Additional suggestion
We could implement a version combobox selection to the switch dialog.