### PR TITLE
AYON: Change login UI works

### DIFF
--- a/common/ayon_common/connection/credentials.py
+++ b/common/ayon_common/connection/credentials.py
@@ -34,7 +34,7 @@ class ChangeUserResult:
     ):
         shutdown = logged_out
         restart = new_url is not None and new_url != old_url
-        token_changed = new_token is not None and new_token == old_token
+        token_changed = new_token is not None and new_token != old_token
 
         self.logged_out = logged_out
         self.old_url = old_url


### PR DESCRIPTION
## Changelog Description
Fixed change of login UI. Logic change UI did show up, new login was successful, but after restart was used the previous login. This change fix the issue.

## Testing notes:
1. Launch ayon mode
2. Login to a server
3. Click Tray > Login
4. Change server and login
5. Process should restart
6. Click Tray > Login
7. You should see server and user from step 4.
