### PR TITLE
Project Manager: Change minimum frame start/end to '0'

### DIFF
--- a/openpype/tools/project_manager/project_manager/view.py
+++ b/openpype/tools/project_manager/project_manager/view.py
@@ -72,8 +72,8 @@ class HierarchyView(QtWidgets.QTreeView):
     column_delegate_defs = {
         "name": NameDef(),
         "type": TypeDef(),
-        "frameStart": NumberDef(1),
-        "frameEnd": NumberDef(1),
+        "frameStart": NumberDef(0),
+        "frameEnd": NumberDef(0),
         "fps": NumberDef(1, decimals=3, step=1),
         "resolutionWidth": NumberDef(0),
         "resolutionHeight": NumberDef(0),


### PR DESCRIPTION
## Changelog Description
Project manager can have frame start/end set to `0`.

## Testing notes:
1. Open project manager
2. Change frame start/end on asset to `0`
