### PR TITLE
Maya: Extract Review settings add Use Background Gradient

### DIFF
--- a/openpype/hosts/maya/api/lib.py
+++ b/openpype/hosts/maya/api/lib.py
@@ -2478,8 +2478,8 @@ def load_capture_preset(data=None):
                     float(value[2]) / 255
                 ]
             disp_options[key] = value
-        else:
-            disp_options['displayGradient'] = True
+        elif key == "displayGradient":
+            disp_options[key] = value
 
     options['display_options'] = disp_options
 

--- a/openpype/settings/defaults/project_settings/maya.json
+++ b/openpype/settings/defaults/project_settings/maya.json
@@ -795,6 +795,7 @@
                     "quality": 95
                 },
                 "Display Options": {
+                    "override_display": true,
                     "background": [
                         125,
                         125,
@@ -813,7 +814,7 @@
                         125,
                         255
                     ],
-                    "override_display": true
+                    "displayGradient": true
                 },
                 "Generic": {
                     "isolate_view": true,

--- a/openpype/settings/entities/schemas/projects_schema/schemas/schema_maya_capture.json
+++ b/openpype/settings/entities/schemas/projects_schema/schemas/schema_maya_capture.json
@@ -48,7 +48,11 @@
                             "type": "label",
                             "label": "<b>Display Options</b>"
                         },
-
+                        {
+                            "type": "boolean",
+                            "key": "override_display",
+                            "label": "Override display options"
+                        },
                         {
                             "type": "color",
                             "key": "background",
@@ -66,8 +70,8 @@
                         },
                         {
                             "type": "boolean",
-                            "key": "override_display",
-                            "label": "Override display options"
+                            "key": "displayGradient",
+                            "label": "Display background gradient"
                         }
                     ]
                 },


### PR DESCRIPTION
## Changelog Description

Add Display Gradient Background toggle in settings to fix support for setting flat background color for reviews.

## Additional info

This fixes #4693.

New setting is `project_settings/maya/publish/ExtractPlayblast/capture_preset/Display Options/displayGradient`

![afbeelding](https://user-images.githubusercontent.com/2439881/228681450-b1b3d07a-829b-4c05-adc0-4d03947c858d.png)

## Testing notes:

1. Tweak the settings `project_settings/maya/publish/ExtractPlayblast/capture_preset/Display Options/displayGradient`
2. Set some diverse colors for background, backgroundTop and backgroundBottom.
3. Make a playblast for both case with gradient enabled and disabled.
