### PR TITLE
General: Update PySide 6 for MacOs

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -124,7 +124,7 @@ version = "5.15.2"
 
 [openpype.qtbinding.darwin]
 package = "PySide6"
-version = "6.4.1"
+version = "6.4.3"
 
 [openpype.qtbinding.linux]
 package = "PySide2"


### PR DESCRIPTION
## Changelog Description
New version of PySide6 does not have issues with settings UI. It is still breaking UI stylesheets so it is not changed for other plaforms but it is enhancement from previous state.

## Testing notes:
Re-fetch third part libraries on MacOs
1. Run OpenPype on MacOs
2. Settings should work without any major issues
