### PR TITLE
Maya: Maya Playblast Options overrides - OP-3847

### DIFF
--- a/openpype/hosts/maya/plugins/publish/collect_review.py
+++ b/openpype/hosts/maya/plugins/publish/collect_review.py
@@ -24,7 +24,9 @@ class CollectReview(pyblish.api.InstancePlugin):
         task = legacy_io.Session["AVALON_TASK"]
 
         # Get panel.
-        instance.data["panel"] = cmds.playblast(activeEditor=True)
+        instance.data["panel"] = cmds.playblast(
+            activeEditor=True
+        ).split("|")[-1]
 
         # get cameras
         members = instance.data['setMembers']


### PR DESCRIPTION
## Changelog Description
When publishing a review in Maya, the extractor would fail due to wrong (long) panel name.

## Testing notes:
1. Disable the override_viewport_options in  `project_settings/maya/publish/ExtractPlayblast/capture_preset/Viewport Options/override_viewport_options`
2. Publish a review in Maya.