### PR TITLE
increment workfile version 3dsmax

### DIFF
--- a/openpype/hosts/max/plugins/publish/increment_workfile_version.py
+++ b/openpype/hosts/max/plugins/publish/increment_workfile_version.py
@@ -16,4 +16,4 @@ class IncrementWorkfileVersion(pyblish.api.ContextPlugin):
         filepath = version_up(path)
 
         rt.saveMaxFile(filepath)
-        self.log.info('Incrementing file version')
+        self.log.info("Incrementing file version")


### PR DESCRIPTION
## Changelog Description
increment workfile version in 3dsmax as if in blender and maya hosts.


## Testing notes:
1. launch 3dsMax via Openpype
2. Publish
3. Check your current filename, it should be incremented one version up and saved 
