### PR TITLE
General: Use right plugin class for Collect Comment

### DIFF
--- a/openpype/plugins/publish/collect_comment.py
+++ b/openpype/plugins/publish/collect_comment.py
@@ -29,7 +29,7 @@ from openpype.pipeline.publish import OpenPypePyblishPluginMixin
 
 
 class CollectInstanceCommentDef(
-    pyblish.api.ContextPlugin,
+    pyblish.api.InstancePlugin,
     OpenPypePyblishPluginMixin
 ):
     label = "Comment per instance"


### PR DESCRIPTION
## Changelog Description
Collect Comment plugin is instance plugin so should inherit from `InstancePlugin` instead of `ContextPlugin`.

## Additional info
Pyblish will resolve the plugin as instance plugin because of `instance` argument in `process` method, but it can be confusing for developer who does not know that.