### PR TITLE
Maya: Make default namespace naming backwards compatible

### DIFF
--- a/openpype/settings/defaults/project_settings/maya.json
+++ b/openpype/settings/defaults/project_settings/maya.json
@@ -1459,7 +1459,7 @@
             ]
         },
         "reference_loader": {
-            "namespace": "{asset_name}_{subset}_##",
+            "namespace": "{asset_name}_{subset}_##_",
             "group_name": "_GRP"
         }
     },


### PR DESCRIPTION
## Changelog Description

Namespaces of loaded references are now _by default_ back to what they were before #4511 

## Additional info

I originally [mentioned it on the PR that the last `_` had to be there](https://github.com/ynput/OpenPype/pull/4511#discussion_r1160707262) but it seems to have been "resolved" at some point and then missed that it wasn't when it merged.

This also influences animation instances. Before #4511 the animation instances were `asset1_rigMain_01_1` in the outliner and subsets were `asset1_rigMain_01_`, after that PR the outliner instances became e.g. `asset1_rigMain_02` (due to name conflict with the namespace and thus the number increasing) and the subsets became `asset1_rigMain_01`. I'm not saying the trailing `_` for the subset names is nice. But at least with this PR the default settings is compatible with how it was before. _This does still highlight an issue with the animations subset names however._

## Testing notes:

1. Load a reference.
2. The namespace should have a trailing `_` after the number and before the `:`
