### PR TITLE
Publisher: Windows reduce command window pop-ups during Publishing

### DIFF
--- a/openpype/lib/execute.py
+++ b/openpype/lib/execute.py
@@ -105,7 +105,7 @@ def run_subprocess(*args, **kwargs):
         # shell=True already tries to hide the console window
         # and passing these creationflags then shows the window again
         # so we avoid it for shell=True cases
-        and not kwargs.get("shell", False)
+        and kwargs.get("shell") is not True
     ):
         kwargs["creationflags"] = (
             subprocess.CREATE_NEW_PROCESS_GROUP

--- a/openpype/lib/execute.py
+++ b/openpype/lib/execute.py
@@ -102,6 +102,10 @@ def run_subprocess(*args, **kwargs):
     if (
         platform.system().lower() == "windows"
         and "creationflags" not in kwargs
+        # shell=True already tries to hide the console window
+        # and passing these creationflags then shows the window again
+        # so we avoid it for shell=True cases
+        and not kwargs.get("shell", False)
     ):
         kwargs["creationflags"] = (
             subprocess.CREATE_NEW_PROCESS_GROUP

--- a/openpype/lib/vendor_bin_utils.py
+++ b/openpype/lib/vendor_bin_utils.py
@@ -224,18 +224,26 @@ def find_tool_in_custom_paths(paths, tool, validation_func=None):
 
 def _check_args_returncode(args):
     try:
-        # Python 2 compatibility where DEVNULL is not available
+        kwargs = {}
+        if platform.system().lower() == "windows":
+            kwargs["creationflags"] = (
+                subprocess.CREATE_NEW_PROCESS_GROUP
+                | getattr(subprocess, "DETACHED_PROCESS", 0)
+                | getattr(subprocess, "CREATE_NO_WINDOW", 0)
+            )
+
         if hasattr(subprocess, "DEVNULL"):
             proc = subprocess.Popen(
                 args,
                 stdout=subprocess.DEVNULL,
                 stderr=subprocess.DEVNULL,
+                **kwargs
             )
             proc.wait()
         else:
             with open(os.devnull, "w") as devnull:
                 proc = subprocess.Popen(
-                    args, stdout=devnull, stderr=devnull,
+                    args, stdout=devnull, stderr=devnull, **kwargs
                 )
                 proc.wait()
 

--- a/openpype/plugins/publish/extract_burnin.py
+++ b/openpype/plugins/publish/extract_burnin.py
@@ -16,9 +16,7 @@ from openpype.lib import (
 
     get_transcode_temp_directory,
     convert_input_paths_for_ffmpeg,
-    should_convert_for_ffmpeg,
-
-    CREATE_NO_WINDOW
+    should_convert_for_ffmpeg
 )
 from openpype.lib.profiles_filtering import filter_profiles
 
@@ -338,8 +336,6 @@ class ExtractBurnin(publish.Extractor):
                     "logger": self.log,
                     "env": {}
                 }
-                if platform.system().lower() == "windows":
-                    process_kwargs["creationflags"] = CREATE_NO_WINDOW
 
                 run_openpype_process(*args, **process_kwargs)
                 # Remove the temporary json

--- a/openpype/scripts/otio_burnin.py
+++ b/openpype/scripts/otio_burnin.py
@@ -345,12 +345,6 @@ class ModifiedBurnins(ffmpeg_burnins.Burnins):
             "stderr": subprocess.PIPE,
             "shell": True,
         }
-        if platform.system().lower() == "windows":
-            kwargs["creationflags"] = (
-                subprocess.CREATE_NEW_PROCESS_GROUP
-                | getattr(subprocess, "DETACHED_PROCESS", 0)
-                | getattr(subprocess, "CREATE_NO_WINDOW", 0)
-            )
         proc = subprocess.Popen(command, **kwargs)
 
         _stdout, _stderr = proc.communicate()


### PR DESCRIPTION
## Changelog Description

Reduce the command line pop-ups that show on Windows during publishing.

## Additional info

This PR can be considered a continuation of PR #4481 
Also mentioned on discord [here](https://discord.com/channels/517362899170230292/517382145552154634/1087768816529985576)

Examples of the pop-ups can be found in the comments [here](https://github.com/ynput/OpenPype/pull/4481#issuecomment-1478126460):

https://user-images.githubusercontent.com/49758407/226671061-7a5b578d-5975-4344-827f-2f993bcf3337.mp4

#### The above video is from BEFORE this PR

---

The pop-ups:

- [x] This PR removes the pop-up shown when opening the Publisher first time
- [x] This PR removes one of the pop-up windows shown during extracting/integrating reviews.
- [x] [This PR fixes this Extract Review call window pop-up](https://github.com/ynput/OpenPype/blob/6754e97490c3462d4fbd27400bdcd9d24c20068d/openpype/plugins/publish/extract_review.py#L392)
- [x] [This PR fixes this Extract Burnin call window pop-up](https://github.com/ynput/OpenPype/blob/c8c31018d656ea206c42e4a083365e21b4252861/openpype/plugins/publish/extract_burnin.py#L344)

I'm not entirely sure how to resolve the last two. It shows both when running from source and also when running from a `openpype_gui.exe` in a build.

## Testing notes:

1. Publish away with reviews and the (new?) publisher
