### PR TITLE
Suggestion to change `integrations` to `hosts`.

### DIFF
--- a/website/sidebars.js
+++ b/website/sidebars.js
@@ -32,7 +32,7 @@ module.exports = {
         {
             type: "category",
             collapsed: false,
-            label: "Integrations",
+            label: "Hosts",
             items: [
                 "artist_hosts_hiero",
                 "artist_hosts_nuke_tut",
@@ -117,7 +117,7 @@ module.exports = {
         },
         {
             type: "category",
-            label: "Integrations",
+            label: "Hosts",
             items: [
                 "admin_hosts_blender",
                 "admin_hosts_hiero",


### PR DESCRIPTION
## Changelog Description
Change sidebar section `Integrations` to `Hosts`.

## Additional info
The reason for this would be to have better terminology alignment with what is in code and daily chat on discord. Found myself searching for `Hosts` in the `Admin` page because the term `Integrations` arent used except maybe on the front page/promotions.
