### PR TITLE
Maya: Add "Include Parent Hierarchy" option in animation creator plugin

### DIFF
--- a/openpype/hosts/maya/plugins/create/create_animation.py
+++ b/openpype/hosts/maya/plugins/create/create_animation.py
@@ -38,7 +38,6 @@ class CreateAnimation(plugin.Creator):
         self.data["visibleOnly"] = False
 
         # Include the groups above the out_SET content
-        # Include parent groups
         self.data["includeParentHierarchy"] = self.include_parent_hierarchy
 
         # Default to exporting world-space

--- a/openpype/hosts/maya/plugins/create/create_animation.py
+++ b/openpype/hosts/maya/plugins/create/create_animation.py
@@ -13,6 +13,7 @@ class CreateAnimation(plugin.Creator):
     icon = "male"
     write_color_sets = False
     write_face_sets = False
+    include_parent_hierarchy = False
     include_user_defined_attributes = False
 
     def __init__(self, *args, **kwargs):
@@ -37,7 +38,8 @@ class CreateAnimation(plugin.Creator):
         self.data["visibleOnly"] = False
 
         # Include the groups above the out_SET content
-        self.data["includeParentHierarchy"] = False  # Include parent groups
+        # Include parent groups
+        self.data["includeParentHierarchy"] = self.include_parent_hierarchy
 
         # Default to exporting world-space
         self.data["worldSpace"] = True

--- a/openpype/settings/defaults/project_settings/maya.json
+++ b/openpype/settings/defaults/project_settings/maya.json
@@ -147,6 +147,7 @@
             "enabled": true,
             "write_color_sets": false,
             "write_face_sets": false,
+            "include_parent_hierarchy": false,
             "include_user_defined_attributes": false,
             "defaults": [
                 "Main"

--- a/openpype/settings/entities/schemas/projects_schema/schemas/schema_maya_create.json
+++ b/openpype/settings/entities/schemas/projects_schema/schemas/schema_maya_create.json
@@ -134,6 +134,11 @@
                 },
                 {
                     "type": "boolean",
+                    "key": "include_parent_hierarchy",
+                    "label": "Include Parent Hierarchy"
+                },
+                {
+                    "type": "boolean",
                     "key": "include_user_defined_attributes",
                     "label": "Include User Defined Attributes"
                 },


### PR DESCRIPTION
## Changelog Description
Add an option in Project Settings > Maya > Creator Plugins > Create Animation to include (or not) parent hierarchy. This is to avoid artists to check manually the option for all create animation.

## Additional info
![image](https://user-images.githubusercontent.com/51854004/225678204-a0213fc8-a344-411e-ba34-2ce3a7c2ac06.png)

