### PR TITLE
Settings: Version settings popup fix

### DIFF
--- a/openpype/tools/settings/settings/widgets.py
+++ b/openpype/tools/settings/settings/widgets.py
@@ -97,6 +97,7 @@ class CompleterView(QtWidgets.QListView):
 
         # Open the widget unactivated
         self.setAttribute(QtCore.Qt.WA_ShowWithoutActivating)
+        self.setAttribute(QtCore.Qt.WA_NoMouseReplay)
         delegate = QtWidgets.QStyledItemDelegate()
         self.setItemDelegate(delegate)
 

--- a/openpype/tools/settings/settings/widgets.py
+++ b/openpype/tools/settings/settings/widgets.py
@@ -4,7 +4,6 @@ from qtpy import QtWidgets, QtCore, QtGui
 import qtawesome
 
 from openpype.client import get_projects
-from openpype.pipeline import AvalonMongoDB
 from openpype.style import get_objected_colors
 from openpype.tools.utils.widgets import ImageButton
 from openpype.tools.utils.lib import paint_image_with_color

--- a/openpype/tools/settings/settings/widgets.py
+++ b/openpype/tools/settings/settings/widgets.py
@@ -242,6 +242,18 @@ class SettingsLineEdit(PlaceholderLineEdit):
         if self._completer is not None:
             self._completer.set_text_filter(text)
 
+    def _completer_should_be_visible(self):
+        return (
+            self.isVisible()
+            and (self.hasFocus() or self._completer.hasFocus())
+        )
+
+    def _show_completer(self):
+        if self._completer_should_be_visible():
+            self._focus_timer.start()
+            self._completer.show()
+            self._update_completer()
+
     def _update_completer(self):
         if self._completer is None or not self._completer.isVisible():
             return
@@ -250,7 +262,7 @@ class SettingsLineEdit(PlaceholderLineEdit):
         self._completer.move(new_point)
 
     def _on_focus_timer(self):
-        if not self.hasFocus() and not self._completer.hasFocus():
+        if not self._completer_should_be_visible():
             self._completer.hide()
             self._focus_timer.stop()
 
@@ -259,9 +271,7 @@ class SettingsLineEdit(PlaceholderLineEdit):
         self.focused_in.emit()
 
         if self._completer is not None:
-            self._focus_timer.start()
-            self._completer.show()
-            self._update_completer()
+            self._show_completer()
 
     def paintEvent(self, event):
         super(SettingsLineEdit, self).paintEvent(event)


### PR DESCRIPTION
## Changelog Description
Version completer popup have issues on some platforms, this should fix those edge cases. Also fixed issue when completer stayed shown fater reset (save).

## Additional info
Most important is that it does not make it worse for windows.

## Testing notes:
Windows & Linux & MacOs:
1. Open settings on windows
2. In System settings go to general in version selector
3. Click into input
4. The popup show up and should not cause a change of focus (infinite focus change from input to popup)
5. Reset settings UI when focus is in the input field