### PR TITLE
Maya: Support .abc files directly for Arnold standin look assignment

### DIFF
--- a/openpype/hosts/maya/tools/mayalookassigner/alembic.py
+++ b/openpype/hosts/maya/tools/mayalookassigner/alembic.py
@@ -1,0 +1,97 @@
+# -*- coding: utf-8 -*-
+"""Tools for loading looks to vray proxies."""
+import os
+from collections import defaultdict
+import logging
+
+import six
+
+import alembic.Abc
+
+
+log = logging.getLogger(__name__)
+
+
+def get_alembic_paths_by_property(filename, attr, verbose=False):
+    # type: (str, str, bool) -> dict
+    """Return attribute value per objects in the Alembic file.
+
+    Reads an Alembic archive hierarchy and retrieves the
+    value from the `attr` properties on the objects.
+
+    Args:
+        filename (str): Full path to Alembic archive to read.
+        attr (str): Id attribute.
+        verbose (bool): Whether to verbosely log missing attributes.
+
+    Returns:
+        dict: Mapping of node full path with its id
+
+    """
+    # Normalize alembic path
+    filename = os.path.normpath(filename)
+    filename = filename.replace("\\", "/")
+    filename = str(filename)  # path must be string
+
+    try:
+        archive = alembic.Abc.IArchive(filename)
+    except RuntimeError:
+        # invalid alembic file - probably vrmesh
+        log.warning("{} is not an alembic file".format(filename))
+        return {}
+    root = archive.getTop()
+
+    iterator = list(root.children)
+    obj_ids = {}
+
+    for obj in iterator:
+        name = obj.getFullName()
+
+        # include children for coming iterations
+        iterator.extend(obj.children)
+
+        props = obj.getProperties()
+        if props.getNumProperties() == 0:
+            # Skip those without properties, e.g. '/materials' in a gpuCache
+            continue
+
+        # THe custom attribute is under the properties' first container under
+        # the ".arbGeomParams"
+        prop = props.getProperty(0)  # get base property
+
+        _property = None
+        try:
+            geo_params = prop.getProperty('.arbGeomParams')
+            _property = geo_params.getProperty(attr)
+        except KeyError:
+            if verbose:
+                log.debug("Missing attr on: {0}".format(name))
+            continue
+
+        if not _property.isConstant():
+            log.warning("Id not constant on: {0}".format(name))
+
+        # Get first value sample
+        value = _property.getValue()[0]
+
+        obj_ids[name] = value
+
+    return obj_ids
+
+
+def get_alembic_ids_cache(path):
+    # type: (str) -> dict
+    """Build a id to node mapping in Alembic file.
+
+    Nodes without IDs are ignored.
+
+    Returns:
+        dict: Mapping of id to nodes in the Alembic.
+
+    """
+    node_ids = get_alembic_paths_by_property(path, attr="cbId")
+    id_nodes = defaultdict(list)
+    for node, _id in six.iteritems(node_ids):
+        id_nodes[_id].append(node)
+
+    return dict(six.iteritems(id_nodes))

--- a/openpype/hosts/maya/tools/mayalookassigner/arnold_standin.py
+++ b/openpype/hosts/maya/tools/mayalookassigner/arnold_standin.py
@@ -9,6 +9,7 @@ from openpype.pipeline import legacy_io
 from openpype.client import get_last_version_by_subset_name
 from openpype.hosts.maya import api
 from . import lib
+from .alembic import get_alembic_ids_cache
 
 
 log = logging.getLogger(__name__)
