### PR TITLE
Hiero: Creator with correct workfile numeric padding input

### DIFF
--- a/openpype/hosts/hiero/api/plugin.py
+++ b/openpype/hosts/hiero/api/plugin.py
@@ -146,6 +146,8 @@ class CreatorWidget(QtWidgets.QDialog):
         return " ".join([str(m.group(0)).capitalize() for m in matches])
 
     def create_row(self, layout, type, text, **kwargs):
+        value_keys = ["setText", "setCheckState", "setValue", "setChecked"]
+
         # get type attribute from qwidgets
         attr = getattr(QtWidgets, type)
 
@@ -167,13 +169,26 @@ class CreatorWidget(QtWidgets.QDialog):
 
         # assign the created attribute to variable
         item = getattr(self, attr_name)
+
+        # set attributes to item which are not values
         for func, val in kwargs.items():
+            if func in value_keys:
+                continue
+
             if getattr(item, func):
+                log.debug("Setting {} to {}".format(func, val))
                 func_attr = getattr(item, func)
                 if isinstance(val, tuple):
                     func_attr(*val)
                 else:
                     func_attr(val)
+
+        # set values to item
+        for value_item in value_keys:
+            if value_item not in kwargs:
+                continue
+            if getattr(item, value_item):
+                getattr(item, value_item)(kwargs[value_item])
 
         # add to layout
         layout.addRow(label, item)
@@ -276,8 +291,11 @@ class CreatorWidget(QtWidgets.QDialog):
             elif v["type"] == "QSpinBox":
                 data[k]["value"] = self.create_row(
                     content_layout, "QSpinBox", v["label"],
-                    setValue=v["value"], setMinimum=0,
+                    setValue=v["value"],
+                    setDisplayIntegerBase=10000,
+                    setRange=(0, 99999), setMinimum=0,
                     setMaximum=100000, setToolTip=tool_tip)
+
         return data
 
 


### PR DESCRIPTION
## Changelog Description
Creator was showing 99 in workfile input for long time, even if users set default value to 1001 in studio settings. This has been fixed now.

## Testing notes:
1. open Hiero workfile project
2. select any clip in timeline and open Creator
3. Select clip creator and hit Create
4. Notice that Workfile start number is set to 1001. It used to show 99.
