### PR TITLE
Hiero/Nuke: adding monitorOut key to settings

### DIFF
--- a/openpype/settings/defaults/project_settings/hiero.json
+++ b/openpype/settings/defaults/project_settings/hiero.json
@@ -21,7 +21,8 @@
             "floatLut": "linear",
             "logLut": "Cineon",
             "viewerLut": "sRGB",
-            "thumbnailLut": "sRGB"
+            "thumbnailLut": "sRGB",
+            "monitorOutLut": "sRGB"
         },
         "regexInputs": {
             "inputs": [

--- a/openpype/settings/entities/schemas/projects_schema/schema_project_hiero.json
+++ b/openpype/settings/entities/schemas/projects_schema/schema_project_hiero.json
@@ -93,6 +93,11 @@
                                     "type": "text",
                                     "key": "thumbnailLut",
                                     "label": "Thumbnails"
+                                },
+                                {
+                                    "type": "text",
+                                    "key": "monitorOutLut",
+                                    "label": "Monitor"
                                 }
                             ]
                         }

--- a/openpype/settings/entities/schemas/projects_schema/schema_project_hiero.json
+++ b/openpype/settings/entities/schemas/projects_schema/schema_project_hiero.json
@@ -48,7 +48,7 @@
                                             "aces_1.1": "aces_1.1 (12, 13)"
                                         },
                                         {
-                                            "aces_1.2": "aces_1.1 (13, 14)"
+                                            "aces_1.2": "aces_1.2 (13, 14)"
                                         },
                                         {
                                             "studio-config-v1.0.0_aces-v1.3_ocio-v2.1": "studio-config-v1.0.0_aces-v1.3_ocio-v2.1 (14)"

--- a/openpype/settings/entities/schemas/projects_schema/schema_project_hiero.json
+++ b/openpype/settings/entities/schemas/projects_schema/schema_project_hiero.json
@@ -42,10 +42,19 @@
                                             "nuke-default": "nuke-default"
                                         },
                                         {
-                                            "aces_1.0.3": "aces_1.0.3"
+                                            "aces_1.0.3": "aces_1.0.3 (12)"
                                         },
                                         {
-                                            "aces_1.1": "aces_1.1"
+                                            "aces_1.1": "aces_1.1 (12, 13)"
+                                        },
+                                        {
+                                            "aces_1.2": "aces_1.1 (13, 14)"
+                                        },
+                                        {
+                                            "studio-config-v1.0.0_aces-v1.3_ocio-v2.1": "studio-config-v1.0.0_aces-v1.3_ocio-v2.1 (14)"
+                                        },
+                                        {
+                                            "cg-config-v1.0.0_aces-v1.3_ocio-v2.1": "cg-config-v1.0.0_aces-v1.3_ocio-v2.1 (14)"
                                         },
                                         {
                                             "custom": "custom"

--- a/openpype/settings/entities/schemas/projects_schema/schemas/schema_nuke_imageio.json
+++ b/openpype/settings/entities/schemas/projects_schema/schemas/schema_nuke_imageio.json
@@ -74,28 +74,34 @@
                                     "nuke-default": "nuke-default"
                                 },
                                 {
-                                    "spi-vfx": "spi-vfx"
+                                    "spi-vfx": "spi-vfx (11)"
                                 },
                                 {
-                                    "spi-anim": "spi-anim"
+                                    "spi-anim": "spi-anim (11)"
                                 },
                                 {
-                                    "aces_0.1.1": "aces_0.1.1"
+                                    "aces_0.1.1": "aces_0.1.1 (11)"
                                 },
                                 {
-                                    "aces_0.7.1": "aces_0.7.1"
+                                    "aces_0.7.1": "aces_0.7.1 (11)"
                                 },
                                 {
-                                    "aces_1.0.1": "aces_1.0.1"
+                                    "aces_1.0.1": "aces_1.0.1 (11)"
                                 },
                                 {
-                                    "aces_1.0.3": "aces_1.0.3"
+                                    "aces_1.0.3": "aces_1.0.3 (11, 12)"
                                 },
                                 {
-                                    "aces_1.1": "aces_1.1"
+                                    "aces_1.1": "aces_1.1 (12, 13)"
                                 },
                                 {
-                                    "aces_1.2": "aces_1.2"
+                                    "aces_1.2": "aces_1.1 (13, 14)"
+                                },
+                                {
+                                    "studio-config-v1.0.0_aces-v1.3_ocio-v2.1": "studio-config-v1.0.0_aces-v1.3_ocio-v2.1 (14)"
+                                },
+                                {
+                                    "cg-config-v1.0.0_aces-v1.3_ocio-v2.1": "cg-config-v1.0.0_aces-v1.3_ocio-v2.1 (14)"
                                 },
                                 {
                                     "custom": "custom"

--- a/openpype/settings/entities/schemas/projects_schema/schemas/schema_nuke_imageio.json
+++ b/openpype/settings/entities/schemas/projects_schema/schemas/schema_nuke_imageio.json
@@ -95,7 +95,7 @@
                                     "aces_1.1": "aces_1.1 (12, 13)"
                                 },
                                 {
-                                    "aces_1.2": "aces_1.1 (13, 14)"
+                                    "aces_1.2": "aces_1.2 (13, 14)"
                                 },
                                 {
                                     "studio-config-v1.0.0_aces-v1.3_ocio-v2.1": "studio-config-v1.0.0_aces-v1.3_ocio-v2.1 (14)"


### PR DESCRIPTION
## Changelog Description
New versions of Hiero were introduced with new colorspace property for Monitor Out. It have been added into project settings. Also added new config names into settings enumerator option.

## Additional info:
I had also included Nuke config names update.

## Testing notes (Hiero 13/14):
1. download file and copy paste content to `project_settings/hiero/imageio/workfile`
[imageio_workfile_settings.txt](https://github.com/ynput/OpenPype/files/11211367/imageio_workfile_settings.txt)

2. make sure `project_settings/hiero/imageio/workfile/monitorOutLut` is having set `ACES/Rec.709` and save settings
3. Open hiero at any task in your testing project (the same project where you configured the colorspace)
4. In Hiero OpenPype menu use `Apply Colorspace` 
![image](https://user-images.githubusercontent.com/40640033/231167581-7471ccb1-e778-4ccf-90f8-8b87b40d5a18.png)
5. then look into Project settings 
![image](https://user-images.githubusercontent.com/40640033/231167756-2738003e-d8ac-4cc3-a60a-093f55f0ccae.png)
6. Look to Colorspace tab and see that all settings are configured correctly as they are in project settings.
7. 
![image](https://user-images.githubusercontent.com/40640033/231168079-5a2de5fc-78f7-4700-a956-7d830603aeb0.png)

