### PR TITLE
Houdini: Fix slow Houdini launch due to shelves generation

### DIFF
--- a/openpype/hosts/houdini/api/pipeline.py
+++ b/openpype/hosts/houdini/api/pipeline.py
@@ -81,7 +81,13 @@ class HoudiniHost(HostBase, IWorkfileHost, ILoadHost, IPublishHost):
         # TODO: make sure this doesn't trigger when
         #       opening with last workfile.
         _set_context_settings()
-        shelves.generate_shelves()
+
+        if not IS_HEADLESS:
+            import hdefereval  # noqa, hdefereval is only available in ui mode
+            # Defer generation of shelves due to issue on Windows where shelf
+            # initialization during start up delays Houdini UI by minutes
+            # making it extremely slow to launch.
+            hdefereval.executeDeferred(shelves.generate_shelves)
 
     def has_unsaved_changes(self):
         return hou.hipFile.hasUnsavedChanges()


### PR DESCRIPTION
## Changelog Description

Shelf generation during Houdini startup would add an insane amount of delay for the Houdini UI to launch correctly. By deferring the shelf generation this takes away the 5+ minutes of delay for the Houdini UI to launch.

## Additional info

The Houdini 'bug' was also described in Shotgrid's houdini toolkit [here](https://github.com/shotgunsoftware/tk-houdini/blob/af194f38b316384726a5555e8851060e95e9afaa/engine.py#L201-L220). (They seem to poll with a Qt timer, but `hdefereval.executeDeferred` seems to work just fine. I also described the problem in [this comment](https://github.com/ynput/OpenPype/issues/4061#issuecomment-1503985901).

## Testing notes:

1. Configure a custom shelf in OP project settings `project_settings/houdini/shelves`