### PR TITLE
Global: Merge review tags

### DIFF
--- a/openpype/hosts/flame/plugins/publish/extract_subset_resources.py
+++ b/openpype/hosts/flame/plugins/publish/extract_subset_resources.py
@@ -326,6 +326,7 @@ class ExtractSubsetResources(publish.Extractor):
             # HACK: `ftrackreview_withLUT` will result only in `ftrackreview`
             if (
                 "thumbnail" in unique_name
+                # TODO: this should not be hardcoded to ftrack
                 or "ftrackreview" in unique_name
             ):
                 repr_name = unique_name.split("_")[0]

--- a/openpype/hosts/flame/startup/openpype_babypublisher/modules/ftrack_lib.py
+++ b/openpype/hosts/flame/startup/openpype_babypublisher/modules/ftrack_lib.py
@@ -127,6 +127,7 @@ class FtrackComponentCreator:
         file = os.path.basename(file_path)
         _n, ext = os.path.splitext(file)
 
+        # TODO: This should not be hardcoded to ftrack
         name = "ftrackreview-mp4" if "mov" in ext else "thumbnail"
 
         component_data = {
@@ -136,6 +137,7 @@ class FtrackComponentCreator:
             "location": location
         }
 
+        # TODO: this should not be hardcoded to ftrack
         if name == "ftrackreview-mp4":
             duration = data["duration"]
             handles = data["handles"]

--- a/openpype/hosts/fusion/plugins/publish/render_local.py
+++ b/openpype/hosts/fusion/plugins/publish/render_local.py
@@ -63,7 +63,7 @@ class Fusionlocal(pyblish.api.InstancePlugin,
 
         # review representation
         if instance.data.get("review", False):
-            repre["tags"] = ["review", "ftrackreview"]
+            repre["tags"] = ["review"]
 
     def render_once(self, context):
         """Render context comp only once, even with more render instances"""

--- a/openpype/hosts/standalonepublisher/plugins/publish/collect_editorial_resources.py
+++ b/openpype/hosts/standalonepublisher/plugins/publish/collect_editorial_resources.py
@@ -202,7 +202,7 @@ class CollectInstanceResources(pyblish.api.InstancePlugin):
                     "step": 1,
                     "fps": self.context.data.get("fps"),
                     "name": "review",
-                    "tags": ["review", "ftrackreview", "delete"],
+                    "tags": ["review", "delete"],
                 })
             instance_data["representations"].append(repre_data)
 
@@ -256,7 +256,7 @@ class CollectInstanceResources(pyblish.api.InstancePlugin):
                     "fps": self.context.data.get("fps"),
                     "name": "review",
                     "thumbnail": True,
-                    "tags": ["review", "ftrackreview", "delete"],
+                    "tags": ["review", "delete"],
                 })
 
             # add to frames for frame range reset only if no collection

--- a/openpype/modules/ftrack/plugins/publish/integrate_ftrack_instances.py
+++ b/openpype/modules/ftrack/plugins/publish/integrate_ftrack_instances.py
@@ -131,7 +131,7 @@ class IntegrateFtrackInstance(pyblish.api.InstancePlugin):
             if repre.get("thumbnail") or "thumbnail" in repre_tags:
                 thumbnail_representations.append(repre)
 
-            elif "ftrackreview" in repre_tags:
+            elif "review" in repre_tags:
                 review_representations.append(repre)
                 if self._is_repre_video(repre):
                     has_movie_review = True

--- a/openpype/modules/kitsu/plugins/publish/integrate_kitsu_review.py
+++ b/openpype/modules/kitsu/plugins/publish/integrate_kitsu_review.py
@@ -25,7 +25,7 @@ class IntegrateKitsuReview(pyblish.api.InstancePlugin):
         # Add review representations as preview of comment
         for representation in instance.data.get("representations", []):
             # Skip if not tagged as review
-            if "kitsureview" not in representation.get("tags", []):
+            if "review" not in representation.get("tags", []):
                 continue
             review_path = representation.get("published_path")
             self.log.debug("Found review at: {}".format(review_path))

--- a/openpype/modules/shotgrid/plugins/publish/integrate_shotgrid_version.py
+++ b/openpype/modules/shotgrid/plugins/publish/integrate_shotgrid_version.py
@@ -46,7 +46,7 @@ class IntegrateShotgridVersion(pyblish.api.InstancePlugin):
                 instance, representation, False
             )
 
