### PR TITLE
Maya: Remove single assembly validation for animation instances

### DIFF
--- a/openpype/hosts/maya/plugins/publish/validate_single_assembly.py
+++ b/openpype/hosts/maya/plugins/publish/validate_single_assembly.py
@@ -19,7 +19,7 @@ class ValidateSingleAssembly(pyblish.api.InstancePlugin):
 
     order = ValidateContentsOrder
     hosts = ['maya']
-    families = ['rig', 'animation']
+    families = ['rig']
     label = 'Single Assembly'
 
     def process(self, instance):


### PR DESCRIPTION
## Changelog Description

Rig groups may now be parented to others groups when `includeParentHierarchy` attribute on the instance is "off".

## Additional info

This additionally means that it is technically possible now to export geometry that is not all part of a single hierarchy in the outliner. However, the chances are very slim since they are based on the `out_SET` of a rig which DOES have that validated. At the same time there isn't actually a direct issue with if there were potentially multiple top level nodes in the export, especially since `includeParentHierarchy=False` would be able to produce that too even if the rig instance itself was a top level group.

Based on Discord discussion [here](https://discord.com/channels/517362899170230292/1096006848664059944) with @friquette, @tokejepsen and @mkolar 

## Testing notes:

1. Publish an animation instance (loaded rig) while the top group of the rig is grouped to an extra group, e.g. a `char_GRP` 