### PR TITLE
Patchelf version locked

### DIFF
--- a/Dockerfile.centos7
+++ b/Dockerfile.centos7
@@ -52,8 +52,7 @@ RUN yum -y install https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.n
 
 # we need to build our own patchelf
 WORKDIR /temp-patchelf
-RUN git clone https://github.com/NixOS/patchelf.git . \
-    && git checkout 0.17.0 \
+RUN git clone -b 0.17.0 --single-branch https://github.com/NixOS/patchelf.git . \
     && source scl_source enable devtoolset-7 \
     && ./bootstrap.sh \
     && ./configure \

--- a/Dockerfile.centos7
+++ b/Dockerfile.centos7
@@ -53,6 +53,7 @@ RUN yum -y install https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.n
 # we need to build our own patchelf
 WORKDIR /temp-patchelf
 RUN git clone https://github.com/NixOS/patchelf.git . \
+    && git checkout 0.17.0 \
     && source scl_source enable devtoolset-7 \
     && ./bootstrap.sh \
     && ./configure \


### PR DESCRIPTION
For Centos dockerfile it is necessary to lock the patchelf version to the older, otherwise the build process fails. 
