### PR TITLE
Houdini: Fix collect current file

### DIFF
--- a/openpype/hosts/houdini/plugins/publish/collect_current_file.py
+++ b/openpype/hosts/houdini/plugins/publish/collect_current_file.py
@@ -1,7 +1,6 @@
 import os
 import hou
 
-from openpype.pipeline import legacy_io
 import pyblish.api
 
 
@@ -11,7 +10,7 @@ class CollectHoudiniCurrentFile(pyblish.api.InstancePlugin):
     order = pyblish.api.CollectorOrder - 0.01
     label = "Houdini Current File"
     hosts = ["houdini"]
-    family = ["workfile"]
+    families = ["workfile"]
 
     def process(self, instance):
         """Inject the current working file"""
@@ -21,7 +20,7 @@ class CollectHoudiniCurrentFile(pyblish.api.InstancePlugin):
             # By default, Houdini will even point a new scene to a path.
             # However if the file is not saved at all and does not exist,
             # we assume the user never set it.
-            filepath = ""
+            current_file = ""
 
         elif os.path.basename(current_file) == "untitled.hip":
             # Due to even a new file being called 'untitled.hip' we are unable


### PR DESCRIPTION
## Changelog Description

Fixes the Workfile publishing getting added into every instance being published from Houdini

## Additional info

- Fix families filtering
- Remove unused import
- Fix correct detection if scene is new but unsaved scene

## Testing notes:

1. In Houdini publish multiple instances including the workfile.
2. Families like `pointcache`, `camera`, etc. should NOT have a `.hip` file (unless it's the workfile of course) 
