### PR TITLE
Maya: Fix getting view and display in Maya 2020 - OP-5035

### DIFF
--- a/openpype/hosts/maya/api/lib.py
+++ b/openpype/hosts/maya/api/lib.py
@@ -3660,6 +3660,12 @@ def get_color_management_preferences():
         regex = re.compile(r"^(?P<view>.+) (?P<display>.+)$")
 
     match = regex.match(data["view_transform"])
+    if not match:
+        raise ValueError(
+            "Unable to parse view and display from Maya view transform: '{}' "
+            "using regex '{}'".format(data["view_transform"], regex.pattern)
+        )
+
     data.update({
         "display": match.group("display"),
         "view": match.group("view")

--- a/openpype/hosts/maya/api/lib.py
+++ b/openpype/hosts/maya/api/lib.py
@@ -3655,6 +3655,10 @@ def get_color_management_preferences():
     # Split view and display from view_transform. view_transform comes in
     # format of "{view} ({display})".
     regex = re.compile(r"^(?P<view>.+) \((?P<display>.+)\)$")
+    if int(cmds.about(version=True)) <= 2020:
+        # view_transform comes in format of "{view} {display}" in 2020.
+        regex = re.compile(r"^(?P<view>.+) (?P<display>.+)$")
+
     match = regex.match(data["view_transform"])
     data.update({
         "display": match.group("display"),


### PR DESCRIPTION
## Changelog Description
The `view_transform` returns a different format in Maya 2020. Fixes #4540 (hopefully).

## Additional info
Error message in current `develop`:
```
Traceback (most recent call last):
  File "C:\Users\tokejepsen\OpenPype\.venv\lib\site-packages\pyblish\plugin.py", line 522, in __explicit_process
    runner(*args)
  File "C:\Users\tokejepsen\OpenPype\openpype\hosts\maya\plugins\publish\collect_render.py", line 162, in process
  File "C:\Users\tokejepsen\OpenPype\openpype\hosts\maya\api\lib_renderproducts.py", line 183, in get
    return renderer(layer, render_instance)
  File "C:\Users\tokejepsen\OpenPype\openpype\hosts\maya\api\lib_renderproducts.py", line 205, in __init__
    self.layer_data.products = self.get_render_products()
  File "C:\Users\tokejepsen\OpenPype\openpype\hosts\maya\api\lib_renderproducts.py", line 707, in get_render_products
    "defaultArnoldDriver.colorManagement"
  File "C:\Users\tokejepsen\OpenPype\openpype\hosts\maya\api\lib_renderproducts.py", line 676, in _get_colorspace
    return resolved_values[self._get_attr(attribute)]()
  File "C:\Users\tokejepsen\OpenPype\openpype\hosts\maya\api\lib.py", line 3680, in get_color_management_output_transform
    preferences = get_color_management_preferences()
  File "C:\Users\tokejepsen\OpenPype\openpype\hosts\maya\api\lib.py", line 3660, in get_color_management_preferences
    "display": match.group("display"),
AttributeError: 'NoneType' object has no attribute 'group'
```

## Testing notes:
1. Setup render in Maya.
2. Publish.
