### PR TITLE
After Effects: fix handles KeyError

### DIFF
--- a/openpype/hosts/aftereffects/plugins/publish/collect_workfile.py
+++ b/openpype/hosts/aftereffects/plugins/publish/collect_workfile.py
@@ -49,8 +49,8 @@ class CollectWorkfile(pyblish.api.ContextPlugin):
         asset_entity = context.data["assetEntity"]
         project_entity = context.data["projectEntity"]
 
-        handle_start = asset_entity["data"].get("handleStart") or context.data.get("handleStart")
-        handle_end = asset_entity["data"].get("handeEnd") or context.data.get("handleEnd")
+        handle_start = asset_entity["data"].get("handleStart") or context.data.get("handleStart")  # noqa
+        handle_end = asset_entity["data"].get("handeEnd") or context.data.get("handleEnd")  # noqa
 
         if handle_start is None or handle_end is None:
             raise KeyError("Handles are not set for this context")

--- a/openpype/hosts/aftereffects/plugins/publish/collect_workfile.py
+++ b/openpype/hosts/aftereffects/plugins/publish/collect_workfile.py
@@ -49,20 +49,14 @@ class CollectWorkfile(pyblish.api.ContextPlugin):
         asset_entity = context.data["assetEntity"]
         project_entity = context.data["projectEntity"]
 
-        handle_start = asset_entity["data"].get("handleStart") or context.data.get("handleStart")  # noqa
-        handle_end = asset_entity["data"].get("handeEnd") or context.data.get("handleEnd")  # noqa
-
-        if handle_start is None or handle_end is None:
-            raise KeyError("Handles are not set for this context")
-
         instance_data = {
             "active": True,
             "asset": asset_entity["name"],
             "task": task,
-            "frameStart": asset_entity["data"]["frameStart"],
-            "frameEnd": asset_entity["data"]["frameEnd"],
-            "handleStart": handle_start,
-            "handleEnd": handle_end,
+            "frameStart": context.data['frameStart'],
+            "frameEnd": context.data['frameEnd'],
+            "handleStart": context.data['handleStart'],
+            "handleEnd": context.data['handleEnd'],
             "fps": asset_entity["data"]["fps"],
             "resolutionWidth": asset_entity["data"].get(
                 "resolutionWidth",

--- a/openpype/hosts/aftereffects/plugins/publish/collect_workfile.py
+++ b/openpype/hosts/aftereffects/plugins/publish/collect_workfile.py
@@ -49,14 +49,20 @@ class CollectWorkfile(pyblish.api.ContextPlugin):
         asset_entity = context.data["assetEntity"]
         project_entity = context.data["projectEntity"]
 
+        handle_start = asset_entity["data"].get("handleStart") or context.data.get("handleStart")
+        handle_end = asset_entity["data"].get("handeEnd") or context.data.get("handleEnd")
+
+        if handle_start is None or handle_end is None:
+            raise KeyError("Handles are not set for this context")
+
         instance_data = {
             "active": True,
             "asset": asset_entity["name"],
             "task": task,
             "frameStart": asset_entity["data"]["frameStart"],
             "frameEnd": asset_entity["data"]["frameEnd"],
-            "handleStart": asset_entity["data"]["handleStart"],
-            "handleEnd": asset_entity["data"]["handleEnd"],
+            "handleStart": handle_start,
+            "handleEnd": handle_end,
             "fps": asset_entity["data"]["fps"],
             "resolutionWidth": asset_entity["data"].get(
                 "resolutionWidth",


### PR DESCRIPTION
## Changelog Description
Sometimes when publishing with AE (we only saw this error on AE 2023), we got a KeyError for the handles in the "Collect Workfile" step. So I did get the handles from the context if ther's no handles in the asset entity.

