### PR TITLE
Maya: Fix Validate Mesh Overlapping UVs plugin

### DIFF
--- a/openpype/hosts/maya/plugins/publish/validate_mesh_overlapping_uvs.py
+++ b/openpype/hosts/maya/plugins/publish/validate_mesh_overlapping_uvs.py
@@ -255,7 +255,7 @@ class ValidateMeshHasOverlappingUVs(pyblish.api.InstancePlugin):
         # Store original uv set
         original_current_uv_set = cmds.polyUVSet(mesh,
                                                  query=True,
-                                                 currentUVSet=True)
+                                                 currentUVSet=True)[0]
 
         overlapping_faces = []
         for uv_set in cmds.polyUVSet(mesh, query=True, allUVSets=True):


### PR DESCRIPTION
## Changelog Description

Fix typo in the code where a maya command returns a `list` instead of `str`.

## Additional info

Bug was introduced in the refactor to remove pymel here: #4724 

## Testing notes:

1. Important: Enable the plug-in in project settings
2. Publish a model with and without overlapping UVs to test the validator.