### PR TITLE
Harmony: render what is in timeline in Harmony locally

### DIFF
--- a/openpype/hosts/harmony/api/TB_sceneOpened.js
+++ b/openpype/hosts/harmony/api/TB_sceneOpened.js
@@ -476,6 +476,25 @@ function start() {
         action.triggered.connect(self.onSubsetManage);
     }
 
+     /**
+      * Set scene settings from DB to the scene
+      */
+    self.onSetSceneSettings = function() {
+          app.avalonClient.send(
+            {
+              "module": "openpype.hosts.harmony.api",
+              "method": "ensure_scene_settings",
+              "args": []
+            },
+            false
+          );
+    };
+    // add Set Scene Settings
+    if (app.avalonMenu == null) {
+        action = menu.addAction('Set Scene Settings...');
+        action.triggered.connect(self.onSetSceneSettings);
+    }
+
     /**
       * Show Experimental dialog
       */

--- a/openpype/hosts/harmony/api/pipeline.py
+++ b/openpype/hosts/harmony/api/pipeline.py
@@ -142,7 +142,7 @@ def application_launch(event):
     harmony.send({"script": script})
     inject_avalon_js()
 
-    ensure_scene_settings()
+    # ensure_scene_settings()
     check_inventory()
 
 

--- a/openpype/hosts/harmony/plugins/publish/extract_render.py
+++ b/openpype/hosts/harmony/plugins/publish/extract_render.py
@@ -25,8 +25,9 @@ class ExtractRender(pyblish.api.InstancePlugin):
         application_path = instance.context.data.get("applicationPath")
         scene_path = instance.context.data.get("scenePath")
         frame_rate = instance.context.data.get("frameRate")
-        frame_start = instance.context.data.get("frameStart")
-        frame_end = instance.context.data.get("frameEnd")
+        # real value from timeline
+        frame_start = instance.context.data.get("frameStartHandle")
+        frame_end = instance.context.data.get("frameEndHandle")
         audio_path = instance.context.data.get("audioPath")
 
         if audio_path and os.path.exists(audio_path):
@@ -55,9 +56,13 @@ class ExtractRender(pyblish.api.InstancePlugin):
 
         # Execute rendering. Ignoring error cause Harmony returns error code
         # always.
-        self.log.info(f"running [ {application_path} -batch {scene_path}")
+
+        args = [application_path, "-batch",
+                "-frames", str(frame_start), str(frame_end),
+                "-scene", scene_path]
+        self.log.info(f"running [ {application_path} {' '.join(args)}")
         proc = subprocess.Popen(
-            [application_path, "-batch", scene_path],
+            args,
             stdout=subprocess.PIPE,
             stderr=subprocess.STDOUT,
             stdin=subprocess.PIPE

--- a/openpype/hosts/harmony/plugins/publish/validate_scene_settings.py
+++ b/openpype/hosts/harmony/plugins/publish/validate_scene_settings.py
@@ -60,7 +60,8 @@ class ValidateSceneSettings(pyblish.api.InstancePlugin):
         #   which is available on 'context.data["assetEntity"]'
         #   - the same approach can be used in 'ValidateSceneSettingsRepair'
         expected_settings = harmony.get_asset_settings()
-        self.log.info("scene settings from DB:".format(expected_settings))
+        self.log.info("scene settings from DB:{}".format(expected_settings))
+        expected_settings.pop("entityType")  # not useful for the validation
 
         expected_settings = _update_frames(dict.copy(expected_settings))
         expected_settings["frameEndHandle"] = expected_settings["frameEnd"] +\
@@ -68,21 +69,32 @@ class ValidateSceneSettings(pyblish.api.InstancePlugin):
 
         if (any(re.search(pattern, os.getenv('AVALON_TASK'))
                 for pattern in self.skip_resolution_check)):
+            self.log.info("Skipping resolution check because of "
+                          "task name and pattern {}".format(
+                            self.skip_resolution_check))
             expected_settings.pop("resolutionWidth")
             expected_settings.pop("resolutionHeight")
 
-        entity_type = expected_settings.get("entityType")
-        if (any(re.search(pattern, entity_type)
+        if (any(re.search(pattern, os.getenv('AVALON_TASK'))
                 for pattern in self.skip_timelines_check)):
+            self.log.info("Skipping frames check because of "
+                          "task name and pattern {}".format(
+                            self.skip_timelines_check))
             expected_settings.pop('frameStart', None)
             expected_settings.pop('frameEnd', None)
-
-        expected_settings.pop("entityType")  # not useful after the check
+            expected_settings.pop('frameStartHandle', None)
+            expected_settings.pop('frameEndHandle', None)
 
         asset_name = instance.context.data['anatomyData']['asset']
         if any(re.search(pattern, asset_name)
                 for pattern in self.frame_check_filter):
-            expected_settings.pop("frameEnd")
+            self.log.info("Skipping frames check because of "
+                          "task name and pattern {}".format(
+                            self.frame_check_filter))
+            expected_settings.pop('frameStart', None)
+            expected_settings.pop('frameEnd', None)
+            expected_settings.pop('frameStartHandle', None)
+            expected_settings.pop('frameEndHandle', None)
 
         # handle case where ftrack uses only two decimal places
         # 23.976023976023978 vs. 23.98

--- a/openpype/hosts/harmony/plugins/publish/validate_scene_settings.py
+++ b/openpype/hosts/harmony/plugins/publish/validate_scene_settings.py
@@ -99,6 +99,7 @@ class ValidateSceneSettings(pyblish.api.InstancePlugin):
             "frameEnd": instance.context.data["frameEnd"],
             "handleStart": instance.context.data.get("handleStart"),
             "handleEnd": instance.context.data.get("handleEnd"),
+            "frameStartHandle": instance.context.data.get("frameStartHandle"),
             "frameEndHandle": instance.context.data.get("frameEndHandle"),
             "resolutionWidth": instance.context.data.get("resolutionWidth"),
             "resolutionHeight": instance.context.data.get("resolutionHeight"),


### PR DESCRIPTION
## Changelog Description
Previously it wasn't possible to render according to what was set in Timeline in scene start/end, just by what it was set in whole timeline.

This allows artist to override what is in DB with what they require (with disabled `Validate Scene Settings`). Now artist can extend scene by additional frames, that shouldn't be rendered, but which might be desired.

Removed explicit set scene settings (eg. applying frames and resolution directly to the scene after launch), added separate menu item to allow artist to do it themselves.

## Additional info
Customer stores turntable frames after scene end frames. Only scene frames should be rendered, but turntable frames should be kept intact.

## Testing notes:
1. extend scene in Harmony by `Scene > Frame > Add Frames at End` (keep both checkboxes toggled)
2. run publish - it should only rendered what is denoted by small black triangles in the timeline
