### PR TITLE
CreateContext: Added option to remove Unknown attributes

### DIFF
--- a/openpype/pipeline/create/context.py
+++ b/openpype/pipeline/create/context.py
@@ -596,7 +596,14 @@ class AttributeValues(object):
             self[_key] = _value
 
     def pop(self, key, default=None):
-        return self._data.pop(key, default)
+        value = self._data.pop(key, default)
+        # Remove attribute definition if is 'UnknownDef'
+        # - gives option to get rid of unknown values
+        attr_def = self._attr_defs_by_key.get(key)
+        if isinstance(attr_def, UnknownDef):
+            self._attr_defs_by_key.pop(key)
+            self._attr_defs.remove(attr_def)
+        return value
 
     def reset_values(self):
         self._data = {}


### PR DESCRIPTION
## Changelog Description
Added option to remove attributes with UnkownAttrDef on instances. Pop of key will also remove the attribute definition from attribute values, so they're not recreated again.

## Additional info
This can be used for fix of instance data during collection after adding to context. The changes will be marked as changes for save but not yet saved to scene. The pop won't remove keys that have valid attribute definitions.

## Testing notes:
1. Create instance with unknown data in creator attributes
2. Remove the key when `CreatedInstance` object is created using `pop`
```python
# Example - this is fake mockup, and in this case 'new_key' should not show up in UI and should not be stored to scene
instance_data["creator_attributes"]["new_key"] = "value"
instance = CreatedInstance(instance_data, self)
instance["creator_attributes"].pop("new_key")
```
