### PR TITLE
Fix name and docstring for Create Workdir Extra Folders prelaunch hook

### DIFF
--- a/openpype/hooks/pre_create_extra_workdir_folders.py
+++ b/openpype/hooks/pre_create_extra_workdir_folders.py
@@ -3,10 +3,13 @@ from openpype.lib import PreLaunchHook
 from openpype.pipeline.workfile import create_workdir_extra_folders
 
 
-class AddLastWorkfileToLaunchArgs(PreLaunchHook):
-    """Add last workfile path to launch arguments.
+class CreateWorkdirExtraFolders(PreLaunchHook):
+    """Create extra folders for the work directory.
 
-    This is not possible to do for all applications the same way.
+    Based on setting `project_settings/global/tools/Workfiles/extra_folders`
+    profile filtering will decide whether extra folders need to be created in
+    the work directory.
+
     """
 
     # Execute after workfile template copy


### PR DESCRIPTION
## Changelog Description

Fix class name and docstring for Create Workdir Extra Folders prelaunch hook

The class name and docstring were originally copied from another plug-in and didn't match the plug-in logic.

This also fixes potentially seeing this twice in your logs. Before:
![afbeelding](https://user-images.githubusercontent.com/2439881/227059803-64f57602-31e8-47ac-bec4-640afea6081d.png)

After:
![afbeelding](https://user-images.githubusercontent.com/2439881/227060048-4082003f-1321-4c57-8f7c-b58cb628ffa1.png)


Where it was actually running both this prelaunch hook and the actual `AddLastWorkfileToLaunchArgs` plugin.

## Testing notes:

1. Start applications with this prelaunchook (enabled by default, although it does not create folders by default)
