### PR TITLE
General: Anatomy templates formatting

### DIFF
--- a/openpype/lib/path_templates.py
+++ b/openpype/lib/path_templates.py
@@ -263,10 +263,10 @@ class TemplatesDict(object):
             ))
 
     def __getitem__(self, key):
-        return self.templates[key]
+        return self.objected_templates[key]
 
     def get(self, key, *args, **kwargs):
-        return self.templates.get(key, *args, **kwargs)
+        return self.objected_templates.get(key, *args, **kwargs)
 
     @property
     def raw_templates(self):

--- a/openpype/lib/path_templates.py
+++ b/openpype/lib/path_templates.py
@@ -256,7 +256,8 @@ class TemplatesDict(object):
         elif isinstance(templates, dict):
             self._raw_templates = copy.deepcopy(templates)
             self._templates = templates
-            self._objected_templates = self.create_objected_templates(templates)
+            self._objected_templates = self.create_objected_templates(
+                templates)
         else:
             raise TypeError("<{}> argument must be a dict, not {}.".format(
                 self.__class__.__name__, str(type(templates))

--- a/openpype/lib/path_templates.py
+++ b/openpype/lib/path_templates.py
@@ -280,8 +280,21 @@ class TemplatesDict(object):
     def objected_templates(self):
         return self._objected_templates
 
-    @classmethod
-    def create_ojected_templates(cls, templates):
+    def _create_template_object(self, template):
+        """Create template object from a template string.
+
+        Separated into method to give option change class of templates.
+
+        Args:
+            template (str): Template string.
+
+        Returns:
+            StringTemplate: Object of template.
+        """
+
+        return StringTemplate(template)
+
+    def create_ojected_templates(self, templates):
         if not isinstance(templates, dict):
             raise TypeError("Expected dict object, got {}".format(
                 str(type(templates))
@@ -297,7 +310,7 @@ class TemplatesDict(object):
             for key in tuple(item.keys()):
                 value = item[key]
                 if isinstance(value, six.string_types):
-                    item[key] = StringTemplate(value)
+                    item[key] = self._create_template_object(value)
                 elif isinstance(value, dict):
                     inner_queue.append(value)
         return objected_templates

--- a/openpype/lib/path_templates.py
+++ b/openpype/lib/path_templates.py
@@ -256,7 +256,7 @@ class TemplatesDict(object):
         elif isinstance(templates, dict):
             self._raw_templates = copy.deepcopy(templates)
             self._templates = templates
-            self._objected_templates = self.create_ojected_templates(templates)
+            self._objected_templates = self.create_objected_templates(templates)
         else:
             raise TypeError("<{}> argument must be a dict, not {}.".format(
                 self.__class__.__name__, str(type(templates))
@@ -294,7 +294,7 @@ class TemplatesDict(object):
 
         return StringTemplate(template)
 
-    def create_ojected_templates(self, templates):
+    def create_objected_templates(self, templates):
         if not isinstance(templates, dict):
             raise TypeError("Expected dict object, got {}".format(
                 str(type(templates))

--- a/openpype/pipeline/anatomy.py
+++ b/openpype/pipeline/anatomy.py
@@ -19,6 +19,7 @@ from openpype.client import get_project
 from openpype.lib.path_templates import (
     TemplateUnsolved,
     TemplateResult,
+    StringTemplate,
     TemplatesDict,
     FormatObject,
 )
@@ -606,6 +607,29 @@ class AnatomyTemplateResult(TemplateResult):
         return self.__class__(tmp, self.rootless)
 
 
+class AnatomyStringTemplate(StringTemplate):
+    """String template which has access to anatomy."""
+
+    def __init__(self, anatomy, template):
+        self._anatomy = anatomy
+        super(AnatomyStringTemplate, self).__init__(template)
+
+    def format(self, data):
+        """Format template and add 'root' key to data if not available.
+
+        Args:
+            data (dict[str, Any]): Formatting data for template.
+
+        Returns:
+            AnatomyTemplateResult: Formatting result.
+        """
+
+        if not data.get("root"):
+            data = copy.deepcopy(data)
+            data["root"] = self.anatomy.roots
+        return super(AnatomyStringTemplate, self).format(data)
+
+
 class AnatomyTemplates(TemplatesDict):
     inner_key_pattern = re.compile(r"(\{@.*?[^{}0]*\})")
     inner_key_name_pattern = re.compile(r"\{@(.*?[^{}0]*)\}")
@@ -692,6 +716,9 @@ class AnatomyTemplates(TemplatesDict):
         self._objected_templates = self.create_ojected_templates(
             solved_templates
         )
+
+    def _create_template_object(self, template):
+        return AnatomyStringTemplate(self, template)
 
     def default_templates(self):
         """Return default templates data with solved inner keys."""

--- a/openpype/pipeline/anatomy.py
+++ b/openpype/pipeline/anatomy.py
@@ -682,7 +682,7 @@ class AnatomyTemplates(TemplatesDict):
 
         result = super(AnatomyTemplates, self)._format_value(value, data)
         if isinstance(result, TemplateResult):
-            rootless_path = self._rootless_path(result, data)
+            rootless_path = self.rootless_path_from_result(result)
             result = AnatomyTemplateResult(result, rootless_path)
         return result
 
@@ -913,7 +913,8 @@ class AnatomyTemplates(TemplatesDict):
 
         return keys_by_subkey
 
-    def _dict_to_subkeys_list(self, subdict, pre_keys=None):
+    @classmethod
+    def _dict_to_subkeys_list(cls, subdict, pre_keys=None):
         if pre_keys is None:
             pre_keys = []
         output = []
@@ -922,7 +923,7 @@ class AnatomyTemplates(TemplatesDict):
             result = list(pre_keys)
             result.append(key)
             if isinstance(value, dict):
-                for item in self._dict_to_subkeys_list(value, result):
+                for item in cls._dict_to_subkeys_list(value, result):
                     output.append(item)
             else:
                 output.append(result)
@@ -935,7 +936,17 @@ class AnatomyTemplates(TemplatesDict):
             return {key_list[0]: value}
         return {key_list[0]: self._keys_to_dicts(key_list[1:], value)}
 
-    def _rootless_path(self, result, final_data):
+    @classmethod
+    def rootless_path_from_result(cls, result):
+        """Calculate rootless path from formatting result.
+
+        Args:
+            result (StringTemplate): Result of StringTemplate formatting.
+
+        Returns:
+            str: Rootless path if result contains one of anatomy roots.
+        """
+
         used_values = result.used_values
         missing_keys = result.missing_keys
         template = result.template
@@ -951,7 +962,7 @@ class AnatomyTemplates(TemplatesDict):
             if "root" in invalid_type:
                 return
 
-        root_keys = self._dict_to_subkeys_list({"root": used_values["root"]})
+        root_keys = cls._dict_to_subkeys_list({"root": used_values["root"]})
         if not root_keys:
             return
 

--- a/openpype/pipeline/anatomy.py
+++ b/openpype/pipeline/anatomy.py
@@ -642,12 +642,6 @@ class AnatomyTemplates(TemplatesDict):
         self.anatomy = anatomy
         self.loaded_project = None
 
-    def __getitem__(self, key):
-        return self.templates[key]
-
-    def get(self, key, default=None):
-        return self.templates.get(key, default)
-
     def reset(self):
         self._raw_templates = None
         self._templates = None

--- a/openpype/pipeline/anatomy.py
+++ b/openpype/pipeline/anatomy.py
@@ -933,7 +933,7 @@ class AnatomyTemplates(TemplatesDict):
         """Calculate rootless path from formatting result.
 
         Args:
-            result (StringTemplate): Result of StringTemplate formatting.
+            result (TemplateResult): Result of StringTemplate formatting.
 
         Returns:
             str: Rootless path if result contains one of anatomy roots.

--- a/openpype/pipeline/anatomy.py
+++ b/openpype/pipeline/anatomy.py
@@ -705,7 +705,7 @@ class AnatomyTemplates(TemplatesDict):
 
         solved_templates = self.solve_template_inner_links(templates)
         self._templates = solved_templates
-        self._objected_templates = self.create_ojected_templates(
+        self._objected_templates = self.create_objected_templates(
             solved_templates
         )
 


### PR DESCRIPTION
## Changelog Description
Added option to format only single template from anatomy instead of formatting all of them all the time. Formatting of all templates is causing slowdowns e.g. during publishing of hundreds of instances.

## Testing notes:
- Anatomy formatting should work as before
- It should be possible to format single template in anatomy
```python
# Example
from openpype.lib import Anatomy
from openpype.pipeline.template_data import get_template_data_with_names

project_name = "*fill*"
asset_name = "*fill*"
task_name = "*fill*"
anatomy = Anatomy(project_name)
fill_data = get_template_data_with_names(
    project_name,
    asset_name,
    task_name)
folder_template = anatomy.templates_obj["work"]["folder"]
folder_path = folder_template.format(fill_data)
print(folder_path)
```
