### PR TITLE
Houdini: Validate VDB Input Node fix error

### DIFF
--- a/openpype/hosts/houdini/plugins/publish/validate_vdb_input_node.py
+++ b/openpype/hosts/houdini/plugins/publish/validate_vdb_input_node.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 import pyblish.api
 from openpype.pipeline import (
-    PublishValidationError
+    PublishXmlValidationError
 )
 
 
@@ -27,10 +27,9 @@ class ValidateVDBInputNode(pyblish.api.InstancePlugin):
     def process(self, instance):
         invalid = self.get_invalid(instance)
         if invalid:
-            raise PublishValidationError(
+            raise PublishXmlValidationError(
                 self,
-                "Node connected to the output node is not of type VDB",
-                title=self.label
+                "Node connected to the output node is not of type VDB"
             )
 
     @classmethod


### PR DESCRIPTION
## Changelog Description

Fix error report for Validate VDB Input node

## Additional info

Without this code change the plug-in would error when reaching the `raise` statement since the arguments weren't correct for the old class.

## Testing notes:

1. Publish VDB with invalid input node.