### PR TITLE
General: Environment variable for default OCIO configs

### DIFF
--- a/openpype/settings/defaults/project_settings/global.json
+++ b/openpype/settings/defaults/project_settings/global.json
@@ -2,8 +2,8 @@
     "imageio": {
         "ocio_config": {
             "filepath": [
-                "{OPENPYPE_ROOT}/vendor/bin/ocioconfig/OpenColorIOConfigs/aces_1.2/config.ocio",
-                "{OPENPYPE_ROOT}/vendor/bin/ocioconfig/OpenColorIOConfigs/nuke-default/config.ocio"
+                "{BUILTIN_OCIO_ROOT}/aces_1.2/config.ocio",
+                "{BUILTIN_OCIO_ROOT}/nuke-default/config.ocio"
             ]
         },
         "file_rules": {

--- a/start.py
+++ b/start.py
@@ -197,6 +197,15 @@ if "--headless" in sys.argv:
 elif os.getenv("OPENPYPE_HEADLESS_MODE") != "1":
     os.environ.pop("OPENPYPE_HEADLESS_MODE", None)
 
+# Set builtin ocio root
+os.environ["BUILTIN_OCIO_ROOT"] = os.path.join(
+    OPENPYPE_ROOT,
+    "vendor",
+    "bin",
+    "ocioconfig",
+    "OpenColorIOConfigs"
+)
+
 # Enabled logging debug mode when "--debug" is passed
 if "--verbose" in sys.argv:
     expected_values = (


### PR DESCRIPTION
## Changelog Description
Define environment variable which lead to root of builtin ocio configs to be able change the root without changing settings. For the path in settings was used `"{OPENPYPE_ROOT}/vendor/bin/ocioconfig/OpenColorIOConfig"` which disallow to change the root somewhere else. That will be needed in AYON where configs won't be part of desktop application but downloaded from server.

## Testing notes:
1. Extraction with OCIO configs should work as did