### PR TITLE
Maya template builder - preserve all references when importing a template

### DIFF
--- a/openpype/hosts/maya/api/workfile_template_builder.py
+++ b/openpype/hosts/maya/api/workfile_template_builder.py
@@ -43,7 +43,13 @@ class MayaTemplateBuilder(AbstractTemplateBuilder):
             ))
 
         cmds.sets(name=PLACEHOLDER_SET, empty=True)
-        new_nodes = cmds.file(path, i=True, returnNewNodes=True)
+        new_nodes = cmds.file(
+            path,
+            i=True,
+            returnNewNodes=True,
+            preserveReferences=True,
+            loadReferenceDepth="all",
+        )
 
         cmds.setAttr(PLACEHOLDER_SET + ".hiddenInOutliner", True)
 


### PR DESCRIPTION
## Changelog Description
When building a template with Maya template builder, we import the template and also the references inside the template file. This causes some problems:
- We cannot use the references to version assets imported by the template.
- When we import the file, the internal reference files are also imported. As a side effect, Maya complains about a reference that no longer exists. 

`// Error: file: /xxx/maya/2023.3/linux/scripts/AETemplates/AEtransformRelated.mel line 58: Reference node 'turntable_mayaSceneMain_01_RN' is not associated with a reference file.`


## Testing notes:
1. Create a template containing some references.
2. Build the workfile with template builder from openpype menu
