### PR TITLE
Maya: Fix Collect Render for V-Ray, Redshift and Renderman for missing colorspace

### DIFF
--- a/openpype/hosts/maya/api/lib_renderproducts.py
+++ b/openpype/hosts/maya/api/lib_renderproducts.py
@@ -857,6 +857,7 @@ class RenderProductsVray(ARenderProducts):
         if default_ext in {"exr (multichannel)", "exr (deep)"}:
             default_ext = "exr"
 
+        colorspace = lib.get_color_management_output_transform()
         products = []
 
         # add beauty as default when not disabled
@@ -868,7 +869,7 @@ class RenderProductsVray(ARenderProducts):
                         productName="",
                         ext=default_ext,
                         camera=camera,
-                        colorspace=lib.get_color_management_output_transform(),
+                        colorspace=colorspace,
                         multipart=self.multipart
                     )
                 )
@@ -882,6 +883,7 @@ class RenderProductsVray(ARenderProducts):
                         productName="Alpha",
                         ext=default_ext,
                         camera=camera,
+                        colorspace=colorspace,
                         multipart=self.multipart
                     )
                 )
@@ -917,7 +919,8 @@ class RenderProductsVray(ARenderProducts):
                         product = RenderProduct(productName=name,
                                                 ext=default_ext,
                                                 aov=aov,
-                                                camera=camera)
+                                                camera=camera,
+                                                colorspace=colorspace)
                         products.append(product)
                 # Continue as we've processed this special case AOV
                 continue
@@ -929,7 +932,7 @@ class RenderProductsVray(ARenderProducts):
                     ext=default_ext,
                     aov=aov,
                     camera=camera,
-                    colorspace=lib.get_color_management_output_transform()
+                    colorspace=colorspace
                 )
                 products.append(product)
 
@@ -1130,6 +1133,7 @@ class RenderProductsRedshift(ARenderProducts):
         products = []
         light_groups_enabled = False
         has_beauty_aov = False
+        colorspace = lib.get_color_management_output_transform()
         for aov in aovs:
             enabled = self._get_attr(aov, "enabled")
             if not enabled:
@@ -1173,7 +1177,8 @@ class RenderProductsRedshift(ARenderProducts):
                             ext=ext,
                             multipart=False,
                             camera=camera,
-                            driver=aov)
+                            driver=aov,
+                            colorspace=colorspace)
                         products.append(product)
 
             if light_groups:
@@ -1188,7 +1193,8 @@ class RenderProductsRedshift(ARenderProducts):
                                         ext=ext,
                                         multipart=False,
                                         camera=camera,
-                                        driver=aov)
+                                        driver=aov,
+                                        colorspace=colorspace)
                 products.append(product)
 
         # When a Beauty AOV is added manually, it will be rendered as
@@ -1204,7 +1210,8 @@ class RenderProductsRedshift(ARenderProducts):
                             RenderProduct(productName=beauty_name,
                                           ext=ext,
                                           multipart=self.multipart,
-                                          camera=camera))
+                                          camera=camera,
+                                          colorspace=colorspace))
 
         return products
 
@@ -1235,6 +1242,8 @@ class RenderProductsRenderman(ARenderProducts):
 
         """
         from rfm2.api.displays import get_displays  # noqa
+
+        colorspace = lib.get_color_management_output_transform()
 
         cameras = [
             self.sanitize_camera_name(c)
@@ -1302,7 +1311,8 @@ class RenderProductsRenderman(ARenderProducts):
                         productName=aov_name,
                         ext=extensions,
                         camera=camera,
-                        multipart=True
+                        multipart=True,
+                        colorspace=colorspace
                     )
 
                     if has_cryptomatte and matte_enabled:
@@ -1311,7 +1321,8 @@ class RenderProductsRenderman(ARenderProducts):
                             aov=cryptomatte_aov,
                             ext=extensions,
                             camera=camera,
-                            multipart=True
+                            multipart=True,
+                            colorspace=colorspace
                         )
                 else:
                     # this code should handle the case where no multipart


### PR DESCRIPTION
## Changelog Description

Fix Collect Render not working for Redshift, V-Ray and Renderman due to missing `colorspace` argument to `RenderProduct` dataclass.

## Additional info

Not entirely sure if this is the correct colorspace solution for all renderers. But at least this should hotfix the collecting not working at all.

## Testing notes:
Test submitting renders with:

- [ ] Maya + Redshift
- [ ] Maya + V-Ray
- [ ] Maya + Renderman
