### PR TITLE
3dsmax: make sure that startup script executes

### DIFF
--- a/openpype/settings/defaults/system_settings/applications.json
+++ b/openpype/settings/defaults/system_settings/applications.json
@@ -133,7 +133,7 @@
                     "linux": []
                 },
                 "arguments": {
-                    "windows": [],
+                    "windows": ["-U MAXScript {OPENPYPE_ROOT}\\openpype\\hosts\\max\\startup\\startup.ms"],
                     "darwin": [],
                     "linux": []
                 },


### PR DESCRIPTION
## Changelog Description
Fixing reliability of OpenPype startup in 3dsmax.

## Additional info
Unfortunately using `ADSK_3DSMAX_STARTUPSCRIPTS_ADDON_DIR` environment variable to specify location of OpenPype startup script isn't very reliable, because of clash with other plugins, some strange race condition happening during the startup of max, or for whatever obscure reason. This fix is forcing max to execute OpenPype startup script via command line argument. Caveat is that it might be harder to connect it to existing pipeline if this functionality is already used.

## Testing notes:
Try to launch 3dsmax with OpenPype integration - it should always work.