### PR TITLE
Maya: Repair image filename when using merged AOVs.

### DIFF
--- a/openpype/hosts/maya/plugins/publish/validate_rendersettings.py
+++ b/openpype/hosts/maya/plugins/publish/validate_rendersettings.py
@@ -413,3 +413,16 @@ class ValidateRenderSettings(pyblish.api.InstancePlugin):
                         "redshiftOptions.imageFormat", asString=True)
                     cmds.setAttr(
                         "{}.fileFormat".format(aov), default_ext)
+
+            if renderer == "arnold":
+                mergeAOVs = cmds.getAttr("defaultArnoldDriver.mergeAOVs")
+                if mergeAOVs:
+                    # Validate against having render pass token if merging
+                    # AOVs, so need to repair it as well.
+                    default_prefix = "<Scene>/<RenderLayer>/<RenderLayer>"
+
+                cmds.setAttr(
+                    "{}.{}".format(node, prefix_attr),
+                    default_prefix,
+                    type="string"
+                )


### PR DESCRIPTION
## Changelog Description
When repairing Arnold render setups with merged AOVs, the user can get into a validate/repair loop because the pipeline validates against having `<RenderPass>` token in the filename with merged AOVs but its in the filename when repairing.

## Testing notes:
1. Setup Arnold render in Maya.
2. Make sure the filename prefix is invalid, so empty.
3. Publish and repair `Render Settings`.
4. Publishing should go through successfully after reparing.
