### PR TITLE
Application launch context: Include app group name in logger

### DIFF
--- a/openpype/lib/applications.py
+++ b/openpype/lib/applications.py
@@ -1273,7 +1273,10 @@ class ApplicationLaunchContext:
                     exc_info=True
                 )
 
-        self.log.debug("Launch of {} finished.".format(self.app_name))
+        self.log.debug("Launch of {}/{} finished.".format(
+            self.app_group.name,
+            self.app_name
+        ))
 
         return self.process
 

--- a/openpype/lib/applications.py
+++ b/openpype/lib/applications.py
@@ -889,7 +889,9 @@ class ApplicationLaunchContext:
         self.modules_manager = ModulesManager()
 
         # Logger
-        logger_name = "{}-{}".format(self.__class__.__name__, self.app_name)
+        logger_name = "{}-{}/{}".format(self.__class__.__name__,
+                                        self.app_group.name,
+                                        self.app_name)
         self.log = Logger.get_logger(logger_name)
 
         self.executable = executable

--- a/openpype/lib/applications.py
+++ b/openpype/lib/applications.py
@@ -1247,8 +1247,8 @@ class ApplicationLaunchContext:
             args = self.clear_launch_args(self.launch_args)
             args_len_str = " ({})".format(len(args))
         self.log.info(
-            "Launching \"{}\" with args{}: {}".format(
-                self.app_name, args_len_str, args
+            "Launching \"{}/{}\" with args{}: {}".format(
+                self.app_group.name, self.app_name, args_len_str, args
             )
         )
         self.launch_args = args


### PR DESCRIPTION
## Changelog Description

Clarify in logs better what app group the ApplicationLaunchContext belongs to and what application is being launched.

Before:

![afbeelding](https://user-images.githubusercontent.com/2439881/227063003-8035ef36-f00c-4ff7-8b11-1eeb51fc884b.png)

After:

![afbeelding](https://user-images.githubusercontent.com/2439881/227062866-c6ffda63-a644-4ace-9f53-f1610623e6f4.png)

## Additional info

For maya it previously only showed e.g. `2023` but now it also shows the app group name `maya` joined together: `maya/2023`

No more - so what's 2023?

## Testing notes:

1. Launch tray from code or console, and check the logs.
