### PR TITLE
Nuke: Workfile Template builder fixes

### DIFF
--- a/openpype/hosts/nuke/api/lib.py
+++ b/openpype/hosts/nuke/api/lib.py
@@ -23,6 +23,9 @@ from openpype.client import (
 
 from openpype.host import HostDirmap
 from openpype.tools.utils import host_tools
+from openpype.pipeline.workfile.workfile_template_builder import (
+    TemplateProfileNotFound
+)
 from openpype.lib import (
     env_value_to_bool,
     Logger,
@@ -2684,7 +2687,10 @@ def start_workfile_template_builder():
 
     # to avoid looping of the callback, remove it!
     log.info("Starting workfile template builder...")
-    build_workfile_template(workfile_creation_enabled=True)
+    try:
+        build_workfile_template(workfile_creation_enabled=True)
+    except TemplateProfileNotFound:
+        log.warning("Template profile not found. Skipping...")
 
     # remove callback since it would be duplicating the workfile
     nuke.removeOnCreate(start_workfile_template_builder, nodeClass="Root")

--- a/openpype/hosts/nuke/api/workfile_template_builder.py
+++ b/openpype/hosts/nuke/api/workfile_template_builder.py
@@ -219,14 +219,17 @@ class NukePlaceholderLoadPlugin(NukePlaceholderPlugin, PlaceholderLoadMixin):
 
         # fix the problem of z_order for backdrops
         self._fix_z_order(placeholder)
-        self._imprint_siblings(placeholder)
+
+        if placeholder.data.get("keep_placeholder"):
+            self._imprint_siblings(placeholder)
 
         if placeholder.data["nb_children"] == 0:
             # save initial nodes positions and dimensions, update them
             # and set inputs and outputs of loaded nodes
+            if placeholder.data.get("keep_placeholder"):
+                self._imprint_inits()
+                self._update_nodes(placeholder, nuke.allNodes(), nodes_loaded)
 
-            self._imprint_inits()
-            self._update_nodes(placeholder, nuke.allNodes(), nodes_loaded)
             self._set_loaded_connections(placeholder)
 
         elif placeholder.data["siblings"]:
@@ -629,14 +632,18 @@ class NukePlaceholderCreatePlugin(
 
         # fix the problem of z_order for backdrops
         self._fix_z_order(placeholder)
-        self._imprint_siblings(placeholder)
+
+        if placeholder.data.get("keep_placeholder"):
+            self._imprint_siblings(placeholder)
 
         if placeholder.data["nb_children"] == 0:
             # save initial nodes positions and dimensions, update them
             # and set inputs and outputs of created nodes
 
-            self._imprint_inits()
-            self._update_nodes(placeholder, nuke.allNodes(), nodes_created)
+            if placeholder.data.get("keep_placeholder"):
+                self._imprint_inits()
+                self._update_nodes(placeholder, nuke.allNodes(), nodes_created)
+
             self._set_created_connections(placeholder)
 
         elif placeholder.data["siblings"]:


### PR DESCRIPTION
## Changelog Description
Popup window after Nuke start is not showing. Knobs with X/Y coordination on nodes where were converted from placeholders are not added if `keepPlaceholders` is witched off.

## Additional info
Paragraphs of text giving context of additional technical information or code examples.

## Testing notes:
1. start with this step
2. follow this step
