### PR TITLE
add farm instance to the render colletor

### DIFF
--- a/openpype/hosts/max/plugins/publish/collect_render.py
+++ b/openpype/hosts/max/plugins/publish/collect_render.py
@@ -62,6 +62,7 @@ class CollectRender(pyblish.api.InstancePlugin):
             "frameStart": context.data['frameStart'],
             "frameEnd": context.data['frameEnd'],
             "version": version_int,
+            "farm" : True
         }
         self.log.info("data: {0}".format(data))
         instance.data.update(data)


### PR DESCRIPTION
## Changelog Description
bug fix for the failure of submitting publish job in 3dsmax

## Additional info
Adding the missing instance data ["farm"] to fix the failing issue.

## Testing notes:
1. Launch 3dsmax via Openpype
2. Create Render Instance
3. Submit Render
4. It will submit the publish job instance along with the job for rendering frame.
