### PR TITLE
Github: Grammar tweaks + uppercase issue title

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,6 +1,6 @@
 name: Bug Report
 description: File a bug report
-title: 'bug: '
+title: 'Bug: '
 labels:
   - 'type: bug'
 body:
@@ -88,11 +88,11 @@ body:
       required: true
   - type: checkboxes
     attributes:
-      label: Is there any more labels you wish to add?
+      label: Are there any labels you wish to add?
       description: Please search labels and identify those related to your bug.
       options:
-        - label: I have searched labels and added any
-          required: true
+      - label: I have added the relevant labels to the bug report.
+        required: true
   - type: textarea
     id: logs
     attributes:

--- a/.github/ISSUE_TEMPLATE/enhancement_request.yml
+++ b/.github/ISSUE_TEMPLATE/enhancement_request.yml
@@ -1,6 +1,6 @@
 name: Enhancement Request
 description: Create a report to help us enhance a particular feature
-title: "enhancement: "
+title: "Enhancement: "
 labels:
   - "type: enhancement"
 body:
@@ -13,28 +13,28 @@ body:
       label: Is there an existing issue for this?
       description: Please search to see if an issue already exists for the bug you encountered.
       options:
-      - label: I have searched the existing issues
+      - label: I have searched the existing issues.
         required: true
   - type: textarea
     id: related-feature
     attributes:
-      label: Please state which of feature you have in mind and describe what are its shortcomings?
+      label: Please describe the feature you have in mind and explain what the current shortcomings are?
       description: A clear and concise description of what the problem is.
     validations:
       required: true
   - type: textarea
     id: enhancement-proposal
     attributes:
-      label: How would you imagine the enhancement of the feature?
+      label: How would you imagine the implementation of the feature?
       description: A clear and concise description of what you want to happen.
     validations:
       required: true
   - type: checkboxes
     attributes:
-      label: Is there any more labels you wish to add?
+      label: Are there any labels you wish to add?
       description: Please search labels and identify those related to your enhancement.
       options:
-      - label: I have searched labels and added any
+      - label: I have added the relevant labels to the enhancement request.
         required: true
   - type: textarea
     id: alternatives


### PR DESCRIPTION
## Changelog Description

Tweak some of the grammar in the issue form templates.

## Additional info

I also made the title `bug: ` and `enhancement: ` to be uppercase just so it's more in line with how issues currently look:

![afbeelding](https://user-images.githubusercontent.com/2439881/230576898-71870ed6-5902-435b-a3b3-e311ebd36e26.png)

---

Also, it would be great if the "checkboxes" for _I added the labels and searched the issues_ would not come into the final issue report - just so that they don't show as "tasks" for the issue plus it just looks weird when reading the issue report too. As an example see this issue report: https://github.com/ynput/OpenPype/issues/4812

## Testing notes:

1. Read the differences
