### PR TITLE
Global: label key in instance data is optional

### DIFF
--- a/openpype/plugins/publish/collect_otio_review.py
+++ b/openpype/plugins/publish/collect_otio_review.py
@@ -87,7 +87,9 @@ class CollectOtioReview(pyblish.api.InstancePlugin):
                 otio_review_clips.append(otio_gap)
 
         if otio_review_clips:
-            instance.data["label"] += " (review)"
+            # add review track to instance and change label to reflect it
+            label = instance.data.get("label", instance.data["subset"])
+            instance.data["label"] = label + " (review)"
             instance.data["families"] += ["review", "ftrack"]
             instance.data["otioReviewClips"] = otio_review_clips
             self.log.info(


### PR DESCRIPTION
## Changelog Description
Collect OTIO review plugin is not crashing if `label` key is missing in instance data.

## Additional info
Label key is conditional. 

## Testing notes:
1. publish from Resolve clip which is having counterpart in reviewable layer
2. all should be published as expected
