### PR TITLE
Tray Publisher: Audio

### DIFF
--- a/openpype/hosts/traypublisher/plugins/create/create_audio.py
+++ b/openpype/hosts/traypublisher/plugins/create/create_audio.py
@@ -1,0 +1,51 @@
+import os
+
+from openpype.lib.attribute_definitions import FileDef
+from openpype.pipeline import (
+    CreatedInstance,
+    CreatorError
+)
+from openpype.hosts.traypublisher.api.plugin import TrayPublishCreator
+
+
+class AudioCreator(TrayPublishCreator):
+    """Creates audio instance on asset."""
+
+    identifier = "io.openpype.creators.traypublisher.audio"
+    label = "Audio"
+    family = "audio"
+    description = "Publish audio files."
+    extensions = [".wav"]
+
+    def get_detail_description(self):
+        return """# Publish audio files."""
+
+    def get_icon(self):
+        return "volume"
+
+    def create(self, subset_name, instance_data, pre_create_data):
+        repr_file = pre_create_data.get("representation_file")
+        if not repr_file:
+            raise CreatorError("No files specified")
+
+        instance_data["path"] = os.path.join(
+            repr_file["directory"], repr_file["filenames"][0]
+        )
+
+        # Create new instance
+        new_instance = CreatedInstance(
+            self.family, subset_name, instance_data, self
+        )
+        self._store_new_instance(new_instance)
+
+    def get_pre_create_attr_defs(self):
+        return [
+            FileDef(
+                "representation_file",
+                folders=False,
+                extensions=self.extensions,
+                allow_sequences=True,
+                single_item=True,
+                label="Representation",
+            )
+        ]

--- a/openpype/hosts/traypublisher/plugins/publish/collect_audio.py
+++ b/openpype/hosts/traypublisher/plugins/publish/collect_audio.py
@@ -1,0 +1,22 @@
+# -*- coding: utf-8 -*-
+import pyblish.api
+from pathlib import Path
+
+
+class CollectAudio(pyblish.api.InstancePlugin):
+    """Collect audio file."""
+    label = "Collect Audio"
+    order = pyblish.api.CollectorOrder
+    families = ["audio"]
+    hosts = ["traypublisher"]
+
+    def process(self, instance):
+        file = Path(instance.data["path"])
+        instance.data["representations"].append(
+            {
+                "name": file.suffix.lstrip("."),
+                "ext": file.suffix.lstrip("."),
+                "files": file.name,
+                "stagingDir": file.parent.as_posix()
+            }
+        )


### PR DESCRIPTION
## Changelog Description
Add initial support for publishing `.wav` files.

## Additional info
Had to ingest audio for #4724 and editorial ingesting was too complicated so ended in up just making the plugins necessary to publish `.wav` files.

Only initial working version so all comments are welcomed.

## Testing notes:
1. Launch Tray Publisher.
2. Publish Audio with a `.wav` file.
