### PR TITLE
Refactor: Remove `handles`, `edit_in` and `edit_out` backwards compatibility

### DIFF
--- a/openpype/hosts/fusion/plugins/load/actions.py
+++ b/openpype/hosts/fusion/plugins/load/actions.py
@@ -72,8 +72,7 @@ class FusionSetFrameRangeWithHandlesLoader(load.LoaderPlugin):
             return
 
         # Include handles
-        handles = version_data.get("handles", 0)
-        start -= handles
-        end += handles
+        start -= version_data.get("handleStart", 0)
+        end += version_data.get("handleEnd", 0)
 
         lib.update_frame_range(start, end)

--- a/openpype/hosts/houdini/api/lib.py
+++ b/openpype/hosts/houdini/api/lib.py
@@ -479,10 +479,6 @@ def reset_framerange():
 
     frame_start = asset_data.get("frameStart")
     frame_end = asset_data.get("frameEnd")
-    # Backwards compatibility
-    if frame_start is None or frame_end is None:
-        frame_start = asset_data.get("edit_in")
-        frame_end = asset_data.get("edit_out")
 
     if frame_start is None or frame_end is None:
         log.warning("No edit information found for %s" % asset_name)

--- a/openpype/hosts/houdini/api/lib.py
+++ b/openpype/hosts/houdini/api/lib.py
@@ -488,14 +488,8 @@ def reset_framerange():
         log.warning("No edit information found for %s" % asset_name)
         return
 
-    handles = asset_data.get("handles") or 0
     handle_start = asset_data.get("handleStart")
-    if handle_start is None:
-        handle_start = handles
-
     handle_end = asset_data.get("handleEnd")
-    if handle_end is None:
-        handle_end = handles
 
     frame_start -= int(handle_start)
     frame_end += int(handle_end)

--- a/openpype/hosts/max/api/lib.py
+++ b/openpype/hosts/max/api/lib.py
@@ -215,13 +215,9 @@ def get_frame_range() -> dict:
         frame_end = asset["data"].get("edit_out")
     if frame_start is None or frame_end is None:
         return
-    handles = asset["data"].get("handles") or 0
+
     handle_start = asset["data"].get("handleStart")
-    if handle_start is None:
-        handle_start = handles
     handle_end = asset["data"].get("handleEnd")
