### PR TITLE
CelAction: conditional workfile parameters from settings

### DIFF
--- a/openpype/hosts/celaction/hooks/pre_celaction_setup.py
+++ b/openpype/hosts/celaction/hooks/pre_celaction_setup.py
@@ -58,23 +58,25 @@ class CelactionPrelaunchHook(PreLaunchHook):
         # Add custom parameters from workfile settings
         if "render_chunk" in workfile_settings["submission_overrides"]:
             parameters += [
-                "--chunk *CHUNK*"
+                "--chunk", "*CHUNK*"
            ]
-        elif "resolution" in workfile_settings["submission_overrides"]:
+        if "resolution" in workfile_settings["submission_overrides"]:
             parameters += [
-                "--resolutionWidth *X*",
-                "--resolutionHeight *Y*"
+                "--resolutionWidth", "*X*",
+                "--resolutionHeight", "*Y*"
             ]
-        elif "frame_range" in workfile_settings["submission_overrides"]:
+        if "frame_range" in workfile_settings["submission_overrides"]:
             parameters += [
-                "--frameStart *START*",
-                "--frameEnd *END*"
+                "--frameStart", "*START*",
+                "--frameEnd", "*END*"
             ]
 
         winreg.SetValueEx(
             hKey, "SubmitParametersTitle", 0, winreg.REG_SZ,
             subprocess.list2cmdline(parameters)
         )
+
+        self.log.debug(f"__ parameters: \"{parameters}\"")
 
         # setting resolution parameters
         path_submit = "\\".join([

--- a/openpype/hosts/celaction/hooks/pre_celaction_setup.py
+++ b/openpype/hosts/celaction/hooks/pre_celaction_setup.py
@@ -56,8 +56,20 @@ class CelactionPrelaunchHook(PreLaunchHook):
         ]
 
         # Add custom parameters from workfile settings
-        if workfile_settings["parameters"]:
-            parameters += workfile_settings["parameters"]
+        if "render_chunk" in workfile_settings["submission_overrides"]:
+            parameters += [
+            "--chunk *CHUNK*"
+        ]
+        elif "resolution" in workfile_settings["submission_overrides"]:
+            parameters += [
+                "--resolutionWidth *X*",
+                "--resolutionHeight *Y*"
+            ]
+        elif "frame_range" in workfile_settings["submission_overrides"]:
+            parameters += [
+                "--frameStart *START*",
+                "--frameEnd *END*"
+            ]
 
         winreg.SetValueEx(
             hKey, "SubmitParametersTitle", 0, winreg.REG_SZ,

--- a/openpype/hosts/celaction/hooks/pre_celaction_setup.py
+++ b/openpype/hosts/celaction/hooks/pre_celaction_setup.py
@@ -58,8 +58,8 @@ class CelactionPrelaunchHook(PreLaunchHook):
         # Add custom parameters from workfile settings
         if "render_chunk" in workfile_settings["submission_overrides"]:
             parameters += [
-            "--chunk *CHUNK*"
-        ]
+                "--chunk *CHUNK*"
+           ]
         elif "resolution" in workfile_settings["submission_overrides"]:
             parameters += [
                 "--resolutionWidth *X*",

--- a/openpype/hosts/celaction/plugins/publish/collect_celaction_cli_kwargs.py
+++ b/openpype/hosts/celaction/plugins/publish/collect_celaction_cli_kwargs.py
@@ -39,7 +39,7 @@ class CollectCelactionCliKwargs(pyblish.api.Collector):
             passing_kwargs[key] = value
 
         if missing_kwargs:
-            raise RuntimeError("Missing arguments {}".format(
+            self.log.debug("Missing arguments {}".format(
                 ", ".join(
                     [f'"{key}"' for key in missing_kwargs]
                 )

--- a/openpype/modules/deadline/plugins/publish/submit_celaction_deadline.py
+++ b/openpype/modules/deadline/plugins/publish/submit_celaction_deadline.py
@@ -106,7 +106,7 @@ class CelactionSubmitDeadline(pyblish.api.InstancePlugin):
 
         # define chunk and priority
         chunk_size = instance.context.data.get("chunk")
-        if chunk_size == 0:
+        if not chunk_size:
             chunk_size = self.deadline_chunk_size
 
         # search for %02d pattern in name, and padding number

--- a/openpype/settings/defaults/project_settings/celaction.json
+++ b/openpype/settings/defaults/project_settings/celaction.json
@@ -10,12 +10,10 @@
         }
     },
     "workfile": {
-        "parameters": [
-            "--chunk *CHUNK*",
-            "--frameStart *START*",
-            "--frameEnd *END*",
-            "--resolutionWidth *X*",
-            "--resolutionHeight *Y*"
+        "submission_overrides": [
+            "render_chunk",
+            "frame_range",
+            "resolution"
         ]
     },
     "publish": {

--- a/openpype/settings/defaults/project_settings/celaction.json
+++ b/openpype/settings/defaults/project_settings/celaction.json
@@ -9,6 +9,15 @@
             "rules": {}
         }
     },
+    "workfile": {
+        "parameters": [
+            "--chunk *CHUNK*",
+            "--frameStart *START*",
+            "--frameEnd *END*",
+            "--resolutionWidth *X*",
+            "--resolutionHeight *Y*"
+        ]
+    },
     "publish": {
         "CollectRenderPath": {
             "output_extension": "png",

--- a/openpype/settings/entities/schemas/projects_schema/schema_project_celaction.json
+++ b/openpype/settings/entities/schemas/projects_schema/schema_project_celaction.json
@@ -29,10 +29,21 @@
             "label": "Workfile",
             "children": [
                 {
-                    "key": "parameters",
-                    "label": "Parameters",
-                    "type": "list",
-                    "object_type": "text"
+                    "key": "submission_overrides",
+                    "label": "Submission workfile overrides",
+                    "type": "enum",
+                    "multiselection": true,
+                    "enum_items": [
+                        {
+                            "render_chunk": "Pass chunk size"
+                        },
+                        {
+                            "frame_range": "Pass frame range"
+                        },
+                        {
+                            "resolution": "Pass resolution"
+                        }
+                    ]
                 }
             ]
         },

--- a/openpype/settings/entities/schemas/projects_schema/schema_project_celaction.json
+++ b/openpype/settings/entities/schemas/projects_schema/schema_project_celaction.json
@@ -25,6 +25,20 @@
         {
             "type": "dict",
             "collapsible": true,
+            "key": "workfile",
+            "label": "Workfile",
+            "children": [
+                {
+                    "key": "parameters",
+                    "label": "Parameters",
+                    "type": "list",
+                    "object_type": "text"
+                }
+            ]
+        },
+        {
+            "type": "dict",
+            "collapsible": true,
             "key": "publish",
             "label": "Publish plugins",
             "children": [


### PR DESCRIPTION
## Changelog Description
Since some productions were requesting excluding some workfile parameters from publishing submission, we needed to move them to settings so those could be altered per project.

## Testing notes:
1. Open Studio settings at CelAction host and remove one of Workfile parameters.
2. Start Celaction on task and go to Submit render > Dialogue window will popup
3. Notice that parameters are not showing up. 
4. hit Submit and after publisher will open and Collect hit Publish
5. all should publish as usual
