### PR TITLE
General: Reduce usage of legacy io

### DIFF
--- a/openpype/hooks/pre_global_host_data.py
+++ b/openpype/hooks/pre_global_host_data.py
@@ -5,7 +5,7 @@ from openpype.lib import (
     prepare_app_environments,
     prepare_context_environments
 )
-from openpype.pipeline import AvalonMongoDB, Anatomy
+from openpype.pipeline import Anatomy
 
 
 class GlobalHostDataHook(PreLaunchHook):
@@ -26,7 +26,6 @@ class GlobalHostDataHook(PreLaunchHook):
 
             "app": app,
 
-            "dbcon": self.data["dbcon"],
             "project_doc": self.data["project_doc"],
             "asset_doc": self.data["asset_doc"],
 
@@ -61,13 +60,6 @@ class GlobalHostDataHook(PreLaunchHook):
         self.log.debug("Project name is set to \"{}\"".format(project_name))
         # Anatomy
         self.data["anatomy"] = Anatomy(project_name)
-
-        # Mongo connection
-        dbcon = AvalonMongoDB()
-        dbcon.Session["AVALON_PROJECT"] = project_name
-        dbcon.install()
-
-        self.data["dbcon"] = dbcon
 
         # Project document
         project_doc = get_project(project_name)

--- a/openpype/host/dirmap.py
+++ b/openpype/host/dirmap.py
@@ -149,7 +149,7 @@ class HostDirmap(object):
             Returns:
                 dict : { "source-path": [XXX], "destination-path": [YYYY]}
         """
-        project_name = os.getenv("AVALON_PROJECT")
+        project_name = self.project_name
 
         mapping = {}
         if (not self.sync_module.enabled or

--- a/openpype/hosts/aftereffects/api/pipeline.py
+++ b/openpype/hosts/aftereffects/api/pipeline.py
@@ -8,10 +8,7 @@ from openpype.lib import Logger, register_event_callback
 from openpype.pipeline import (
     register_loader_plugin_path,
     register_creator_plugin_path,
-    deregister_loader_plugin_path,
-    deregister_creator_plugin_path,
     AVALON_CONTAINER_ID,
-    legacy_io,
 )
 from openpype.pipeline.load import any_outdated_containers
 import openpype.hosts.aftereffects

--- a/openpype/hosts/aftereffects/plugins/publish/collect_render.py
+++ b/openpype/hosts/aftereffects/plugins/publish/collect_render.py
@@ -133,7 +133,7 @@ class CollectAERender(publish.AbstractCollectRender):
             if is_local:
                 # for local renders
                 instance = self._update_for_local(
-                    project_settings, instance, project_entity
+                    instance, project_entity, project_settings
                 )
             else:
                 fam = "render.farm"
@@ -213,7 +213,7 @@ class CollectAERender(publish.AbstractCollectRender):
         # for submit_publish_job
         return base_dir
 
-    def _update_for_local(self, project_settings, instance, project_entity):
+    def _update_for_local(self, instance, project_entity, project_settings):
         """Update old saved instances to current publishing format"""
         instance.stagingDir = tempfile.mkdtemp()
         instance.projectEntity = project_entity

--- a/openpype/hosts/aftereffects/plugins/publish/collect_render.py
+++ b/openpype/hosts/aftereffects/plugins/publish/collect_render.py
@@ -53,6 +53,7 @@ class CollectAERender(publish.AbstractCollectRender):
         version = context.data["version"]
 
         project_entity = context.data["projectEntity"]
+        project_settings = context.data["project_settings"]
 
         compositions = CollectAERender.get_stub().get_items(True)
         compositions_by_id = {item.id: item for item in compositions}
@@ -131,7 +132,9 @@ class CollectAERender(publish.AbstractCollectRender):
                 is_local = not inst.data["creator_attributes"].get("farm")
             if is_local:
                 # for local renders
-                instance = self._update_for_local(instance, project_entity)
+                instance = self._update_for_local(
+                    project_settings, instance, project_entity
+                )
             else:
                 fam = "render.farm"
                 if fam not in instance.families:
@@ -210,7 +213,7 @@ class CollectAERender(publish.AbstractCollectRender):
         # for submit_publish_job
         return base_dir
 
-    def _update_for_local(self, instance, project_entity):
+    def _update_for_local(self, project_settings, instance, project_entity):
         """Update old saved instances to current publishing format"""
         instance.stagingDir = tempfile.mkdtemp()
         instance.projectEntity = project_entity
@@ -218,8 +221,7 @@ class CollectAERender(publish.AbstractCollectRender):
         if fam not in instance.families:
             instance.families.append(fam)
 
-        settings = get_project_settings(os.getenv("AVALON_PROJECT"))
-        reviewable_subset_filter = (settings["deadline"]
+        reviewable_subset_filter = (project_settings["deadline"]
                                     ["publish"]
                                     ["ProcessSubmittedJobOnFarm"]
                                     ["aov_filter"].get(self.hosts[0]))

--- a/openpype/hosts/aftereffects/plugins/publish/collect_workfile.py
+++ b/openpype/hosts/aftereffects/plugins/publish/collect_workfile.py
@@ -1,7 +1,6 @@
 import os
 
 import pyblish.api
-from openpype.pipeline import legacy_io
 from openpype.pipeline.create import get_subset_name
 
 
@@ -44,7 +43,7 @@ class CollectWorkfile(pyblish.api.ContextPlugin):
         instance.data["publish"] = instance.data["active"]  # for DL
 
     def _get_new_instance(self, context, scene_file):
-        task = legacy_io.Session["AVALON_TASK"]
+        task = context.data["task"]
         version = context.data["version"]
         asset_entity = context.data["assetEntity"]
         project_entity = context.data["projectEntity"]

--- a/openpype/hosts/aftereffects/plugins/publish/validate_instance_asset.py
+++ b/openpype/hosts/aftereffects/plugins/publish/validate_instance_asset.py
@@ -1,6 +1,6 @@
 import pyblish.api
 
-from openpype.pipeline import legacy_io
+from openpype.pipeline import get_current_asset_name
 from openpype.pipeline.publish import (
     ValidateContentsOrder,
     PublishXmlValidationError,
@@ -30,7 +30,7 @@ class ValidateInstanceAssetRepair(pyblish.api.Action):
         for instance in instances:
             data = stub.read(instance[0])
 
-            data["asset"] = legacy_io.Session["AVALON_ASSET"]
+            data["asset"] = get_current_asset_name()
             stub.imprint(instance[0].instance_id, data)
 
 
@@ -54,7 +54,7 @@ class ValidateInstanceAsset(pyblish.api.InstancePlugin):
 
     def process(self, instance):
         instance_asset = instance.data["asset"]
-        current_asset = legacy_io.Session["AVALON_ASSET"]
+        current_asset = get_current_asset_name()
         msg = (
             f"Instance asset {instance_asset} is not the same "
             f"as current context {current_asset}."

--- a/openpype/hosts/blender/api/ops.py
+++ b/openpype/hosts/blender/api/ops.py
@@ -16,7 +16,7 @@ import bpy
 import bpy.utils.previews
 
 from openpype import style
-from openpype.pipeline import legacy_io
+from openpype.pipeline import get_current_asset_name, get_current_task_name
 from openpype.tools.utils import host_tools
 
 from .workio import OpenFileCacher
@@ -283,7 +283,7 @@ class LaunchLoader(LaunchQtApp):
 
     def before_window_show(self):
         self._window.set_context(
-            {"asset": legacy_io.Session["AVALON_ASSET"]},
+            {"asset": get_current_asset_name()},
             refresh=True
         )
 
@@ -331,8 +331,8 @@ class LaunchWorkFiles(LaunchQtApp):
     def execute(self, context):
         result = super().execute(context)
         self._window.set_context({
-            "asset": legacy_io.Session["AVALON_ASSET"],
-            "task": legacy_io.Session["AVALON_TASK"]
+            "asset": get_current_asset_name(),
+            "task": get_current_task_name()
         })
         return result
 
@@ -362,8 +362,8 @@ class TOPBAR_MT_avalon(bpy.types.Menu):
         else:
             pyblish_menu_icon_id = 0
 
-        asset = legacy_io.Session['AVALON_ASSET']
-        task = legacy_io.Session['AVALON_TASK']
+        asset = get_current_asset_name()
+        task = get_current_task_name()
         context_label = f"{asset}, {task}"
         context_label_item = layout.row()
         context_label_item.operator(

--- a/openpype/hosts/blender/api/pipeline.py
+++ b/openpype/hosts/blender/api/pipeline.py
@@ -14,6 +14,8 @@ from openpype.client import get_asset_by_name
 from openpype.pipeline import (
     schema,
     legacy_io,
+    get_current_project_name,
+    get_current_asset_name,
     register_loader_plugin_path,
     register_creator_plugin_path,
     deregister_loader_plugin_path,
@@ -84,8 +86,8 @@ def uninstall():
 
 
 def set_start_end_frames():
-    project_name = legacy_io.active_project()
-    asset_name = legacy_io.Session["AVALON_ASSET"]
+    project_name = get_current_project_name()
+    asset_name = get_current_asset_name()
     asset_doc = get_asset_by_name(project_name, asset_name)
 
     scene = bpy.context.scene

--- a/openpype/hosts/blender/plugins/create/create_action.py
+++ b/openpype/hosts/blender/plugins/create/create_action.py
@@ -2,7 +2,7 @@
 
 import bpy
 
-from openpype.pipeline import legacy_io
+from openpype.pipeline import get_current_task_name
 import openpype.hosts.blender.api.plugin
 from openpype.hosts.blender.api import lib
 
@@ -22,7 +22,7 @@ class CreateAction(openpype.hosts.blender.api.plugin.Creator):
         name = openpype.hosts.blender.api.plugin.asset_name(asset, subset)
         collection = bpy.data.collections.new(name=name)
         bpy.context.scene.collection.children.link(collection)
-        self.data['task'] = legacy_io.Session.get('AVALON_TASK')
+        self.data['task'] = get_current_task_name()
         lib.imprint(collection, self.data)
 
         if (self.options or {}).get("useSelection"):

--- a/openpype/hosts/blender/plugins/create/create_animation.py
+++ b/openpype/hosts/blender/plugins/create/create_animation.py
@@ -2,7 +2,7 @@
 
 import bpy
 
-from openpype.pipeline import legacy_io
+from openpype.pipeline import get_current_task_name
 from openpype.hosts.blender.api import plugin, lib, ops
 from openpype.hosts.blender.api.pipeline import AVALON_INSTANCES
 
@@ -37,7 +37,7 @@ class CreateAnimation(plugin.Creator):
         # asset_group.empty_display_type = 'SINGLE_ARROW'
         asset_group = bpy.data.collections.new(name=name)
         instances.children.link(asset_group)
-        self.data['task'] = legacy_io.Session.get('AVALON_TASK')
+        self.data['task'] = get_current_task_name()
         lib.imprint(asset_group, self.data)
 
         if (self.options or {}).get("useSelection"):

--- a/openpype/hosts/blender/plugins/create/create_camera.py
+++ b/openpype/hosts/blender/plugins/create/create_camera.py
@@ -2,7 +2,7 @@
 
 import bpy
 
-from openpype.pipeline import legacy_io
+from openpype.pipeline import get_current_task_name
 from openpype.hosts.blender.api import plugin, lib, ops
 from openpype.hosts.blender.api.pipeline import AVALON_INSTANCES
 
@@ -35,7 +35,7 @@ class CreateCamera(plugin.Creator):
         asset_group = bpy.data.objects.new(name=name, object_data=None)
         asset_group.empty_display_type = 'SINGLE_ARROW'
         instances.objects.link(asset_group)
-        self.data['task'] = legacy_io.Session.get('AVALON_TASK')
+        self.data['task'] = get_current_task_name()
         print(f"self.data: {self.data}")
         lib.imprint(asset_group, self.data)
 

--- a/openpype/hosts/blender/plugins/create/create_layout.py
+++ b/openpype/hosts/blender/plugins/create/create_layout.py
@@ -2,7 +2,7 @@
 
 import bpy
 
-from openpype.pipeline import legacy_io
+from openpype.pipeline import get_current_task_name
 from openpype.hosts.blender.api import plugin, lib, ops
 from openpype.hosts.blender.api.pipeline import AVALON_INSTANCES
 
@@ -34,7 +34,7 @@ class CreateLayout(plugin.Creator):
         asset_group = bpy.data.objects.new(name=name, object_data=None)
         asset_group.empty_display_type = 'SINGLE_ARROW'
         instances.objects.link(asset_group)
-        self.data['task'] = legacy_io.Session.get('AVALON_TASK')
+        self.data['task'] = get_current_task_name()
         lib.imprint(asset_group, self.data)
 
         # Add selected objects to instance

--- a/openpype/hosts/blender/plugins/create/create_model.py
+++ b/openpype/hosts/blender/plugins/create/create_model.py
@@ -2,7 +2,7 @@
 
 import bpy
 
-from openpype.pipeline import legacy_io
+from openpype.pipeline import get_current_task_name
 from openpype.hosts.blender.api import plugin, lib, ops
 from openpype.hosts.blender.api.pipeline import AVALON_INSTANCES
 
@@ -34,7 +34,7 @@ class CreateModel(plugin.Creator):
         asset_group = bpy.data.objects.new(name=name, object_data=None)
         asset_group.empty_display_type = 'SINGLE_ARROW'
         instances.objects.link(asset_group)
-        self.data['task'] = legacy_io.Session.get('AVALON_TASK')
+        self.data['task'] = get_current_task_name()
         lib.imprint(asset_group, self.data)
 
         # Add selected objects to instance

--- a/openpype/hosts/blender/plugins/create/create_pointcache.py
+++ b/openpype/hosts/blender/plugins/create/create_pointcache.py
@@ -2,7 +2,7 @@
 
 import bpy
 
-from openpype.pipeline import legacy_io
+from openpype.pipeline import get_current_task_name
 import openpype.hosts.blender.api.plugin
 from openpype.hosts.blender.api import lib
 
@@ -22,7 +22,7 @@ class CreatePointcache(openpype.hosts.blender.api.plugin.Creator):
         name = openpype.hosts.blender.api.plugin.asset_name(asset, subset)
         collection = bpy.data.collections.new(name=name)
         bpy.context.scene.collection.children.link(collection)
-        self.data['task'] = legacy_io.Session.get('AVALON_TASK')
+        self.data['task'] = get_current_task_name()
         lib.imprint(collection, self.data)
 
         if (self.options or {}).get("useSelection"):

--- a/openpype/hosts/blender/plugins/create/create_review.py
+++ b/openpype/hosts/blender/plugins/create/create_review.py
@@ -2,7 +2,7 @@
 
 import bpy
 
-from openpype.pipeline import legacy_io
+from openpype.pipeline import get_current_task_name
 from openpype.hosts.blender.api import plugin, lib, ops
 from openpype.hosts.blender.api.pipeline import AVALON_INSTANCES
 
@@ -33,7 +33,7 @@ class CreateReview(plugin.Creator):
         name = plugin.asset_name(asset, subset)
         asset_group = bpy.data.collections.new(name=name)
         instances.children.link(asset_group)
-        self.data['task'] = legacy_io.Session.get('AVALON_TASK')
+        self.data['task'] = get_current_task_name()
         lib.imprint(asset_group, self.data)
 
         if (self.options or {}).get("useSelection"):

--- a/openpype/hosts/blender/plugins/create/create_rig.py
+++ b/openpype/hosts/blender/plugins/create/create_rig.py
@@ -2,7 +2,7 @@
 
 import bpy
 
-from openpype.pipeline import legacy_io
+from openpype.pipeline import get_current_task_name
 from openpype.hosts.blender.api import plugin, lib, ops
 from openpype.hosts.blender.api.pipeline import AVALON_INSTANCES
 
@@ -34,7 +34,7 @@ class CreateRig(plugin.Creator):
         asset_group = bpy.data.objects.new(name=name, object_data=None)
         asset_group.empty_display_type = 'SINGLE_ARROW'
         instances.objects.link(asset_group)
-        self.data['task'] = legacy_io.Session.get('AVALON_TASK')
+        self.data['task'] = get_current_task_name()
         lib.imprint(asset_group, self.data)
 
         # Add selected objects to instance

--- a/openpype/hosts/blender/plugins/publish/collect_current_file.py
+++ b/openpype/hosts/blender/plugins/publish/collect_current_file.py
@@ -2,7 +2,7 @@ import os
 import bpy
 
 import pyblish.api
-from openpype.pipeline import legacy_io
+from openpype.pipeline import get_current_task_name, get_current_asset_name
 from openpype.hosts.blender.api import workio
 
 
@@ -37,7 +37,7 @@ class CollectBlenderCurrentFile(pyblish.api.ContextPlugin):
         folder, file = os.path.split(current_file)
         filename, ext = os.path.splitext(file)
 
-        task = legacy_io.Session["AVALON_TASK"]
+        task = get_current_task_name()
 
         data = {}
 
@@ -47,7 +47,7 @@ class CollectBlenderCurrentFile(pyblish.api.ContextPlugin):
 
         data.update({
             "subset": subset,
-            "asset": os.getenv("AVALON_ASSET", None),
+            "asset": get_current_asset_name(),
             "label": subset,
             "publish": True,
             "family": "workfile",

--- a/openpype/hosts/blender/plugins/publish/collect_review.py
+++ b/openpype/hosts/blender/plugins/publish/collect_review.py
@@ -39,7 +39,7 @@ class CollectReview(pyblish.api.InstancePlugin):
 
         if not instance.data.get("remove"):
 
-            task = get_current_task_name()
+            task = instance.context.data["task"]
 
             instance.data.update({
                 "subset": f"{task}Review",

--- a/openpype/hosts/blender/plugins/publish/collect_review.py
+++ b/openpype/hosts/blender/plugins/publish/collect_review.py
@@ -1,7 +1,6 @@
 import bpy
 
 import pyblish.api
-from openpype.pipeline import get_current_task_name
 
 
 class CollectReview(pyblish.api.InstancePlugin):

--- a/openpype/hosts/blender/plugins/publish/collect_review.py
+++ b/openpype/hosts/blender/plugins/publish/collect_review.py
@@ -1,7 +1,7 @@
 import bpy
 
 import pyblish.api
-from openpype.pipeline import legacy_io
+from openpype.pipeline import get_current_task_name
 
 
 class CollectReview(pyblish.api.InstancePlugin):
@@ -39,7 +39,7 @@ class CollectReview(pyblish.api.InstancePlugin):
 
         if not instance.data.get("remove"):
 
-            task = legacy_io.Session.get("AVALON_TASK")
+            task = get_current_task_name()
 
             instance.data.update({
                 "subset": f"{task}Review",

--- a/openpype/hosts/celaction/plugins/publish/collect_celaction_instances.py
+++ b/openpype/hosts/celaction/plugins/publish/collect_celaction_instances.py
@@ -1,6 +1,5 @@
 import os
 import pyblish.api
-from openpype.pipeline import legacy_io
 
 
 class CollectCelactionInstances(pyblish.api.ContextPlugin):
@@ -10,7 +9,7 @@ class CollectCelactionInstances(pyblish.api.ContextPlugin):
     order = pyblish.api.CollectorOrder + 0.1
 
     def process(self, context):
-        task = legacy_io.Session["AVALON_TASK"]
+        task = context.data["task"]
         current_file = context.data["currentFile"]
         staging_dir = os.path.dirname(current_file)
         scene_file = os.path.basename(current_file)

--- a/openpype/hosts/flame/api/menu.py
+++ b/openpype/hosts/flame/api/menu.py
@@ -1,7 +1,9 @@
-import os
-from qtpy import QtWidgets
 from copy import deepcopy
 from pprint import pformat
+
+from qtpy import QtWidgets
+
+from openpype.pipeline import get_current_project_name
 from openpype.tools.utils.host_tools import HostToolsHelper
 
 menu_group_name = 'OpenPype'
@@ -61,10 +63,10 @@ class _FlameMenuApp(object):
             self.framework.prefs_global, self.name)
 
         self.mbox = QtWidgets.QMessageBox()
-
+        project_name = get_current_project_name()
         self.menu = {
             "actions": [{
-                'name': os.getenv("AVALON_PROJECT", "project"),
+                'name': project_name or "project",
                 'isEnabled': False
             }],
             "name": self.menu_group_name

--- a/openpype/hosts/flame/plugins/publish/collect_timeline_otio.py
+++ b/openpype/hosts/flame/plugins/publish/collect_timeline_otio.py
@@ -2,7 +2,6 @@ import pyblish.api
 
 import openpype.hosts.flame.api as opfapi
 from openpype.hosts.flame.otio import flame_export
-from openpype.pipeline import legacy_io
 from openpype.pipeline.create import get_subset_name
 
 
@@ -19,7 +18,7 @@ class CollecTimelineOTIO(pyblish.api.ContextPlugin):
 
         # main
         asset_doc = context.data["assetEntity"]
-        task_name = legacy_io.Session["AVALON_TASK"]
+        task_name = context.data["task"]
         project = opfapi.get_current_project()
         sequence = opfapi.get_current_sequence(opfapi.CTX.selection)
 

--- a/openpype/hosts/fusion/api/lib.py
+++ b/openpype/hosts/fusion/api/lib.py
@@ -14,7 +14,7 @@ from openpype.client import (
 )
 from openpype.pipeline import (
     switch_container,
-    legacy_io,
+    get_current_project_name,
 )
 from openpype.pipeline.context_tools import get_current_project_asset
 
@@ -206,7 +206,7 @@ def switch_item(container,
 
     # Collect any of current asset, subset and representation if not provided
     #   so we can use the original name from those.
-    project_name = legacy_io.active_project()
+    project_name = get_current_project_name()
     if any(not x for x in [asset_name, subset_name, representation_name]):
         repre_id = container["representation"]
         representation = get_representation_by_id(project_name, repre_id)

--- a/openpype/hosts/fusion/api/menu.py
+++ b/openpype/hosts/fusion/api/menu.py
@@ -12,7 +12,7 @@ from openpype.hosts.fusion.api.lib import (
     set_asset_framerange,
     set_asset_resolution,
 )
-from openpype.pipeline import legacy_io
+from openpype.pipeline import get_current_asset_name
 from openpype.resources import get_openpype_icon_filepath
 
 from .pipeline import FusionEventHandler
@@ -125,7 +125,7 @@ class OpenPypeMenu(QtWidgets.QWidget):
 
     def on_task_changed(self):
         # Update current context label
-        label = legacy_io.Session["AVALON_ASSET"]
+        label = get_current_asset_name()
         self.asset_label.setText(label)
 
     def register_callback(self, name, fn):

--- a/openpype/hosts/fusion/deploy/Scripts/Comp/OpenPype/switch_ui.py
+++ b/openpype/hosts/fusion/deploy/Scripts/Comp/OpenPype/switch_ui.py
@@ -11,7 +11,7 @@ from openpype.client import get_assets
 from openpype import style
 from openpype.pipeline import (
     install_host,
-    legacy_io,
+    get_current_project_name,
 )
 from openpype.hosts.fusion import api
 from openpype.pipeline.context_tools import get_workdir_from_session
@@ -167,7 +167,7 @@ class App(QtWidgets.QWidget):
         return items
 
     def collect_asset_names(self):
-        project_name = legacy_io.active_project()
+        project_name = get_current_project_name()
         asset_docs = get_assets(project_name, fields=["name"])
         asset_names = {
             asset_doc["name"]

--- a/openpype/hosts/fusion/plugins/create/create_saver.py
+++ b/openpype/hosts/fusion/plugins/create/create_saver.py
@@ -151,9 +151,9 @@ class CreateSaver(Creator):
         comp = tool.Comp()
 
         # Allow regular non-managed savers to also be picked up
-        project = legacy_io.Session["AVALON_PROJECT"]
-        asset = legacy_io.Session["AVALON_ASSET"]
-        task = legacy_io.Session["AVALON_TASK"]
+        project = self.create_context.get_current_project_name()
+        asset = self.create_context.get_current_asset_name()
+        task = self.create_context.get_current_task_name()
 
         asset_doc = get_asset_by_name(project_name=project, asset_name=asset)
 

--- a/openpype/hosts/fusion/plugins/create/create_workfile.py
+++ b/openpype/hosts/fusion/plugins/create/create_workfile.py
@@ -7,7 +7,6 @@ from openpype.client import get_asset_by_name
 from openpype.pipeline import (
     AutoCreator,
     CreatedInstance,
-    legacy_io,
 )
 
 
@@ -65,10 +64,10 @@ class FusionWorkfileCreator(AutoCreator):
                 existing_instance = instance
                 break
 
-        project_name = legacy_io.Session["AVALON_PROJECT"]
-        asset_name = legacy_io.Session["AVALON_ASSET"]
-        task_name = legacy_io.Session["AVALON_TASK"]
-        host_name = legacy_io.Session["AVALON_APP"]
+        project_name = self.create_context.get_current_project_name()
+        asset_name = self.create_context.get_current_asset_name()
+        task_name = self.create_context.get_current_task_name()
+        host_name = self.create_context.host_name
 
         if existing_instance is None:
             asset_doc = get_asset_by_name(project_name, asset_name)

--- a/openpype/hosts/harmony/api/README.md
+++ b/openpype/hosts/harmony/api/README.md
@@ -610,7 +610,7 @@ class ImageSequenceLoader(load.LoaderPlugin):
     def update(self, container, representation):
         node = container.pop("node")
 
-        project_name = legacy_io.active_project()
+        project_name = get_current_project_name()
         version = get_version_by_id(project_name, representation["parent"])
         files = []
         for f in version["data"]["files"]:

--- a/openpype/hosts/harmony/plugins/publish/collect_farm_render.py
+++ b/openpype/hosts/harmony/plugins/publish/collect_farm_render.py
@@ -5,7 +5,6 @@ from pathlib import Path
 import attr
 
 from openpype.lib import get_formatted_current_time
-from openpype.pipeline import legacy_io
 from openpype.pipeline import publish
 from openpype.pipeline.publish import RenderInstance
 import openpype.hosts.harmony.api as harmony
@@ -99,6 +98,8 @@ class CollectFarmRender(publish.AbstractCollectRender):
 
         self_name = self.__class__.__name__
 
+        asset_name = context.data["asset"]
+
         for node in context.data["allNodes"]:
             data = harmony.read(node)
 
@@ -141,7 +142,7 @@ class CollectFarmRender(publish.AbstractCollectRender):
                 source=context.data["currentFile"],
                 label=node.split("/")[1],
                 subset=subset_name,
-                asset=legacy_io.Session["AVALON_ASSET"],
+                asset=asset_name,
                 task=task_name,
                 attachTo=False,
                 setMembers=[node],

--- a/openpype/hosts/harmony/plugins/publish/collect_palettes.py
+++ b/openpype/hosts/harmony/plugins/publish/collect_palettes.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
 """Collect palettes from Harmony."""
-import os
 import json
 import re
 
@@ -32,6 +31,7 @@ class CollectPalettes(pyblish.api.ContextPlugin):
             if (not any([re.search(pattern, task_name)
                          for pattern in self.allowed_tasks])):
                 return
+        asset_name = context.data["asset"]
 
         for name, id in palettes.items():
             instance = context.create_instance(name)
@@ -39,7 +39,7 @@ class CollectPalettes(pyblish.api.ContextPlugin):
                 "id": id,
                 "family": "harmony.palette",
                 'families': [],
-                "asset": os.environ["AVALON_ASSET"],
+                "asset": asset_name,
                 "subset": "{}{}".format("palette", name)
             })
             self.log.info(

--- a/openpype/hosts/harmony/plugins/publish/collect_workfile.py
+++ b/openpype/hosts/harmony/plugins/publish/collect_workfile.py
@@ -36,5 +36,5 @@ class CollectWorkfile(pyblish.api.ContextPlugin):
             "family": family,
             "families": [family],
             "representations": [],
-            "asset": os.environ["AVALON_ASSET"]
+            "asset": context.data["asset"]
         })

--- a/openpype/hosts/harmony/plugins/publish/extract_template.py
+++ b/openpype/hosts/harmony/plugins/publish/extract_template.py
@@ -75,7 +75,7 @@ class ExtractTemplate(publish.Extractor):
             instance.data["representations"] = [representation]
 
         instance.data["version_name"] = "{}_{}".format(
-            instance.data["subset"], os.environ["AVALON_TASK"])
+            instance.data["subset"], instance.context.data["task"])
 
     def get_backdrops(self, node: str) -> list:
         """Get backdrops for the node.

