### PR TITLE
3dsmax: render instance settings in creator

### DIFF
--- a/openpype/hosts/max/plugins/create/create_render.py
+++ b/openpype/hosts/max/plugins/create/create_render.py
@@ -1,8 +1,22 @@
 # -*- coding: utf-8 -*-
 """Creator plugin for creating camera."""
 from openpype.hosts.max.api import plugin
+from openpype.lib import (
+    TextDef,
+    BoolDef,
+    NumberDef,
+)
 from openpype.pipeline import CreatedInstance
 from openpype.hosts.max.api.lib_rendersettings import RenderSettings
+from openpype.settings import get_project_settings
+from openpype.pipeline import legacy_io
+
+
+def setting(project_setting=None):
+    render_setting = get_project_settings(
+        legacy_io.Session["AVALON_PROJECT"]
+    )
+    return render_setting["deadline"]["publish"]["MaxSubmitDeadline"]
 
 
 class CreateRender(plugin.MaxCreator):
@@ -31,3 +45,39 @@ class CreateRender(plugin.MaxCreator):
         RenderSettings().set_render_camera(sel_obj)
         # set output paths for rendering(mandatory for deadline)
         RenderSettings().render_output(container_name)
+
+    def get_instance_attr_defs(self):
+        return [
+            BoolDef("use_published",
+                    default=setting()["active"],
+                    label="Use Published Scene"),
+
+            NumberDef("priority",
+                      minimum=1,
+                      maximum=250,
+                      decimals=0,
+                      default=setting()["priority"],
+                      label="Priority"),
+
+            NumberDef("chunkSize",
+                      minimum=1,
+                      maximum=50,
+                      decimals=0,
+                      default=setting()["chunk_size"],
+                      label="Chunk Size"),
+
+            TextDef("group",
+                    default=setting()["group"],
+                    label="Group Name"),
+
+            TextDef("deadline_pool",
+                    default=setting()["deadline_pool"],
+                    label="Deadline Pool"),
+
+            TextDef("deadline_pool_secondary",
+                    default=setting()["deadline_pool_secondary"],
+                    label="Deadline Pool Secondary")
+        ]
+
+    def get_pre_create_attr_defs(self):
+        return self.get_instance_attr_defs()

--- a/openpype/hosts/max/plugins/publish/collect_render.py
+++ b/openpype/hosts/max/plugins/publish/collect_render.py
@@ -47,11 +47,13 @@ class CollectRender(pyblish.api.InstancePlugin):
         self.log.debug(f"Setting {version_int} to context.")
         context.data["version"] = version_int
 
+        creator_attr = instance.data["creator_attributes"]
+
         # setup the plugin as 3dsmax for the internal renderer
         data = {
             "subset": instance.name,
             "asset": asset,
-            "publish": True,
+            "publish": creator_attr["use_published"],
             "maxversion": str(get_max_version()),
             "imageFormat": img_format,
             "family": 'maxrender',
@@ -61,7 +63,12 @@ class CollectRender(pyblish.api.InstancePlugin):
             "plugin": "3dsmax",
             "frameStart": context.data['frameStart'],
             "frameEnd": context.data['frameEnd'],
-            "version": version_int
+            "version": version_int,
+            "priority": creator_attr["priority"],
+            "chunkSize": creator_attr["chunkSize"],
+            "group": creator_attr["group"],
+            "primaryPool": creator_attr["deadline_pool"],
+            "secondaryPool": creator_attr["deadline_pool_secondary"]
         }
         self.log.info("data: {0}".format(data))
         instance.data.update(data)

--- a/openpype/modules/deadline/plugins/publish/collect_pools.py
+++ b/openpype/modules/deadline/plugins/publish/collect_pools.py
@@ -10,7 +10,7 @@ class CollectDeadlinePools(pyblish.api.InstancePlugin):
 
     order = pyblish.api.CollectorOrder + 0.420
     label = "Collect Deadline Pools"
-    families = ["rendering", "render.farm", "renderFarm", "renderlayer"]
+    families = ["rendering", "render.farm", "renderFarm", "renderlayer", "maxrender"]
 
     primary_pool = None
     secondary_pool = None

--- a/openpype/modules/deadline/plugins/publish/submit_max_deadline.py
+++ b/openpype/modules/deadline/plugins/publish/submit_max_deadline.py
@@ -21,7 +21,7 @@ class MaxPluginInfo(object):
     SaveFile = attr.ib(default=True)
     IgnoreInputs = attr.ib(default=True)
 
-
+#TODO: add the optional attirbute
 class MaxSubmitDeadline(abstract_submit_deadline.AbstractSubmitDeadline):
 
     label = "Submit Render to Deadline"
@@ -49,11 +49,13 @@ class MaxSubmitDeadline(abstract_submit_deadline.AbstractSubmitDeadline):
 
         instance = self._instance
         context = instance.context
-
         # Always use the original work file name for the Job name even when
         # rendering is done from the published Work File. The original work
         # file name is clearer because it can also have subversion strings,
         # etc. which are stripped for the published file.
+        if not instance.data.get("publish"):
+            self.use_published = False
+
         src_filepath = context.data["currentFile"]
         src_filename = os.path.basename(src_filepath)
 
@@ -71,13 +73,10 @@ class MaxSubmitDeadline(abstract_submit_deadline.AbstractSubmitDeadline):
 
         job_info.Pool = instance.data.get("primaryPool")
         job_info.SecondaryPool = instance.data.get("secondaryPool")
-        job_info.ChunkSize = instance.data.get("chunkSize", 1)
+        job_info.ChunkSize = instance.data.get("chunkSize", self.chunk_size)
         job_info.Comment = context.data.get("comment")
         job_info.Priority = instance.data.get("priority", self.priority)
-        job_info.FramesPerTask = instance.data.get("framesPerTask", 1)
-
-        if self.group:
-            job_info.Group = self.group
+        job_info.Group = instance.data.get("group", self.group)
 
         # Add options from RenderGlobals
         render_globals = instance.data.get("renderGlobals", {})


### PR DESCRIPTION
## Changelog Description
Allows user preset the pools, group and use_published settings in Render Creator in the Max Hosts.
User can set the settings before or after creating instance in the new publisher

![image](https://user-images.githubusercontent.com/64118225/226306492-072d7353-0114-4d34-bb50-04ced7732db7.png)

![image](https://user-images.githubusercontent.com/64118225/226306934-8d0de03d-06b8-4a3a-b0a2-898d2e9c694b.png)

## Testing notes:
If creating new render instance...
1. Choose Render from choose publish type
2.  Fill in the settings
3. Create the instance
4. Publish it

If there is render instance.....
1. Click Publish in the new Publisher
2. Click maxrenderMain
3. Edit the settings
5. Publish it
