### PR TITLE
3dsmax: move startup script logic to hook

### DIFF
--- a/openpype/hosts/max/hooks/force_startup_script.py
+++ b/openpype/hosts/max/hooks/force_startup_script.py
@@ -1,0 +1,24 @@
+# -*- coding: utf-8 -*-
+"""Pre-launch to force 3ds max startup script."""
+from openpype.lib import PreLaunchHook
+import os
+
+
+class ForceStartupScript(PreLaunchHook):
+    """Inject OpenPype environment to 3ds max.
+
+    Note that this works in combination whit 3dsmax startup script that
+    is translating it back to PYTHONPATH for cases when 3dsmax drops PYTHONPATH
+    environment.
+
+    Hook `GlobalHostDataHook` must be executed before this hook.
+    """
+    app_groups = ["3dsmax"]
+    order = 11
+
+    def execute(self):
+        startup_args = [
+            "-U",
+            "MAXScript",
+            f"{os.getenv('OPENPYPE_ROOT')}\\openpype\\hosts\\max\\startup\\startup.ms"]  # noqa
+        self.launch_context.launch_args.append(startup_args)

--- a/openpype/settings/defaults/system_settings/applications.json
+++ b/openpype/settings/defaults/system_settings/applications.json
@@ -119,9 +119,7 @@
         "label": "3ds max",
         "icon": "{}/app_icons/3dsmax.png",
         "host_name": "max",
-        "environment": {
-            "ADSK_3DSMAX_STARTUPSCRIPTS_ADDON_DIR": "{OPENPYPE_ROOT}\\openpype\\hosts\\max\\startup"
-        },
+        "environment": {},
         "variants": {
             "2023": {
                 "use_python_2": false,

--- a/openpype/settings/defaults/system_settings/applications.json
+++ b/openpype/settings/defaults/system_settings/applications.json
@@ -133,9 +133,7 @@
                     "linux": []
                 },
                 "arguments": {
-                    "windows": [
-                        "-U MAXScript {OPENPYPE_ROOT}\\openpype\\hosts\\max\\startup\\startup.ms"
-                    ],
+                    "windows": [],
                     "darwin": [],
                     "linux": []
                 },


### PR DESCRIPTION
## Changelog Description
Startup script for OpenPype was interfering with Open Last Workfile feature. Moving this loggic from simple command line argument in the Settings to pre-launch hook is solving the order of command line arguments and making both features work.

## Additional info
3dsmax has inconsistent behaviour about running custom startup script. The most reliable of them is passing `-U` command line argument with path to script file. But this argument can have multiple values so having it as the last one can make it work with specifying workfile.

## Testing notes:
1. Make sure there is no `-U ...` argument in Setting for 3dsmax.
2. Delete `ADSK_3DSMAX_STARTUPSCRIPTS_ADDON_DIR` env variable if present, it shouldn't be needed anymore
3. Run 3dsmax on task with already existing workfile

You should see OpenPype menu and the last workfile should open automatically.
