### PR TITLE
General: Use right validation for ffmpeg executable

### DIFF
--- a/openpype/lib/vendor_bin_utils.py
+++ b/openpype/lib/vendor_bin_utils.py
@@ -375,7 +375,7 @@ def get_ffmpeg_tool_path(tool="ffmpeg"):
     # Look to PATH for the tool
     if not tool_executable_path:
         from_path = find_executable(tool)
-        if from_path and _oiio_executable_validation(from_path):
+        if from_path and _ffmpeg_executable_validation(from_path):
             tool_executable_path = from_path
 
     CachedToolPaths.cache_executable_path(tool, tool_executable_path)


### PR DESCRIPTION
## Changelog Description
Use ffmpeg exec validation for ffmpeg executables instead of oiio exec validation. The validation is used as last possible source of ffmpeg from `PATH` environment variables, which is an edge case but can cause issues.

## Testing notes:
1. Remove ffmpeg from vendor bin
2. Make sure `"OPENPYPE_FFMPEG_PATHS"` env is not set
3. Add ffmpeg executable to `"PATH"` env variable
4. Open OpenPype and try to get ffmpeg path
