### PR TITLE
General: Filter available applications

### DIFF
--- a/openpype/modules/ftrack/event_handlers_user/action_applications.py
+++ b/openpype/modules/ftrack/event_handlers_user/action_applications.py
@@ -124,6 +124,11 @@ class AppplicationsAction(BaseAction):
         if not avalon_project_apps:
             return False
 
+        settings = self.get_project_settings_from_event(
+            event, avalon_project_doc["name"])
+
+        only_available = settings["applications"]["only_available"]
+
         items = []
         for app_name in avalon_project_apps:
             app = self.application_manager.applications.get(app_name)
@@ -131,6 +136,10 @@ class AppplicationsAction(BaseAction):
                 continue
 
             if app.group.name in CUSTOM_LAUNCH_APP_GROUPS:
+                continue
+
+            # Skip applications without valid executables
+            if only_available and not app.find_executable():
                 continue
 
             app_icon = app.icon

--- a/openpype/settings/defaults/project_settings/applications.json
+++ b/openpype/settings/defaults/project_settings/applications.json
@@ -1,3 +1,3 @@
 {
-    "only_available": true
+    "only_available": false
 }

--- a/openpype/settings/defaults/project_settings/applications.json
+++ b/openpype/settings/defaults/project_settings/applications.json
@@ -1,0 +1,3 @@
+{
+    "only_available": true
+}

--- a/openpype/settings/entities/schemas/projects_schema/schema_main.json
+++ b/openpype/settings/entities/schemas/projects_schema/schema_main.json
@@ -84,6 +84,10 @@
                 },
                 {
                     "type": "schema",
+                    "name": "schema_project_applications"
+                },
+                {
+                    "type": "schema",
                     "name": "schema_project_max"
                 },
                 {

--- a/openpype/settings/entities/schemas/projects_schema/schema_project_applications.json
+++ b/openpype/settings/entities/schemas/projects_schema/schema_project_applications.json
@@ -1,0 +1,14 @@
+{
+    "type": "dict",
+    "key": "applications",
+    "label": "Applications",
+    "collapsible": true,
+    "is_file": true,
+    "children": [
+        {
+            "type": "boolean",
+            "key": "only_available",
+            "label": "Show only available applications"
+        }
+    ]
+}

--- a/openpype/tools/launcher/models.py
+++ b/openpype/tools/launcher/models.py
@@ -19,6 +19,7 @@ from openpype.lib.applications import (
     CUSTOM_LAUNCH_APP_GROUPS,
     ApplicationManager
 )
+from openpype.settings import get_project_settings
 from openpype.pipeline import discover_launcher_actions
 from openpype.tools.utils.lib import (
     DynamicQThread,
@@ -94,6 +95,8 @@ class ActionModel(QtGui.QStandardItemModel):
         if not project_doc:
             return actions
 
+        project_settings = get_project_settings(project_name)
+        only_available = project_settings["applications"]["only_available"]
         self.application_manager.refresh()
         for app_def in project_doc["config"]["apps"]:
             app_name = app_def["name"]
@@ -102,6 +105,9 @@ class ActionModel(QtGui.QStandardItemModel):
                 continue
 
             if app.group.name in CUSTOM_LAUNCH_APP_GROUPS:
+                continue
+
+            if only_available and not app.find_executable():
                 continue
 
             # Get from app definition, if not there from app in project


### PR DESCRIPTION
## Changelog Description
Added option to filter applications that don't have valid executable available in settings in launcher and ftrack actions. This option can be disabled in new settings category `Applications`. The filtering is by default disabled.

## Testing notes:
1. Enable `project_settings/applications/only_available`
2. Make sure there is application which have set paths that don't lead to executable available on your machine
3. Add the application to a project
4. Open launcher and go to a task in project / Open actions on task in ftrack
5. The application should not be there
