### PR TITLE
Nuke: Nukenodes family instance without frame range

### DIFF
--- a/openpype/hosts/nuke/plugins/load/load_backdrop.py
+++ b/openpype/hosts/nuke/plugins/load/load_backdrop.py
@@ -54,22 +54,19 @@ class LoadBackdropNodes(load.LoaderPlugin):
         version = context['version']
         version_data = version.get("data", {})
         vname = version.get("name", None)
-        first = version_data.get("frameStart", None)
-        last = version_data.get("frameEnd", None)
         namespace = namespace or context['asset']['name']
         colorspace = version_data.get("colorspace", None)
         object_name = "{}_{}".format(name, namespace)
 
         # prepare data for imprinting
         # add additional metadata from the version to imprint to Avalon knob
-        add_keys = ["frameStart", "frameEnd", "handleStart", "handleEnd",
-                    "source", "author", "fps"]
+        add_keys = ["source", "author", "fps"]
 
-        data_imprint = {"frameStart": first,
-                        "frameEnd": last,
-                        "version": vname,
-                        "colorspaceInput": colorspace,
-                        "objectName": object_name}
+        data_imprint = {
+            "version": vname,
+            "colorspaceInput": colorspace,
+            "objectName": object_name
+        }
 
         for k in add_keys:
             data_imprint.update({k: version_data[k]})
@@ -204,18 +201,13 @@ class LoadBackdropNodes(load.LoaderPlugin):
         name = container['name']
         version_data = version_doc.get("data", {})
         vname = version_doc.get("name", None)
-        first = version_data.get("frameStart", None)
-        last = version_data.get("frameEnd", None)
         namespace = container['namespace']
         colorspace = version_data.get("colorspace", None)
         object_name = "{}_{}".format(name, namespace)
 
-        add_keys = ["frameStart", "frameEnd", "handleStart", "handleEnd",
-                    "source", "author", "fps"]
+        add_keys = ["source", "author", "fps"]
 
         data_imprint = {"representation": str(representation["_id"]),
-                        "frameStart": first,
-                        "frameEnd": last,
                         "version": vname,
                         "colorspaceInput": colorspace,
                         "objectName": object_name}

--- a/openpype/hosts/nuke/plugins/publish/collect_backdrop.py
+++ b/openpype/hosts/nuke/plugins/publish/collect_backdrop.py
@@ -51,38 +51,10 @@ class CollectBackdrops(pyblish.api.InstancePlugin):
         instance.data["label"] = "{0} ({1} nodes)".format(
             bckn.name(), len(instance.data["transientData"]["childNodes"]))
 
-        instance.data["families"].append(instance.data["family"])
-
-        # Get frame range
-        handle_start = instance.context.data["handleStart"]
-        handle_end = instance.context.data["handleEnd"]
-        first_frame = int(nuke.root()["first_frame"].getValue())
-        last_frame = int(nuke.root()["last_frame"].getValue())
-
         # get version
         version = instance.context.data.get('version')
 
-        if not version:
-            raise RuntimeError("Script name has no version in the name.")
+        if version:
+            instance.data['version'] = version
 
-        instance.data['version'] = version
-
-        # Add version data to instance
-        version_data = {
-            "handles": handle_start,
-            "handleStart": handle_start,
-            "handleEnd": handle_end,
-            "frameStart": first_frame + handle_start,
-            "frameEnd": last_frame - handle_end,
-            "version": int(version),
-            "families": [instance.data["family"]] + instance.data["families"],
-            "subset": instance.data["subset"],
-            "fps": instance.context.data["fps"]
-        }
-
-        instance.data.update({
-            "versionData": version_data,
-            "frameStart": first_frame,
-            "frameEnd": last_frame
-        })
         self.log.info("Backdrop instance collected: `{}`".format(instance))


### PR DESCRIPTION
## Changelog Description
No need to add frame range data into `nukenodes` (backdrop) family publishes - since those are timeless.

## Testing notes:
1. Open your favorite testing workfile in Nuke
2. Create randomly some nodes and select them all
3. Create Backdrop publishable instance with selection enabled
4. publish
5. Open Loader and see there are no frame range data 
![image](https://user-images.githubusercontent.com/40640033/226616222-41b6abe8-55f7-4c07-bebe-310074c0e8ad.png)

6. Load nukenodes family node and see nothing is broken
7. ideally update it from older to newer version if you are having loaded nukenodes from previouse publishes.

# Dependency
https://github.com/ynput/OpenPype/pull/4383
