### PR TITLE
Integrator: Enforce unique destination transfers, disallow overwrites in queued transfers

### DIFF
--- a/openpype/lib/file_transaction.py
+++ b/openpype/lib/file_transaction.py
@@ -13,6 +13,16 @@ else:
     from shutil import copyfile
 
 
+class DuplicateDestinationError(ValueError):
+    """Error raised when transfer destination already exists in queue.
+
+    The error is only raised if `allow_queue_replacements` is False on the
+    FileTransaction instance and the added file to transfer is of a different
+    src file than the one already detected in the queue.
+
+    """
+
+
 class FileTransaction(object):
     """File transaction with rollback options.
 
@@ -85,7 +95,7 @@ class FileTransaction(object):
                 return
             else:
                 if not self._allow_queue_replacements:
-                    raise RuntimeError(
+                    raise DuplicateDestinationError(
                         "Transfer to destination is already in queue: "
                         "{} -> {}. It's not allowed to be replaced by "
                         "a new transfer from {}".format(

--- a/openpype/plugins/publish/integrate.py
+++ b/openpype/plugins/publish/integrate.py
@@ -24,7 +24,10 @@ from openpype.client import (
     get_version_by_name,
 )
 from openpype.lib import source_hash
-from openpype.lib.file_transaction import FileTransaction
+from openpype.lib.file_transaction import (
+    FileTransaction,
+    DuplicateDestinationError
+)
 from openpype.pipeline.publish import (
     KnownPublishError,
     get_publish_template_name,
@@ -175,6 +178,13 @@ class IntegrateAsset(pyblish.api.InstancePlugin):
                                             allow_queue_replacements=False)
         try:
             self.register(instance, file_transactions, filtered_repres)
+        except DuplicateDestinationError as exc:
+            # Raise DuplicateDestinationError as KnownPublishError
+            # and rollback the transactions
+            file_transactions.rollback()
+            six.reraise(KnownPublishError,
+                        KnownPublishError(exc),
+                        sys.exc_info()[2])
         except Exception:
             # clean destination
             # todo: preferably we'd also rollback *any* changes to the database

--- a/openpype/plugins/publish/integrate.py
+++ b/openpype/plugins/publish/integrate.py
@@ -170,7 +170,9 @@ class IntegrateAsset(pyblish.api.InstancePlugin):
             ).format(instance.data["family"]))
             return
 
-        file_transactions = FileTransaction(log=self.log)
+        file_transactions = FileTransaction(log=self.log,
+                                            # Enforce unique transfers
+                                            allow_queue_replacements=False)
         try:
             self.register(instance, file_transactions, filtered_repres)
         except Exception:


### PR DESCRIPTION
## Changelog Description

Fix #4656 by enforcing unique destination transfers in the Integrator. It's now disallowed to a destination in the file transaction queue with a new source path during the publish.

## Additional info

Note that this is per instance - it doesn't validate cross-instance destinations in the context

## Testing notes:

1. Try integrating e.g. the example in #4656 
