### PR TITLE
Publisher: Fix reset shortcut sequence

### DIFF
--- a/openpype/tools/publisher/window.py
+++ b/openpype/tools/publisher/window.py
@@ -439,7 +439,9 @@ class PublisherWindow(QtWidgets.QDialog):
             event.accept()
             return
 
-        if event.matches(ResetKeySequence):
+        if ResetKeySequence.matches(
+            QtGui.QKeySequence(event.key() | event.modifiers())
+        ):
             if not self.controller.publish_is_running:
                 self.reset()
             event.accept()


### PR DESCRIPTION
## Changelog Description
Fix bug created in https://github.com/ynput/OpenPype/pull/4676 where key sequence is checked using unsupported method. The check was changed to convert event into `QKeySequence` object which can be compared to prepared sequence.

## Testing notes:
1. Open Publisher (e.g. TrayPublisher)
2. Pres Ctrl + R
3. Publisher should reset
