### PR TITLE
Harmony: Handle zip files with deeper structure

### DIFF
--- a/openpype/hosts/harmony/api/lib.py
+++ b/openpype/hosts/harmony/api/lib.py
@@ -242,9 +242,15 @@ def launch_zip_file(filepath):
     print(f"Localizing {filepath}")
 
     temp_path = get_local_harmony_path(filepath)
+    scene_name = os.path.basename(temp_path)
+    if os.path.exists(os.path.join(temp_path, scene_name)):
+        # unzipped with duplicated scene_name
+        temp_path = os.path.join(temp_path, scene_name)
+
     scene_path = os.path.join(
-        temp_path, os.path.basename(temp_path) + ".xstage"
+        temp_path, scene_name + ".xstage"
     )
+
     unzip = False
     if os.path.exists(scene_path):
         # Check remote scene is newer than local.
@@ -261,6 +267,10 @@ def launch_zip_file(filepath):
     if unzip:
         with _ZipFile(filepath, "r") as zip_ref:
             zip_ref.extractall(temp_path)
+
+        if os.path.exists(os.path.join(temp_path, scene_name)):
+            # unzipped with duplicated scene_name
+            temp_path = os.path.join(temp_path, scene_name)
 
     # Close existing scene.
     if ProcessContext.pid:
@@ -309,7 +319,7 @@ def launch_zip_file(filepath):
         )
 
     if not os.path.exists(scene_path):
-        print("error: cannot determine scene file")
+        print("error: cannot determine scene file {}".format(scene_path))
         ProcessContext.server.stop()
         return
 


### PR DESCRIPTION
## Changelog Description
External Harmony zip files might contain one additional level with scene name.

## Additional info
Without this zip files would fail with not really helpful `error: cannot determine scene file`.
Zip files like this might come from external artists as they are used to zip scene folder, not only select everything under scene folder

## Testing notes:
1. try to open this workfile zip in Harmony
[my_uploaded_scene.zip](https://github.com/ynput/OpenPype/files/11158094/my_uploaded_scene.zip)