--- a/openpype/hosts/harmony/plugins/publish/validate_instances.py
+++ b/openpype/hosts/harmony/plugins/publish/validate_instances.py
@@ -1,8 +1,7 @@
-import os
-
 import pyblish.api
 
 import openpype.hosts.harmony.api as harmony
+from openpype.pipeline import get_current_asset_name
 from openpype.pipeline.publish import (
     ValidateContentsOrder,
     PublishXmlValidationError,
@@ -30,7 +29,7 @@ class ValidateInstanceRepair(pyblish.api.Action):
 
         for instance in instances:
             data = harmony.read(instance.data["setMembers"][0])
-            data["asset"] = os.environ["AVALON_ASSET"]
+            data["asset"] = get_current_asset_name()
             harmony.imprint(instance.data["setMembers"][0], data)
 
 
@@ -44,7 +43,7 @@ class ValidateInstance(pyblish.api.InstancePlugin):
 
     def process(self, instance):
         instance_asset = instance.data["asset"]
-        current_asset = os.environ["AVALON_ASSET"]
+        current_asset = get_current_asset_name()
         msg = (
             "Instance asset is not the same as current asset:"
             f"\nInstance: {instance_asset}\nCurrent: {current_asset}"

--- a/openpype/hosts/harmony/plugins/publish/validate_scene_settings.py
+++ b/openpype/hosts/harmony/plugins/publish/validate_scene_settings.py
@@ -67,7 +67,9 @@ class ValidateSceneSettings(pyblish.api.InstancePlugin):
         expected_settings["frameEndHandle"] = expected_settings["frameEnd"] +\
             expected_settings["handleEnd"]
 
-        if (any(re.search(pattern, os.getenv('AVALON_TASK'))
+        task_name = instance.context.data["task"]
+
+        if (any(re.search(pattern, task_name)
                 for pattern in self.skip_resolution_check)):
             self.log.info("Skipping resolution check because of "
                           "task name and pattern {}".format(

--- a/openpype/hosts/hiero/api/lib.py
+++ b/openpype/hosts/hiero/api/lib.py
@@ -23,7 +23,7 @@ except ImportError:
 
 from openpype.client import get_project
 from openpype.settings import get_project_settings
-from openpype.pipeline import legacy_io, Anatomy
+from openpype.pipeline import Anatomy, get_current_project_name
 from openpype.pipeline.load import filter_containers
 from openpype.lib import Logger
 from . import tags
@@ -620,7 +620,7 @@ def get_publish_attribute(tag):
 
 def sync_avalon_data_to_workfile():
     # import session to get project dir
-    project_name = legacy_io.Session["AVALON_PROJECT"]
+    project_name = get_current_project_name()
 
     anatomy = Anatomy(project_name)
     work_template = anatomy.templates["work"]["path"]
@@ -815,7 +815,7 @@ class PublishAction(QtWidgets.QAction):
 #     # create root node and save all metadata
 #     root_node = hiero.core.nuke.RootNode()
 #
-#     anatomy = Anatomy(os.environ["AVALON_PROJECT"])
+#     anatomy = Anatomy(get_current_project_name())
 #     work_template = anatomy.templates["work"]["path"]
 #     root_path = anatomy.root_value_for_template(work_template)
 #
@@ -1035,7 +1035,7 @@ def _set_hrox_project_knobs(doc, **knobs):
 
 
 def apply_colorspace_project():
-    project_name = os.getenv("AVALON_PROJECT")
+    project_name = get_current_project_name()
     # get path the the active projects
     project = get_current_project(remove_untitled=True)
     current_file = project.path()
@@ -1092,7 +1092,7 @@ def apply_colorspace_project():
 
 
 def apply_colorspace_clips():
-    project_name = os.getenv("AVALON_PROJECT")
+    project_name = get_current_project_name()
     project = get_current_project(remove_untitled=True)
     clips = project.clips()
 
@@ -1246,7 +1246,7 @@ def check_inventory_versions(track_items=None):
     if not containers:
         return
 
-    project_name = legacy_io.active_project()
+    project_name = get_current_project_name()
     filter_result = filter_containers(containers, project_name)
     for container in filter_result.latest:
         set_track_color(container["_item"], clip_color_last)

--- a/openpype/hosts/hiero/api/menu.py
+++ b/openpype/hosts/hiero/api/menu.py
@@ -4,17 +4,30 @@ import sys
 import hiero.core
 from hiero.ui import findMenuAction
 
+from qtpy import QtGui
+
 from openpype.lib import Logger
-from openpype.pipeline import legacy_io
 from openpype.tools.utils import host_tools
+from openpype.settings import get_project_settings
+from openpype.pipeline import (
+    get_current_project_name,
+    get_current_asset_name,
+    get_current_task_name
+)
 
 from . import tags
-from openpype.settings import get_project_settings
 
 log = Logger.get_logger(__name__)
 
 self = sys.modules[__name__]
 self._change_context_menu = None
+
+
+def get_context_label():
+    return "{}, {}".format(
+        get_current_asset_name(),
+        get_current_task_name()
+    )
 
 
 def update_menu_task_label():
@@ -27,10 +40,7 @@ def update_menu_task_label():
         log.warning("Can't find menuItem: {}".format(object_name))
         return
 
-    label = "{}, {}".format(
-        legacy_io.Session["AVALON_ASSET"],
-        legacy_io.Session["AVALON_TASK"]
-    )
+    label = get_context_label()
 
     menu = found_menu.menu()
     self._change_context_menu = label
@@ -43,7 +53,6 @@ def menu_install():
 
     """
 
-    from qtpy import QtGui
     from . import (
         publish, launch_workfiles_app, reload_config,
         apply_colorspace_project, apply_colorspace_clips
@@ -56,10 +65,7 @@ def menu_install():
 
     menu_name = os.environ['AVALON_LABEL']
 
-    context_label = "{0}, {1}".format(
-        legacy_io.Session["AVALON_ASSET"],
-        legacy_io.Session["AVALON_TASK"]
-    )
+    context_label = get_context_label()
 
     self._change_context_menu = context_label
 
@@ -154,7 +160,7 @@ def add_scripts_menu():
         return
 
     # load configuration of custom menu
-    project_settings = get_project_settings(os.getenv("AVALON_PROJECT"))
+    project_settings = get_project_settings(get_current_project_name())
     config = project_settings["hiero"]["scriptsmenu"]["definition"]
     _menu = project_settings["hiero"]["scriptsmenu"]["name"]
 

--- a/openpype/hosts/hiero/api/tags.py
+++ b/openpype/hosts/hiero/api/tags.py
@@ -5,7 +5,7 @@ import hiero
 
 from openpype.client import get_project, get_assets
 from openpype.lib import Logger
-from openpype.pipeline import legacy_io
+from openpype.pipeline import get_current_project_name
 
 log = Logger.get_logger(__name__)
 
@@ -142,7 +142,7 @@ def add_tags_to_workfile():
     nks_pres_tags = tag_data()
 
     # Get project task types.
-    project_name = legacy_io.active_project()
+    project_name = get_current_project_name()
     project_doc = get_project(project_name)
     tasks = project_doc["config"]["tasks"]
     nks_pres_tags["[Tasks]"] = {}

--- a/openpype/hosts/hiero/plugins/load/load_clip.py
+++ b/openpype/hosts/hiero/plugins/load/load_clip.py
@@ -3,8 +3,8 @@ from openpype.client import (
     get_last_version_by_subset_id
 )
 from openpype.pipeline import (
-    legacy_io,
     get_representation_path,
+    get_current_project_name,
 )
 from openpype.lib.transcoding import (
     VIDEO_EXTENSIONS,
@@ -148,7 +148,7 @@ class LoadClip(phiero.SequenceLoader):
         track_item = phiero.get_track_items(
             track_item_name=namespace).pop()
 
-        project_name = legacy_io.active_project()
+        project_name = get_current_project_name()
         version_doc = get_version_by_id(project_name, representation["parent"])
 
         version_data = version_doc.get("data", {})
@@ -211,7 +211,7 @@ class LoadClip(phiero.SequenceLoader):
 
     @classmethod
     def set_item_color(cls, track_item, version_doc):
-        project_name = legacy_io.active_project()
+        project_name = get_current_project_name()
         last_version_doc = get_last_version_by_subset_id(
             project_name, version_doc["parent"], fields=["_id"]
         )

--- a/openpype/hosts/hiero/plugins/load/load_effects.py
+++ b/openpype/hosts/hiero/plugins/load/load_effects.py
@@ -9,8 +9,8 @@ from openpype.client import (
 from openpype.pipeline import (
     AVALON_CONTAINER_ID,
     load,
-    legacy_io,
-    get_representation_path
+    get_representation_path,
+    get_current_project_name
 )
 from openpype.hosts.hiero import api as phiero
 from openpype.lib import Logger
@@ -168,7 +168,7 @@ class LoadEffects(load.LoaderPlugin):
         namespace = container['namespace']
 
         # get timeline in out data
-        project_name = legacy_io.active_project()
+        project_name = get_current_project_name()
         version_doc = get_version_by_id(project_name, representation["parent"])
         version_data = version_doc["data"]
         clip_in = version_data["clipIn"]

--- a/openpype/hosts/hiero/plugins/publish/precollect_workfile.py
+++ b/openpype/hosts/hiero/plugins/publish/precollect_workfile.py
@@ -7,7 +7,6 @@ from qtpy.QtGui import QPixmap
 
 import hiero.ui
 
-from openpype.pipeline import legacy_io
 from openpype.hosts.hiero import api as phiero
 from openpype.hosts.hiero.api.otio import hiero_export
 
@@ -20,7 +19,7 @@ class PrecollectWorkfile(pyblish.api.ContextPlugin):
 
     def process(self, context):
 
-        asset = legacy_io.Session["AVALON_ASSET"]
+        asset = context.data["asset"]
         subset = "workfile"
         project = phiero.get_current_project()
         active_timeline = hiero.ui.activeSequence()

--- a/openpype/hosts/hiero/plugins/publish_old_workflow/collect_assetbuilds.py
+++ b/openpype/hosts/hiero/plugins/publish_old_workflow/collect_assetbuilds.py
@@ -1,6 +1,5 @@
 from pyblish import api
 from openpype.client import get_assets
-from openpype.pipeline import legacy_io
 
 
 class CollectAssetBuilds(api.ContextPlugin):
@@ -18,7 +17,7 @@ class CollectAssetBuilds(api.ContextPlugin):
     hosts = ["hiero"]
 
     def process(self, context):
-        project_name = legacy_io.active_project()
+        project_name = context.data["projectName"]
         asset_builds = {}
         for asset in get_assets(project_name):
             if asset["data"]["entityType"] == "AssetBuild":

--- a/openpype/hosts/houdini/api/lib.py
+++ b/openpype/hosts/houdini/api/lib.py
@@ -9,7 +9,7 @@ import json
 import six
 
 from openpype.client import get_asset_by_name
-from openpype.pipeline import legacy_io
+from openpype.pipeline import get_current_project_name, get_current_asset_name
 from openpype.pipeline.context_tools import get_current_project_asset
 
 import hou
@@ -77,8 +77,8 @@ def generate_ids(nodes, asset_id=None):
     """
 
     if asset_id is None:
-        project_name = legacy_io.active_project()
-        asset_name = legacy_io.Session["AVALON_ASSET"]
+        project_name = get_current_project_name()
+        asset_name = get_current_asset_name()
         # Get the asset ID from the database for the asset of current context
         asset_doc = get_asset_by_name(project_name, asset_name, fields=["_id"])
 
@@ -471,8 +471,8 @@ def maintained_selection():
 def reset_framerange():
     """Set frame range to current asset"""
 
-    project_name = legacy_io.active_project()
-    asset_name = legacy_io.Session["AVALON_ASSET"]
+    project_name = get_current_project_name()
+    asset_name = get_current_asset_name()
     # Get the asset ID from the database for the asset of current context
     asset_doc = get_asset_by_name(project_name, asset_name)
     asset_data = asset_doc["data"]

--- a/openpype/hosts/houdini/api/shelves.py
+++ b/openpype/hosts/houdini/api/shelves.py
@@ -4,6 +4,7 @@ import logging
 import platform
 
 from openpype.settings import get_project_settings
+from openpype.pipeline import get_current_project_name
 
 import hou
 
@@ -17,7 +18,8 @@ def generate_shelves():
     current_os = platform.system().lower()
 
     # load configuration of houdini shelves
-    project_settings = get_project_settings(os.getenv("AVALON_PROJECT"))
+    project_name = get_current_project_name()
+    project_settings = get_project_settings(project_name)
     shelves_set_config = project_settings["houdini"]["shelves"]
 
     if not shelves_set_config:

--- a/openpype/hosts/houdini/plugins/create/create_hda.py
+++ b/openpype/hosts/houdini/plugins/create/create_hda.py
@@ -4,7 +4,6 @@ from openpype.client import (
     get_asset_by_name,
     get_subsets,
 )
-from openpype.pipeline import legacy_io
 from openpype.hosts.houdini.api import plugin
 
 
@@ -21,7 +20,7 @@ class CreateHDA(plugin.HoudiniCreator):
         # type: (str) -> bool
         """Check if existing subset name versions already exists."""
         # Get all subsets of the current asset
-        project_name = legacy_io.active_project()
+        project_name = self.project_name
         asset_doc = get_asset_by_name(
             project_name, self.data["asset"], fields=["_id"]
         )

--- a/openpype/hosts/houdini/plugins/create/create_workfile.py
+++ b/openpype/hosts/houdini/plugins/create/create_workfile.py
@@ -4,7 +4,6 @@ from openpype.hosts.houdini.api import plugin
 from openpype.hosts.houdini.api.lib import read, imprint
 from openpype.hosts.houdini.api.pipeline import CONTEXT_CONTAINER
 from openpype.pipeline import CreatedInstance, AutoCreator
-from openpype.pipeline import legacy_io
 from openpype.client import get_asset_by_name
 import hou
 
@@ -27,9 +26,9 @@ class CreateWorkfile(plugin.HoudiniCreatorBase, AutoCreator):
             ), None)
 
         project_name = self.project_name
-        asset_name = legacy_io.Session["AVALON_ASSET"]
-        task_name = legacy_io.Session["AVALON_TASK"]
-        host_name = legacy_io.Session["AVALON_APP"]
+        asset_name = self.create_context.get_current_asset_name()
+        task_name = self.create_context.get_current_task_name()
+        host_name = self.host_name
 
         if current_instance is None:
             asset_doc = get_asset_by_name(project_name, asset_name)

--- a/openpype/hosts/houdini/plugins/publish/collect_usd_bootstrap.py
+++ b/openpype/hosts/houdini/plugins/publish/collect_usd_bootstrap.py
@@ -1,7 +1,6 @@
 import pyblish.api
 
 from openpype.client import get_subset_by_name, get_asset_by_name
-from openpype.pipeline import legacy_io
 import openpype.lib.usdlib as usdlib
 
 
@@ -51,7 +50,7 @@ class CollectUsdBootstrap(pyblish.api.InstancePlugin):
 
         self.log.debug("Add bootstrap for: %s" % bootstrap)
 
-        project_name = legacy_io.active_project()
+        project_name = instance.context.data["projectName"]
         asset = get_asset_by_name(project_name, instance.data["asset"])
         assert asset, "Asset must exist: %s" % asset
 

--- a/openpype/hosts/houdini/plugins/publish/extract_usd_layered.py
+++ b/openpype/hosts/houdini/plugins/publish/extract_usd_layered.py
@@ -14,7 +14,6 @@ from openpype.client import (
 )
 from openpype.pipeline import (
     get_representation_path,
-    legacy_io,
     publish,
 )
 import openpype.hosts.houdini.api.usd as hou_usdlib
@@ -250,7 +249,7 @@ class ExtractUSDLayered(publish.Extractor):
 
         # Set up the dependency for publish if they have new content
         # compared to previous publishes
-        project_name = legacy_io.active_project()
+        project_name = instance.context.data["projectName"]
         for dependency in active_dependencies:
             dependency_fname = dependency.data["usdFilename"]
 

--- a/openpype/hosts/houdini/plugins/publish/validate_usd_shade_model_exists.py
+++ b/openpype/hosts/houdini/plugins/publish/validate_usd_shade_model_exists.py
@@ -4,7 +4,6 @@ import re
 import pyblish.api
 
 from openpype.client import get_subset_by_name
-from openpype.pipeline import legacy_io
 from openpype.pipeline.publish import ValidateContentsOrder
 from openpype.pipeline import PublishValidationError
 
@@ -18,7 +17,7 @@ class ValidateUSDShadeModelExists(pyblish.api.InstancePlugin):
     label = "USD Shade model exists"
 
     def process(self, instance):
-        project_name = legacy_io.active_project()
+        project_name = instance.context["projectName"]
         asset_name = instance.data["asset"]
         subset = instance.data["subset"]
 

--- a/openpype/hosts/houdini/plugins/publish/validate_usd_shade_model_exists.py
+++ b/openpype/hosts/houdini/plugins/publish/validate_usd_shade_model_exists.py
@@ -17,7 +17,7 @@ class ValidateUSDShadeModelExists(pyblish.api.InstancePlugin):
     label = "USD Shade model exists"
 
     def process(self, instance):
-        project_name = instance.context["projectName"]
+        project_name = instance.context.data["projectName"]
         asset_name = instance.data["asset"]
         subset = instance.data["subset"]
 

--- a/openpype/hosts/houdini/vendor/husdoutputprocessors/avalon_uri_processor.py
+++ b/openpype/hosts/houdini/vendor/husdoutputprocessors/avalon_uri_processor.py
@@ -5,7 +5,7 @@ import husdoutputprocessors.base as base
 import colorbleed.usdlib as usdlib
 
 from openpype.client import get_asset_by_name
-from openpype.pipeline import legacy_io, Anatomy
+from openpype.pipeline import Anatomy, get_current_project_name
 
 
 class AvalonURIOutputProcessor(base.OutputProcessorBase):
@@ -122,7 +122,7 @@ class AvalonURIOutputProcessor(base.OutputProcessorBase):
 
         """
 
-        PROJECT = legacy_io.Session["AVALON_PROJECT"]
+        PROJECT = get_current_project_name()
         anatomy = Anatomy(PROJECT)
         asset_doc = get_asset_by_name(PROJECT, asset)
         if not asset_doc:

--- a/openpype/hosts/max/api/lib_renderproducts.py
+++ b/openpype/hosts/max/api/lib_renderproducts.py
@@ -10,7 +10,7 @@ from openpype.hosts.max.api.lib import (
 )
 from openpype.pipeline.context_tools import get_current_project_asset
 from openpype.settings import get_project_settings
-from openpype.pipeline import legacy_io
+from openpype.pipeline import get_current_project_name
 
 
 class RenderProducts(object):
@@ -19,7 +19,7 @@ class RenderProducts(object):
         self._project_settings = project_settings
         if not self._project_settings:
             self._project_settings = get_project_settings(
-                legacy_io.Session["AVALON_PROJECT"]
+                get_current_project_name()
             )
 
     def render_product(self, container):

--- a/openpype/hosts/max/api/lib_rendersettings.py
+++ b/openpype/hosts/max/api/lib_rendersettings.py
@@ -2,7 +2,7 @@ import os
 from pymxs import runtime as rt
 from openpype.lib import Logger
 from openpype.settings import get_project_settings
-from openpype.pipeline import legacy_io
+from openpype.pipeline import get_current_project_name
 from openpype.pipeline.context_tools import get_current_project_asset
 
 from openpype.hosts.max.api.lib import (
@@ -31,7 +31,7 @@ class RenderSettings(object):
         self._project_settings = project_settings
         if not self._project_settings:
             self._project_settings = get_project_settings(
-                legacy_io.Session["AVALON_PROJECT"]
+                get_current_project_name()
             )
 
     def set_render_camera(self, selection):

--- a/openpype/hosts/max/plugins/publish/collect_workfile.py
+++ b/openpype/hosts/max/plugins/publish/collect_workfile.py
@@ -4,7 +4,6 @@ import os
 import pyblish.api
 
 from pymxs import runtime as rt
-from openpype.pipeline import legacy_io
 
 
 class CollectWorkfile(pyblish.api.ContextPlugin):
@@ -26,7 +25,7 @@ class CollectWorkfile(pyblish.api.ContextPlugin):
 
         filename, ext = os.path.splitext(file)
 
-        task = legacy_io.Session["AVALON_TASK"]
+        task = context.data["task"]
 
         data = {}
 
@@ -36,7 +35,7 @@ class CollectWorkfile(pyblish.api.ContextPlugin):
 
         data.update({
             "subset": subset,
-            "asset": os.getenv("AVALON_ASSET", None),
+            "asset": context.data["asset"],
             "label": subset,
             "publish": True,
             "family": 'workfile',

--- a/openpype/hosts/max/plugins/publish/extract_pointcloud.py
+++ b/openpype/hosts/max/plugins/publish/extract_pointcloud.py
@@ -5,15 +5,6 @@ from pymxs import runtime as rt
 from openpype.hosts.max.api import (
     maintained_selection
 )
-from openpype.settings import get_project_settings
-from openpype.pipeline import legacy_io
-
-
-def get_setting(project_setting=None):
-    project_setting = get_project_settings(
-        legacy_io.Session["AVALON_PROJECT"]
-    )
-    return (project_setting["max"]["PointCloud"])
 
 
 class ExtractPointCloud(publish.Extractor):
@@ -48,6 +39,8 @@ class ExtractPointCloud(publish.Extractor):
     def process(self, instance):
         start = int(instance.context.data.get("frameStart"))
         end = int(instance.context.data.get("frameEnd"))
+        project_setting = instance.context.data["project_settings"]
+        point_cloud_settings = project_setting["max"]["PointCloud"]
         container = instance.data["instance_node"]
         self.log.info("Extracting PRT...")
 
@@ -59,7 +52,8 @@ class ExtractPointCloud(publish.Extractor):
             job_args = self.export_particle(container,
                                             start,
                                             end,
-                                            path)
+                                            path,
+                                            point_cloud_settings)
             for job in job_args:
                 rt.execute(job)
 
@@ -88,7 +82,8 @@ class ExtractPointCloud(publish.Extractor):
                         container,
                         start,
                         end,
-                        filepath):
+                        filepath,
+                        point_cloud_settings):
         job_args = []
         opt_list = self.get_operators(container)
         for operator in opt_list:
@@ -107,7 +102,8 @@ class ExtractPointCloud(publish.Extractor):
             mode = "{0}.PRTPartitionsMode=2".format(operator)
             job_args.append(mode)
 
-            additional_args = self.get_custom_attr(operator)
+            additional_args = self.get_custom_attr(
+                point_cloud_settings, operator)
             for args in additional_args:
                 job_args.append(args)
 
@@ -137,11 +133,11 @@ class ExtractPointCloud(publish.Extractor):
 
         return opt_list
 
-    def get_custom_attr(self, operator):
+    def get_custom_attr(self, point_cloud_settings, operator):
         """Get Custom Attributes"""
 
         custom_attr_list = []
-        attr_settings = get_setting()["attribute"]
+        attr_settings = point_cloud_settings["attribute"]
         for key, value in attr_settings.items():
             custom_attr = "{0}.PRTChannels_{1}=True".format(operator,
                                                             value)

--- a/openpype/hosts/max/plugins/publish/extract_pointcloud.py
+++ b/openpype/hosts/max/plugins/publish/extract_pointcloud.py
@@ -103,7 +103,7 @@ class ExtractPointCloud(publish.Extractor):
             job_args.append(mode)
 
             additional_args = self.get_custom_attr(
-                point_cloud_settings, operator)
+                operator, point_cloud_settings)
             for args in additional_args:
                 job_args.append(args)
 
@@ -133,7 +133,7 @@ class ExtractPointCloud(publish.Extractor):
 
         return opt_list
 
-    def get_custom_attr(self, point_cloud_settings, operator):
+    def get_custom_attr(self, operator, point_cloud_settings):
         """Get Custom Attributes"""
 
         custom_attr_list = []

--- a/openpype/hosts/max/plugins/publish/validate_pointcloud.py
+++ b/openpype/hosts/max/plugins/publish/validate_pointcloud.py
@@ -1,15 +1,6 @@
 import pyblish.api
 from openpype.pipeline import PublishValidationError
 from pymxs import runtime as rt
-from openpype.settings import get_project_settings
-from openpype.pipeline import legacy_io
-
-
-def get_setting(project_setting=None):
-    project_setting = get_project_settings(
-        legacy_io.Session["AVALON_PROJECT"]
-    )
-    return (project_setting["max"]["PointCloud"])
 
 
 class ValidatePointCloud(pyblish.api.InstancePlugin):
@@ -107,6 +98,9 @@ class ValidatePointCloud(pyblish.api.InstancePlugin):
         self.log.info("Validating tyFlow custom "
                       "attributes for {}".format(container))
 
+        project_setting = instance.context.data["project_settings"]
+        point_cloud_settings = project_setting["max"]["PointCloud"]
+
         con = rt.getNodeByName(container)
         selection_list = list(con.Children)
         for sel in selection_list:
@@ -121,7 +115,7 @@ class ValidatePointCloud(pyblish.api.InstancePlugin):
                 if boolean:
                     opt = "${0}.{1}.export_particles".format(sel.name,
                                                              event_name)
-                    attributes = get_setting()["attribute"]
+                    attributes = point_cloud_settings["attribute"]
                     for key, value in attributes.items():
                         custom_attr = "{0}.PRTChannels_{1}".format(opt,
                                                                    value)

--- a/openpype/hosts/maya/api/action.py
+++ b/openpype/hosts/maya/api/action.py
@@ -4,7 +4,6 @@ from __future__ import absolute_import
 import pyblish.api
 
 from openpype.client import get_asset_by_name
-from openpype.pipeline import legacy_io
 from openpype.pipeline.publish import get_errored_instances_from_context
 
 
@@ -80,7 +79,7 @@ class GenerateUUIDsOnInvalidAction(pyblish.api.Action):
         asset_doc = instance.data.get("assetEntity")
         if not asset_doc:
             asset_name = instance.data["asset"]
-            project_name = legacy_io.active_project()
+            project_name = instance.context["projectName"]
             self.log.info((
                 "Asset is not stored on instance."
                 " Querying by name \"{}\" from project \"{}\""

--- a/openpype/hosts/maya/api/action.py
+++ b/openpype/hosts/maya/api/action.py
@@ -79,7 +79,7 @@ class GenerateUUIDsOnInvalidAction(pyblish.api.Action):
         asset_doc = instance.data.get("assetEntity")
         if not asset_doc:
             asset_name = instance.data["asset"]
-            project_name = instance.context["projectName"]
+            project_name = instance.context.data["projectName"]
             self.log.info((
                 "Asset is not stored on instance."
                 " Querying by name \"{}\" from project \"{}\""

--- a/openpype/hosts/maya/api/commands.py
+++ b/openpype/hosts/maya/api/commands.py
@@ -3,7 +3,7 @@
 from maya import cmds
 
 from openpype.client import get_asset_by_name, get_project
-from openpype.pipeline import legacy_io
+from openpype.pipeline import get_current_project_name, get_current_asset_name
 
 
 class ToolWindows:
@@ -85,8 +85,8 @@ def reset_resolution():
     resolution_height = 1080
 
     # Get resolution from asset
-    project_name = legacy_io.active_project()
-    asset_name = legacy_io.Session["AVALON_ASSET"]
+    project_name = get_current_project_name()
+    asset_name = get_current_asset_name()
     asset_doc = get_asset_by_name(project_name, asset_name)
     resolution = _resolution_from_document(asset_doc)
     # Try get resolution from project

--- a/openpype/hosts/maya/api/lib.py
+++ b/openpype/hosts/maya/api/lib.py
@@ -1454,7 +1454,7 @@ def get_container_members(container):
 
 
 # region LOOKDEV
-def list_looks(asset_id):
+def list_looks(project_name, asset_id):
     """Return all look subsets for the given asset
 
     This assumes all look subsets start with "look*" in their names.
@@ -1463,7 +1463,6 @@ def list_looks(asset_id):
     # the name associated with the asset
     # TODO this should probably look for family 'look' instead of checking
     #   subset name that can not start with family
-    project_name = get_current_project_name()
     subset_docs = get_subsets(project_name, asset_ids=[asset_id])
     return [
         subset_doc

--- a/openpype/hosts/maya/api/lib.py
+++ b/openpype/hosts/maya/api/lib.py
@@ -25,7 +25,8 @@ from openpype.client import (
 )
 from openpype.settings import get_project_settings
 from openpype.pipeline import (
-    legacy_io,
+    get_current_project_name,
+    get_current_asset_name,
     discover_loader_plugins,
     loaders_from_representation,
     get_representation_path,
@@ -1325,8 +1326,8 @@ def generate_ids(nodes, asset_id=None):
 
     if asset_id is None:
         # Get the asset ID from the database for the asset of current context
-        project_name = legacy_io.active_project()
-        asset_name = legacy_io.Session["AVALON_ASSET"]
+        project_name = get_current_project_name()
+        asset_name = get_current_asset_name()
         asset_doc = get_asset_by_name(project_name, asset_name, fields=["_id"])
         assert asset_doc, "No current asset found in Session"
         asset_id = asset_doc['_id']
@@ -1458,12 +1459,11 @@ def list_looks(asset_id):
 
     This assumes all look subsets start with "look*" in their names.
     """
-
     # # get all subsets with look leading in
     # the name associated with the asset
     # TODO this should probably look for family 'look' instead of checking
     #   subset name that can not start with family
-    project_name = legacy_io.active_project()
+    project_name = get_current_project_name()
     subset_docs = get_subsets(project_name, asset_ids=[asset_id])
     return [
         subset_doc
@@ -1485,7 +1485,7 @@ def assign_look_by_version(nodes, version_id):
         None
     """
 
-    project_name = legacy_io.active_project()
+    project_name = get_current_project_name()
 
     # Get representations of shader file and relationships
     look_representation = get_representation_by_name(
@@ -1551,7 +1551,7 @@ def assign_look(nodes, subset="lookDefault"):
         parts = pype_id.split(":", 1)
         grouped[parts[0]].append(node)
 
-    project_name = legacy_io.active_project()
+    project_name = get_current_project_name()
     subset_docs = get_subsets(
         project_name, subset_names=[subset], asset_ids=grouped.keys()
     )
@@ -2067,8 +2067,8 @@ def get_frame_range():
     """Get the current assets frame range and handles."""
 
     # Set frame start/end
-    project_name = legacy_io.active_project()
-    asset_name = legacy_io.Session["AVALON_ASSET"]
+    project_name = get_current_project_name()
+    asset_name = get_current_asset_name()
     asset = get_asset_by_name(project_name, asset_name)
 
     frame_start = asset["data"].get("frameStart")
@@ -2145,7 +2145,7 @@ def reset_scene_resolution():
         None
     """
 
-    project_name = legacy_io.active_project()
+    project_name = get_current_project_name()
     project_doc = get_project(project_name)
     project_data = project_doc["data"]
     asset_data = get_current_project_asset()["data"]
@@ -3074,7 +3074,7 @@ def iter_shader_edits(relationships, shader_nodes, nodes_by_id, label=None):
 def set_colorspace():
     """Set Colorspace from project configuration
     """
-    project_name = os.getenv("AVALON_PROJECT")
+    project_name = get_current_project_name()
     imageio = get_project_settings(project_name)["maya"]["imageio"]
 
     # Maya 2022+ introduces new OCIO v2 color management settings that

--- a/openpype/hosts/maya/api/lib.py
+++ b/openpype/hosts/maya/api/lib.py
@@ -2203,7 +2203,6 @@ def set_context_settings():
         None
     """
 
-    # Todo (Wijnand): apply renderer and resolution of project
 
     # Set project fps
     set_scene_fps(get_fps_for_current_context())

--- a/openpype/hosts/maya/api/lib_rendersettings.py
+++ b/openpype/hosts/maya/api/lib_rendersettings.py
@@ -37,7 +37,7 @@ class RenderSettings(object):
 
     def __init__(self, project_settings=None):
         if not project_settings:
-             project_settings = get_project_settings(
+            project_settings = get_project_settings(
                 get_current_project_name()
             )
         render_settings = project_settings["maya"]["RenderSettings"]

--- a/openpype/hosts/maya/api/lib_rendersettings.py
+++ b/openpype/hosts/maya/api/lib_rendersettings.py
@@ -6,13 +6,9 @@ import six
 import sys
 
 from openpype.lib import Logger
-from openpype.settings import (
-    get_project_settings,
-    get_current_project_settings
-)
+from openpype.settings import get_project_settings
 
-from openpype.pipeline import legacy_io
-from openpype.pipeline import CreatorError
+from openpype.pipeline import CreatorError, get_current_project_name
 from openpype.pipeline.context_tools import get_current_project_asset
 from openpype.hosts.maya.api.lib import reset_frame_range
 
@@ -25,21 +21,6 @@ class RenderSettings(object):
         'renderman': 'rmanGlobals.imageFileFormat',
         'redshift': 'defaultRenderGlobals.imageFilePrefix',
         'mayahardware2': 'defaultRenderGlobals.imageFilePrefix'
-    }
-
-    _image_prefixes = {
-        'vray': get_current_project_settings()["maya"]["RenderSettings"]["vray_renderer"]["image_prefix"], # noqa
-        'arnold': get_current_project_settings()["maya"]["RenderSettings"]["arnold_renderer"]["image_prefix"],  # noqa
-        'renderman': get_current_project_settings()["maya"]["RenderSettings"]["renderman_renderer"]["image_prefix"], # noqa
-        'redshift': get_current_project_settings()["maya"]["RenderSettings"]["redshift_renderer"]["image_prefix"]  # noqa
-    }
-
-    # Renderman only
-    _image_dir = {
-        'renderman': get_current_project_settings()["maya"]["RenderSettings"]["renderman_renderer"]["image_dir"], # noqa
-        'cryptomatte': get_current_project_settings()["maya"]["RenderSettings"]["renderman_renderer"]["cryptomatte_dir"], # noqa
-        'imageDisplay': get_current_project_settings()["maya"]["RenderSettings"]["renderman_renderer"]["imageDisplay_dir"], # noqa
-        "watermark": get_current_project_settings()["maya"]["RenderSettings"]["renderman_renderer"]["watermark_dir"] # noqa
     }
 
     _aov_chars = {
@@ -55,11 +36,30 @@ class RenderSettings(object):
         return cls._image_prefix_nodes[renderer]
 
     def __init__(self, project_settings=None):
-        self._project_settings = project_settings
-        if not self._project_settings:
-            self._project_settings = get_project_settings(
-                legacy_io.Session["AVALON_PROJECT"]
+        if not project_settings:
+             project_settings = get_project_settings(
+                get_current_project_name()
             )
+        render_settings = project_settings["maya"]["RenderSettings"]
+        image_prefixes = {
+            "vray": render_settings["vray_renderer"]["image_prefix"],
+            "arnold": render_settings["arnold_renderer"]["image_prefix"],
+            "renderman": render_settings["renderman_renderer"]["image_prefix"],
+            "redshift": render_settings["redshift_renderer"]["image_prefix"]
+        }
+
+        # TODO probably should be stored to more explicit attribute
+        # Renderman only
+        renderman_settings = render_settings["renderman_renderer"]
+        _image_dir = {
+            "renderman": renderman_settings["image_dir"],
+            "cryptomatte": renderman_settings["cryptomatte_dir"],
+            "imageDisplay": renderman_settings["imageDisplay_dir"],
+            "watermark": renderman_settings["watermark_dir"]
+        }
+        self._image_prefixes = image_prefixes
+        self._image_dir = _image_dir
+        self._project_settings = project_settings
 
     def set_default_renderer_settings(self, renderer=None):
         """Set basic settings based on renderer."""

--- a/openpype/hosts/maya/api/menu.py
+++ b/openpype/hosts/maya/api/menu.py
@@ -7,7 +7,11 @@ import maya.utils
 import maya.cmds as cmds
 
 from openpype.settings import get_project_settings
-from openpype.pipeline import legacy_io
+from openpype.pipeline import (
+    get_current_project_name,
+    get_current_asset_name,
+    get_current_task_name
+)
 from openpype.pipeline.workfile import BuildWorkfile
 from openpype.tools.utils import host_tools
 from openpype.hosts.maya.api import lib, lib_rendersettings
@@ -35,6 +39,13 @@ def _get_menu(menu_name=None):
     return widgets.get(menu_name)
 
 
+def get_context_label():
+    return "{}, {}".format(
+        get_current_asset_name(),
+        get_current_task_name()
+    )
+
+
 def install():
     if cmds.about(batch=True):
         log.info("Skipping openpype.menu initialization in batch mode..")
@@ -45,19 +56,15 @@ def install():
         parent_widget = get_main_window()
         cmds.menu(
             MENU_NAME,
-            label=legacy_io.Session["AVALON_LABEL"],
+            label=os.environ.get("AVALON_LABEL") or "OpenPype",
             tearOff=True,
             parent="MayaWindow"
         )
 
         # Create context menu
-        context_label = "{}, {}".format(
-            legacy_io.Session["AVALON_ASSET"],
-            legacy_io.Session["AVALON_TASK"]
-        )
         cmds.menuItem(
             "currentContext",
-            label=context_label,
+            label=get_context_label(),
             parent=MENU_NAME,
             enable=False
         )
@@ -192,7 +199,8 @@ def install():
             return
 
         # load configuration of custom menu
-        project_settings = get_project_settings(os.getenv("AVALON_PROJECT"))
+        project_name = get_current_project_name()
+        project_settings = get_project_settings(project_name)
         config = project_settings["maya"]["scriptsmenu"]["definition"]
         _menu = project_settings["maya"]["scriptsmenu"]["name"]
 
@@ -249,8 +257,5 @@ def update_menu_task_label():
         log.warning("Can't find menuItem: {}".format(object_name))
         return
 
-    label = "{}, {}".format(
-        legacy_io.Session["AVALON_ASSET"],
-        legacy_io.Session["AVALON_TASK"]
-    )
+    label = get_context_label()
     cmds.menuItem(object_name, edit=True, label=label)

--- a/openpype/hosts/maya/api/pipeline.py
+++ b/openpype/hosts/maya/api/pipeline.py
@@ -23,6 +23,9 @@ from openpype.lib import (
 )
 from openpype.pipeline import (
     legacy_io,
+    get_current_project_name,
+    get_current_asset_name,
+    get_current_task_name,
     register_loader_plugin_path,
     register_inventory_action_path,
     register_creator_plugin_path,
@@ -71,7 +74,7 @@ class MayaHost(HostBase, IWorkfileHost, ILoadHost):
         self._op_events = {}
 
     def install(self):
-        project_name = legacy_io.active_project()
+        project_name = get_current_project_name()
         project_settings = get_project_settings(project_name)
         # process path mapping
         dirmap_processor = MayaDirmap("maya", project_name, project_settings)
@@ -299,7 +302,7 @@ def _remove_workfile_lock():
 def handle_workfile_locks():
     if lib.IS_HEADLESS:
         return False
-    project_name = legacy_io.active_project()
+    project_name = get_current_project_name()
     return is_workfile_lock_enabled(MayaHost.name, project_name)
 
 
@@ -656,9 +659,9 @@ def on_task_changed():
         lib.update_content_on_context_change()
 
     msg = "  project: {}\n  asset: {}\n  task:{}".format(
-        legacy_io.active_project(),
-        legacy_io.Session["AVALON_ASSET"],
-        legacy_io.Session["AVALON_TASK"]
+        get_current_project_name(),
+        get_current_asset_name(),
+        get_current_task_name()
     )
 
     lib.show_message(
@@ -673,7 +676,7 @@ def before_workfile_open():
 
 
 def before_workfile_save(event):
-    project_name = legacy_io.active_project()
+    project_name = get_current_project_name()
     if handle_workfile_locks():
         _remove_workfile_lock()
     workdir_path = event["workdir_path"]

--- a/openpype/hosts/maya/api/setdress.py
+++ b/openpype/hosts/maya/api/setdress.py
@@ -18,13 +18,13 @@ from openpype.client import (
 )
 from openpype.pipeline import (
     schema,
-    legacy_io,
     discover_loader_plugins,
     loaders_from_representation,
     load_container,
     update_container,
     remove_container,
     get_representation_path,
+    get_current_project_name,
 )
 from openpype.hosts.maya.api.lib import (
     matrix_equals,
@@ -289,7 +289,7 @@ def update_package_version(container, version):
     """
 
     # Versioning (from `core.maya.pipeline`)
-    project_name = legacy_io.active_project()
+    project_name = get_current_project_name()
     current_representation = get_representation_by_id(
         project_name, container["representation"]
     )
@@ -332,7 +332,7 @@ def update_package(set_container, representation):
     """
 
     # Load the original package data
-    project_name = legacy_io.active_project()
+    project_name = get_current_project_name()
     current_representation = get_representation_by_id(
         project_name, set_container["representation"]
     )
@@ -382,7 +382,7 @@ def update_scene(set_container, containers, current_data, new_data, new_file):
     from openpype.hosts.maya.lib import DEFAULT_MATRIX, get_container_transforms
 
     set_namespace = set_container['namespace']
-    project_name = legacy_io.active_project()
+    project_name = get_current_project_name()
 
     # Update the setdress hierarchy alembic
     set_root = get_container_transforms(set_container, root=True)

--- a/openpype/hosts/maya/hooks/pre_copy_mel.py
+++ b/openpype/hosts/maya/hooks/pre_copy_mel.py
@@ -16,4 +16,5 @@ class PreCopyMel(PreLaunchHook):
             self.log.warning("BUG: Workdir is not filled.")
             return
 
-        create_workspace_mel(workdir, project_doc["name"])
+        project_settings = self.data["project_settings"]
+        create_workspace_mel(workdir, project_doc["name"], project_settings)

--- a/openpype/hosts/maya/hooks/pre_copy_mel.py
+++ b/openpype/hosts/maya/hooks/pre_copy_mel.py
@@ -10,10 +10,10 @@ class PreCopyMel(PreLaunchHook):
     app_groups = ["maya"]
 
     def execute(self):
-        project_name = self.launch_context.env.get("AVALON_PROJECT")
+        project_doc = self.data["project_doc"]
         workdir = self.launch_context.env.get("AVALON_WORKDIR")
         if not workdir:
             self.log.warning("BUG: Workdir is not filled.")
             return
 
-        create_workspace_mel(workdir, project_name)
+        create_workspace_mel(workdir, project_doc["name"])

--- a/openpype/hosts/maya/lib.py
+++ b/openpype/hosts/maya/lib.py
@@ -12,8 +12,8 @@ def create_workspace_mel(workdir, project_name, project_settings=None):
         os.makedirs(workdir)
 
     if not project_settings:
-        project_setting = get_project_settings(project_name)
-    mel_script = project_setting["maya"].get("mel_workspace")
+        project_settings = get_project_settings(project_name)
+    mel_script = project_settings["maya"].get("mel_workspace")
 
     # Skip if mel script in settings is empty
     if not mel_script:

--- a/openpype/hosts/maya/lib.py
+++ b/openpype/hosts/maya/lib.py
@@ -3,7 +3,7 @@ from openpype.settings import get_project_settings
 from openpype.lib import Logger
 
 
-def create_workspace_mel(workdir, project_name):
+def create_workspace_mel(workdir, project_name, project_settings=None):
     dst_filepath = os.path.join(workdir, "workspace.mel")
     if os.path.exists(dst_filepath):
         return
@@ -11,7 +11,8 @@ def create_workspace_mel(workdir, project_name):
     if not os.path.exists(workdir):
         os.makedirs(workdir)
 
-    project_setting = get_project_settings(project_name)
+    if not project_settings:
+        project_setting = get_project_settings(project_name)
     mel_script = project_setting["maya"].get("mel_workspace")
 
     # Skip if mel script in settings is empty

--- a/openpype/hosts/maya/plugins/create/create_render.py
+++ b/openpype/hosts/maya/plugins/create/create_render.py
@@ -15,7 +15,7 @@ from openpype.settings import (
 )
 from openpype.lib import requests_get
 from openpype.modules import ModulesManager
-from openpype.pipeline import legacy_io
+from openpype.pipeline import get_current_project_name
 from openpype.hosts.maya.api import (
     lib,
     lib_rendersettings,
@@ -76,7 +76,7 @@ class CreateRender(plugin.Creator):
 
         # Defaults
         self._project_settings = get_project_settings(
-            legacy_io.Session["AVALON_PROJECT"])
+            get_current_project_name())
         if self._project_settings["maya"]["RenderSettings"]["apply_render_settings"]: # noqa
             lib_rendersettings.RenderSettings().set_default_renderer_settings()
 

--- a/openpype/hosts/maya/plugins/create/create_rendersetup.py
+++ b/openpype/hosts/maya/plugins/create/create_rendersetup.py
@@ -1,8 +1,9 @@
+from maya import cmds
+from openpype.pipeline import get_current_project_name
 from openpype.hosts.maya.api import (
     lib,
     plugin
 )
-from maya import cmds
 
 
 class CreateRenderSetup(plugin.Creator):
@@ -30,7 +31,7 @@ class CreateRenderSetup(plugin.Creator):
 
         # from pype.api import get_project_settings
         # import maya.app.renderSetup.model.renderSetup as renderSetup
-        # settings = get_project_settings(os.environ['AVALON_PROJECT'])
+        # settings = get_project_settings(get_current_project_name())
         # layer = settings['maya']['create']['renderSetup']["layer"]
 
         # rs = renderSetup.instance()

--- a/openpype/hosts/maya/plugins/create/create_rendersetup.py
+++ b/openpype/hosts/maya/plugins/create/create_rendersetup.py
@@ -1,5 +1,4 @@
 from maya import cmds
-from openpype.pipeline import get_current_project_name
 from openpype.hosts.maya.api import (
     lib,
     plugin

--- a/openpype/hosts/maya/plugins/create/create_unreal_skeletalmesh.py
+++ b/openpype/hosts/maya/plugins/create/create_unreal_skeletalmesh.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 """Creator for Unreal Skeletal Meshes."""
 from openpype.hosts.maya.api import plugin, lib
-from openpype.pipeline import legacy_io
+from openpype.pipeline import get_current_asset_name
 from maya import cmds  # noqa
 
 
@@ -26,7 +26,7 @@ class CreateUnrealSkeletalMesh(plugin.Creator):
         dynamic_data = super(CreateUnrealSkeletalMesh, cls).get_dynamic_data(
             variant, task_name, asset_id, project_name, host_name
         )
-        dynamic_data["asset"] = legacy_io.Session.get("AVALON_ASSET")
+        dynamic_data["asset"] = get_current_asset_name()
         return dynamic_data
 
     def process(self):

--- a/openpype/hosts/maya/plugins/create/create_unreal_staticmesh.py
+++ b/openpype/hosts/maya/plugins/create/create_unreal_staticmesh.py
@@ -1,8 +1,7 @@
 # -*- coding: utf-8 -*-
 """Creator for Unreal Static Meshes."""
 from openpype.hosts.maya.api import plugin, lib
-from openpype.settings import get_project_settings
-from openpype.pipeline import legacy_io
+from openpype.pipeline import get_current_asset_name
 from maya import cmds  # noqa
 
 
@@ -14,20 +13,14 @@ class CreateUnrealStaticMesh(plugin.Creator):
     icon = "cube"
     dynamic_subset_keys = ["asset"]
 
-    def __init__(self, *args, **kwargs):
-        """Constructor."""
-        super(CreateUnrealStaticMesh, self).__init__(*args, **kwargs)
-        self._project_settings = get_project_settings(
-            legacy_io.Session["AVALON_PROJECT"])
-
     @classmethod
     def get_dynamic_data(
-            cls, variant, task_name, asset_id, project_name, host_name
+        cls, variant, task_name, asset_id, project_name, host_name
     ):
         dynamic_data = super(CreateUnrealStaticMesh, cls).get_dynamic_data(
             variant, task_name, asset_id, project_name, host_name
         )
-        dynamic_data["asset"] = legacy_io.Session.get("AVALON_ASSET")
+        dynamic_data["asset"] = get_current_asset_name()
         return dynamic_data
 
     def process(self):

--- a/openpype/hosts/maya/plugins/create/create_vrayscene.py
+++ b/openpype/hosts/maya/plugins/create/create_vrayscene.py
@@ -20,7 +20,7 @@ from openpype.settings import (
 from openpype.lib import requests_get
 from openpype.pipeline import (
     CreatorError,
-    legacy_io,
+    get_current_project_name,
 )
 from openpype.modules import ModulesManager
 
@@ -48,7 +48,7 @@ class CreateVRayScene(plugin.Creator):
             self.deadline_servers = {}
             return
         self._project_settings = get_project_settings(
-            legacy_io.Session["AVALON_PROJECT"])
+            get_current_project_name())
 
         try:
             default_servers = deadline_settings["deadline_urls"]

--- a/openpype/hosts/maya/plugins/inventory/import_modelrender.py
+++ b/openpype/hosts/maya/plugins/inventory/import_modelrender.py
@@ -8,7 +8,7 @@ from openpype.client import (
 from openpype.pipeline import (
     InventoryAction,
     get_representation_context,
-    legacy_io,
+    get_current_project_name,
 )
 from openpype.hosts.maya.api.lib import (
     maintained_selection,
@@ -35,7 +35,7 @@ class ImportModelRender(InventoryAction):
     def process(self, containers):
         from maya import cmds
 
-        project_name = legacy_io.active_project()
+        project_name = get_current_project_name()
         for container in containers:
             con_name = container["objectName"]
             nodes = []
@@ -68,7 +68,7 @@ class ImportModelRender(InventoryAction):
 
         from maya import cmds
 
-        project_name = legacy_io.active_project()
+        project_name = get_current_project_name()
         repre_docs = get_representations(
             project_name, version_ids=[version_id], fields=["_id", "name"]
         )

--- a/openpype/hosts/maya/plugins/load/load_audio.py
+++ b/openpype/hosts/maya/plugins/load/load_audio.py
@@ -6,7 +6,7 @@ from openpype.client import (
     get_version_by_id,
 )
 from openpype.pipeline import (
-    legacy_io,
+    get_current_project_name,
     load,
     get_representation_path,
 )
@@ -70,7 +70,7 @@ class AudioLoader(load.LoaderPlugin):
         )
 
         # Set frame range.
-        project_name = legacy_io.active_project()
+        project_name = get_current_project_name()
         version = get_version_by_id(
             project_name, representation["parent"], fields=["parent"]
         )

--- a/openpype/hosts/maya/plugins/load/load_gpucache.py
+++ b/openpype/hosts/maya/plugins/load/load_gpucache.py
@@ -37,7 +37,8 @@ class GpuCacheLoader(load.LoaderPlugin):
         label = "{}:{}".format(namespace, name)
         root = cmds.group(name=label, empty=True)
 
-        settings = get_project_settings(os.environ['AVALON_PROJECT'])
+        project_name = context["project"]["name"]
+        settings = get_project_settings(project_name)
         colors = settings['maya']['load']['colors']
         c = colors.get('model')
         if c is not None:

--- a/openpype/hosts/maya/plugins/load/load_image.py
+++ b/openpype/hosts/maya/plugins/load/load_image.py
@@ -4,7 +4,8 @@ import copy
 from openpype.lib import EnumDef
 from openpype.pipeline import (
     load,
-    get_representation_context
+    get_representation_context,
+    get_current_host_name,
 )
 from openpype.pipeline.load.utils import get_representation_path_from_context
 from openpype.pipeline.colorspace import (
@@ -266,7 +267,7 @@ class FileNodeLoader(load.LoaderPlugin):
 
         # Assume colorspace from filepath based on project settings
         project_name = context["project"]["name"]
-        host_name = os.environ.get("AVALON_APP")
+        host_name = get_current_host_name()
         project_settings = get_project_settings(project_name)
 
         config_data = get_imageio_config(

--- a/openpype/hosts/maya/plugins/load/load_image_plane.py
+++ b/openpype/hosts/maya/plugins/load/load_image_plane.py
@@ -6,9 +6,9 @@ from openpype.client import (
     get_version_by_id,
 )
 from openpype.pipeline import (
-    legacy_io,
     load,
-    get_representation_path
+    get_representation_path,
+    get_current_project_name,
 )
 from openpype.hosts.maya.api.pipeline import containerise
 from openpype.hosts.maya.api.lib import unique_namespace
@@ -214,7 +214,7 @@ class ImagePlaneLoader(load.LoaderPlugin):
         )
 
         # Set frame range.
-        project_name = legacy_io.active_project()
+        project_name = get_current_project_name()
         version = get_version_by_id(
             project_name, representation["parent"], fields=["parent"]
         )

--- a/openpype/hosts/maya/plugins/load/load_look.py
+++ b/openpype/hosts/maya/plugins/load/load_look.py
@@ -7,7 +7,7 @@ from qtpy import QtWidgets
 
 from openpype.client import get_representation_by_name
 from openpype.pipeline import (
-    legacy_io,
+    get_current_project_name,
     get_representation_path,
 )
 import openpype.hosts.maya.api.plugin
@@ -78,7 +78,7 @@ class LookLoader(openpype.hosts.maya.api.plugin.ReferenceLoader):
         shader_nodes = cmds.ls(members, type='shadingEngine')
         nodes = set(self._get_nodes_with_shader(shader_nodes))
 
-        project_name = legacy_io.active_project()
+        project_name = get_current_project_name()
         json_representation = get_representation_by_name(
             project_name, "json", representation["parent"]
         )

--- a/openpype/hosts/maya/plugins/load/load_redshift_proxy.py
+++ b/openpype/hosts/maya/plugins/load/load_redshift_proxy.py
@@ -57,7 +57,8 @@ class RedshiftProxyLoader(load.LoaderPlugin):
             return
 
         # colour the group node
-        settings = get_project_settings(os.environ['AVALON_PROJECT'])
+        project_name = context["project"]["name"]
+        settings = get_project_settings(project_name)
         colors = settings['maya']['load']['colors']
         c = colors.get(family)
         if c is not None:

--- a/openpype/hosts/maya/plugins/load/load_reference.py
+++ b/openpype/hosts/maya/plugins/load/load_reference.py
@@ -4,7 +4,7 @@ import contextlib
 from maya import cmds
 
 from openpype.settings import get_project_settings
-from openpype.pipeline import legacy_io
+from openpype.pipeline import get_current_asset_name
 from openpype.pipeline.create import (
     legacy_create,
     get_legacy_creator_by_name,
@@ -125,6 +125,8 @@ class ReferenceLoader(openpype.hosts.maya.api.plugin.ReferenceLoader):
         except ValueError:
             family = "model"
 
+        project_name = context["project"]["name"]
+
         group_name = "{}:_GRP".format(namespace)
         # True by default to keep legacy behaviours
         attach_to_root = options.get("attach_to_root", True)
@@ -132,8 +134,7 @@ class ReferenceLoader(openpype.hosts.maya.api.plugin.ReferenceLoader):
         path = self.filepath_from_context(context)
         with maintained_selection():
             cmds.loadPlugin("AbcImport.mll", quiet=True)
-            file_url = self.prepare_root_value(path,
-                                               context["project"]["name"])
+            file_url = self.prepare_root_value(path, project_name)
             nodes = cmds.file(file_url,
                               namespace=namespace,
                               sharedReferenceFile=False,
@@ -179,7 +180,7 @@ class ReferenceLoader(openpype.hosts.maya.api.plugin.ReferenceLoader):
 
                 cmds.setAttr(group_name + ".displayHandle", 1)
 
-                settings = get_project_settings(os.environ['AVALON_PROJECT'])
+                settings = get_project_settings(project_name)
                 colors = settings['maya']['load']['colors']
                 c = colors.get(family)
                 if c is not None:
@@ -240,7 +241,7 @@ class ReferenceLoader(openpype.hosts.maya.api.plugin.ReferenceLoader):
         roots = cmds.ls(self[:], assemblies=True, long=True)
         assert roots, "No root nodes in rig, this is a bug."
 
-        asset = legacy_io.Session["AVALON_ASSET"]
+        asset = get_current_asset_name()
         dependency = str(context["representation"]["_id"])
 
         self.log.info("Creating subset: {}".format(namespace))

--- a/openpype/hosts/maya/plugins/load/load_vdb_to_arnold.py
+++ b/openpype/hosts/maya/plugins/load/load_vdb_to_arnold.py
@@ -48,7 +48,8 @@ class LoadVDBtoArnold(load.LoaderPlugin):
         label = "{}:{}".format(namespace, name)
         root = cmds.group(name=label, empty=True)
 
-        settings = get_project_settings(os.environ['AVALON_PROJECT'])
+        project_name = context["project"]["name"]
+        settings = get_project_settings(project_name)
         colors = settings['maya']['load']['colors']
 
         c = colors.get(family)

--- a/openpype/hosts/maya/plugins/load/load_vdb_to_redshift.py
+++ b/openpype/hosts/maya/plugins/load/load_vdb_to_redshift.py
@@ -67,7 +67,8 @@ class LoadVDBtoRedShift(load.LoaderPlugin):
         label = "{}:{}".format(namespace, name)
         root = cmds.createNode("transform", name=label)
 
-        settings = get_project_settings(os.environ['AVALON_PROJECT'])
+        project_name = context["project"]["name"]
+        settings = get_project_settings(project_name)
         colors = settings['maya']['load']['colors']
 
         c = colors.get(family)

--- a/openpype/hosts/maya/plugins/load/load_vdb_to_vray.py
+++ b/openpype/hosts/maya/plugins/load/load_vdb_to_vray.py
@@ -127,7 +127,8 @@ class LoadVDBtoVRay(load.LoaderPlugin):
         label = "{}:{}_VDB".format(namespace, name)
         root = cmds.group(name=label, empty=True)
 
-        settings = get_project_settings(os.environ['AVALON_PROJECT'])
+        project_name = context["project"]["name"]
+        settings = get_project_settings(project_name)
         colors = settings['maya']['load']['colors']
 
         c = colors.get(family)

--- a/openpype/hosts/maya/plugins/load/load_vrayproxy.py
+++ b/openpype/hosts/maya/plugins/load/load_vrayproxy.py
@@ -12,9 +12,9 @@ import maya.cmds as cmds
 from openpype.client import get_representation_by_name
 from openpype.settings import get_project_settings
 from openpype.pipeline import (
-    legacy_io,
     load,
-    get_representation_path
+    get_current_project_name,
+    get_representation_path,
 )
 from openpype.hosts.maya.api.lib import (
     maintained_selection,
@@ -78,7 +78,8 @@ class VRayProxyLoader(load.LoaderPlugin):
             return
 
         # colour the group node
-        settings = get_project_settings(os.environ['AVALON_PROJECT'])
+        project_name = context["project"]["name"]
+        settings = get_project_settings(project_name)
         colors = settings['maya']['load']['colors']
         c = colors.get(family)
         if c is not None:
@@ -187,7 +188,7 @@ class VRayProxyLoader(load.LoaderPlugin):
         """
         self.log.debug(
             "Looking for abc in published representations of this version.")
-        project_name = legacy_io.active_project()
+        project_name = get_current_project_name()
         abc_rep = get_representation_by_name(project_name, "abc", version_id)
         if abc_rep:
             self.log.debug("Found, we'll link alembic to vray proxy.")

--- a/openpype/hosts/maya/plugins/load/load_vrayscene.py
+++ b/openpype/hosts/maya/plugins/load/load_vrayscene.py
@@ -56,7 +56,8 @@ class VRaySceneLoader(load.LoaderPlugin):
             return
 
         # colour the group node
-        settings = get_project_settings(os.environ['AVALON_PROJECT'])
+        project_name = context["project"]["name"]
+        settings = get_project_settings(project_name)
         colors = settings['maya']['load']['colors']
         c = colors.get(family)
         if c is not None:

--- a/openpype/hosts/maya/plugins/load/load_yeti_cache.py
+++ b/openpype/hosts/maya/plugins/load/load_yeti_cache.py
@@ -68,8 +68,9 @@ class YetiCacheLoader(load.LoaderPlugin):
 
         group_name = "{}:{}".format(namespace, name)
         group_node = cmds.group(nodes, name=group_name)
+        project_name = context["project"]["name"]
 
-        settings = get_project_settings(os.environ['AVALON_PROJECT'])
+        settings = get_project_settings(project_name)
         colors = settings['maya']['load']['colors']
 
         c = colors.get(family)

--- a/openpype/hosts/maya/plugins/publish/collect_render.py
+++ b/openpype/hosts/maya/plugins/publish/collect_render.py
@@ -50,7 +50,6 @@ import maya.app.renderSetup.model.renderSetup as renderSetup
 import pyblish.api
 
 from openpype.lib import get_formatted_current_time
-from openpype.pipeline import legacy_io
 from openpype.hosts.maya.api.lib_renderproducts import get as get_layer_render_products  # noqa: E501
 from openpype.hosts.maya.api import lib
 
@@ -92,7 +91,7 @@ class CollectMayaRender(pyblish.api.ContextPlugin):
         render_globals = render_instance
         collected_render_layers = render_instance.data["setMembers"]
         filepath = context.data["currentFile"].replace("\\", "/")
-        asset = legacy_io.Session["AVALON_ASSET"]
+        asset = context.data["asset"]
         workspace = context.data["workspaceDir"]
 
         # Retrieve render setup layers

--- a/openpype/hosts/maya/plugins/publish/collect_review.py
+++ b/openpype/hosts/maya/plugins/publish/collect_review.py
@@ -4,7 +4,6 @@ import pymel.core as pm
 import pyblish.api
 
 from openpype.client import get_subset_by_name
-from openpype.pipeline import legacy_io
 from openpype.hosts.maya.api.lib import get_attribute_input
 
 
@@ -22,7 +21,8 @@ class CollectReview(pyblish.api.InstancePlugin):
 
         self.log.debug('instance: {}'.format(instance))
 
-        task = legacy_io.Session["AVALON_TASK"]
+        project_name = instance.context.data["projectName"]
+        task = instance.context.data["task"]
 
         # Get panel.
         instance.data["panel"] = cmds.playblast(
@@ -42,7 +42,6 @@ class CollectReview(pyblish.api.InstancePlugin):
 
         objectset = instance.context.data['objectsets']
 
-        reviewable_subset = None
         reviewable_subset = list(set(members) & set(objectset))
         if reviewable_subset:
             assert len(reviewable_subset) <= 1, "Multiple subsets for review"
@@ -90,7 +89,6 @@ class CollectReview(pyblish.api.InstancePlugin):
         else:
             legacy_subset_name = task + 'Review'
             asset_doc = instance.context.data['assetEntity']
-            project_name = legacy_io.active_project()
             subset_doc = get_subset_by_name(
                 project_name,
                 legacy_subset_name,

--- a/openpype/hosts/maya/plugins/publish/collect_vrayscene.py
+++ b/openpype/hosts/maya/plugins/publish/collect_vrayscene.py
@@ -7,7 +7,6 @@ from maya import cmds
 
 import pyblish.api
 
-from openpype.pipeline import legacy_io
 from openpype.lib import get_formatted_current_time
 from openpype.hosts.maya.api import lib
 
@@ -118,7 +117,7 @@ class CollectVrayScene(pyblish.api.InstancePlugin):
                 # instance subset
                 "family": "vrayscene_layer",
                 "families": ["vrayscene_layer"],
-                "asset": legacy_io.Session["AVALON_ASSET"],
+                "asset": context.data["asset"],
                 "time": get_formatted_current_time(),
                 "author": context.data["user"],
                 # Add source to allow tracing back to the scene from

--- a/openpype/hosts/maya/plugins/publish/collect_workfile.py
+++ b/openpype/hosts/maya/plugins/publish/collect_workfile.py
@@ -2,7 +2,6 @@ import os
 import pyblish.api
 
 from maya import cmds
-from openpype.pipeline import legacy_io
 
 
 class CollectWorkfile(pyblish.api.ContextPlugin):
@@ -20,7 +19,7 @@ class CollectWorkfile(pyblish.api.ContextPlugin):
         folder, file = os.path.split(current_file)
         filename, ext = os.path.splitext(file)
 
-        task = legacy_io.Session["AVALON_TASK"]
+        task = context.data["task"]
 
         data = {}
 
@@ -30,7 +29,7 @@ class CollectWorkfile(pyblish.api.ContextPlugin):
 
         data.update({
             "subset": subset,
-            "asset": os.getenv("AVALON_ASSET", None),
+            "asset": context.data["asset"],
             "label": subset,
             "publish": True,
             "family": 'workfile',

--- a/openpype/hosts/maya/plugins/publish/extract_layout.py
+++ b/openpype/hosts/maya/plugins/publish/extract_layout.py
@@ -6,7 +6,7 @@ from maya import cmds
 from maya.api import OpenMaya as om
 
 from openpype.client import get_representation_by_id
-from openpype.pipeline import legacy_io, publish
+from openpype.pipeline import publish
 
 
 class ExtractLayout(publish.Extractor):
@@ -30,7 +30,7 @@ class ExtractLayout(publish.Extractor):
 
         json_data = []
         # TODO representation queries can be refactored to be faster
-        project_name = legacy_io.active_project()
+        project_name = instance.context.data["projectName"]
 
         for asset in cmds.sets(str(instance), query=True):
             # Find the container

--- a/openpype/hosts/maya/plugins/publish/submit_maya_muster.py
+++ b/openpype/hosts/maya/plugins/publish/submit_maya_muster.py
@@ -265,6 +265,8 @@ class MayaSubmitMuster(pyblish.api.InstancePlugin):
 
         context = instance.context
         workspace = context.data["workspaceDir"]
+        project_name = context.data["projectName"]
+        asset_name = context.data["asset"]
 
         filepath = None
 
@@ -371,8 +373,8 @@ class MayaSubmitMuster(pyblish.api.InstancePlugin):
                     "jobId": -1,
                     "startOn": 0,
                     "parentId": -1,
-                    "project": os.environ.get('AVALON_PROJECT') or scene,
-                    "shot": os.environ.get('AVALON_ASSET') or scene,
+                    "project": project_name or scene,
+                    "shot": asset_name or scene,
                     "camera": instance.data.get("cameras")[0],
                     "dependMode": 0,
                     "packetSize": 4,

--- a/openpype/hosts/maya/plugins/publish/validate_model_name.py
+++ b/openpype/hosts/maya/plugins/publish/validate_model_name.py
@@ -7,7 +7,6 @@ import platform
 from maya import cmds
 
 import pyblish.api
-from openpype.pipeline import get_current_project_name, get_current_asset_name
 from openpype.pipeline.publish import ValidateContentsOrder
 import openpype.hosts.maya.api.action
 from openpype.hosts.maya.api.shader_definition_editor import (
@@ -71,7 +70,13 @@ class ValidateModelName(pyblish.api.InstancePlugin):
             invalid.append(top_group)
         else:
             if "asset" in r.groupindex:
-                if m.group("asset") != get_current_asset_name():
+                # TODO change to only 'instance.data["asset"]' when legacy
+                #   create is not used in Maya
+                asset_name = (
+                    instance.data.get("asset")
+                    or instance.context.data["asset"]
+                )
+                if m.group("asset") != asset_name:
                     cls.log.error("Invalid asset name in top level group.")
                     return top_group
             if "subset" in r.groupindex:
@@ -79,7 +84,7 @@ class ValidateModelName(pyblish.api.InstancePlugin):
                     cls.log.error("Invalid subset name in top level group.")
                     return top_group
             if "project" in r.groupindex:
-                if m.group("project") != get_current_project_name():
+                if m.group("project") != instance.context.data["projectName"]:
                     cls.log.error("Invalid project name in top level group.")
                     return top_group
 

--- a/openpype/hosts/maya/plugins/publish/validate_model_name.py
+++ b/openpype/hosts/maya/plugins/publish/validate_model_name.py
@@ -70,7 +70,6 @@ class ValidateModelName(pyblish.api.InstancePlugin):
             cls.log.error("name doesn't match regex {}".format(regex))
             invalid.append(top_group)
         else:
-            , get_current_asset_name
             if "asset" in r.groupindex:
                 if m.group("asset") != get_current_asset_name():
                     cls.log.error("Invalid asset name in top level group.")

--- a/openpype/hosts/maya/plugins/publish/validate_model_name.py
+++ b/openpype/hosts/maya/plugins/publish/validate_model_name.py
@@ -7,7 +7,7 @@ import platform
 from maya import cmds
 
 import pyblish.api
-from openpype.pipeline import legacy_io
+from openpype.pipeline import get_current_project_name, get_current_asset_name
 from openpype.pipeline.publish import ValidateContentsOrder
 import openpype.hosts.maya.api.action
 from openpype.hosts.maya.api.shader_definition_editor import (
@@ -70,8 +70,9 @@ class ValidateModelName(pyblish.api.InstancePlugin):
             cls.log.error("name doesn't match regex {}".format(regex))
             invalid.append(top_group)
         else:
+            , get_current_asset_name
             if "asset" in r.groupindex:
-                if m.group("asset") != legacy_io.Session["AVALON_ASSET"]:
+                if m.group("asset") != get_current_asset_name():
                     cls.log.error("Invalid asset name in top level group.")
                     return top_group
             if "subset" in r.groupindex:
@@ -79,7 +80,7 @@ class ValidateModelName(pyblish.api.InstancePlugin):
                     cls.log.error("Invalid subset name in top level group.")
                     return top_group
             if "project" in r.groupindex:
-                if m.group("project") != legacy_io.Session["AVALON_PROJECT"]:
+                if m.group("project") != get_current_project_name():
                     cls.log.error("Invalid project name in top level group.")
                     return top_group
 

--- a/openpype/hosts/maya/plugins/publish/validate_node_ids_in_database.py
+++ b/openpype/hosts/maya/plugins/publish/validate_node_ids_in_database.py
@@ -1,7 +1,6 @@
 import pyblish.api
 
 from openpype.client import get_assets
-from openpype.pipeline import legacy_io
 from openpype.pipeline.publish import ValidatePipelineOrder
 import openpype.hosts.maya.api.action
 from openpype.hosts.maya.api import lib
@@ -43,7 +42,7 @@ class ValidateNodeIdsInDatabase(pyblish.api.InstancePlugin):
                                                       nodes=instance[:])
 
         # check ids against database ids
-        project_name = legacy_io.active_project()
+        project_name = instance.context.data["projectName"]
         asset_docs = get_assets(project_name, fields=["_id"])
         db_asset_ids = {
             str(asset_doc["_id"])

--- a/openpype/hosts/maya/plugins/publish/validate_renderlayer_aovs.py
+++ b/openpype/hosts/maya/plugins/publish/validate_renderlayer_aovs.py
@@ -2,7 +2,6 @@ import pyblish.api
 
 from openpype.client import get_subset_by_name
 import openpype.hosts.maya.api.action
-from openpype.pipeline import legacy_io
 
 
 class ValidateRenderLayerAOVs(pyblish.api.InstancePlugin):
@@ -35,7 +34,7 @@ class ValidateRenderLayerAOVs(pyblish.api.InstancePlugin):
     def get_invalid(self, instance):
         invalid = []
 
-        project_name = legacy_io.active_project()
+        project_name = instance.context.data["projectName"]
         asset_doc = instance.data["assetEntity"]
         render_passes = instance.data.get("renderPasses", [])
         for render_pass in render_passes:

--- a/openpype/hosts/maya/plugins/publish/validate_unreal_staticmesh_naming.py
+++ b/openpype/hosts/maya/plugins/publish/validate_unreal_staticmesh_naming.py
@@ -5,8 +5,6 @@ import re
 import pyblish.api
 
 import openpype.hosts.maya.api.action
-from openpype.pipeline import legacy_io
-from openpype.settings import get_project_settings
 from openpype.pipeline.publish import ValidateContentsOrder
 
 
@@ -64,9 +62,7 @@ class ValidateUnrealStaticMeshName(pyblish.api.InstancePlugin):
 
         invalid = []
 
-        project_settings = get_project_settings(
-            legacy_io.Session["AVALON_PROJECT"]
-        )
+        project_settings = instance.context.data["project_settings"]
         collision_prefixes = (
             project_settings
             ["maya"]

--- a/openpype/hosts/maya/startup/userSetup.py
+++ b/openpype/hosts/maya/startup/userSetup.py
@@ -2,7 +2,7 @@ import os
 from functools import partial
 
 from openpype.settings import get_project_settings
-from openpype.pipeline import install_host
+from openpype.pipeline import install_host, get_current_project_name
 from openpype.hosts.maya.api import MayaHost
 
 from maya import cmds
@@ -29,18 +29,19 @@ if bool(int(os.environ.get(key, "0"))):
 
 
 # Build a shelf.
-settings = get_project_settings(os.environ['AVALON_PROJECT'])
+project_name = get_current_project_name()
+settings = get_project_settings(project_name)
 shelf_preset = settings['maya'].get('project_shelf')
 
 if shelf_preset:
-    project = os.environ["AVALON_PROJECT"]
-
-    icon_path = os.path.join(os.environ['OPENPYPE_PROJECT_SCRIPTS'],
-                             project, "icons")
+    icon_path = os.path.join(
+        os.environ['OPENPYPE_PROJECT_SCRIPTS'],
+        project_name,
+        "icons")
     icon_path = os.path.abspath(icon_path)
 
     for i in shelf_preset['imports']:
-        import_string = "from {} import {}".format(project, i)
+        import_string = "from {} import {}".format(project_name, i)
         print(import_string)
         exec(import_string)
 

--- a/openpype/hosts/maya/tools/mayalookassigner/app.py
+++ b/openpype/hosts/maya/tools/mayalookassigner/app.py
@@ -4,9 +4,9 @@ import logging
 
 from qtpy import QtWidgets, QtCore
 
-from openpype.client import get_last_version_by_subset_id
 from openpype import style
-from openpype.pipeline import legacy_io
+from openpype.client import get_last_version_by_subset_id
+from openpype.pipeline import get_current_project_name
 from openpype.tools.utils.lib import qt_app_context
 from openpype.hosts.maya.api.lib import assign_look_by_version
 
@@ -212,7 +212,7 @@ class MayaLookAssignerWindow(QtWidgets.QWidget):
         selection = self.assign_selected.isChecked()
         asset_nodes = self.asset_outliner.get_nodes(selection=selection)
 
-        project_name = legacy_io.active_project()
+        project_name = get_current_project_name()
         start = time.time()
         for i, (asset, item) in enumerate(asset_nodes.items()):
 

--- a/openpype/hosts/maya/tools/mayalookassigner/commands.py
+++ b/openpype/hosts/maya/tools/mayalookassigner/commands.py
@@ -1,14 +1,14 @@
-from collections import defaultdict
-import logging
 import os
+import logging
+from collections import defaultdict
 
 import maya.cmds as cmds
 
-from openpype.client import get_asset_by_id
+from openpype.client import get_assets, get_asset_by_id
 from openpype.pipeline import (
-    legacy_io,
     remove_container,
     registered_host,
+    get_current_project_name,
 )
 from openpype.hosts.maya.api import lib
 
@@ -145,18 +145,24 @@ def create_items_from_nodes(nodes):
         log.warning("No id hashes")
         return asset_view_items
 
-    project_name = legacy_io.active_project()
-    for _id, id_nodes in id_hashes.items():
-        asset = get_asset_by_id(project_name, _id, fields=["name"])
+    project_name = get_current_project_name()
+    asset_ids = set(id_hashes.keys())
+    asset_docs = get_assets(project_name, asset_ids, fields=["name"])
+    asset_docs_by_id = {
+        str(asset_doc["_id"]): asset_doc
+        for asset_doc in asset_docs
+    }
 
+    for asset_id, id_nodes in id_hashes.items():
+        asset_doc = asset_docs_by_id.get(asset_id)
         # Skip if asset id is not found
-        if not asset:
+        if not asset_doc:
             log.warning("Id not found in the database, skipping '%s'." % _id)
             log.warning("Nodes: %s" % id_nodes)
             continue
 
         # Collect available look subsets for this asset
-        looks = lib.list_looks(asset["_id"])
+        looks = lib.list_looks(asset_doc["_id"])
 
         # Collect namespaces the asset is found in
         namespaces = set()
@@ -165,8 +171,8 @@ def create_items_from_nodes(nodes):
             namespaces.add(namespace)
 
         asset_view_items.append({
-            "label": asset["name"],
-            "asset": asset,
+            "label": asset_doc["name"],
+            "asset": asset_doc,
             "looks": looks,
             "namespaces": namespaces
         })

--- a/openpype/hosts/maya/tools/mayalookassigner/commands.py
+++ b/openpype/hosts/maya/tools/mayalookassigner/commands.py
@@ -162,7 +162,7 @@ def create_items_from_nodes(nodes):
             continue
 
         # Collect available look subsets for this asset
-        looks = lib.list_looks(asset_doc["_id"])
+        looks = lib.list_looks(project_name, asset_doc["_id"])
 
         # Collect namespaces the asset is found in
         namespaces = set()

--- a/openpype/hosts/maya/tools/mayalookassigner/commands.py
+++ b/openpype/hosts/maya/tools/mayalookassigner/commands.py
@@ -4,7 +4,7 @@ from collections import defaultdict
 
 import maya.cmds as cmds
 
-from openpype.client import get_assets, get_asset_by_id
+from openpype.client import get_assets
 from openpype.pipeline import (
     remove_container,
     registered_host,

--- a/openpype/hosts/maya/tools/mayalookassigner/vray_proxies.py
+++ b/openpype/hosts/maya/tools/mayalookassigner/vray_proxies.py
@@ -15,12 +15,12 @@ from openpype.client import (
     get_last_version_by_subset_name,
 )
 from openpype.pipeline import (
-    legacy_io,
     load_container,
     loaders_from_representation,
     discover_loader_plugins,
     get_representation_path,
     registered_host,
+    get_current_project_name,
 )
 from openpype.hosts.maya.api import lib
 
@@ -160,7 +160,7 @@ def get_look_relationships(version_id):
         dict: Dictionary of relations.
     """
 
-    project_name = legacy_io.active_project()
+    project_name = get_current_project_name()
     json_representation = get_representation_by_name(
         project_name, representation_name="json", version_id=version_id
     )
@@ -187,7 +187,7 @@ def load_look(version_id):
 
     """
 
-    project_name = legacy_io.active_project()
+    project_name = get_current_project_name()
     # Get representations of shader file and relationships
     look_representation = get_representation_by_name(
         project_name, representation_name="ma", version_id=version_id
@@ -247,7 +247,7 @@ def vrayproxy_assign_look(vrayproxy, subset="lookDefault"):
         asset_id = node_id.split(":", 1)[0]
         node_ids_by_asset_id[asset_id].add(node_id)
 
-    project_name = legacy_io.active_project()
+    project_name = get_current_project_name()
     for asset_id, node_ids in node_ids_by_asset_id.items():
 
         # Get latest look version

--- a/openpype/hosts/nuke/api/lib.py
+++ b/openpype/hosts/nuke/api/lib.py
@@ -2293,7 +2293,6 @@ class WorkfileSettings(object):
         """Set resolution to project resolution."""
         log.info("Resetting resolution")
         project_name = get_current_project_name()
-        project = get_project(project_name)
         asset_name = get_current_asset_name()
         asset = get_asset_by_name(project_name, asset_name)
         asset_data = asset.get('data', {})
@@ -2308,7 +2307,7 @@ class WorkfileSettings(object):
             "pixel_aspect": asset_data.get(
                 'pixelAspect',
                 asset_data.get('pixel_aspect', 1)),
-            "name": project["name"]
+            "name": project_name
         }
 
         if any(x for x in data.values() if x is None):

--- a/openpype/hosts/nuke/api/lib.py
+++ b/openpype/hosts/nuke/api/lib.py
@@ -37,8 +37,10 @@ from openpype.modules import ModulesManager
 from openpype.pipeline.template_data import get_template_data_with_names
 from openpype.pipeline import (
     discover_legacy_creator_plugins,
-    legacy_io,
     Anatomy,
+    get_current_host_name,
+    get_current_project_name,
+    get_current_asset_name,
 )
 from openpype.pipeline.context_tools import (
     get_current_project_asset,
@@ -962,7 +964,7 @@ def check_inventory_versions():
     if not repre_ids:
         return
 
-    project_name = legacy_io.active_project()
+    project_name = get_current_project_name()
     # Find representations based on found containers
     repre_docs = get_representations(
         project_name,
@@ -1138,7 +1140,7 @@ def format_anatomy(data):
     project_name = anatomy.project_name
     asset_name = data["asset"]
     task_name = data["task"]
-    host_name = os.environ["AVALON_APP"]
+    host_name = get_current_host_name()
     context_data = get_template_data_with_names(
         project_name, asset_name, task_name, host_name
     )
@@ -1468,7 +1470,7 @@ def create_write_node_legacy(
         if knob["name"] == "file_type":
             representation = knob["value"]
 
-    host_name = os.environ.get("AVALON_APP")
+    host_name = get_current_host_name()
     try:
         data.update({
             "app": host_name,
@@ -1921,13 +1923,13 @@ class WorkfileSettings(object):
     def __init__(self, root_node=None, nodes=None, **kwargs):
         project_doc = kwargs.get("project")
         if project_doc is None:
-            project_name = legacy_io.active_project()
+            project_name = get_current_project_name()
             project_doc = get_project(project_name)
 
         Context._project_doc = project_doc
         self._asset = (
             kwargs.get("asset_name")
-            or legacy_io.Session["AVALON_ASSET"]
+            or get_current_asset_name()
         )
         self._asset_entity = get_current_project_asset(self._asset)
         self._root_node = root_node or nuke.root()
@@ -2023,7 +2025,7 @@ class WorkfileSettings(object):
 
             # get resolved ocio config path
             config_data = get_imageio_config(
-                legacy_io.active_project(), "nuke"
+                get_current_project_name(), "nuke"
             )
 
         # first set OCIO
@@ -2290,9 +2292,9 @@ class WorkfileSettings(object):
     def reset_resolution(self):
         """Set resolution to project resolution."""
         log.info("Resetting resolution")
-        project_name = legacy_io.active_project()
+        project_name = get_current_project_name()
         project = get_project(project_name)
-        asset_name = legacy_io.Session["AVALON_ASSET"]
+        asset_name = get_current_asset_name()
         asset = get_asset_by_name(project_name, asset_name)
         asset_data = asset.get('data', {})
 
@@ -2369,7 +2371,7 @@ class WorkfileSettings(object):
         from .utils import set_context_favorites
 
         work_dir = os.getenv("AVALON_WORKDIR")
-        asset = os.getenv("AVALON_ASSET")
+        asset = get_current_asset_name()
         favorite_items = OrderedDict()
 
         # project
@@ -2775,7 +2777,8 @@ def add_scripts_menu():
         return
 
     # load configuration of custom menu
-    project_settings = get_project_settings(os.getenv("AVALON_PROJECT"))
+    project_name = get_current_project_name()
+    project_settings = get_project_settings(project_name)
     config = project_settings["nuke"]["scriptsmenu"]["definition"]
     _menu = project_settings["nuke"]["scriptsmenu"]["name"]
 
@@ -2793,7 +2796,8 @@ def add_scripts_menu():
 def add_scripts_gizmo():
 
     # load configuration of custom menu
-    project_settings = get_project_settings(os.getenv("AVALON_PROJECT"))
+    project_name = get_current_project_name()
+    project_settings = get_project_settings(project_name)
     platform_name = platform.system().lower()
 
     for gizmo_settings in project_settings["nuke"]["gizmo"]:

--- a/openpype/hosts/nuke/api/pipeline.py
+++ b/openpype/hosts/nuke/api/pipeline.py
@@ -209,6 +209,13 @@ def _show_workfiles():
     host_tools.show_workfiles(parent=None, on_top=False)
 
 
+def get_context_label():
+    return "{0}, {1}".format(
+        get_current_asset_name(),
+        get_current_task_name()
+    )
+
+
 def _install_menu():
     """Install Avalon menu into Nuke's main menu bar."""
 
@@ -218,10 +225,7 @@ def _install_menu():
     menu = menubar.addMenu(MENU_LABEL)
 
     if not ASSIST:
-        label = "{0}, {1}".format(
-            get_current_asset_name(),
-            get_current_task_name()
-        )
+        label = get_context_label()
         Context.context_label = label
         context_action = menu.addCommand(label)
         context_action.setEnabled(False)
@@ -327,9 +331,7 @@ def change_context_label():
     menubar = nuke.menu("Nuke")
     menu = menubar.findItem(MENU_LABEL)
 
-    label = "{0}, {1}".format(
-        get_current_asset_name(), get_current_task_name()
-    )
+    label = get_context_label()
 
     rm_item = [
         (i, item) for i, item in enumerate(menu.items())

--- a/openpype/hosts/nuke/api/pipeline.py
+++ b/openpype/hosts/nuke/api/pipeline.py
@@ -20,6 +20,8 @@ from openpype.pipeline import (
     register_creator_plugin_path,
     register_inventory_action_path,
     AVALON_CONTAINER_ID,
+    get_current_asset_name,
+    get_current_task_name,
 )
 from openpype.pipeline.workfile import BuildWorkfile
 from openpype.tools.utils import host_tools
@@ -217,7 +219,8 @@ def _install_menu():
 
     if not ASSIST:
         label = "{0}, {1}".format(
-            os.environ["AVALON_ASSET"], os.environ["AVALON_TASK"]
+            get_current_asset_name(),
+            get_current_task_name()
         )
         Context.context_label = label
         context_action = menu.addCommand(label)
@@ -325,7 +328,7 @@ def change_context_label():
     menu = menubar.findItem(MENU_LABEL)
 
     label = "{0}, {1}".format(
-        os.environ["AVALON_ASSET"], os.environ["AVALON_TASK"]
+        get_current_asset_name(), get_current_task_name()
     )
 
     rm_item = [

--- a/openpype/hosts/nuke/api/plugin.py
+++ b/openpype/hosts/nuke/api/plugin.py
@@ -19,7 +19,7 @@ from openpype.pipeline import (
     CreatorError,
     Creator as NewCreator,
     CreatedInstance,
-    legacy_io
+    get_current_task_name
 )
 from .lib import (
     INSTANCE_DATA_KNOB,
@@ -1174,7 +1174,7 @@ def convert_to_valid_instaces():
 
     from openpype.hosts.nuke.api import workio
 
-    task_name = legacy_io.Session["AVALON_TASK"]
+    task_name = get_current_task_name()
 
     # save into new workfile
     current_file = workio.current_file()

--- a/openpype/hosts/nuke/plugins/create/workfile_creator.py
+++ b/openpype/hosts/nuke/plugins/create/workfile_creator.py
@@ -3,7 +3,6 @@ from openpype.client import get_asset_by_name
 from openpype.pipeline import (
     AutoCreator,
     CreatedInstance,
-    legacy_io,
 )
 from openpype.hosts.nuke.api import (
     INSTANCE_DATA_KNOB,
@@ -27,10 +26,10 @@ class WorkfileCreator(AutoCreator):
             root_node, api.INSTANCE_DATA_KNOB
         )
 
-        project_name = legacy_io.Session["AVALON_PROJECT"]
-        asset_name = legacy_io.Session["AVALON_ASSET"]
-        task_name = legacy_io.Session["AVALON_TASK"]
-        host_name = legacy_io.Session["AVALON_APP"]
+        project_name = self.create_context.get_current_project_name()
+        asset_name = self.create_context.get_current_asset_name()
+        task_name = self.create_context.get_current_task_name()
+        host_name = self.create_context.host_name
 
         asset_doc = get_asset_by_name(project_name, asset_name)
         subset_name = self.get_subset_name(

--- a/openpype/hosts/nuke/plugins/load/load_backdrop.py
+++ b/openpype/hosts/nuke/plugins/load/load_backdrop.py
@@ -6,8 +6,8 @@ from openpype.client import (
     get_last_version_by_subset_id,
 )
 from openpype.pipeline import (
-    legacy_io,
     load,
+    get_current_project_name,
     get_representation_path,
 )
 from openpype.hosts.nuke.api.lib import (
@@ -190,7 +190,7 @@ class LoadBackdropNodes(load.LoaderPlugin):
 
         # get main variables
         # Get version from io
-        project_name = legacy_io.active_project()
+        project_name = get_current_project_name()
         version_doc = get_version_by_id(project_name, representation["parent"])
 
         # get corresponding node

--- a/openpype/hosts/nuke/plugins/load/load_camera_abc.py
+++ b/openpype/hosts/nuke/plugins/load/load_camera_abc.py
@@ -5,8 +5,8 @@ from openpype.client import (
     get_last_version_by_subset_id
 )
 from openpype.pipeline import (
-    legacy_io,
     load,
+    get_current_project_name,
     get_representation_path,
 )
 from openpype.hosts.nuke.api import (
@@ -110,7 +110,7 @@ class AlembicCameraLoader(load.LoaderPlugin):
             None
         """
         # Get version from io
-        project_name = legacy_io.active_project()
+        project_name = get_current_project_name()
         version_doc = get_version_by_id(project_name, representation["parent"])
 
         object_name = container['objectName']
@@ -182,7 +182,7 @@ class AlembicCameraLoader(load.LoaderPlugin):
         """ Coloring a node by correct color by actual version
         """
         # get all versions in list
-        project_name = legacy_io.active_project()
+        project_name = get_current_project_name()
         last_version_doc = get_last_version_by_subset_id(
             project_name, version_doc["parent"], fields=["_id"]
         )

--- a/openpype/hosts/nuke/plugins/load/load_clip.py
+++ b/openpype/hosts/nuke/plugins/load/load_clip.py
@@ -8,7 +8,7 @@ from openpype.client import (
     get_last_version_by_subset_id,
 )
 from openpype.pipeline import (
-    legacy_io,
+    get_current_project_name,
     get_representation_path,
 )
 from openpype.hosts.nuke.api.lib import (
@@ -268,7 +268,7 @@ class LoadClip(plugin.NukeLoader):
             if "addRetime" in key
         ]
 
-        project_name = legacy_io.active_project()
+        project_name = get_current_project_name()
         version_doc = get_version_by_id(project_name, representation["parent"])
 
         version_data = version_doc.get("data", {})

--- a/openpype/hosts/nuke/plugins/load/load_effects.py
+++ b/openpype/hosts/nuke/plugins/load/load_effects.py
@@ -156,7 +156,7 @@ class LoadEffects(load.LoaderPlugin):
         """
         # get main variables
         # Get version from io
-        project_name = get_current_asset_name()
+        project_name = get_current_project_name()
         version_doc = get_version_by_id(project_name, representation["parent"])
 
         # get corresponding node

--- a/openpype/hosts/nuke/plugins/load/load_effects.py
+++ b/openpype/hosts/nuke/plugins/load/load_effects.py
@@ -8,8 +8,8 @@ from openpype.client import (
     get_last_version_by_subset_id,
 )
 from openpype.pipeline import (
-    legacy_io,
     load,
+    get_current_asset_name,
     get_representation_path,
 )
 from openpype.hosts.nuke.api import (
@@ -156,7 +156,7 @@ class LoadEffects(load.LoaderPlugin):
         """
         # get main variables
         # Get version from io
-        project_name = legacy_io.active_project()
+        project_name = get_current_asset_name()
         version_doc = get_version_by_id(project_name, representation["parent"])
 
         # get corresponding node

--- a/openpype/hosts/nuke/plugins/load/load_effects.py
+++ b/openpype/hosts/nuke/plugins/load/load_effects.py
@@ -9,7 +9,7 @@ from openpype.client import (
 )
 from openpype.pipeline import (
     load,
-    get_current_asset_name,
+    get_current_project_name,
     get_representation_path,
 )
 from openpype.hosts.nuke.api import (

--- a/openpype/hosts/nuke/plugins/load/load_effects_ip.py
+++ b/openpype/hosts/nuke/plugins/load/load_effects_ip.py
@@ -8,8 +8,8 @@ from openpype.client import (
     get_last_version_by_subset_id,
 )
 from openpype.pipeline import (
-    legacy_io,
     load,
+    get_current_project_name,
     get_representation_path,
 )
 from openpype.hosts.nuke.api import lib
@@ -161,7 +161,7 @@ class LoadEffectsInputProcess(load.LoaderPlugin):
 
         # get main variables
         # Get version from io
-        project_name = legacy_io.active_project()
+        project_name = get_current_project_name()
         version_doc = get_version_by_id(project_name, representation["parent"])
 
         # get corresponding node

--- a/openpype/hosts/nuke/plugins/load/load_gizmo.py
+++ b/openpype/hosts/nuke/plugins/load/load_gizmo.py
@@ -5,8 +5,8 @@ from openpype.client import (
     get_last_version_by_subset_id,
 )
 from openpype.pipeline import (
-    legacy_io,
     load,
+    get_current_project_name,
     get_representation_path,
 )
 from openpype.hosts.nuke.api.lib import (
@@ -106,7 +106,7 @@ class LoadGizmo(load.LoaderPlugin):
 
         # get main variables
         # Get version from io
-        project_name = legacy_io.active_project()
+        project_name = get_current_project_name()
         version_doc = get_version_by_id(project_name, representation["parent"])
 
         # get corresponding node

--- a/openpype/hosts/nuke/plugins/load/load_gizmo_ip.py
+++ b/openpype/hosts/nuke/plugins/load/load_gizmo_ip.py
@@ -6,8 +6,8 @@ from openpype.client import (
     get_last_version_by_subset_id,
 )
 from openpype.pipeline import (
-    legacy_io,
     load,
+    get_current_project_name,
     get_representation_path,
 )
 from openpype.hosts.nuke.api.lib import (
@@ -113,7 +113,7 @@ class LoadGizmoInputProcess(load.LoaderPlugin):
 
         # get main variables
         # Get version from io
-        project_name = legacy_io.active_project()
+        project_name = get_current_project_name()
         version_doc = get_version_by_id(project_name, representation["parent"])
 
         # get corresponding node

--- a/openpype/hosts/nuke/plugins/load/load_image.py
+++ b/openpype/hosts/nuke/plugins/load/load_image.py
@@ -7,8 +7,8 @@ from openpype.client import (
     get_last_version_by_subset_id,
 )
 from openpype.pipeline import (
-    legacy_io,
     load,
+    get_current_project_name,
     get_representation_path,
 )
 from openpype.hosts.nuke.api.lib import (
@@ -202,7 +202,7 @@ class LoadImage(load.LoaderPlugin):
                 format(frame_number, "0{}".format(padding)))
 
         # Get start frame from version data
-        project_name = legacy_io.active_project()
+        project_name = get_current_project_name()
         version_doc = get_version_by_id(project_name, representation["parent"])
         last_version_doc = get_last_version_by_subset_id(
             project_name, version_doc["parent"], fields=["_id"]

--- a/openpype/hosts/nuke/plugins/load/load_model.py
+++ b/openpype/hosts/nuke/plugins/load/load_model.py
@@ -5,8 +5,8 @@ from openpype.client import (
     get_last_version_by_subset_id,
 )
 from openpype.pipeline import (
-    legacy_io,
     load,
+    get_current_project_name,
     get_representation_path,
 )
 from openpype.hosts.nuke.api.lib import maintained_selection
@@ -115,7 +115,7 @@ class AlembicModelLoader(load.LoaderPlugin):
             None
         """
         # Get version from io
-        project_name = legacy_io.active_project()
+        project_name = get_current_project_name()
         version_doc = get_version_by_id(project_name, representation["parent"])
         object_name = container['objectName']
         # get corresponding node
@@ -190,7 +190,7 @@ class AlembicModelLoader(load.LoaderPlugin):
     def node_version_color(self, version, node):
         """ Coloring a node by correct color by actual version"""
 
-        project_name = legacy_io.active_project()
+        project_name = get_current_project_name()
         last_version_doc = get_last_version_by_subset_id(
             project_name, version["parent"], fields=["_id"]
         )

--- a/openpype/hosts/nuke/plugins/load/load_script_precomp.py
+++ b/openpype/hosts/nuke/plugins/load/load_script_precomp.py
@@ -5,7 +5,7 @@ from openpype.client import (
     get_last_version_by_subset_id,
 )
 from openpype.pipeline import (
-    legacy_io,
+    get_current_project_name,
     load,
     get_representation_path,
 )
@@ -124,7 +124,7 @@ class LinkAsGroup(load.LoaderPlugin):
         root = get_representation_path(representation).replace("\\", "/")
 
         # Get start frame from version data
-        project_name = legacy_io.active_project()
+        project_name = get_current_project_name()
         version_doc = get_version_by_id(project_name, representation["parent"])
         last_version_doc = get_last_version_by_subset_id(
             project_name, version_doc["parent"], fields=["_id"]

--- a/openpype/hosts/nuke/plugins/publish/collect_reads.py
+++ b/openpype/hosts/nuke/plugins/publish/collect_reads.py
@@ -2,8 +2,6 @@ import os
 import re
 import nuke
 import pyblish.api
-from openpype.client import get_asset_by_name
-from openpype.pipeline import legacy_io
 
 
 class CollectNukeReads(pyblish.api.InstancePlugin):
@@ -15,16 +13,9 @@ class CollectNukeReads(pyblish.api.InstancePlugin):
     families = ["source"]
 
     def process(self, instance):
-        node = instance.data["transientData"]["node"]
-
-        project_name = legacy_io.active_project()
-        asset_name = legacy_io.Session["AVALON_ASSET"]
-        asset_doc = get_asset_by_name(project_name, asset_name)
-
-        self.log.debug("asset_doc: {}".format(asset_doc["data"]))
-
         self.log.debug("checking instance: {}".format(instance))
 
+        node = instance.data["transientData"]["node"]
         if node.Class() != "Read":
             return
 
@@ -123,7 +114,7 @@ class CollectNukeReads(pyblish.api.InstancePlugin):
             "frameStart": first_frame,
             "frameEnd": last_frame,
             "colorspace": colorspace,
-            "handles": int(asset_doc["data"].get("handles", 0)),
+            "handles": 0,
             "step": 1,
             "fps": int(nuke.root()['fps'].value())
         })

--- a/openpype/hosts/photoshop/api/pipeline.py
+++ b/openpype/hosts/photoshop/api/pipeline.py
@@ -6,11 +6,8 @@ import pyblish.api
 
 from openpype.lib import register_event_callback, Logger
 from openpype.pipeline import (
-    legacy_io,
     register_loader_plugin_path,
     register_creator_plugin_path,
-    deregister_loader_plugin_path,
-    deregister_creator_plugin_path,
     AVALON_CONTAINER_ID,
 )
 
@@ -110,14 +107,6 @@ class PhotoshopHost(HostBase, IWorkfileHost, ILoadHost, IPublishHost):
         item = data
         item["id"] = "publish_context"
         _get_stub().imprint(item["id"], item)
-
-    def get_context_title(self):
-        """Returns title for Creator window"""
-
-        project_name = legacy_io.Session["AVALON_PROJECT"]
-        asset_name = legacy_io.Session["AVALON_ASSET"]
-        task_name = legacy_io.Session["AVALON_TASK"]
-        return "{}/{}/{}".format(project_name, asset_name, task_name)
 
     def list_instances(self):
         """List all created instances to publish from current workfile.

--- a/openpype/hosts/photoshop/plugins/publish/collect_instances.py
+++ b/openpype/hosts/photoshop/plugins/publish/collect_instances.py
@@ -5,7 +5,6 @@ import pyblish.api
 from openpype.settings import get_project_settings
 from openpype.hosts.photoshop import api as photoshop
 from openpype.lib import prepare_template_data
-from openpype.pipeline import legacy_io
 
 
 class CollectInstances(pyblish.api.ContextPlugin):
@@ -92,7 +91,7 @@ class CollectInstances(pyblish.api.ContextPlugin):
                 "CreateImage", {}).get(
                 "defaults", [''])
             family = "image"
-            task_name = legacy_io.Session["AVALON_TASK"]
+            task_name = context.data["task"]
             asset_name = context.data["assetEntity"]["name"]
 
             variant = context.data.get("variant") or variants[0]

--- a/openpype/hosts/photoshop/plugins/publish/collect_review.py
+++ b/openpype/hosts/photoshop/plugins/publish/collect_review.py
@@ -47,6 +47,6 @@ class CollectReview(pyblish.api.ContextPlugin):
             "family": family,
             "families": [],
             "representations": [],
-            "asset": os.environ["AVALON_ASSET"],
+            "asset": context.data["asset"],
             "publish": self.publish
         })

--- a/openpype/hosts/photoshop/plugins/publish/collect_workfile.py
+++ b/openpype/hosts/photoshop/plugins/publish/collect_workfile.py
@@ -48,7 +48,7 @@ class CollectWorkfile(pyblish.api.ContextPlugin):
                 "family": family,
                 "families": [],
                 "representations": [],
-                "asset": os.environ["AVALON_ASSET"]
+                "asset": context.data["asset"]
             })
         else:
             instance = existing_instance

--- a/openpype/hosts/photoshop/plugins/publish/validate_instance_asset.py
+++ b/openpype/hosts/photoshop/plugins/publish/validate_instance_asset.py
@@ -1,6 +1,6 @@
 import pyblish.api
 
-from openpype.pipeline import legacy_io
+from openpype.pipeline import get_current_asset_name
 from openpype.pipeline.publish import (
     ValidateContentsOrder,
     PublishXmlValidationError,
@@ -28,10 +28,10 @@ class ValidateInstanceAssetRepair(pyblish.api.Action):
         # Apply pyblish.logic to get the instances for the plug-in
         instances = pyblish.api.instances_by_plugin(failed, plugin)
         stub = photoshop.stub()
+        current_asset_name = get_current_asset_name()
         for instance in instances:
             data = stub.read(instance[0])
-
-            data["asset"] = legacy_io.Session["AVALON_ASSET"]
+            data["asset"] = current_asset_name
             stub.imprint(instance[0], data)
 
 
@@ -55,7 +55,7 @@ class ValidateInstanceAsset(OptionalPyblishPluginMixin,
 
     def process(self, instance):
         instance_asset = instance.data["asset"]
-        current_asset = legacy_io.Session["AVALON_ASSET"]
+        current_asset = get_current_asset_name()
 
         if instance_asset != current_asset:
             msg = (

--- a/openpype/hosts/resolve/plugins/load/load_clip.py
+++ b/openpype/hosts/resolve/plugins/load/load_clip.py
@@ -7,7 +7,7 @@ from openpype.client import (
 # from openpype.hosts import resolve
 from openpype.pipeline import (
     get_representation_path,
-    legacy_io,
+    get_current_project_name,
 )
 from openpype.hosts.resolve.api import lib, plugin
 from openpype.hosts.resolve.api.pipeline import (
@@ -109,7 +109,7 @@ class LoadClip(plugin.TimelineItemLoader):
         namespace = container['namespace']
         timeline_item_data = lib.get_pype_timeline_item_by_name(namespace)
         timeline_item = timeline_item_data["clip"]["item"]
-        project_name = legacy_io.active_project()
+        project_name = get_current_project_name()
         version = get_version_by_id(project_name, representation["parent"])
         version_data = version.get("data", {})
         version_name = version.get("name", None)
@@ -152,7 +152,7 @@ class LoadClip(plugin.TimelineItemLoader):
         # define version name
         version_name = version.get("name", None)
         # get all versions in list
-        project_name = legacy_io.active_project()
+        project_name = get_current_project_name()
         last_version_doc = get_last_version_by_subset_id(
             project_name,
             version["parent"],

--- a/openpype/hosts/resolve/plugins/publish/precollect_workfile.py
+++ b/openpype/hosts/resolve/plugins/publish/precollect_workfile.py
@@ -1,8 +1,8 @@
 import pyblish.api
 from pprint import pformat
 
+from openpype.pipeline import get_current_asset_name
 from openpype.hosts.resolve import api as rapi
-from openpype.pipeline import legacy_io
 from openpype.hosts.resolve.otio import davinci_export
 
 
@@ -14,7 +14,7 @@ class PrecollectWorkfile(pyblish.api.ContextPlugin):
 
     def process(self, context):
 
-        asset = legacy_io.Session["AVALON_ASSET"]
+        asset = get_current_asset_name()
         subset = "workfile"
         project = rapi.get_current_project()
         fps = project.GetSetting("timelineFrameRate")

--- a/openpype/hosts/tvpaint/plugins/load/load_workfile.py
+++ b/openpype/hosts/tvpaint/plugins/load/load_workfile.py
@@ -3,7 +3,7 @@ import os
 from openpype.lib import StringTemplate
 from openpype.pipeline import (
     registered_host,
-    legacy_io,
+    get_current_context,
     Anatomy,
 )
 from openpype.pipeline.workfile import (
@@ -55,9 +55,10 @@ class LoadWorkfile(plugin.Loader):
         task_name = work_context.get("task")
         # Far cases when there is workfile without work_context
         if not asset_name:
-            project_name = legacy_io.active_project()
-            asset_name = legacy_io.Session["AVALON_ASSET"]
-            task_name = legacy_io.Session["AVALON_TASK"]
+            context = get_current_context()
+            project_name = context["project_name"]
+            asset_name = context["asset_name"]
+            task_name = context["task_name"]
 
         template_key = get_workfile_template_key_from_context(
             asset_name,

--- a/openpype/hosts/unreal/plugins/load/load_camera.py
+++ b/openpype/hosts/unreal/plugins/load/load_camera.py
@@ -9,7 +9,7 @@ from unreal import EditorLevelUtils
 from openpype.client import get_assets, get_asset_by_name
 from openpype.pipeline import (
     AVALON_CONTAINER_ID,
-    legacy_io,
+    get_current_project_name,
 )
 from openpype.hosts.unreal.api import plugin
 from openpype.hosts.unreal.api import pipeline as unreal_pipeline
@@ -169,7 +169,7 @@ class CameraLoader(plugin.Loader):
         EditorLevelLibrary.save_all_dirty_levels()
         EditorLevelLibrary.load_level(level)
 
-        project_name = legacy_io.active_project()
+        project_name = get_current_project_name()
         # TODO refactor
         #   - Creating of hierarchy should be a function in unreal integration
         #       - it's used in multiple loaders but must not be loader's logic

--- a/openpype/hosts/unreal/plugins/load/load_layout.py
+++ b/openpype/hosts/unreal/plugins/load/load_layout.py
@@ -20,7 +20,7 @@ from openpype.pipeline import (
     load_container,
     get_representation_path,
     AVALON_CONTAINER_ID,
-    legacy_io,
+    get_current_project_name,
 )
 from openpype.pipeline.context_tools import get_current_project_asset
 from openpype.settings import get_current_project_settings
@@ -363,7 +363,7 @@ class LayoutLoader(plugin.Loader):
             factory=unreal.LevelSequenceFactoryNew()
         )
 
-        project_name = legacy_io.active_project()
+        project_name = get_current_project_name()
         asset_data = get_asset_by_name(
             project_name,
             h_dir.split('/')[-1],
@@ -421,7 +421,7 @@ class LayoutLoader(plugin.Loader):
         if not version_ids:
             return output
 
-        project_name = legacy_io.active_project()
+        project_name = get_current_project_name()
         repre_docs = get_representations(
             project_name,
             representation_names=["fbx", "abc"],
@@ -722,7 +722,7 @@ class LayoutLoader(plugin.Loader):
                     frame_ranges[i + 1][0], frame_ranges[i + 1][1],
                     [level])
 
-            project_name = legacy_io.active_project()
+            project_name = get_current_project_name()
             data = get_asset_by_name(project_name, asset)["data"]
             shot.set_display_rate(
                 unreal.FrameRate(data.get("fps"), 1.0))

--- a/openpype/hosts/unreal/plugins/load/load_layout_existing.py
+++ b/openpype/hosts/unreal/plugins/load/load_layout_existing.py
@@ -11,7 +11,7 @@ from openpype.pipeline import (
     load_container,
     get_representation_path,
     AVALON_CONTAINER_ID,
-    legacy_io,
+    get_current_project_name,
 )
 from openpype.hosts.unreal.api import plugin
 from openpype.hosts.unreal.api import pipeline as upipeline
@@ -435,7 +435,7 @@ class ExistingLayoutLoader(plugin.Loader):
         asset_dir = container.get('namespace')
 
         source_path = get_representation_path(representation)
-        project_name = legacy_io.active_project()
+        project_name = get_current_project_name()
         containers = self._process(source_path, project_name)
 
         data = {

--- a/openpype/hosts/unreal/plugins/publish/extract_layout.py
+++ b/openpype/hosts/unreal/plugins/publish/extract_layout.py
@@ -8,7 +8,7 @@ from unreal import EditorLevelLibrary as ell
 from unreal import EditorAssetLibrary as eal
 
 from openpype.client import get_representation_by_name
-from openpype.pipeline import legacy_io, publish
+from openpype.pipeline import publish
 
 
 class ExtractLayout(publish.Extractor):
@@ -32,7 +32,7 @@ class ExtractLayout(publish.Extractor):
             "Wrong level loaded"
 
         json_data = []
-        project_name = legacy_io.active_project()
+        project_name = instance.context.data["projectName"]
 
         for member in instance[:]:
             actor = ell.get_actor_reference(member)

--- a/openpype/lib/applications.py
+++ b/openpype/lib/applications.py
@@ -1371,13 +1371,8 @@ def get_app_environments_for_context(
     """
 
     from openpype.modules import ModulesManager
-    from openpype.pipeline import AvalonMongoDB, Anatomy
+    from openpype.pipeline import Anatomy
     from openpype.lib.openpype_version import is_running_staging
-
-    # Avalon database connection
-    dbcon = AvalonMongoDB()
-    dbcon.Session["AVALON_PROJECT"] = project_name
-    dbcon.install()
 
     # Project document
     project_doc = get_project(project_name)
@@ -1400,7 +1395,6 @@ def get_app_environments_for_context(
 
         "app": app,
 
-        "dbcon": dbcon,
         "project_doc": project_doc,
         "asset_doc": asset_doc,
 
@@ -1414,9 +1408,6 @@ def get_app_environments_for_context(
 
     prepare_app_environments(data, env_group, modules_manager)
     prepare_context_environments(data, env_group, modules_manager)
-
-    # Discard avalon connection
-    dbcon.uninstall()
 
     return data["env"]
 

--- a/openpype/lib/usdlib.py
+++ b/openpype/lib/usdlib.py
@@ -9,7 +9,7 @@ except ImportError:
     from mvpxr import Usd, UsdGeom, Sdf, Kind
 
 from openpype.client import get_project, get_asset_by_name
-from openpype.pipeline import legacy_io, Anatomy
+from openpype.pipeline import Anatomy, get_current_project_name
 
 log = logging.getLogger(__name__)
 
@@ -126,7 +126,7 @@ def create_model(filename, asset, variant_subsets):
 
     """
 
-    project_name = legacy_io.active_project()
+    project_name = get_current_project_name()
     asset_doc = get_asset_by_name(project_name, asset)
     assert asset_doc, "Asset not found: %s" % asset
 
@@ -177,7 +177,7 @@ def create_shade(filename, asset, variant_subsets):
 
     """
 
-    project_name = legacy_io.active_project()
+    project_name = get_current_project_name()
     asset_doc = get_asset_by_name(project_name, asset)
     assert asset_doc, "Asset not found: %s" % asset
 
@@ -213,7 +213,7 @@ def create_shade_variation(filename, asset, model_variant, shade_variants):
 
     """
 
-    project_name = legacy_io.active_project()
+    project_name = get_current_project_name()
     asset_doc = get_asset_by_name(project_name, asset)
     assert asset_doc, "Asset not found: %s" % asset
 
@@ -314,7 +314,7 @@ def get_usd_master_path(asset, subset, representation):
 
     """
 
-    project_name = legacy_io.active_project()
+    project_name = get_current_project_name()
     anatomy = Anatomy(project_name)
     project_doc = get_project(
         project_name,

--- a/openpype/modules/deadline/plugins/publish/submit_max_deadline.py
+++ b/openpype/modules/deadline/plugins/publish/submit_max_deadline.py
@@ -178,17 +178,17 @@ class MaxSubmitDeadline(abstract_submit_deadline.AbstractSubmitDeadline,
 
         self.log.debug("Submitting 3dsMax render..")
         project_settings = instance.context.data["project_settings"]
-        payload = self._use_published_name(project_settings, payload_data)
+        payload = self._use_published_name(payload_data, project_settings)
         job_info, plugin_info = payload
         self.submit(self.assemble_payload(job_info, plugin_info))
 
-    def _use_published_name(self, project_settings, data):
+    def _use_published_name(self, data, project_settings):
         instance = self._instance
         job_info = copy.deepcopy(self.job_info)
         plugin_info = copy.deepcopy(self.plugin_info)
         plugin_data = {}
 
-        multipass = get_multipass_setting(project_setting)
+        multipass = get_multipass_setting(project_settings)
         if multipass:
             plugin_data["DisableMultipass"] = 0
         else:

--- a/openpype/modules/deadline/plugins/publish/submit_max_deadline.py
+++ b/openpype/modules/deadline/plugins/publish/submit_max_deadline.py
@@ -177,18 +177,16 @@ class MaxSubmitDeadline(abstract_submit_deadline.AbstractSubmitDeadline,
         }
 
         self.log.debug("Submitting 3dsMax render..")
-        payload = self._use_published_name(payload_data)
+        project_settings = instance.context["project_settings"]
+        payload = self._use_published_name(project_settings, payload_data)
         job_info, plugin_info = payload
         self.submit(self.assemble_payload(job_info, plugin_info))
 
-    def _use_published_name(self, data):
+    def _use_published_name(self, project_settings, data):
         instance = self._instance
         job_info = copy.deepcopy(self.job_info)
         plugin_info = copy.deepcopy(self.plugin_info)
         plugin_data = {}
-        project_setting = get_project_settings(
-            legacy_io.Session["AVALON_PROJECT"]
-        )
 
         multipass = get_multipass_setting(project_setting)
         if multipass:

--- a/openpype/modules/deadline/plugins/publish/submit_max_deadline.py
+++ b/openpype/modules/deadline/plugins/publish/submit_max_deadline.py
@@ -177,7 +177,7 @@ class MaxSubmitDeadline(abstract_submit_deadline.AbstractSubmitDeadline,
         }
 
         self.log.debug("Submitting 3dsMax render..")
-        project_settings = instance.context["project_settings"]
+        project_settings = instance.context.data["project_settings"]
         payload = self._use_published_name(project_settings, payload_data)
         job_info, plugin_info = payload
         self.submit(self.assemble_payload(job_info, plugin_info))

--- a/openpype/modules/deadline/plugins/publish/submit_maya_remote_publish_deadline.py
+++ b/openpype/modules/deadline/plugins/publish/submit_maya_remote_publish_deadline.py
@@ -117,8 +117,8 @@ class MayaSubmitRemotePublishDeadline(pyblish.api.InstancePlugin):
 
         # TODO replace legacy_io with context.data
         environment["AVALON_PROJECT"] = project_name
-        environment["AVALON_ASSET"] = legacy_io.Session["AVALON_ASSET"]
-        environment["AVALON_TASK"] = legacy_io.Session["AVALON_TASK"]
+        environment["AVALON_ASSET"] = instance.context.data["asset"]
+        environment["AVALON_TASK"] = instance.context.data["task"]
         environment["AVALON_APP_NAME"] = os.environ.get("AVALON_APP_NAME")
         environment["OPENPYPE_LOG_NO_COLORS"] = "1"
         environment["OPENPYPE_REMOTE_JOB"] = "1"

--- a/openpype/modules/deadline/plugins/publish/submit_publish_job.py
+++ b/openpype/modules/deadline/plugins/publish/submit_publish_job.py
@@ -227,13 +227,11 @@ class ProcessSubmittedJobOnFarm(pyblish.api.InstancePlugin):
         instance_version = instance.data.get("version")  # take this if exists
         if instance_version != 1:
             override_version = instance_version
-        project_name = instance.context.data["projectName"]
-        asset_name = instance.data.get("asset")
-        task_name = instance.data.get("task")
+
         output_dir = self._get_publish_folder(
             instance.context.data['anatomy'],
             deepcopy(instance.data["anatomyData"]),
-            asset_name,
+            instance.data.get("asset"),
             instances[0]["subset"],
             'render',
             override_version
@@ -245,9 +243,9 @@ class ProcessSubmittedJobOnFarm(pyblish.api.InstancePlugin):
             self._create_metadata_path(instance)
 
         environment = {
-            "AVALON_PROJECT": project_name,
-            "AVALON_ASSET": asset_name,
-            "AVALON_TASK": task_name,
+            "AVALON_PROJECT": instance.context.data["projectName"],
+            "AVALON_ASSET": instance.context.data["asset"],
+            "AVALON_TASK": instance.context.data["task"],
             "OPENPYPE_USERNAME": instance.context.data["user"],
             "OPENPYPE_PUBLISH_JOB": "1",
             "OPENPYPE_RENDER_JOB": "0",

--- a/openpype/modules/ftrack/plugins/publish/collect_ftrack_api.py
+++ b/openpype/modules/ftrack/plugins/publish/collect_ftrack_api.py
@@ -1,8 +1,6 @@
 import logging
 import pyblish.api
 
-from openpype.pipeline import legacy_io
-
 
 class CollectFtrackApi(pyblish.api.ContextPlugin):
     """ Collects an ftrack session and the current task id. """
@@ -24,9 +22,9 @@ class CollectFtrackApi(pyblish.api.ContextPlugin):
         self.log.debug("Ftrack user: \"{0}\"".format(session.api_user))
 
         # Collect task
-        project_name = legacy_io.Session["AVALON_PROJECT"]
-        asset_name = legacy_io.Session["AVALON_ASSET"]
-        task_name = legacy_io.Session["AVALON_TASK"]
+        project_name = context.data["projectName"]
+        asset_name = context.data["asset"]
+        task_name = context.data["task"]
 
         # Find project entity
         project_query = 'Project where full_name is "{0}"'.format(project_name)

--- a/openpype/modules/royalrender/plugins/publish/collect_sequences_from_job.py
+++ b/openpype/modules/royalrender/plugins/publish/collect_sequences_from_job.py
@@ -189,7 +189,7 @@ class CollectSequencesFromJob(pyblish.api.ContextPlugin):
                     "families": list(families),
                     "subset": subset,
                     "asset": data.get(
-                        "asset", legacy_io.Session["AVALON_ASSET"]
+                        "asset", context.data["asset"]
                     ),
                     "stagingDir": root,
                     "frameStart": start,

--- a/openpype/modules/shotgrid/plugins/publish/collect_shotgrid_entities.py
+++ b/openpype/modules/shotgrid/plugins/publish/collect_shotgrid_entities.py
@@ -14,7 +14,7 @@ class CollectShotgridEntities(pyblish.api.ContextPlugin):
 
         avalon_project = context.data.get("projectEntity")
         avalon_asset = context.data.get("assetEntity")
-        avalon_task_name = os.getenv("AVALON_TASK")
+        avalon_task_name = context.data.get("task")
 
         self.log.info(avalon_project)
         self.log.info(avalon_asset)

--- a/openpype/pipeline/__init__.py
+++ b/openpype/pipeline/__init__.py
@@ -87,6 +87,7 @@ from .context_tools import (
     deregister_host,
     get_process_id,
 
+    get_global_context,
     get_current_context,
     get_current_host_name,
     get_current_project_name,
@@ -184,6 +185,7 @@ __all__ = (
     "deregister_host",
     "get_process_id",
 
+    "get_global_context",
     "get_current_context",
     "get_current_host_name",
     "get_current_project_name",

--- a/openpype/pipeline/context_tools.py
+++ b/openpype/pipeline/context_tools.py
@@ -311,7 +311,7 @@ def get_current_host_name():
     """Current host name.
 
     Function is based on currently registered host integration or environment
-    variant 'AVALON_APP'.
+    variable 'AVALON_APP'.
 
     Returns:
         Union[str, None]: Name of host integration in current process or None.
@@ -324,6 +324,26 @@ def get_current_host_name():
 
 
 def get_global_context():
+    """Global context defined in environment variables.
+
+    Values here may not reflect current context of host integration. The
+    function can be used on startup before a host is registered.
+
+    Use 'get_current_context' to make sure you'll get current host integration
+    context info.
+
+    Example:
+        {
+            "project_name": "Commercial",
+            "asset_name": "Bunny",
+            "task_name": "Animation",
+        }
+
+    Returns:
+        dict[str, Union[str, None]]: Context defined with environment
+            variables.
+    """
+
     return {
         "project_name": os.environ.get("AVALON_PROJECT"),
         "asset_name": os.environ.get("AVALON_ASSET"),

--- a/openpype/pipeline/create/creator_plugins.py
+++ b/openpype/pipeline/create/creator_plugins.py
@@ -624,12 +624,12 @@ def discover_convertor_plugins(*args, **kwargs):
 
 
 def discover_legacy_creator_plugins():
-    from openpype.lib import Logger
+    from openpype.pipeline import get_current_project_name
 
     log = Logger.get_logger("CreatorDiscover")
 
     plugins = discover(LegacyCreator)
-    project_name = os.environ.get("AVALON_PROJECT")
+    project_name = get_current_project_name()
     system_settings = get_system_settings()
     project_settings = get_project_settings(project_name)
     for plugin in plugins:

--- a/openpype/pipeline/template_data.py
+++ b/openpype/pipeline/template_data.py
@@ -128,7 +128,7 @@ def get_task_template_data(project_doc, asset_doc, task_name):
     Args:
         project_doc (Dict[str, Any]): Queried project document.
         asset_doc (Dict[str, Any]): Queried asset document.
-        tas_name (str): Name of task for which data should be returned.
+        task_name (str): Name of task for which data should be returned.
 
     Returns:
         Dict[str, Dict[str, str]]: Template data

--- a/openpype/pipeline/workfile/build_workfile.py
+++ b/openpype/pipeline/workfile/build_workfile.py
@@ -9,7 +9,6 @@ from '~/openpype/pipeline/workfile/workfile_template_builder'. Which gives
 more abilities to define how build happens but require more code to achive it.
 """
 
-import os
 import re
 import collections
 import json
@@ -26,7 +25,6 @@ from openpype.lib import (
     filter_profiles,
     Logger,
 )
-from openpype.pipeline import legacy_io
 from openpype.pipeline.load import (
     discover_loader_plugins,
     IncompatibleLoaderError,
@@ -102,11 +100,17 @@ class BuildWorkfile:
             List[Dict[str, Any]]: Loaded containers during build.
         """
 
+        from openpype.pipeline.context_tools import (
+            get_current_project_name,
+            get_current_asset_name,
+            get_current_task_name,
+        )
+
         loaded_containers = []
 
         # Get current asset name and entity
-        project_name = legacy_io.active_project()
-        current_asset_name = legacy_io.Session["AVALON_ASSET"]
+        project_name = get_current_project_name()
+        current_asset_name = get_current_asset_name()
         current_asset_entity = get_asset_by_name(
             project_name, current_asset_name
         )
@@ -135,7 +139,7 @@ class BuildWorkfile:
             return loaded_containers
 
         # Get current task name
-        current_task_name = legacy_io.Session["AVALON_TASK"]
+        current_task_name = get_current_task_name()
 
         # Load workfile presets for task
         self.build_presets = self.get_build_presets(
@@ -236,9 +240,14 @@ class BuildWorkfile:
             Dict[str, Any]: preset per entered task name
         """
 
-        host_name = os.environ["AVALON_APP"]
+        from openpype.pipeline.context_tools import (
+            get_current_host_name,
+            get_current_project_name,
+        )
+
+        host_name = get_current_host_name()
         project_settings = get_project_settings(
-            legacy_io.Session["AVALON_PROJECT"]
+            get_current_project_name()
         )
 
         host_settings = project_settings.get(host_name) or {}
@@ -651,13 +660,15 @@ class BuildWorkfile:
         ```
         """
 
+        from openpype.pipeline.context_tools import get_current_project_name
+
         output = {}
         if not asset_docs:
             return output
 
         asset_docs_by_ids = {asset["_id"]: asset for asset in asset_docs}
 
-        project_name = legacy_io.active_project()
+        project_name = get_current_project_name()
         subsets = list(get_subsets(
             project_name, asset_ids=asset_docs_by_ids.keys()
         ))

--- a/openpype/pipeline/workfile/workfile_template_builder.py
+++ b/openpype/pipeline/workfile/workfile_template_builder.py
@@ -28,8 +28,7 @@ from openpype.settings import (
     get_project_settings,
     get_system_settings,
 )
-from openpype.host import IWorkfileHost
-from openpype.host import HostBase
+from openpype.host import IWorkfileHost, HostBase
 from openpype.lib import (
     Logger,
     StringTemplate,
@@ -37,7 +36,7 @@ from openpype.lib import (
     attribute_definitions,
 )
 from openpype.lib.attribute_definitions import get_attributes_keys
-from openpype.pipeline import legacy_io, Anatomy
+from openpype.pipeline import Anatomy
 from openpype.pipeline.load import (
     get_loaders_by_name,
     get_contexts_for_repre_docs,
@@ -124,15 +123,30 @@ class AbstractTemplateBuilder(object):
 
     @property
     def project_name(self):
-        return legacy_io.active_project()
+        if isinstance(self._host, HostBase):
+            return self._host.get_current_project_name()
+        return os.getenv("AVALON_PROJECT")
 
     @property
     def current_asset_name(self):
-        return legacy_io.Session["AVALON_ASSET"]
+        if isinstance(self._host, HostBase):
+            return self._host.get_current_asset_name()
+        return os.getenv("AVALON_ASSET")
 
     @property
     def current_task_name(self):
-        return legacy_io.Session["AVALON_TASK"]
+        if isinstance(self._host, HostBase):
+            return self._host.get_current_task_name()
+        return os.getenv("AVALON_TASK")
+
+    def get_current_context(self):
+        if isinstance(self._host, HostBase):
+            return self._host.get_current_context()
+        return {
+            "project_name": self.project_name,
+            "asset_name": self.current_asset_name,
+            "task_name": self.current_task_name
+        }
 
     @property
     def system_settings(self):
@@ -787,9 +801,8 @@ class AbstractTemplateBuilder(object):
         fill_data["root"] = anatomy.roots
         fill_data["project"] = {
             "name": project_name,
-            "code": anatomy["attributes"]["code"]
+            "code": anatomy.project_code,
         }
-
 
         result = StringTemplate.format_template(path, fill_data)
         if result.solved:
@@ -1680,9 +1693,10 @@ class PlaceholderCreateMixin(object):
         creator_plugin = self.builder.get_creators_by_name()[creator_name]
 
         # create subset name
-        project_name = legacy_io.Session["AVALON_PROJECT"]
-        task_name = legacy_io.Session["AVALON_TASK"]
-        asset_name = legacy_io.Session["AVALON_ASSET"]
+        context = self._builder.get_current_context()
+        project_name = context["project_name"]
+        asset_name = context["asset_name"]
+        task_name = context["task_name"]
 
         if legacy_create:
             asset_doc = get_asset_by_name(

--- a/openpype/plugins/publish/collect_current_context.py
+++ b/openpype/plugins/publish/collect_current_context.py
@@ -6,7 +6,7 @@ Provides:
 """
 
 import pyblish.api
-from openpype.pipeline import legacy_io
+from openpype.pipeline import get_current_context
 
 
 class CollectCurrentContext(pyblish.api.ContextPlugin):
@@ -19,24 +19,20 @@ class CollectCurrentContext(pyblish.api.ContextPlugin):
     label = "Collect Current context"
 
     def process(self, context):
-        # Make sure 'legacy_io' is intalled
-        legacy_io.install()
-
         # Check if values are already set
         project_name = context.data.get("projectName")
         asset_name = context.data.get("asset")
         task_name = context.data.get("task")
+
+        curent_context = get_current_context()
         if not project_name:
-            project_name = legacy_io.current_project()
-            context.data["projectName"] = project_name
+            context.data["projectName"] = curent_context["project_name"]
 
         if not asset_name:
-            asset_name = legacy_io.Session.get("AVALON_ASSET")
-            context.data["asset"] = asset_name
+            context.data["asset"] = curent_context["asset_name"]
 
         if not task_name:
-            task_name = legacy_io.Session.get("AVALON_TASK")
-            context.data["task"] = task_name
+            context.data["task"] = curent_context["task_name"]
 
         # QUESTION should we be explicit with keys? (the same on instances)
         #   - 'asset' -> 'assetName'

--- a/openpype/plugins/publish/collect_current_context.py
+++ b/openpype/plugins/publish/collect_current_context.py
@@ -24,15 +24,15 @@ class CollectCurrentContext(pyblish.api.ContextPlugin):
         asset_name = context.data.get("asset")
         task_name = context.data.get("task")
 
-        curent_context = get_current_context()
+        current_context = get_current_context()
         if not project_name:
-            context.data["projectName"] = curent_context["project_name"]
+            context.data["projectName"] = current_context["project_name"]
 
         if not asset_name:
-            context.data["asset"] = curent_context["asset_name"]
+            context.data["asset"] = current_context["asset_name"]
 
         if not task_name:
-            context.data["task"] = curent_context["task_name"]
+            context.data["task"] = current_context["task_name"]
 
         # QUESTION should we be explicit with keys? (the same on instances)
         #   - 'asset' -> 'assetName'

--- a/openpype/pype_commands.py
+++ b/openpype/pype_commands.py
@@ -90,7 +90,10 @@ class PypeCommands:
         from openpype.lib import Logger
         from openpype.lib.applications import get_app_environments_for_context
         from openpype.modules import ModulesManager
-        from openpype.pipeline import install_openpype_plugins
+        from openpype.pipeline import (
+            install_openpype_plugins,
+            get_global_context,
+        )
         from openpype.tools.utils.host_tools import show_publish
         from openpype.tools.utils.lib import qt_app_context
 
@@ -112,12 +115,14 @@ class PypeCommands:
         if not any(paths):
             raise RuntimeError("No publish paths specified")
 
-        if os.getenv("AVALON_APP_NAME"):
+        app_full_name = os.getenv("AVALON_APP_NAME")
+        if app_full_name:
+            context = get_global_context()
             env = get_app_environments_for_context(
-                os.environ["AVALON_PROJECT"],
-                os.environ["AVALON_ASSET"],
-                os.environ["AVALON_TASK"],
-                os.environ["AVALON_APP_NAME"]
+                context["project_name"],
+                context["asset_name"],
+                context["task_name"],
+                app_full_name
             )
             os.environ.update(env)
 

--- a/openpype/scripts/fusion_switch_shot.py
+++ b/openpype/scripts/fusion_switch_shot.py
@@ -15,6 +15,7 @@ from openpype.pipeline import (
     install_host,
     registered_host,
     legacy_io,
+    get_current_project_name,
 )
 
 from openpype.pipeline.context_tools import get_workdir_from_session
@@ -130,7 +131,7 @@ def update_frame_range(comp, representations):
     """
 
     version_ids = [r["parent"] for r in representations]
-    project_name = legacy_io.active_project()
+    project_name = get_current_project_name()
     versions = list(get_versions(project_name, version_ids=version_ids))
 
     start = min(v["data"]["frameStart"] for v in versions)
@@ -161,7 +162,7 @@ def switch(asset_name, filepath=None, new=True):
 
     # Assert asset name exists
     # It is better to do this here then to wait till switch_shot does it
-    project_name = legacy_io.active_project()
+    project_name = get_current_project_name()
     asset = get_asset_by_name(project_name, asset_name)
     assert asset, "Could not find '%s' in the database" % asset_name
 

--- a/openpype/tools/adobe_webserver/app.py
+++ b/openpype/tools/adobe_webserver/app.py
@@ -16,7 +16,7 @@ from wsrpc_aiohttp import (
     WSRPCClient
 )
 
-from openpype.pipeline import legacy_io
+from openpype.pipeline import get_global_context
 
 log = logging.getLogger(__name__)
 
@@ -80,9 +80,10 @@ class WebServerTool:
                              loop=asyncio.get_event_loop())
         await client.connect()
 
-        project = legacy_io.Session["AVALON_PROJECT"]
-        asset = legacy_io.Session["AVALON_ASSET"]
-        task = legacy_io.Session["AVALON_TASK"]
+        context = get_global_context()
+        project = context["project_name"]
+        asset = context["asset_name"]
+        task = context["task_name"]
         log.info("Sending context change to {}-{}-{}".format(project,
                                                              asset,
                                                              task))

--- a/openpype/tools/creator/window.py
+++ b/openpype/tools/creator/window.py
@@ -8,7 +8,11 @@ from openpype.client import get_asset_by_name, get_subsets
 from openpype import style
 from openpype.settings import get_current_project_settings
 from openpype.tools.utils.lib import qt_app_context
-from openpype.pipeline import legacy_io
+from openpype.pipeline import (
+    get_current_project_name,
+    get_current_asset_name,
+    get_current_task_name,
+)
 from openpype.pipeline.create import (
     SUBSET_NAME_ALLOWED_SYMBOLS,
     legacy_create,
@@ -216,7 +220,7 @@ class CreatorWindow(QtWidgets.QDialog):
             self._set_valid_state(False)
             return
 
-        project_name = legacy_io.active_project()
+        project_name = get_current_project_name()
         asset_doc = None
         if creator_plugin:
             # Get the asset from the database which match with the name
@@ -237,7 +241,7 @@ class CreatorWindow(QtWidgets.QDialog):
             return
 
         asset_id = asset_doc["_id"]
-        task_name = legacy_io.Session["AVALON_TASK"]
+        task_name = get_current_task_name()
 
         # Calculate subset name with Creator plugin
         subset_name = creator_plugin.get_subset_name(
@@ -369,7 +373,7 @@ class CreatorWindow(QtWidgets.QDialog):
             self.setStyleSheet(style.load_stylesheet())
 
     def refresh(self):
-        self._asset_name_input.setText(legacy_io.Session["AVALON_ASSET"])
+        self._asset_name_input.setText(get_current_asset_name())
 
         self._creators_model.reset()
 
@@ -382,7 +386,7 @@ class CreatorWindow(QtWidgets.QDialog):
         )
         current_index = None
         family = None
-        task_name = legacy_io.Session.get("AVALON_TASK", None)
+        task_name = get_current_task_name() or None
         lowered_task_name = task_name.lower()
         if task_name:
             for _family, _task_names in pype_project_setting.items():

--- a/openpype/tools/publisher/control.py
+++ b/openpype/tools/publisher/control.py
@@ -26,7 +26,6 @@ from openpype.pipeline import (
     PublishValidationError,
     KnownPublishError,
     registered_host,
-    legacy_io,
     get_process_id,
 )
 from openpype.pipeline.create import (

--- a/openpype/tools/sceneinventory/model.py
+++ b/openpype/tools/sceneinventory/model.py
@@ -15,7 +15,7 @@ from openpype.client import (
     get_representation_by_id,
 )
 from openpype.pipeline import (
-    legacy_io,
+    get_current_project_name,
     schema,
     HeroVersionType,
     registered_host,
@@ -62,7 +62,7 @@ class InventoryModel(TreeModel):
         if not self.sync_enabled:
             return
 
-        project_name = legacy_io.current_project()
+        project_name = get_current_project_name()
         active_site = sync_server.get_active_site(project_name)
         remote_site = sync_server.get_remote_site(project_name)
 
@@ -307,7 +307,7 @@ class InventoryModel(TreeModel):
         """
 
         # NOTE: @iLLiCiTiT this need refactor
-        project_name = legacy_io.active_project()
+        project_name = get_current_project_name()
 
         self.beginResetModel()
 

--- a/openpype/tools/utils/host_tools.py
+++ b/openpype/tools/utils/host_tools.py
@@ -10,7 +10,7 @@ from openpype.host import IWorkfileHost, ILoadHost
 from openpype.lib import Logger
 from openpype.pipeline import (
     registered_host,
-    legacy_io,
+    get_current_asset_name,
 )
 
 from .lib import qt_app_context
@@ -96,7 +96,7 @@ class HostToolsHelper:
                 use_context = False
 
             if use_context:
-                context = {"asset": legacy_io.Session["AVALON_ASSET"]}
+                context = {"asset": get_current_asset_name()}
                 loader_tool.set_context(context, refresh=True)
             else:
                 loader_tool.refresh()

--- a/openpype/tools/utils/lib.py
+++ b/openpype/tools/utils/lib.py
@@ -18,7 +18,11 @@ from openpype.style import (
 from openpype.resources import get_image_path
 from openpype.lib import filter_profiles, Logger
 from openpype.settings import get_project_settings
-from openpype.pipeline import registered_host
+from openpype.pipeline import (
+    registered_host,
+    get_current_context,
+    get_current_host_name,
+)
 
 from .constants import CHECKED_INT, UNCHECKED_INT
 
@@ -44,7 +48,6 @@ def checkstate_enum_to_int(state):
     if state == QtCore.Qt.PartiallyChecked:
         return 1
     return 2
-
 
 
 def center_window(window):
@@ -496,10 +499,11 @@ class FamilyConfigCache:
             return
 
         # Update the icons from the project configuration
-        project_name = os.environ.get("AVALON_PROJECT")
-        asset_name = os.environ.get("AVALON_ASSET")
-        task_name = os.environ.get("AVALON_TASK")
-        host_name = os.environ.get("AVALON_APP")
+        context = get_current_context()
+        project_name = context["project_name"]
+        asset_name = context["asset_name"]
+        task_name = context["task_name"]
+        host_name = get_current_host_name()
         if not all((project_name, asset_name, task_name)):
             return
 

--- a/openpype/tools/workfiles/files_widget.py
+++ b/openpype/tools/workfiles/files_widget.py
@@ -21,6 +21,7 @@ from openpype.pipeline import (
     registered_host,
     legacy_io,
     Anatomy,
+    get_current_project_name,
 )
 from openpype.pipeline.context_tools import (
     compute_session_changes,
@@ -99,7 +100,7 @@ class FilesWidget(QtWidgets.QWidget):
         self._task_type = None
 
         # Pype's anatomy object for current project
-        project_name = legacy_io.Session["AVALON_PROJECT"]
+        project_name = get_current_project_name()
         self.anatomy = Anatomy(project_name)
         self.project_name = project_name
         # Template key used to get work template from anatomy templates

--- a/openpype/tools/workfiles/window.py
+++ b/openpype/tools/workfiles/window.py
@@ -310,7 +310,7 @@ class Window(QtWidgets.QWidget):
         workfile_doc = None
         if asset_id and task_name and filepath:
             filename = os.path.split(filepath)[1]
-            project_name = get_current_project_name()
+            project_name = self.project_name
             workfile_doc = get_workfile_info(
                 project_name, asset_id, task_name, filename
             )
@@ -341,7 +341,7 @@ class Window(QtWidgets.QWidget):
         if not update_data:
             return
 
-        project_name = get_current_project_name()
+        project_name = self.project_name
 
         session = OperationsSession()
         session.update_entity(
@@ -358,7 +358,7 @@ class Window(QtWidgets.QWidget):
             return
 
         filename = os.path.split(filepath)[1]
-        project_name = get_current_project_name()
+        project_name = self.project_name
         return get_workfile_info(
             project_name, asset_id, task_name, filename
         )
@@ -370,7 +370,7 @@ class Window(QtWidgets.QWidget):
 
         workdir, filename = os.path.split(filepath)
 
-        project_name = get_current_project_name()
+        project_name = self.project_name
         asset_id = self.assets_widget.get_selected_asset_id()
         task_name = self.tasks_widget.get_selected_task_name()
 

--- a/openpype/tools/workfiles/window.py
+++ b/openpype/tools/workfiles/window.py
@@ -14,7 +14,12 @@ from openpype.client.operations import (
 )
 from openpype import style
 from openpype import resources
-from openpype.pipeline import Anatomy
+from openpype.pipeline import (
+    Anatomy,
+    get_current_project_name,
+    get_current_asset_name,
+    get_current_task_name,
+)
 from openpype.pipeline import legacy_io
 from openpype.tools.utils.assets_widget import SingleSelectAssetsWidget
 from openpype.tools.utils.tasks_widget import TasksWidget
@@ -265,8 +270,8 @@ class Window(QtWidgets.QWidget):
 
         if use_context is None or use_context is True:
             context = {
-                "asset": legacy_io.Session["AVALON_ASSET"],
-                "task": legacy_io.Session["AVALON_TASK"]
+                "asset": get_current_asset_name(),
+                "task": get_current_task_name()
             }
             self.set_context(context)
 
@@ -276,7 +281,7 @@ class Window(QtWidgets.QWidget):
 
     @property
     def project_name(self):
-        return legacy_io.Session["AVALON_PROJECT"]
+        return get_current_project_name()
 
     def showEvent(self, event):
         super(Window, self).showEvent(event)
@@ -305,7 +310,7 @@ class Window(QtWidgets.QWidget):
         workfile_doc = None
         if asset_id and task_name and filepath:
             filename = os.path.split(filepath)[1]
-            project_name = legacy_io.active_project()
+            project_name = get_current_project_name()
             workfile_doc = get_workfile_info(
                 project_name, asset_id, task_name, filename
             )
@@ -336,7 +341,7 @@ class Window(QtWidgets.QWidget):
         if not update_data:
             return
 
-        project_name = legacy_io.active_project()
+        project_name = get_current_project_name()
 
         session = OperationsSession()
         session.update_entity(
@@ -353,7 +358,7 @@ class Window(QtWidgets.QWidget):
             return
 
         filename = os.path.split(filepath)[1]
-        project_name = legacy_io.active_project()
+        project_name = get_current_project_name()
         return get_workfile_info(
             project_name, asset_id, task_name, filename
         )
@@ -365,7 +370,7 @@ class Window(QtWidgets.QWidget):
 
         workdir, filename = os.path.split(filepath)
 
-        project_name = legacy_io.active_project()
+        project_name = get_current_project_name()
         asset_id = self.assets_widget.get_selected_asset_id()
         task_name = self.tasks_widget.get_selected_task_name()
 

--- a/poetry.lock
+++ b/poetry.lock
@@ -303,6 +303,24 @@ pycodestyle = ">=2.10.0"
 tomli = {version = "*", markers = "python_version < \"3.11\""}
 
 [[package]]
+name = "ayon-python-api"
+version = "0.1.16"
+description = "AYON Python API"
+category = "main"
+optional = false
+python-versions = "*"
+files = [
+    {file = "ayon-python-api-0.1.16.tar.gz", hash = "sha256:666110954dd75b2be1699a29b4732cfb0bcb09d01f64fba4449bfc8ac1fb43f1"},
+    {file = "ayon_python_api-0.1.16-py3-none-any.whl", hash = "sha256:bbcd6df1f80ddf32e653a1bb31289cb5fd1a8bea36ab4c8e6aef08c41b6393de"},
+]
+
+[package.dependencies]
+appdirs = ">=1,<2"
+requests = ">=2.27.1"
+six = ">=1.15"
+Unidecode = ">=1.2.0"
+
+[[package]]
 name = "babel"
 version = "2.11.0"
 description = "Internationalization utilities"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -70,6 +70,7 @@ requests = "^2.25.1"
 pysftp = "^0.2.9"
 dropbox = "^11.20.0"
 aiohttp-middlewares = "^2.0.0"
+ayon-python-api = "^0.1"
 opencolorio = "^2.2.0"
 Unidecode = "^1.2"
 


### PR DESCRIPTION
## Changelog Description
Replace usages of `legacy_io` with getter methods or reuse already available information. Create plugins using CreateContext are using context from CreateContext object. Loaders are usign getter function from context tools. Publish plugin are using information instance.data or context.data. In some cases were pieces of code refactored a little e.g. fps getter in maya.

## Additional info
In some cases were made comprimises, that are not perfect but changes don't affect current workflow e.g. using current project/asset/task from context.data during publishing, which would require to change order of plugins but that would require much more validation.

Not all places were replaced. In some cases, e.g. tools related code, it is impossible to just stop using legacy io as is used as source for current context using session. We should look for AVALON_APP, AVALON_APP_NAME and AVALON_WORKDIR in future PRs.

## Testing notes:
### Code review
1. Go through code and validate that I didn't make typo (e.g. use `get_current_asset_name` where should be used `get_current_task_name`)

### Practical review
1. Open any host where changes were made
2. Try publish something
3. In case of Maya and Nuke try to use deadline

Resolves https://github.com/ynput/OpenPype/issues/1730