### PR TITLE
Improve logging of used app + tool envs on application launch

### DIFF
--- a/openpype/lib/applications.py
+++ b/openpype/lib/applications.py
@@ -1508,8 +1508,8 @@ def prepare_app_environments(
         if key in source_env:
             source_env[key] = value
 
-    # `added_env_keys` has debug purpose
-    added_env_keys = {app.group.name, app.name}
+    # `app_and_tool_labels` has debug purpose
+    app_and_tool_labels = ["/".join([app.group.name, app.name])]
     # Environments for application
     environments = [
         app.group.environment,
@@ -1532,15 +1532,14 @@ def prepare_app_environments(
         for group_name in sorted(groups_by_name.keys()):
             group = groups_by_name[group_name]
             environments.append(group.environment)
-            added_env_keys.add(group_name)
             for tool_name in sorted(tool_by_group_name[group_name].keys()):
                 tool = tool_by_group_name[group_name][tool_name]
                 environments.append(tool.environment)
-                added_env_keys.add(tool.name)
+                app_and_tool_labels.append("/".join([group_name, tool_name]))
 
     log.debug(
         "Will add environments for apps and tools: {}".format(
-            ", ".join(added_env_keys)
+            ", ".join(app_and_tool_labels)
         )
     )
 


### PR DESCRIPTION
## Changelog Description

Improve logging of what apps + tool environments got loaded for an application launch.

#### Before

Before unordered (due to `set`) and unclear what belonged to what:
```
  - { GlobalHostDataHook }: [  Will add environments for apps and tools: mtoa, 2023, 3-2, 3-1, maya  ]
```
![before](https://user-images.githubusercontent.com/2439881/227056378-c757087c-9a89-4814-b385-cd25f5493cf5.png)

#### After

After order is preserved and app name / tool names match:
```
  - { GlobalHostDataHook }: [  Will add environments for apps and tools: maya/2023, mtoa/3-1, mtoa/3-2  ]
```
![afbeelding](https://user-images.githubusercontent.com/2439881/227056357-baa2a47a-b0d6-4ee7-9cb6-bd6312bf320a.png)

### Additional info

Additional benefit is that now you can also see/debug in what order the environments were build - so that if one env var ended up overriding one of another tool this might help to debug what could've overwitten what.

_Ignore the fact that for this test case in the screenshots/examples I added both mtoa 3.1 and 3.2 into a single asset_

## Testing notes:
1. Launch Tray (from code or openpype_console)
2. Launch an application, read the console log