### PR TITLE
Publisher: Plugin active attribute is respected

### DIFF
--- a/openpype/pipeline/publish/lib.py
+++ b/openpype/pipeline/publish/lib.py
@@ -354,6 +354,59 @@ def publish_plugins_discover(paths=None):
     return result
 
 
+def _get_plugin_settings(host_name, project_settings, plugin, log):
+    """Get plugin settings based on host name and plugin name.
+
+    Args:
+        host_name (str): Name of host.
+        project_settings (dict[str, Any]): Project settings.
+        plugin (pyliblish.Plugin): Plugin where settings are applied.
+        log (logging.Logger): Logger to log messages.
+
+    Returns:
+        dict[str, Any]: Plugin settings {'attribute': 'value'}.
+    """
+
+    try:
+        return (
+            project_settings
+            [host_name]
+            ["publish"]
+            [plugin.__name__]
+        )
+    except KeyError:
+        pass
+
+    # host determined from path
+    filepath = os.path.normpath(inspect.getsourcefile(plugin))
+    filepath = os.path.normpath(filepath)
+
+    split_path = filepath.split(os.path.sep)
+    if len(split_path) < 4:
+        log.warning(
+            'plugin path too short to extract host {}'.format(filepath)
+        )
+        return {}
+
+    host_from_file = split_path[-4]
+    plugin_kind = split_path[-2]
+
+    # TODO: change after all plugins are moved one level up
+    if host_from_file == "openpype":
+        host_from_file = "global"
+
+    try:
+        return (
+            project_settings
+            [host_from_file]
+            [plugin_kind]
+            [plugin.__name__]
+        )
+    except KeyError:
+        pass
+    return {}
+
+
 def filter_pyblish_plugins(plugins):
     """Pyblish plugin filter which applies OpenPype settings.
 

--- a/openpype/pipeline/publish/lib.py
+++ b/openpype/pipeline/publish/lib.py
@@ -367,6 +367,7 @@ def _get_plugin_settings(host_name, project_settings, plugin, log):
         dict[str, Any]: Plugin settings {'attribute': 'value'}.
     """
 
+    # Use project settings from host name category when available
     try:
         return (
             project_settings
@@ -377,7 +378,8 @@ def _get_plugin_settings(host_name, project_settings, plugin, log):
     except KeyError:
         pass
 
-    # host determined from path
+    # Category determined from path
+    # - usually path is './<category>/plugins/publish/<plugin file>'
     filepath = os.path.normpath(inspect.getsourcefile(plugin))
     filepath = os.path.normpath(filepath)
 

--- a/openpype/pipeline/publish/lib.py
+++ b/openpype/pipeline/publish/lib.py
@@ -454,13 +454,13 @@ def filter_pyblish_plugins(plugins):
                 host_name, project_settings, plugin, log
             )
             for option, value in plugin_settins.items():
-                if option == "enabled" and value is False:
-                    log.info('removing plugin {}'.format(plugin.__name__))
-                    plugins.remove(plugin)
-                else:
-                    log.info('setting {}:{} on plugin {}'.format(
-                        option, value, plugin.__name__))
-                    setattr(plugin, option, value)
+                log.info("setting {}:{} on plugin {}".format(
+                    option, value, plugin.__name__))
+                setattr(plugin, option, value)
+
+        # Remove disabled plugins
+        if getattr(plugin, "enabled", True) is False:
+            plugins.remove(plugin)
 
 
 def find_close_plugin(close_plugin_name, log):

--- a/openpype/tools/publisher/control.py
+++ b/openpype/tools/publisher/control.py
@@ -28,7 +28,7 @@ from openpype.pipeline import (
     KnownPublishError,
     registered_host,
     get_process_id,
-    OpenPypePyblishPluginMixin,
+    OptionalPyblishPluginMixin,
 )
 from openpype.pipeline.create import (
     CreateContext,
@@ -2312,9 +2312,9 @@ class PublisherController(BasePublisherController):
         """Decide if publish plugin is active.
 
         This is hack because 'active' is mis-used in mixin
-        'OpenPypePyblishPluginMixin' where 'active' is used for default value
+        'OptionalPyblishPluginMixin' where 'active' is used for default value
         of optional plugins. Because of that is 'active' state of plugin
-        which inherit from 'OpenPypePyblishPluginMixin' ignored. That affects
+        which inherit from 'OptionalPyblishPluginMixin' ignored. That affects
         headless publishing inside host, potentially remote publishing.
 
         We have to change that to match pyblish base, but we can do that
@@ -2335,7 +2335,7 @@ class PublisherController(BasePublisherController):
         if not plugin.optional:
             return False
 
-        if OpenPypePyblishPluginMixin in inspect.getmro(plugin):
+        if OptionalPyblishPluginMixin in inspect.getmro(plugin):
             return True
         return False
 

--- a/openpype/tools/publisher/control.py
+++ b/openpype/tools/publisher/control.py
@@ -2347,11 +2347,9 @@ class PublisherController(BasePublisherController):
         states of currently processed publish plugin and instance. Also
         change state of processed orders like validation order has passed etc.
 
-        Also stops publishing if should stop on validation.
-
-        QUESTION:
-        Does validate button still make sense?
+        Also stops publishing, if should stop on validation.
         """
+
         for idx, plugin in enumerate(self._publish_plugins):
             self._publish_progress = idx
 
@@ -2487,7 +2485,11 @@ def collect_families_from_instances(instances, only_active=False):
         instances(list<pyblish.api.Instance>): List of publish instances from
             which are families collected.
         only_active(bool): Return families only for active instances.
+
+    Returns:
+        list[str]: Families available on instances.
     """
+
     all_families = set()
     for instance in instances:
         if only_active:


### PR DESCRIPTION
## Changelog Description
Publisher consider plugin's `active` attribute, so the plugin is not processed when `active` is set to `False`. But we use the attribute in `OptionalPyblishPluginMixin` for different purposes, so I've added hack bypass of the active state validation when plugin inherit from the mixin. This is temporary solution which cannot be changed until all hosts use Publisher otherwise global plugins would be broken. Also plugins which have `enabled` set to `False` are filtered out -> this happened only when automated settings were applied and the settings contained `"enabled"` key se to `False`.

## Additional info
This is hotfix for current state, so if it does not break anything, we can discuss full and proper fix [here](https://github.com/ynput/OpenPype/issues/4796).

## Testing notes:
- Enabled state
1. Choose/Create a context plugin which does not have settings
2. Add `enabled = False` to class definition of the plugin
3. Open Publisher (e.g. TrayPublisher) and run publishing
4. The plugin should not be processed and should not appear in UI at all

- Active state (without mixin)
1. Choose/Create a context plugin which does not inherit from `OptionalPyblishPluginMixin`
2. Add `active = False` to the plugin
3. Open Publisher (e.g. TrayPublisher) and run publishing
4. The plugin should not be processed and should be visible under skipped plugins

- Active state (with mixin)
1. Choose/Create a context plugin which does inherit from `OptionalPyblishPluginMixin`
2. Add `optional=True` and `active = False` to the plugin
3. Open Publisher (e.g. TrayPublisher)
4. The plugin should have checkbox when `Options` (`Context`) is selected in create mode
5. Run publishing
6. The plugin should be processed and should be visible in processed plugins