### PR TITLE
Kitsu: Slightly less strict with instance data

### DIFF
--- a/openpype/modules/kitsu/plugins/publish/collect_kitsu_entities.py
+++ b/openpype/modules/kitsu/plugins/publish/collect_kitsu_entities.py
@@ -29,7 +29,7 @@ class CollectKitsuEntities(pyblish.api.ContextPlugin):
             if not zou_asset_data:
                 raise ValueError("Zou asset data not found in OpenPype!")
 
-            task_name = instance.data.get("task")
+            task_name = instance.data.get("task", context.data.get("task"))
             if not task_name:
                 continue
 

--- a/openpype/modules/kitsu/plugins/publish/integrate_kitsu_note.py
+++ b/openpype/modules/kitsu/plugins/publish/integrate_kitsu_note.py
@@ -48,7 +48,10 @@ class IntegrateKitsuNote(pyblish.api.ContextPlugin):
     def process(self, context):
         for instance in context:
             # Check if instance is a review by checking its family
-            if "review" not in instance.data["families"]:
+            # Allow a match to primary family or any of families
+            families = set([instance.data["family"]] +
+                            instance.data.get("families", []))
+            if "review" not in families:
                 continue
 
             kitsu_task = instance.data.get("kitsu_task")

--- a/openpype/modules/kitsu/plugins/publish/integrate_kitsu_review.py
+++ b/openpype/modules/kitsu/plugins/publish/integrate_kitsu_review.py
@@ -12,10 +12,9 @@ class IntegrateKitsuReview(pyblish.api.InstancePlugin):
     optional = True
 
     def process(self, instance):
-        task = instance.data["kitsu_task"]["id"]
-        comment = instance.data["kitsu_comment"]["id"]
 
         # Check comment has been created
+        comment = instance.data.get("kitsu_comment", {}).get("id")
         if not comment:
             self.log.debug(
                 "Comment not created, review not pushed to preview."
@@ -23,6 +22,7 @@ class IntegrateKitsuReview(pyblish.api.InstancePlugin):
             return
 
         # Add review representations as preview of comment
+        task = instance.data["kitsu_task"]["id"]
         for representation in instance.data.get("representations", []):
             # Skip if not tagged as review
             if "kitsureview" not in representation.get("tags", []):


### PR DESCRIPTION
## Changelog Description

- Allow to take task name from context if asset doesn't have any. Fixes an issue with Photoshop's review instance not having `task` in data.
- Allow to match "review" against both `instance.data["family"]` and `instance.data["families"]` because some instances don't have the primary family in families, e.g. in Photoshop and TVPaint.
- Do not error on Integrate Kitsu Review whenever for whatever reason Integrate Kitsu Note did not created a comment but just log the message that it was unable to connect a review.

## Additional info

These came from issues reported on Discord [here](https://discord.com/channels/517362899170230292/563751989075378201/1088047135938842664) and [here](https://discord.com/channels/517362899170230292/1088080160823193643)

## Testing notes:

1. Publish some things using Kitsu module with comments and without comments, with reviews and without reviews preferably from a few different DCCs
