### PR TITLE
Maya: bug fix for passing zoom settings if review is attached to subset

### DIFF
--- a/openpype/hosts/maya/plugins/publish/collect_review.py
+++ b/openpype/hosts/maya/plugins/publish/collect_review.py
@@ -79,6 +79,7 @@ class CollectReview(pyblish.api.InstancePlugin):
                 data['review_width'] = instance.data['review_width']
                 data['review_height'] = instance.data['review_height']
                 data["isolate"] = instance.data["isolate"]
+                data["panZoom"] = instance.data.get("panZoom", False)
                 cmds.setAttr(str(instance) + '.active', 1)
                 self.log.debug('data {}'.format(instance.context[i].data))
                 instance.context[i].data.update(data)

--- a/openpype/hosts/maya/plugins/publish/collect_review.py
+++ b/openpype/hosts/maya/plugins/publish/collect_review.py
@@ -80,7 +80,7 @@ class CollectReview(pyblish.api.InstancePlugin):
                 data['review_height'] = instance.data['review_height']
                 data["isolate"] = instance.data["isolate"]
                 data["panZoom"] = instance.data.get("panZoom", False)
-                data["panel"] =instance.data["panel"]
+                data["panel"] = instance.data["panel"]
                 cmds.setAttr(str(instance) + '.active', 1)
                 self.log.debug('data {}'.format(instance.context[i].data))
                 instance.context[i].data.update(data)

--- a/openpype/hosts/maya/plugins/publish/collect_review.py
+++ b/openpype/hosts/maya/plugins/publish/collect_review.py
@@ -80,6 +80,7 @@ class CollectReview(pyblish.api.InstancePlugin):
                 data['review_height'] = instance.data['review_height']
                 data["isolate"] = instance.data["isolate"]
                 data["panZoom"] = instance.data.get("panZoom", False)
+                data["panel"] =instance.data["panel"]
                 cmds.setAttr(str(instance) + '.active', 1)
                 self.log.debug('data {}'.format(instance.context[i].data))
                 instance.context[i].data.update(data)


### PR DESCRIPTION
## Changelog Description
Fix for attaching review to subset with pan/zoom option.

## Additional info
Recent changes allowed publishing of reviews with pan/zoom enabled, but introduced bug in case review is attached to subset. This is providing fix


## Testing notes:
1. Create review attached to something (model)
2. Publish

Publish should proceed normally.
