### PR TITLE
TrayPublisher: Move 'BatchMovieCreator' settings to 'create' subcategory

### DIFF
--- a/openpype/hosts/traypublisher/plugins/create/create_movie_batch.py
+++ b/openpype/hosts/traypublisher/plugins/create/create_movie_batch.py
@@ -36,11 +36,9 @@ class BatchMovieCreator(TrayPublishCreator):
     # Position batch creator after simple creators
     order = 110
 
-    def __init__(self, project_settings, *args, **kwargs):
-        super(BatchMovieCreator, self).__init__(project_settings,
-                                                *args, **kwargs)
+    def apply_settings(self, project_settings, system_settings):
         creator_settings = (
-            project_settings["traypublisher"]["BatchMovieCreator"]
+            project_settings["traypublisher"]["create"]["BatchMovieCreator"]
         )
         self.default_variants = creator_settings["default_variants"]
         self.default_tasks = creator_settings["default_tasks"]
@@ -151,4 +149,3 @@ class BatchMovieCreator(TrayPublishCreator):
         File names must then contain only asset name, or asset name + version.
         (eg. 'chair.mov', 'chair_v001.mov', not really safe `my_chair_v001.mov`
         """
-

--- a/openpype/settings/defaults/project_settings/traypublisher.json
+++ b/openpype/settings/defaults/project_settings/traypublisher.json
@@ -303,16 +303,18 @@
             ]
         }
     },
-    "BatchMovieCreator": {
-        "default_variants": [
-            "Main"
-        ],
-        "default_tasks": [
-            "Compositing"
-        ],
-        "extensions": [
-            ".mov"
-        ]
+    "create": {
+        "BatchMovieCreator": {
+            "default_variants": [
+                "Main"
+            ],
+            "default_tasks": [
+                "Compositing"
+            ],
+            "extensions": [
+                ".mov"
+            ]
+        }
     },
     "publish": {
         "ValidateFrameRange": {

--- a/openpype/settings/entities/schemas/projects_schema/schema_project_traypublisher.json
+++ b/openpype/settings/entities/schemas/projects_schema/schema_project_traypublisher.json
@@ -26,7 +26,7 @@
             "type": "list",
             "collapsible": true,
             "key": "simple_creators",
-            "label": "Creator plugins",
+            "label": "Simple Create Plugins",
             "use_label_wrap": true,
             "collapsible_key": true,
             "object_type": {

--- a/openpype/settings/entities/schemas/projects_schema/schema_project_traypublisher.json
+++ b/openpype/settings/entities/schemas/projects_schema/schema_project_traypublisher.json
@@ -293,7 +293,9 @@
         },
         {
             "key": "create",
+            "label": "Create plugins",
             "type": "dict",
+            "collapsible": true,
             "children": [
                 {
                     "type": "dict",

--- a/openpype/settings/entities/schemas/projects_schema/schema_project_traypublisher.json
+++ b/openpype/settings/entities/schemas/projects_schema/schema_project_traypublisher.json
@@ -292,40 +292,46 @@
             ]
         },
         {
+            "key": "create",
             "type": "dict",
-            "collapsible": true,
-            "key": "BatchMovieCreator",
-            "label": "Batch Movie Creator",
-            "collapsible_key": true,
             "children": [
                 {
-                    "type": "label",
-                    "label": "Allows to publish multiple video files in one go. <br />Name of matching asset is parsed from file names ('asset.mov', 'asset_v001.mov', 'my_asset_to_publish.mov')"
-                },
-                {
-                    "type": "list",
-                    "key": "default_variants",
-                    "label": "Default variants",
-                    "object_type": {
-                        "type": "text"
-                    }
-                },
-                {
-                    "type": "list",
-                    "key": "default_tasks",
-                    "label": "Default tasks",
-                    "object_type": {
-                        "type": "text"
-                    }
-                },
-                {
-                    "type": "list",
-                    "key": "extensions",
-                    "label": "Extensions",
-                    "use_label_wrap": true,
+                    "type": "dict",
+                    "collapsible": true,
+                    "key": "BatchMovieCreator",
+                    "label": "Batch Movie Creator",
                     "collapsible_key": true,
-                    "collapsed": false,
-                    "object_type": "text"
+                    "children": [
+                        {
+                            "type": "label",
+                            "label": "Allows to publish multiple video files in one go. <br />Name of matching asset is parsed from file names ('asset.mov', 'asset_v001.mov', 'my_asset_to_publish.mov')"
+                        },
+                        {
+                            "type": "list",
+                            "key": "default_variants",
+                            "label": "Default variants",
+                            "object_type": {
+                                "type": "text"
+                            }
+                        },
+                        {
+                            "type": "list",
+                            "key": "default_tasks",
+                            "label": "Default tasks",
+                            "object_type": {
+                                "type": "text"
+                            }
+                        },
+                        {
+                            "type": "list",
+                            "key": "extensions",
+                            "label": "Extensions",
+                            "use_label_wrap": true,
+                            "collapsible_key": true,
+                            "collapsed": false,
+                            "object_type": "text"
+                        }
+                    ]
                 }
             ]
         },


### PR DESCRIPTION
## Changelog Description
Moved settings for `BatchMoviewCreator` into subcategory `create` in settings. Changes are made to match other hosts settings chema and structure.

## Additional info
Simple creators have separated category because they're not used the same way. Changed how settings are applied to creator plugin.

## Testing notes:
1. Create plugin should still work as did.