-            if "shotgridreview" in representation.get("tags", []):
+            if "review" in representation.get("tags", []):
 
                 if representation["ext"] in ["mov", "avi"]:
                     self.log.info(

--- a/openpype/plugins/publish/extract_burnin.py
+++ b/openpype/plugins/publish/extract_burnin.py
@@ -267,6 +267,8 @@ class ExtractBurnin(publish.Extractor):
                 new_repre["stagingDir"] = src_repre_staging_dir
 
                 # Keep "ftrackreview" tag only on first output
+                # TODO: What do we do here to remove `ftrackreview`
+                #       Do we remove the `review` tag instead?
                 if first_output:
                     first_output = False
                 elif "ftrackreview" in new_repre["tags"]:

--- a/openpype/plugins/publish/extract_trim_video_audio.py
+++ b/openpype/plugins/publish/extract_trim_video_audio.py
@@ -120,7 +120,7 @@ class ExtractTrimVideoAudio(publish.Extractor):
             if ext in [".mov", ".mp4"] and reviewable:
                 repre.update({
                     "thumbnail": True,
-                    "tags": ["review", "ftrackreview", "delete"]})
+                    "tags": ["review", "delete"]})
 
             instance.data["representations"].append(repre)
 

--- a/openpype/settings/defaults/project_settings/global.json
+++ b/openpype/settings/defaults/project_settings/global.json
@@ -81,9 +81,7 @@
                     "outputs": {
                         "png": {
                             "ext": "png",
-                            "tags": [
-                                "ftrackreview"
-                            ],
+                            "tags": ["review"],
                             "burnins": [],
                             "ffmpeg_args": {
                                 "video_filters": [],
@@ -139,8 +137,7 @@
                             "ext": "mp4",
                             "tags": [
                                 "burnin",
-                                "ftrackreview",
-                                "kitsureview"
+                                "review"
                             ],
                             "burnins": [],
                             "ffmpeg_args": {

--- a/openpype/settings/defaults/project_settings/photoshop.json
+++ b/openpype/settings/defaults/project_settings/photoshop.json
@@ -51,14 +51,12 @@
             "max_downscale_size": 8192,
             "jpg_options": {
                 "tags": [
-                    "review",
-                    "ftrackreview"
+                    "review"
                 ]
             },
             "mov_options": {
                 "tags": [
-                    "review",
-                    "ftrackreview"
+                    "review"
                 ]
             }
         }

--- a/openpype/settings/entities/schemas/README.md
+++ b/openpype/settings/entities/schemas/README.md
@@ -431,7 +431,7 @@ How output of the schema could look like on save:
     "multiselection": true,
     "enum_items": [
         {"burnin": "Add burnins"},
-        {"ftrackreview": "Add to Ftrack"},
+        {"review": "Add as review (upload to production tracker)"},
         {"delete": "Delete output"},
         {"slate-frame": "Add slate frame"},
         {"no-handles": "Skip handle frames"}

--- a/openpype/settings/entities/schemas/projects_schema/schemas/schema_representation_tags.json
+++ b/openpype/settings/entities/schemas/projects_schema/schemas/schema_representation_tags.json
@@ -11,15 +11,6 @@
             "review": "Create review"
         },
         {
-            "ftrackreview": "Add review to Ftrack"
-        },
-        {
-            "shotgridreview": "Add review to Shotgrid"
-        },
-        {
-            "kitsureview": "Add review to Kitsu"
-        },
-        {
             "delete": "Delete output"
         },
         {

--- a/openpype/tools/settings/settings/README.md
+++ b/openpype/tools/settings/settings/README.md
@@ -259,7 +259,7 @@
     "multiselection": true,
     "enum_items": [
         {"burnin": "Add burnins"},
-        {"ftrackreview": "Add to Ftrack"},
+        {"review": "Add as review (upload to production tracker)"},
         {"delete": "Delete output"},
         {"slate-frame": "Add slate frame"},
         {"no-hnadles": "Skip handle frames"}

--- a/website/docs/dev_settings.md
+++ b/website/docs/dev_settings.md
@@ -501,7 +501,7 @@ How output of the schema could look like on save:
     "multiselection": true,
     "enum_items": [
         {"burnin": "Add burnins"},
-        {"ftrackreview": "Add to Ftrack"},
+        {"review": "Add as review (upload to production tracker)"},
         {"delete": "Delete output"},
         {"slate-frame": "Add slate frame"},
         {"no-handles": "Skip handle frames"}


### PR DESCRIPTION
## Changelog Description

This removes the tags `kitsureview`, `ftrackreview` and `shotgridreview` and instead refactors it to just be the `review` tag instead.

## Additional info

Consider this a **WIP refactor** to quickly identify the areas of code this might touch.

⚠️ Note: I'm not sure how to refactor the `ftrackreview-mp4` naming, etc. so there are some todos that I added to look into.

There are also these strings that I saw in the codebase:
```
ftrackreview-image  Images reviewable in the browser
ftrackreview-mp4    H.264/mp4 video reviewable in browser
ftrackreview-webm   WebM video reviewable in browser
```
Which I think are names needed by the ftrack API maybe so I suppose it's needed to at least in the end get those names for the ftrack component names.

This fixes #4569 

## Testing notes:

1. Test the touched areas of code, it will mostly be related to "reviews" as both stills and videos.
2. Test publishing with production trackers and without:
- [ ] Shotgrid
- [ ] Kitsu
- [ ] Ftrack
