### PR TITLE
TVPaint: Review can be made from any instance

### DIFF
--- a/openpype/hosts/tvpaint/plugins/publish/extract_sequence.py
+++ b/openpype/hosts/tvpaint/plugins/publish/extract_sequence.py
@@ -144,7 +144,7 @@ class ExtractSequence(pyblish.api.Extractor):
 
         # Fill tags and new families from project settings
         tags = []
-        if family_lowered == "review":
+        if "review" in instance.data["families"]:
             tags.append("review")
 
         # Sequence of one frame


### PR DESCRIPTION
## Changelog Description
Add `"review"` tag to output of extract sequence if instance is marked for review. At this moment only instances with family `"review"` were able to define input for `ExtractReview` plugin which is not right.

## Additional info
The request is to be able ignore review creator and use just scene render creator for `render` output which also creates reviewable. That is not possible now.

## Testing notes:
1. Open TVPaint
2. Enable Scene Render instance
3. Enable Review on the instance
4. Hit Publish
5. A reviewable should be created
