### PR TITLE
Remove "preview" data from representation

### DIFF
--- a/openpype/hosts/blender/plugins/publish/extract_playblast.py
+++ b/openpype/hosts/blender/plugins/publish/extract_playblast.py
@@ -116,7 +116,6 @@ class ExtractPlayblast(publish.Extractor):
             "frameStart": start,
             "frameEnd": end,
             "fps": fps,
-            "preview": True,
             "tags": tags,
             "camera_name": camera
         }

--- a/openpype/hosts/maya/plugins/publish/extract_playblast.py
+++ b/openpype/hosts/maya/plugins/publish/extract_playblast.py
@@ -241,7 +241,6 @@ class ExtractPlayblast(publish.Extractor):
             "frameStart": start,
             "frameEnd": end,
             "fps": fps,
-            "preview": True,
             "tags": tags,
             "camera_name": camera_node_name
         }

--- a/openpype/hosts/photoshop/plugins/publish/extract_review.py
+++ b/openpype/hosts/photoshop/plugins/publish/extract_review.py
@@ -129,7 +129,6 @@ class ExtractReview(publish.Extractor):
             "frameStart": 1,
             "frameEnd": no_of_frames,
             "fps": fps,
-            "preview": True,
             "tags": self.mov_options['tags']
         })
 

--- a/openpype/plugins/publish/extract_review.py
+++ b/openpype/plugins/publish/extract_review.py
@@ -414,7 +414,6 @@ class ExtractReview(pyblish.api.InstancePlugin):
             })
 
             # Force to pop these key if are in new repre
-            new_repre.pop("preview", None)
             new_repre.pop("thumbnail", None)
             if "clean_name" in new_repre.get("tags", []):
                 new_repre.pop("outputName")


### PR DESCRIPTION
## Changelog Description

Remove "preview" data from representation

## Additional info

[It came up on discord that this might just be some legacy remains](https://discord.com/channels/517362899170230292/517382145552154634/1091016061719171252)

## Testing notes:

1. Publish reviews, previews or whatever you think might be related to this mysterious "preview" representation data.