### PR TITLE
Maya: local variable 'arnold_standins' referenced before assignment - OP-5542

### DIFF
--- a/openpype/hosts/maya/tools/mayalookassigner/app.py
+++ b/openpype/hosts/maya/tools/mayalookassigner/app.py
@@ -263,13 +263,13 @@ class MayaLookAssignerWindow(QtWidgets.QWidget):
                 for standin in arnold_standins:
                     if standin in nodes:
                         arnold_standin.assign_look(standin, subset_name)
+                        
+                nodes = list(set(item["nodes"]).difference(arnold_standins))
             else:
                 self.echo(
                     "Could not assign to aiStandIn because mtoa plugin is not "
                     "loaded."
                 )
-
-            nodes = list(set(item["nodes"]).difference(arnold_standins))
 
             # Assign look
             if nodes:

--- a/openpype/hosts/maya/tools/mayalookassigner/app.py
+++ b/openpype/hosts/maya/tools/mayalookassigner/app.py
@@ -250,7 +250,7 @@ class MayaLookAssignerWindow(QtWidgets.QWidget):
                     if vp in nodes:
                         vrayproxy_assign_look(vp, subset_name)
 
-                nodes = list(set(item["nodes"]).difference(vray_proxies))
+                nodes = list(set(nodes).difference(vray_proxies))
             else:
                 self.echo(
                     "Could not assign to VRayProxy because vrayformaya plugin "
@@ -260,10 +260,12 @@ class MayaLookAssignerWindow(QtWidgets.QWidget):
             # Assign Arnold Standin look.
             if cmds.pluginInfo("mtoa", query=True, loaded=True):
                 arnold_standins = set(cmds.ls(type="aiStandIn", long=True))
+                
                 for standin in arnold_standins:
                     if standin in nodes:
                         arnold_standin.assign_look(standin, subset_name)
-                nodes = list(set(item["nodes"]).difference(arnold_standins))
+                
+                nodes = list(set(nodes).difference(arnold_standins))
             else:
                 self.echo(
                     "Could not assign to aiStandIn because mtoa plugin is not "

--- a/openpype/hosts/maya/tools/mayalookassigner/app.py
+++ b/openpype/hosts/maya/tools/mayalookassigner/app.py
@@ -260,11 +260,11 @@ class MayaLookAssignerWindow(QtWidgets.QWidget):
             # Assign Arnold Standin look.
             if cmds.pluginInfo("mtoa", query=True, loaded=True):
                 arnold_standins = set(cmds.ls(type="aiStandIn", long=True))
-                
+
                 for standin in arnold_standins:
                     if standin in nodes:
                         arnold_standin.assign_look(standin, subset_name)
-                
+
                 nodes = list(set(nodes).difference(arnold_standins))
             else:
                 self.echo(

--- a/openpype/hosts/maya/tools/mayalookassigner/app.py
+++ b/openpype/hosts/maya/tools/mayalookassigner/app.py
@@ -263,7 +263,6 @@ class MayaLookAssignerWindow(QtWidgets.QWidget):
                 for standin in arnold_standins:
                     if standin in nodes:
                         arnold_standin.assign_look(standin, subset_name)
-                        
                 nodes = list(set(item["nodes"]).difference(arnold_standins))
             else:
                 self.echo(


### PR DESCRIPTION
## Changelog Description
MayaLookAssigner erroring when MTOA is not loaded:

```
# Traceback (most recent call last):
#   File "\openpype\hosts\maya\tools\mayalookassigner\app.py", line 272, in on_process_selected
#     nodes = list(set(item["nodes"]).difference(arnold_standins))
# UnboundLocalError: local variable 'arnold_standins' referenced before assignment
```

## Testing notes:
1. Unload `mtoa.mll`.
2. Assign a Vray look.
