### PR TITLE
Nuke: settings and optional attribute in publisher for some validators

### DIFF
--- a/openpype/hosts/nuke/plugins/publish/validate_asset_name.py
+++ b/openpype/hosts/nuke/plugins/publish/validate_asset_name.py
@@ -9,8 +9,8 @@ import openpype.hosts.nuke.api.lib as nlib
 from openpype.pipeline.publish import (
     ValidateContentsOrder,
     PublishXmlValidationError,
+    OptionalPyblishPluginMixin
 )
-
 
 class SelectInvalidInstances(pyblish.api.Action):
     """Select invalid instances in Outliner."""
@@ -92,7 +92,10 @@ class RepairSelectInvalidInstances(pyblish.api.Action):
             nlib.set_node_data(node, nlib.INSTANCE_DATA_KNOB, node_data)
 
 
-class ValidateCorrectAssetName(pyblish.api.InstancePlugin):
+class ValidateCorrectAssetName(
+    pyblish.api.InstancePlugin,
+    OptionalPyblishPluginMixin
+):
     """Validator to check if instance asset match context asset.
 
     When working in per-shot style you always publish data in context of
@@ -111,6 +114,9 @@ class ValidateCorrectAssetName(pyblish.api.InstancePlugin):
     optional = True
 
     def process(self, instance):
+        if not self.is_active(instance.data):
+            return
+
         asset = instance.data.get("asset")
         context_asset = instance.context.data["assetEntity"]["name"]
         node = instance.data["transientData"]["node"]

--- a/openpype/hosts/nuke/plugins/publish/validate_backdrop.py
+++ b/openpype/hosts/nuke/plugins/publish/validate_backdrop.py
@@ -1,8 +1,12 @@
 import nuke
 import pyblish
 from openpype.hosts.nuke import api as napi
-from openpype.pipeline import PublishXmlValidationError
 
+from openpype.pipeline.publish import (
+    ValidateContentsOrder,
+    PublishXmlValidationError,
+    OptionalPyblishPluginMixin
+)
 
 class SelectCenterInNodeGraph(pyblish.api.Action):
     """
@@ -46,12 +50,15 @@ class SelectCenterInNodeGraph(pyblish.api.Action):
         nuke.zoom(2, [min(all_xC), min(all_yC)])
 
 
-class ValidateBackdrop(pyblish.api.InstancePlugin):
+class ValidateBackdrop(
+    pyblish.api.InstancePlugin,
+    OptionalPyblishPluginMixin
+):
     """ Validate amount of nodes on backdrop node in case user
     forgotten to add nodes above the publishing backdrop node.
     """
 
-    order = pyblish.api.ValidatorOrder
+    order = ValidateContentsOrder
     optional = True
     families = ["nukenodes"]
     label = "Validate Backdrop"
@@ -59,6 +66,9 @@ class ValidateBackdrop(pyblish.api.InstancePlugin):
     actions = [SelectCenterInNodeGraph]
 
     def process(self, instance):
+        if not self.is_active(instance.data):
+            return
+
         child_nodes = instance.data["transientData"]["childNodes"]
         connections_out = instance.data["transientData"]["nodeConnectionsOut"]
 

--- a/openpype/hosts/nuke/plugins/publish/validate_script_attributes.py
+++ b/openpype/hosts/nuke/plugins/publish/validate_script_attributes.py
@@ -18,7 +18,7 @@ class ValidateScriptAttributes(
 
     order = pyblish.api.ValidatorOrder + 0.1
     families = ["workfile"]
-    label = "Validatte script attributes"
+    label = "Validate script attributes"
     hosts = ["nuke"]
     optional = True
     actions = [RepairAction]

--- a/openpype/settings/defaults/project_settings/nuke.json
+++ b/openpype/settings/defaults/project_settings/nuke.json
@@ -363,6 +363,11 @@
             "optional": true,
             "active": true
         },
+        "ValidateBackdrop": {
+            "enabled": true,
+            "optional": true,
+            "active": true
+        },
         "ValidateScript": {
             "enabled": true,
             "optional": true,

--- a/openpype/settings/entities/schemas/projects_schema/schemas/schema_nuke_publish.json
+++ b/openpype/settings/entities/schemas/projects_schema/schemas/schema_nuke_publish.json
@@ -62,7 +62,7 @@
             "template_data": [
                 {
                     "key": "ValidateCorrectAssetName",
-                    "label": "Validate Correct Asset name"
+                    "label": "Validate Correct Asset Name"
                 }
             ]
         },
@@ -72,7 +72,7 @@
             "template_data": [
                 {
                     "key": "ValidateContainers",
-                    "label": "ValidateContainers"
+                    "label": "Validate Containers"
                 }
             ]
         },
@@ -81,7 +81,7 @@
             "collapsible": true,
             "checkbox_key": "enabled",
             "key": "ValidateKnobs",
-            "label": "ValidateKnobs",
+            "label": "Validate Knobs",
             "is_group": true,
             "children": [
                 {
@@ -103,6 +103,10 @@
                 {
                     "key": "ValidateOutputResolution",
                     "label": "Validate Output Resolution"
+                },
+                {
+                    "key": "ValidateBackdrop",
+                    "label": "Validate Backdrop"
                 },
                 {
                     "key": "ValidateGizmo",


### PR DESCRIPTION
## Changelog Description
New publisher is supporting optional switch for plugins which is offered in Publisher in Right panel. Some plugins were missing this switch and also settings which would offer the optionality.  

## Testing notes:
1. in settings go to `project_settings/nuke/publish/ValidateBackdrop` and leave settings open. 
2. Open nuke in test workfile and create several nodes, select them and Create Nukenode family (backdrop) instance. 
3. switch to publisher and select created instance. 
4. notice in right panel is offered Validate Backdrop switch
5. Go to the settings and disable `Optional` toggle and save
6. refresh the nuke publisher and notice that the switch is removed