-    if handle_end is None:
-        handle_end = handles
     return {
         "frameStart": frame_start,
         "frameEnd": frame_end,

--- a/openpype/hosts/max/api/lib.py
+++ b/openpype/hosts/max/api/lib.py
@@ -209,10 +209,7 @@ def get_frame_range() -> dict:
     asset = get_current_project_asset()
     frame_start = asset["data"].get("frameStart")
     frame_end = asset["data"].get("frameEnd")
-    # Backwards compatibility
-    if frame_start is None or frame_end is None:
-        frame_start = asset["data"].get("edit_in")
-        frame_end = asset["data"].get("edit_out")
+
     if frame_start is None or frame_end is None:
         return
 

--- a/openpype/hosts/maya/api/lib.py
+++ b/openpype/hosts/maya/api/lib.py
@@ -2073,10 +2073,6 @@ def get_frame_range():
 
     frame_start = asset["data"].get("frameStart")
     frame_end = asset["data"].get("frameEnd")
-    # Backwards compatibility
-    if frame_start is None or frame_end is None:
-        frame_start = asset["data"].get("edit_in")
-        frame_end = asset["data"].get("edit_out")
 
     if frame_start is None or frame_end is None:
         cmds.warning("No edit information found for %s" % asset_name)

--- a/openpype/hosts/maya/api/lib.py
+++ b/openpype/hosts/maya/api/lib.py
@@ -2082,14 +2082,8 @@ def get_frame_range():
         cmds.warning("No edit information found for %s" % asset_name)
         return
 
-    handles = asset["data"].get("handles") or 0
-    handle_start = asset["data"].get("handleStart")
-    if handle_start is None:
-        handle_start = handles
-
-    handle_end = asset["data"].get("handleEnd")
-    if handle_end is None:
-        handle_end = handles
+    handle_start = asset["data"].get("handleStart") or 0
+    handle_end = asset["data"].get("handleEnd") or 0
 
     return {
         "frameStart": frame_start,

--- a/openpype/hosts/maya/plugins/publish/collect_instances.py
+++ b/openpype/hosts/maya/plugins/publish/collect_instances.py
@@ -149,13 +149,6 @@ class CollectInstances(pyblish.api.ContextPlugin):
 
             # Append start frame and end frame to label if present
             if "frameStart" and "frameEnd" in data:
-
-                # Backwards compatibility for 'handles' data
-                if "handles" in data:
-                    data["handleStart"] = data["handles"]
-                    data["handleEnd"] = data["handles"]
-                    data.pop('handles')
-
                 # Take handles from context if not set locally on the instance
                 for key in ["handleStart", "handleEnd"]:
                     if key not in data:

--- a/openpype/hosts/maya/plugins/publish/collect_review.py
+++ b/openpype/hosts/maya/plugins/publish/collect_review.py
@@ -74,7 +74,6 @@ class CollectReview(pyblish.api.InstancePlugin):
                 data['frameEndHandle'] = instance.data["frameEndHandle"]
                 data["frameStart"] = instance.data["frameStart"]
                 data["frameEnd"] = instance.data["frameEnd"]
-                data['handles'] = instance.data.get('handles', None)
                 data['step'] = instance.data['step']
                 data['fps'] = instance.data['fps']
                 data['review_width'] = instance.data['review_width']

--- a/openpype/hosts/maya/plugins/publish/extract_vrayproxy.py
+++ b/openpype/hosts/maya/plugins/publish/extract_vrayproxy.py
@@ -30,9 +30,7 @@ class ExtractVRayProxy(publish.Extractor):
             # non-animated subsets
             keys = ["frameStart", "frameEnd",
                     "handleStart", "handleEnd",
-                    "frameStartHandle", "frameEndHandle",
-                    # Backwards compatibility
-                    "handles"]
+                    "frameStartHandle", "frameEndHandle"]
             for key in keys:
                 instance.data.pop(key, None)
 

--- a/openpype/hosts/maya/plugins/publish/validate_frame_range.py
+++ b/openpype/hosts/maya/plugins/publish/validate_frame_range.py
@@ -4,6 +4,7 @@ from maya import cmds
 from openpype.pipeline.publish import (
     RepairAction,
     ValidateContentsOrder,
+    PublishValidationError
 )
 from openpype.hosts.maya.api.lib_rendersetup import (
     get_attr_overrides,
@@ -49,7 +50,6 @@ class ValidateFrameRange(pyblish.api.InstancePlugin):
 
         frame_start_handle = int(context.data.get("frameStartHandle"))
         frame_end_handle = int(context.data.get("frameEndHandle"))
-        handles = int(context.data.get("handles"))
         handle_start = int(context.data.get("handleStart"))
         handle_end = int(context.data.get("handleEnd"))
         frame_start = int(context.data.get("frameStart"))
@@ -65,8 +65,6 @@ class ValidateFrameRange(pyblish.api.InstancePlugin):
         # basic sanity checks
         assert frame_start_handle <= frame_end_handle, (
             "start frame is lower then end frame")
-
-        assert handles >= 0, ("handles cannot have negative values")
 
         # compare with data on instance
         errors = []

--- a/openpype/hosts/nuke/plugins/load/actions.py
+++ b/openpype/hosts/nuke/plugins/load/actions.py
@@ -74,8 +74,7 @@ class SetFrameRangeWithHandlesLoader(load.LoaderPlugin):
             return
 
         # Include handles
-        handles = version_data.get("handles", 0)
-        start -= handles
-        end += handles
+        start -= version_data.get("handleStart", 0)
+        end += version_data.get("handleEnd", 0)
 
         lib.update_frame_range(start, end)

--- a/openpype/hosts/nuke/plugins/load/load_script_precomp.py
+++ b/openpype/hosts/nuke/plugins/load/load_script_precomp.py
@@ -138,7 +138,6 @@ class LinkAsGroup(load.LoaderPlugin):
             "version": version_doc.get("name"),
             "colorspace": version_data.get("colorspace"),
             "source": version_data.get("source"),
-            "handles": version_data.get("handles"),
             "fps": version_data.get("fps"),
             "author": version_data.get("author")
         })

--- a/openpype/hosts/nuke/plugins/publish/collect_context_data.py
+++ b/openpype/hosts/nuke/plugins/publish/collect_context_data.py
@@ -49,8 +49,6 @@ class CollectContextData(pyblish.api.ContextPlugin):
             "resolutionHeight": resolution_height,
             "pixelAspect": pixel_aspect,
 
-            # backward compatibility handles
-            "handles": handle_start,
             "handleStart": handle_start,
             "handleEnd": handle_end,
             "step": 1,