@@ -68,6 +69,11 @@ def get_nodes_by_id(standin):
         (dict): Dictionary with node full name/path and id.
     """
     path = cmds.getAttr(standin + ".dso")
+
+    if path.endswith(".abc"):
+        # Support alembic files directly
+        return get_alembic_ids_cache(path)
+
     json_path = None
     for f in os.listdir(os.path.dirname(path)):
         if f.endswith(".json"):

--- a/openpype/hosts/maya/tools/mayalookassigner/vray_proxies.py
+++ b/openpype/hosts/maya/tools/mayalookassigner/vray_proxies.py
@@ -1,106 +1,18 @@
 # -*- coding: utf-8 -*-
 """Tools for loading looks to vray proxies."""
-import os
 from collections import defaultdict
 import logging
 
-import six
-
-import alembic.Abc
 from maya import cmds
 
 from openpype.client import get_last_version_by_subset_name
 from openpype.pipeline import legacy_io
 import openpype.hosts.maya.lib as maya_lib
 from . import lib
+from .alembic import get_alembic_ids_cache
 
 
 log = logging.getLogger(__name__)
-
-
-def get_alembic_paths_by_property(filename, attr, verbose=False):
-    # type: (str, str, bool) -> dict
-    """Return attribute value per objects in the Alembic file.
-
-    Reads an Alembic archive hierarchy and retrieves the
-    value from the `attr` properties on the objects.
-
-    Args:
-        filename (str): Full path to Alembic archive to read.
-        attr (str): Id attribute.
-        verbose (bool): Whether to verbosely log missing attributes.
-
-    Returns:
-        dict: Mapping of node full path with its id
-
-    """
-    # Normalize alembic path
-    filename = os.path.normpath(filename)
-    filename = filename.replace("\\", "/")
-    filename = str(filename)  # path must be string
-
-    try:
-        archive = alembic.Abc.IArchive(filename)
-    except RuntimeError:
-        # invalid alembic file - probably vrmesh
-        log.warning("{} is not an alembic file".format(filename))
-        return {}
-    root = archive.getTop()
-
-    iterator = list(root.children)
-    obj_ids = {}
-
-    for obj in iterator:
-        name = obj.getFullName()
-
-        # include children for coming iterations
-        iterator.extend(obj.children)
-
-        props = obj.getProperties()
-        if props.getNumProperties() == 0:
-            # Skip those without properties, e.g. '/materials' in a gpuCache
-            continue
-
-        # THe custom attribute is under the properties' first container under
-        # the ".arbGeomParams"
-        prop = props.getProperty(0)  # get base property
-
-        _property = None
-        try:
-            geo_params = prop.getProperty('.arbGeomParams')
-            _property = geo_params.getProperty(attr)
-        except KeyError:
-            if verbose:
-                log.debug("Missing attr on: {0}".format(name))
-            continue
-
-        if not _property.isConstant():
-            log.warning("Id not constant on: {0}".format(name))
-
-        # Get first value sample
-        value = _property.getValue()[0]
-
-        obj_ids[name] = value
-
-    return obj_ids
-
-
-def get_alembic_ids_cache(path):
-    # type: (str) -> dict
-    """Build a id to node mapping in Alembic file.
-
-    Nodes without IDs are ignored.
-
-    Returns:
-        dict: Mapping of id to nodes in the Alembic.
-
-    """
-    node_ids = get_alembic_paths_by_property(path, attr="cbId")
-    id_nodes = defaultdict(list)
-    for node, _id in six.iteritems(node_ids):
-        id_nodes[_id].append(node)
-
-    return dict(six.iteritems(id_nodes))
 
 
 def assign_vrayproxy_shaders(vrayproxy, assignments):


### PR DESCRIPTION
## Changelog Description

If `.abc` file is loaded into arnold standin support look assignment through the `cbId` attributes in the alembic file.

## Additional info

This is an enhancement after feature https://github.com/ynput/OpenPype/pull/4460 to allow Alembic files to also get looks assigned in arnold proxies as was requested on discord [here](https://discord.com/channels/517362899170230292/563751989075378201/1097828501924610068).

This re-uses the alembic functionality that was already there for vray proxies.

## Testing notes:

1. Load a `.abc` file in arnold standin
2. Assign a look