### PR TITLE
Ftrack: Ftrack additional families filtering

### DIFF
--- a/openpype/modules/ftrack/plugins/publish/collect_ftrack_family.py
+++ b/openpype/modules/ftrack/plugins/publish/collect_ftrack_family.py
@@ -70,7 +70,7 @@ class CollectFtrackFamily(pyblish.api.InstancePlugin):
             result_str = "Adding"
             self.log.debug("Adding ftrack family for '{}'".format(family))
             if "ftrack" not in families:
-                instance.data["families"].append("ftrack")
+                families.append("ftrack")
 
         self.log.info("{} 'ftrack' family for instance with '{}'".format(
             result_str, family

--- a/openpype/modules/ftrack/plugins/publish/collect_ftrack_family.py
+++ b/openpype/modules/ftrack/plugins/publish/collect_ftrack_family.py
@@ -11,18 +11,18 @@ from openpype.lib import filter_profiles
 
 
 class CollectFtrackFamily(pyblish.api.InstancePlugin):
+    """Adds explicitly 'ftrack' to families to upload instance to FTrack.
+
+    Uses selection by combination of hosts/families/tasks names via
+    profiles resolution.
+
+    Triggered everywhere, checks instance against configured.
+
+    Checks advanced filtering which works on 'families' not on main
+    'family', as some variants dynamically resolves addition of ftrack
+    based on 'families' (editorial drives it by presence of 'review')
     """
-        Adds explicitly 'ftrack' to families to upload instance to FTrack.
 
-        Uses selection by combination of hosts/families/tasks names via
-        profiles resolution.
-
-        Triggered everywhere, checks instance against configured.
-
-        Checks advanced filtering which works on 'families' not on main
-        'family', as some variants dynamically resolves addition of ftrack
-        based on 'families' (editorial drives it by presence of 'review')
-    """
     label = "Collect Ftrack Family"
     order = pyblish.api.CollectorOrder + 0.4990
 
@@ -33,7 +33,6 @@ class CollectFtrackFamily(pyblish.api.InstancePlugin):
             self.log.warning("No profiles present for adding Ftrack family")
             return
 
-        add_ftrack_family = False
         host_name = instance.context.data["hostName"]
         family = instance.data["family"]
         task_name = instance.data.get("task")
@@ -43,8 +42,13 @@ class CollectFtrackFamily(pyblish.api.InstancePlugin):
             "families": family,
             "tasks": task_name
         }
-        profile = filter_profiles(self.profiles, filtering_criteria,
-                                  logger=self.log)
+        profile = filter_profiles(
+            self.profiles,
+            filtering_criteria,
+            logger=self.log
+        )
+
+        add_ftrack_family = False
         families = instance.data.setdefault("families", [])
 
         if profile:
@@ -61,40 +65,33 @@ class CollectFtrackFamily(pyblish.api.InstancePlugin):
                     add_ftrack_family
                 )
 
-            if add_ftrack_family:
-                self.log.debug("Adding ftrack family for '{}'".
-                               format(instance.data.get("family")))
-
-                if families:
-                    if "ftrack" not in families:
-                        instance.data["families"].append("ftrack")
-                else:
-                    instance.data["families"] = ["ftrack"]
-
         result_str = "Adding"
-        if not add_ftrack_family:
+        if add_ftrack_family:
             result_str = "Not adding"
+            self.log.debug("Adding ftrack family for '{}'".format(family))
+            if "ftrack" not in families:
+                instance.data["families"].append("ftrack")
+
         self.log.info("{} 'ftrack' family for instance with '{}'".format(
             result_str, family
         ))
 
-    def _get_add_ftrack_f_from_addit_filters(self,
-                                             additional_filters,
-                                             families,
-                                             add_ftrack_family):
-        """
-            Compares additional filters - working on instance's families.
+    def _get_add_ftrack_f_from_addit_filters(
+        self, additional_filters, families, add_ftrack_family
+    ):
+        """Compares additional filters - working on instance's families.
 
-            Triggered for more detailed filtering when main family matches,
-            but content of 'families' actually matter.
-            (For example 'review' in 'families' should result in adding to
-            Ftrack)
+        Triggered for more detailed filtering when main family matches,
+        but content of 'families' actually matter.
+        (For example 'review' in 'families' should result in adding to
+        Ftrack)
 
-            Args:
-                additional_filters (dict) - from Setting
-                families (list) - subfamilies
-                add_ftrack_family (bool) - add ftrack to families if True
+        Args:
+            additional_filters (dict) - from Setting
+            families (set[str]) - subfamilies
+            add_ftrack_family (bool) - add ftrack to families if True
         """
+
         override_filter = None
         override_filter_value = -1
         for additional_filter in additional_filters:

--- a/openpype/modules/ftrack/plugins/publish/collect_ftrack_family.py
+++ b/openpype/modules/ftrack/plugins/publish/collect_ftrack_family.py
@@ -65,9 +65,9 @@ class CollectFtrackFamily(pyblish.api.InstancePlugin):
                     add_ftrack_family
                 )
 
-        result_str = "Adding"
+        result_str = "Not adding"
         if add_ftrack_family:
-            result_str = "Not adding"
+            result_str = "Adding"
             self.log.debug("Adding ftrack family for '{}'".format(family))
             if "ftrack" not in families:
                 instance.data["families"].append("ftrack")

--- a/openpype/modules/ftrack/plugins/publish/collect_ftrack_family.py
+++ b/openpype/modules/ftrack/plugins/publish/collect_ftrack_family.py
@@ -7,7 +7,6 @@ Provides:
 """
 import pyblish.api
 
-from openpype.pipeline import legacy_io
 from openpype.lib import filter_profiles
 
 
@@ -35,10 +34,9 @@ class CollectFtrackFamily(pyblish.api.InstancePlugin):
             return
 
         add_ftrack_family = False
-        task_name = instance.data.get("task",
-                                      legacy_io.Session["AVALON_TASK"])
-        host_name = legacy_io.Session["AVALON_APP"]
+        host_name = instance.context.data["hostName"]
         family = instance.data["family"]
+        task_name = instance.data.get("task")
 
         filtering_criteria = {
             "hosts": host_name,

--- a/openpype/modules/ftrack/plugins/publish/collect_ftrack_family.py
+++ b/openpype/modules/ftrack/plugins/publish/collect_ftrack_family.py
@@ -55,13 +55,13 @@ class CollectFtrackFamily(pyblish.api.InstancePlugin):
             add_ftrack_family = profile["add_ftrack_family"]
             additional_filters = profile.get("advanced_filtering")
             if additional_filters:
-                families_s = set(families) | {family}
+                families_set = set(families) | {family}
                 self.log.info(
                     "'{}' families used for additional filtering".format(
-                        families_s))
+                        families_set))
                 add_ftrack_family = self._get_add_ftrack_f_from_addit_filters(
                     additional_filters,
-                    families_s,
+                    families_set,
                     add_ftrack_family
                 )
 

--- a/openpype/modules/ftrack/plugins/publish/collect_ftrack_family.py
+++ b/openpype/modules/ftrack/plugins/publish/collect_ftrack_family.py
@@ -68,7 +68,6 @@ class CollectFtrackFamily(pyblish.api.InstancePlugin):
         result_str = "Not adding"
         if add_ftrack_family:
             result_str = "Adding"
-            self.log.debug("Adding ftrack family for '{}'".format(family))
             if "ftrack" not in families:
                 families.append("ftrack")
 

--- a/openpype/modules/ftrack/plugins/publish/collect_ftrack_family.py
+++ b/openpype/modules/ftrack/plugins/publish/collect_ftrack_family.py
@@ -47,18 +47,19 @@ class CollectFtrackFamily(pyblish.api.InstancePlugin):
         }
         profile = filter_profiles(self.profiles, filtering_criteria,
                                   logger=self.log)
+        families = instance.data.setdefault("families", [])
 
         if profile:
-            families = instance.data.get("families")
             add_ftrack_family = profile["add_ftrack_family"]
-
             additional_filters = profile.get("advanced_filtering")
             if additional_filters:
-                self.log.info("'{}' families used for additional filtering".
-                              format(families))
+                families_s = set(families) | {family}
+                self.log.info(
+                    "'{}' families used for additional filtering".format(
+                        families_s))
                 add_ftrack_family = self._get_add_ftrack_f_from_addit_filters(
                     additional_filters,
-                    families,
+                    families_s,
                     add_ftrack_family
                 )
 


### PR DESCRIPTION
## Changelog Description
Ftrack family collector makes sure the subset family is also in instance families for additional families filtering.

## Additional info
When additional filtering would look for combination of `"render"` and `"review"` families on instance it would not work when the `"render"` would be subset family.

## Testing notes:
1. Define additional filtering of families with `"plate"` and `"review"` for Collect Ftrack Familiy in `traypublisher` (in a way that you can validate it works)
2. Open Tray Publisher
3. Create Plate with review representation
4. Hit validate (you don't need to publish to validate the collector works)
5. The instance should have/not have `"ftrack"` family based on your settings