### PR TITLE
Maya Template Builder - Remove default cameras from renderable cameras

### DIFF
--- a/openpype/hosts/maya/api/workfile_template_builder.py
+++ b/openpype/hosts/maya/api/workfile_template_builder.py
@@ -49,7 +49,10 @@ class MayaTemplateBuilder(AbstractTemplateBuilder):
         default_cameras = [cam for cam in cmds.ls(cameras=True)
                            if cmds.camera(cam, query=True, startupCamera=True)]
         for cam in default_cameras:
-            if not cmds.objExists("{}.renderable".format(cam)):
+            if not cmds.attributeQuery("renderable", node=cam, exists=True):
+                self.log.debug(
+                    "Camera {} has no attribute 'renderable'".format(cam)
+                )
                 continue
             cmds.setAttr("{}.renderable".format(cam), 0)
 

--- a/openpype/hosts/maya/api/workfile_template_builder.py
+++ b/openpype/hosts/maya/api/workfile_template_builder.py
@@ -45,6 +45,13 @@ class MayaTemplateBuilder(AbstractTemplateBuilder):
         cmds.sets(name=PLACEHOLDER_SET, empty=True)
         new_nodes = cmds.file(path, i=True, returnNewNodes=True)
 
+        # make default cameras non-renderable
+        default_cameras = [u'perspShape']
+        for cam in default_cameras:
+            if not cmds.objExists("{}.renderable".format(cam)):
+                continue
+            cmds.setAttr("{}.renderable".format(cam), 0)
+
         cmds.setAttr(PLACEHOLDER_SET + ".hiddenInOutliner", True)
 
         imported_sets = cmds.ls(new_nodes, set=True)

--- a/openpype/hosts/maya/api/workfile_template_builder.py
+++ b/openpype/hosts/maya/api/workfile_template_builder.py
@@ -46,7 +46,8 @@ class MayaTemplateBuilder(AbstractTemplateBuilder):
         new_nodes = cmds.file(path, i=True, returnNewNodes=True)
 
         # make default cameras non-renderable
-        default_cameras = [u'perspShape']
+        default_cameras = [cam for cam in cmds.ls(cameras=True)
+                           if cmds.camera(cam, query=True, startupCamera=True)]
         for cam in default_cameras:
             if not cmds.objExists("{}.renderable".format(cam)):
                 continue


### PR DESCRIPTION
## Changelog Description
When we build an asset workfile with build workfile from template inside Maya, we load our turntable camera. But then we end up with 2 renderables camera : **persp** the one imported from the template.
We need to remove the **persp** camera (or any other default camera) from renderable cameras when building the work file.

## Testing notes:
1. In Maya, build a scene from the template.
2. Check the render settings so that there is no persp camera in the list renderble cameras. 
