### PR TITLE
Nuke: Legacy convertor skips deprecation warnings

### DIFF
--- a/openpype/hosts/nuke/api/lib.py
+++ b/openpype/hosts/nuke/api/lib.py
@@ -495,17 +495,17 @@ def get_avalon_knob_data(node, prefix="avalon:", create=True):
         data (dict)
     """
 
+    data = {}
+    if AVALON_TAB not in node.knobs():
+        return data
+
     # check if lists
     if not isinstance(prefix, list):
-        prefix = list([prefix])
-
-    data = dict()
+        prefix = [prefix]
 
     # loop prefix
     for p in prefix:
         # check if the node is avalon tracked
-        if AVALON_TAB not in node.knobs():
-            continue
         try:
             # check if data available on the node
             test = node[AVALON_DATA_GROUP].value()
@@ -516,8 +516,7 @@ def get_avalon_knob_data(node, prefix="avalon:", create=True):
             if create:
                 node = set_avalon_knob_data(node)
                 return get_avalon_knob_data(node)
-            else:
-                return {}
+            return {}
 
         # get data from filtered knobs
         data.update({k.replace(p, ''): node[k].value()

--- a/openpype/hosts/nuke/plugins/create/convert_legacy.py
+++ b/openpype/hosts/nuke/plugins/create/convert_legacy.py
@@ -2,7 +2,8 @@ from openpype.pipeline.create.creator_plugins import SubsetConvertorPlugin
 from openpype.hosts.nuke.api.lib import (
     INSTANCE_DATA_KNOB,
     get_node_data,
-    get_avalon_knob_data
+    get_avalon_knob_data,
+    AVALON_TAB,
 )
 from openpype.hosts.nuke.api.plugin import convert_to_valid_instaces
 
@@ -17,11 +18,13 @@ class LegacyConverted(SubsetConvertorPlugin):
         legacy_found = False
         # search for first available legacy item
         for node in nuke.allNodes(recurseGroups=True):
-
             if node.Class() in ["Viewer", "Dot"]:
                 continue
 
             if get_node_data(node, INSTANCE_DATA_KNOB):
+                continue
+
+            if AVALON_TAB not in node.knobs():
                 continue
 
             # get data from avalon knob


### PR DESCRIPTION
## Changelog Description
Nuke legacy convertor was triggering deprecated function which is causing a lot of logs which slows down whole process. Changed the convertor to skip all nodes without `AVALON_TAB` to avoid the warnings.

## Testing notes:
1. Legacy convertor should not trigger deprecation warnings if there are not any deprecated nodes in the scene
2. Legacy convertor should discover legacy nodes if they are there
