### PR TITLE
Maya: Fix Look Maya 2020 Py2 support for Extract Look

### DIFF
--- a/openpype/hosts/maya/plugins/publish/extract_look.py
+++ b/openpype/hosts/maya/plugins/publish/extract_look.py
@@ -26,7 +26,7 @@ HARDLINK = 2
 
 
 @attr.s
-class TextureResult:
+class TextureResult(object):
     """The resulting texture of a processed file for a resource"""
     # Path to the file
     path = attr.ib()


### PR DESCRIPTION
## Changelog Description

Fix Extract Look supporting python 2.7 for Maya 2020.

## Additional info

`attr` dataclass must be new style class.

## Testing notes:

1. Publish look from Maya 2020.
