### PR TITLE
3dsmax: opening last workfile

### DIFF
--- a/openpype/hooks/pre_add_last_workfile_arg.py
+++ b/openpype/hooks/pre_add_last_workfile_arg.py
@@ -14,6 +14,7 @@ class AddLastWorkfileToLaunchArgs(PreLaunchHook):
     # Execute after workfile template copy
     order = 10
     app_groups = [
+        "3dsmax",
         "maya",
         "nuke",
         "nukex",


### PR DESCRIPTION
## Changelog Description
Supports opening last saved workfile in 3dsmax host.

## Testing notes:
1. Launch 3dsMax via Openpype
2. If you saved workfile in 3dsmax before, it automatically opens the last saved workfile after launch
