### PR TITLE
Workfiles: keep Browse always enabled

### DIFF
--- a/openpype/tools/workfiles/files_widget.py
+++ b/openpype/tools/workfiles/files_widget.py
@@ -617,14 +617,24 @@ class FilesWidget(QtWidgets.QWidget):
         ext_filter = "Work File (*{0})".format(
             " *".join(self._get_host_extensions())
         )
+        dir_key = "directory"
+        if qtpy.API in ("pyside", "pyside2", "pyside6"):
+            dir_key = "dir"
+
+        workfile_root = self._workfiles_root
+        # Find existing directory of workfile root
+        #   - Qt will use 'cwd' instead, if path does not exist, which may lead
+        #       to igniter directory
+        while workfile_root:
+            if os.path.exists(workfile_root):
+                break
+            workfile_root = os.path.dirname(workfile_root)
+
         kwargs = {
             "caption": "Work Files",
-            "filter": ext_filter
+            "filter": ext_filter,
+            dir_key: workfile_root
         }
-        if qtpy.API in ("pyside", "pyside2", "pyside6"):
-            kwargs["dir"] = self._workfiles_root
-        else:
-            kwargs["directory"] = self._workfiles_root
 
         work_file = QtWidgets.QFileDialog.getOpenFileName(**kwargs)[0]
         if work_file:

--- a/openpype/tools/workfiles/files_widget.py
+++ b/openpype/tools/workfiles/files_widget.py
@@ -379,7 +379,7 @@ class FilesWidget(QtWidgets.QWidget):
 
             # Disable/Enable buttons based on available files in model
             has_valid_items = self._workarea_files_model.has_valid_items()
-            self._btn_browse.setEnabled(has_valid_items)
+            self._btn_browse.setEnabled(True)
             self._btn_open.setEnabled(has_valid_items)
 
             if self._publish_context_select_mode:

--- a/openpype/tools/workfiles/save_as_dialog.py
+++ b/openpype/tools/workfiles/save_as_dialog.py
@@ -51,7 +51,7 @@ class CommentMatcher(object):
         # Create a regex group for extensions
         extensions = registered_host().file_extensions()
         any_extension = "(?:{})".format(
-            "|".join(re.escape(ext[1:]) for ext in extensions)
+            "|".join(re.escape(ext.lstrip(".")) for ext in extensions)
         )
 
         # Use placeholders that will never be in the filename
@@ -373,7 +373,7 @@ class SaveAsDialog(QtWidgets.QDialog):
         if not data["comment"]:
             data.pop("comment", None)
 
-        data["ext"] = data["ext"][1:]
+        data["ext"] = data["ext"].lstrip(".")
 
         anatomy_filled = self.anatomy.format(data)
         return anatomy_filled[self.template_key]["file"]
@@ -413,7 +413,7 @@ class SaveAsDialog(QtWidgets.QDialog):
             if not data["comment"]:
                 data.pop("comment", None)
 
-            data["ext"] = data["ext"][1:]
+            data["ext"] = data["ext"].lstrip(".")
 
             version = get_last_workfile_with_version(
                 self.root, template, data, extensions


### PR DESCRIPTION
## Changelog Description
Browse might make sense even if there are no workfiles present, actually in that case it makes the most sense (eg. I want to locate workfile from outside - from Desktop for example).

## Testing notes:
1. Browse button in Workfiles should be enabled even in new tasks where no workfiles are present