### PR TITLE
Houdini: Update $JOB variable on task change

### DIFF
--- a/openpype/hosts/houdini/api/pipeline.py
+++ b/openpype/hosts/houdini/api/pipeline.py
@@ -367,7 +367,7 @@ def on_task_changed():
 
     # Update Houdini JOB variable
     log.info("Updating JOB variable to: {}".format(workdir))
-    hou.hscript("set JOB={}".format(workdir.replace("\\", "/")))
+    hou.hscript("set -g JOB={}".format(workdir.replace("\\", "/")))
 
     # Dirty all nodes using the $JOB variable
     hou.hscript("varchange -V JOB")


### PR DESCRIPTION
## Changelog Description

Update Houdini JOB variable on task change.

## Additional info

This intends to fix https://github.com/ynput/OpenPype/issues/4035

However, I've opened this as a **draft** because I'd like to open discussion on the usage of the `$JOB` variable. The Houdini docs for example describe to use the variable for the project and not per asset. The question becomes whether updating $JOB in OpenPype with this logic is what most studios would want or not. Or whether we should actually be setting it to a different value (e.g. project root) to begin with instead of per task context.

Tagging @gabormarinov @fabiaserra since I believe they are Houdini OpenPype users too.

## Testing notes:

1. [ ] Start Houdini (it should have `JOB` set on launch due to the `cwd` being the workdir on launch).
2. [ ] On task change (e.g. saving into another asset) it should set the JOB variable.
3. [ ] It might be good to also test loading from another asset's existing HIP file that originally had the wrong JOB variable because the task changed callback _might_ be called before the scene open and thus the opening of the scene might then overwrite the JOB var again. In that case we might want to set [`hou.allowEnvironmentToOverwriteVariable("JOB", True)`
](https://www.sidefx.com/docs/houdini/hom/hou/allowEnvironmentToOverwriteVariable.html).
