### PR TITLE
Houdini: Implement `switch` method on loaders

### DIFF
--- a/openpype/hosts/houdini/plugins/load/load_alembic.py
+++ b/openpype/hosts/houdini/plugins/load/load_alembic.py
@@ -104,3 +104,6 @@ class AbcLoader(load.LoaderPlugin):
 
         node = container["node"]
         node.destroy()
+
+    def switch(self, container, representation):
+        self.update(container, representation)

--- a/openpype/hosts/houdini/plugins/load/load_alembic_archive.py
+++ b/openpype/hosts/houdini/plugins/load/load_alembic_archive.py
@@ -73,3 +73,6 @@ class AbcArchiveLoader(load.LoaderPlugin):
 
         node = container["node"]
         node.destroy()
+
+    def switch(self, container, representation):
+        self.update(container, representation)

--- a/openpype/hosts/houdini/plugins/load/load_bgeo.py
+++ b/openpype/hosts/houdini/plugins/load/load_bgeo.py
@@ -106,3 +106,6 @@ class BgeoLoader(load.LoaderPlugin):
 
         node = container["node"]
         node.destroy()
+
+    def switch(self, container, representation):
+        self.update(container, representation)

--- a/openpype/hosts/houdini/plugins/load/load_camera.py
+++ b/openpype/hosts/houdini/plugins/load/load_camera.py
@@ -192,3 +192,6 @@ class CameraLoader(load.LoaderPlugin):
 
         new_node.moveToGoodPosition()
         return new_node
+
+    def switch(self, container, representation):
+        self.update(container, representation)

--- a/openpype/hosts/houdini/plugins/load/load_image.py
+++ b/openpype/hosts/houdini/plugins/load/load_image.py
@@ -125,3 +125,6 @@ class ImageLoader(load.LoaderPlugin):
         prefix, padding, suffix = first_fname.rsplit(".", 2)
         fname = ".".join([prefix, "$F{}".format(len(padding)), suffix])
         return os.path.join(root, fname).replace("\\", "/")
+
+    def switch(self, container, representation):
+        self.update(container, representation)

--- a/openpype/hosts/houdini/plugins/load/load_usd_layer.py
+++ b/openpype/hosts/houdini/plugins/load/load_usd_layer.py
@@ -79,3 +79,6 @@ class USDSublayerLoader(load.LoaderPlugin):
 
         node = container["node"]
         node.destroy()
+
+    def switch(self, container, representation):
+        self.update(container, representation)

--- a/openpype/hosts/houdini/plugins/load/load_usd_reference.py
+++ b/openpype/hosts/houdini/plugins/load/load_usd_reference.py
@@ -79,3 +79,6 @@ class USDReferenceLoader(load.LoaderPlugin):
 
         node = container["node"]
         node.destroy()
+
+    def switch(self, container, representation):
+        self.update(container, representation)

--- a/openpype/hosts/houdini/plugins/load/load_vdb.py
+++ b/openpype/hosts/houdini/plugins/load/load_vdb.py
@@ -102,3 +102,6 @@ class VdbLoader(load.LoaderPlugin):
 
         node = container["node"]
         node.destroy()
+
+    def switch(self, container, representation):
+        self.update(container, representation)


### PR DESCRIPTION
## Changelog Description

Implement `switch` method on loaders

## Additional info

Fixes #4865 

- Houdini ass loader is skipped: it already had it implemented.
- Houdini hda loader is skipped: I wasn't too sure whether it'd be safe to implement it for the HDA loader.
- _Note that I believe technically the switching allows to switch "loaders" as well instead of only asset, subset or representation and that the `update` method should check for that I believe. However, I haven't seen any implementation as of yet that actually does so._

## Testing notes:

1. Load using the changes loaders.
2. Test switching to another asset (or representation), etc.