--- a/openpype/hosts/nuke/plugins/publish/collect_gizmo.py
+++ b/openpype/hosts/nuke/plugins/publish/collect_gizmo.py
@@ -28,7 +28,6 @@ class CollectGizmo(pyblish.api.InstancePlugin):
 
         # Add version data to instance
         version_data = {
-            "handles": handle_start,
             "handleStart": handle_start,
             "handleEnd": handle_end,
             "frameStart": first_frame + handle_start,

--- a/openpype/hosts/nuke/plugins/publish/collect_model.py
+++ b/openpype/hosts/nuke/plugins/publish/collect_model.py
@@ -28,7 +28,6 @@ class CollectModel(pyblish.api.InstancePlugin):
 
         # Add version data to instance
         version_data = {
-            "handles": handle_start,
             "handleStart": handle_start,
             "handleEnd": handle_end,
             "frameStart": first_frame + handle_start,

--- a/openpype/hosts/nuke/plugins/publish/collect_reads.py
+++ b/openpype/hosts/nuke/plugins/publish/collect_reads.py
@@ -103,7 +103,6 @@ class CollectNukeReads(pyblish.api.InstancePlugin):
 
         # Add version data to instance
         version_data = {
-            "handles": handle_start,
             "handleStart": handle_start,
             "handleEnd": handle_end,
             "frameStart": first_frame + handle_start,
@@ -123,7 +122,8 @@ class CollectNukeReads(pyblish.api.InstancePlugin):
             "frameStart": first_frame,
             "frameEnd": last_frame,
             "colorspace": colorspace,
-            "handles": int(asset_doc["data"].get("handles", 0)),
+            "handleStart": handle_start,
+            "handleEnd": handle_end,
             "step": 1,
             "fps": int(nuke.root()['fps'].value())
         })

--- a/openpype/hosts/tvpaint/api/pipeline.py
+++ b/openpype/hosts/tvpaint/api/pipeline.py
@@ -504,13 +504,8 @@ def set_context_settings(project_name, asset_doc):
         print("Frame range was not found!")
         return
 
-    handles = asset_doc["data"].get("handles") or 0
     handle_start = asset_doc["data"].get("handleStart")
     handle_end = asset_doc["data"].get("handleEnd")
-
-    if handle_start is None or handle_end is None:
-        handle_start = handles
-        handle_end = handles
 
     # Always start from 0 Mark In and set only Mark Out
     mark_in = 0

--- a/openpype/plugins/publish/collect_context_entities.py
+++ b/openpype/plugins/publish/collect_context_entities.py
@@ -72,24 +72,9 @@ class CollectContextEntities(pyblish.api.ContextPlugin):
         context.data["frameStart"] = frame_start
         context.data["frameEnd"] = frame_end
 
-        handles = data.get("handles") or 0
-        handle_start = data.get("handleStart")
-        if handle_start is None:
-            handle_start = handles
-            self.log.info((
-                "Key \"handleStart\" is not set."
-                " Using value from \"handles\" key {}."
-            ).format(handle_start))
+        handle_start = data.get("handleStart") or 0
+        handle_end = data.get("handleEnd") or 0
 
-        handle_end = data.get("handleEnd")
-        if handle_end is None:
-            handle_end = handles
-            self.log.info((
-                "Key \"handleEnd\" is not set."
-                " Using value from \"handles\" key {}."
-            ).format(handle_end))
-
-        context.data["handles"] = int(handles)
         context.data["handleStart"] = int(handle_start)
         context.data["handleEnd"] = int(handle_end)
 

--- a/openpype/plugins/publish/extract_burnin.py
+++ b/openpype/plugins/publish/extract_burnin.py
@@ -457,12 +457,6 @@ class ExtractBurnin(publish.Extractor):
             frame_end = 1
         frame_end = int(frame_end)
 
-        handles = instance.data.get("handles")
-        if handles is None:
-            handles = context.data.get("handles")
-            if handles is None:
-                handles = 0
-
         handle_start = instance.data.get("handleStart")
         if handle_start is None:
             handle_start = context.data.get("handleStart")

--- a/openpype/plugins/publish/integrate.py
+++ b/openpype/plugins/publish/integrate.py
@@ -912,7 +912,7 @@ class IntegrateAsset(pyblish.api.InstancePlugin):
 
         # Include optional data if present in
         optionals = [
-            "frameStart", "frameEnd", "step", "handles",
+            "frameStart", "frameEnd", "step",
             "handleEnd", "handleStart", "sourceHashes"
         ]
         for key in optionals:

--- a/openpype/plugins/publish/integrate_legacy.py
+++ b/openpype/plugins/publish/integrate_legacy.py
@@ -987,7 +987,7 @@ class IntegrateAssetNew(pyblish.api.InstancePlugin):
 
         # Include optional data if present in
         optionals = [
-            "frameStart", "frameEnd", "step", "handles",
+            "frameStart", "frameEnd", "step",
             "handleEnd", "handleStart", "sourceHashes"
         ]
         for key in optionals:

--- a/openpype/tools/loader/model.py
+++ b/openpype/tools/loader/model.py
@@ -365,8 +365,6 @@ class SubsetsModel(TreeModel, BaseRepresentationModel):
         handle_end = version_data.get("handleEnd", None)
         if handle_start is not None and handle_end is not None:
             handles = "{}-{}".format(str(handle_start), str(handle_end))
-        else:
-            handles = version_data.get("handles", None)
 
         if frame_start is not None and frame_end is not None:
             # Remove superfluous zeros from numbers (3.0 -> 3) to improve


### PR DESCRIPTION
## Changelog Description

Removes backward compatibiliy fallback for data called `handles`, `edit_in` and `edit_out`.

## Additional info

This intends to fix #4709 

## Testing notes:

1. Test the areas of the code that were touched.
2. Use set frame range action in Maya, Fusion, Nuke
3. Load script precomp in Nuke
4. Publish reviews from a few hosts, like Maya + Nuke
5. Publish "reads" and "model" from Nuke
6. Publishes tested for this PR should still load and update as expected.
7. The loader tool should still nicely show the handles

Also please check whether I've found all cases of handles in the codebase :)