### PR TITLE
Loader: Fix missing variable

### DIFF
--- a/openpype/tools/loader/model.py
+++ b/openpype/tools/loader/model.py
@@ -361,10 +361,11 @@ class SubsetsModel(TreeModel, BaseRepresentationModel):
             version_data.get("endFrame", None)
         )
 
+        handles_label = None
         handle_start = version_data.get("handleStart", None)
         handle_end = version_data.get("handleEnd", None)
         if handle_start is not None and handle_end is not None:
-            handles = "{}-{}".format(str(handle_start), str(handle_end))
+            handles_label = "{}-{}".format(str(handle_start), str(handle_end))
 
         if frame_start is not None and frame_end is not None:
             # Remove superfluous zeros from numbers (3.0 -> 3) to improve
@@ -401,7 +402,7 @@ class SubsetsModel(TreeModel, BaseRepresentationModel):
             "frameStart": frame_start,
             "frameEnd": frame_end,
             "duration": duration,
-            "handles": handles,
+            "handles": handles_label,
             "frames": frames,
             "step": version_data.get("step", None),
         })


### PR DESCRIPTION
## Changelog Description
There is missing variable `handles` in loader tool after https://github.com/ynput/OpenPype/pull/4746. The variable was renamed to `handles_label` and is initialized to `None` if handles are not available.

## Testing notes:
1. Make sure there is a version without handles information.
2. Open loader
3. The version should work and be shown in UI
