### PR TITLE
Load Rig References - Change Rig to Animation in Animation instance

### DIFF
--- a/openpype/hosts/maya/api/lib.py
+++ b/openpype/hosts/maya/api/lib.py
@@ -3937,7 +3937,9 @@ def get_capture_preset(task_name, task_type, subset, project_settings, log):
     return capture_preset or {}
 
 
-def create_rig_animation_instance(nodes, context, namespace, options, log=None):
+def create_rig_animation_instance(
+    nodes, context, namespace, options, log=None
+):
     """Create an animation publish instance for loaded rigs.
 
     See the RecreateRigAnimationInstance inventory action on how to use this
@@ -3971,6 +3973,12 @@ def create_rig_animation_instance(nodes, context, namespace, options, log=None):
     asset = legacy_io.Session["AVALON_ASSET"]
     dependency = str(context["representation"]["_id"])
 
+    custom_subset = options.get("animationSubsetName")
+
+    if custom_subset:
+        rig_subset = context['subset']['name']
+        namespace = namespace.replace(rig_subset, custom_subset)
+
     if log:
         log.info("Creating subset: {}".format(namespace))
 
@@ -3982,6 +3990,6 @@ def create_rig_animation_instance(nodes, context, namespace, options, log=None):
             creator_plugin,
             name=namespace,
             asset=asset,
-            options=options.update({"useSelection": True}),
+            options={"useSelection": True},
             data={"dependencies": dependency}
         )

--- a/openpype/hosts/maya/api/lib.py
+++ b/openpype/hosts/maya/api/lib.py
@@ -190,6 +190,44 @@ def maintained_selection():
             cmds.select(clear=True)
 
 
+def get_custom_namespace(custom_namespace):
+    """Return unique namespace.
+
+    The input namespace can contain a single group
+    of '#' number tokens to indicate where the namespace's
+    unique index should go. The amount of tokens defines
+    the zero padding of the number, e.g ### turns into 001.
+
+    Warning: Note that a namespace will always be
+        prefixed with a _ if it starts with a digit
+
+    Example:
+        >>> get_custom_namespace("myspace_##_")
+        # myspace_01_
+        >>> get_custom_namespace("##_myspace")
+        # _01_myspace
+        >>> get_custom_namespace("myspace##")
+        # myspace01
+
+    """
+    split = re.split("([#]+)", custom_namespace, 1)
+
+    if len(split) == 3:
+        base, padding, suffix = split
+        padding = "%0{}d".format(len(padding))
+    else:
+        base = split[0]
+        padding = "%02d"  # default padding
+        suffix = ""
+
+    return unique_namespace(
+        base,
+        format=padding,
+        prefix="_" if not base or base[0].isdigit() else "",
+        suffix=suffix
+    )
+
+
 def unique_namespace(namespace, format="%02d", prefix="", suffix=""):
     """Return unique namespace
 
@@ -3974,10 +4012,21 @@ def create_rig_animation_instance(
     dependency = str(context["representation"]["_id"])
 
     custom_subset = options.get("animationSubsetName")
-
     if custom_subset:
-        rig_subset = context['subset']['name']
-        namespace = namespace.replace(rig_subset, custom_subset)
+        formatting_data = {
+            "asset_name": context['asset']['name'],
+            "asset_type": context['asset']['type'],
+            "subset": context['subset']['name'],
+            "family": (
+                context['subset']['data'].get('family') or
+                context['subset']['data']['families'][0]
+            )
+        }
+        namespace = get_custom_namespace(
+            custom_subset.format(
+                **formatting_data
+            )
+        )
 
     if log:
         log.info("Creating subset: {}".format(namespace))

--- a/openpype/hosts/maya/api/lib.py
+++ b/openpype/hosts/maya/api/lib.py
@@ -3976,7 +3976,7 @@ def get_capture_preset(task_name, task_type, subset, project_settings, log):
 
 
 def create_rig_animation_instance(
-    nodes, context, namespace, options, log=None
+    nodes, context, namespace, options=None, log=None
 ):
     """Create an animation publish instance for loaded rigs.
 
@@ -3987,13 +3987,16 @@ def create_rig_animation_instance(
         nodes (list): Member nodes of the rig instance.
         context (dict): Representation context of the rig container
         namespace (str): Namespace of the rig container
-        options (dict): Additional loader data
+        options (dict, optional): Additional loader data
         log (logging.Logger, optional): Logger to log to if provided
 
     Returns:
         None
 
     """
+    if options is None:
+        options = {}
+
     output = next((node for node in nodes if
                    node.endswith("out_SET")), None)
     controls = next((node for node in nodes if

--- a/openpype/hosts/maya/api/lib.py
+++ b/openpype/hosts/maya/api/lib.py
@@ -3987,6 +3987,7 @@ def create_rig_animation_instance(
         nodes (list): Member nodes of the rig instance.
         context (dict): Representation context of the rig container
         namespace (str): Namespace of the rig container
+        options (dict): Additional loader data
         log (logging.Logger, optional): Logger to log to if provided
 
     Returns:

--- a/openpype/hosts/maya/api/lib.py
+++ b/openpype/hosts/maya/api/lib.py
@@ -3937,7 +3937,7 @@ def get_capture_preset(task_name, task_type, subset, project_settings, log):
     return capture_preset or {}
 
 
-def create_rig_animation_instance(nodes, context, namespace, log=None):
+def create_rig_animation_instance(nodes, context, namespace, options, log=None):
     """Create an animation publish instance for loaded rigs.
 
     See the RecreateRigAnimationInstance inventory action on how to use this
@@ -3982,6 +3982,6 @@ def create_rig_animation_instance(nodes, context, namespace, log=None):
             creator_plugin,
             name=namespace,
             asset=asset,
-            options={"useSelection": True},
+            options=options.update({"useSelection": True}),
             data={"dependencies": dependency}
         )

--- a/openpype/hosts/maya/api/plugin.py
+++ b/openpype/hosts/maya/api/plugin.py
@@ -84,44 +84,6 @@ def get_reference_node_parents(ref):
     return parents
 
 
-def get_custom_namespace(custom_namespace):
-    """Return unique namespace.
-
-    The input namespace can contain a single group
-    of '#' number tokens to indicate where the namespace's
-    unique index should go. The amount of tokens defines
-    the zero padding of the number, e.g ### turns into 001.
-
-    Warning: Note that a namespace will always be
-        prefixed with a _ if it starts with a digit
-
-    Example:
-        >>> get_custom_namespace("myspace_##_")
-        # myspace_01_
-        >>> get_custom_namespace("##_myspace")
-        # _01_myspace
-        >>> get_custom_namespace("myspace##")
-        # myspace01
-
-    """
-    split = re.split("([#]+)", custom_namespace, 1)
-
-    if len(split) == 3:
-        base, padding, suffix = split
-        padding = "%0{}d".format(len(padding))
-    else:
-        base = split[0]
-        padding = "%02d"  # default padding
-        suffix = ""
-
-    return lib.unique_namespace(
-        base,
-        format=padding,
-        prefix="_" if not base or base[0].isdigit() else "",
-        suffix=suffix
-    )
-
-
 class Creator(LegacyCreator):
     defaults = ['Main']
 

--- a/openpype/hosts/maya/api/plugin.py
+++ b/openpype/hosts/maya/api/plugin.py
@@ -178,7 +178,7 @@ class ReferenceLoader(Loader):
         count = options.get("count") or 1
 
         for c in range(0, count):
-            namespace = get_custom_namespace(custom_namespace)
+            namespace = lib.get_custom_namespace(custom_namespace)
             group_name = "{}:{}".format(
                 namespace,
                 custom_group_name

--- a/openpype/hosts/maya/plugins/load/load_reference.py
+++ b/openpype/hosts/maya/plugins/load/load_reference.py
@@ -223,7 +223,7 @@ class ReferenceLoader(openpype.hosts.maya.api.plugin.ReferenceLoader):
     def _post_process_rig(self, name, namespace, context, options):
         nodes = self[:]
         create_rig_animation_instance(
-            nodes, context, namespace, log=self.log
+            nodes, context, namespace, options, log=self.log
         )
 
     def _lock_camera_transforms(self, nodes):

--- a/openpype/hosts/maya/plugins/load/load_reference.py
+++ b/openpype/hosts/maya/plugins/load/load_reference.py
@@ -223,7 +223,7 @@ class ReferenceLoader(openpype.hosts.maya.api.plugin.ReferenceLoader):
     def _post_process_rig(self, name, namespace, context, options):
         nodes = self[:]
         create_rig_animation_instance(
-            nodes, context, namespace, options, log=self.log
+            nodes, context, namespace, options=options, log=self.log
         )
 
     def _lock_camera_transforms(self, nodes):

--- a/website/docs/admin_hosts_maya.md
+++ b/website/docs/admin_hosts_maya.md
@@ -247,15 +247,24 @@ Fill in the necessary fields (the optional fields are regex filters)
 ![new place holder](assets/maya-placeholder_new.png)
 
 
-    - Builder type: Whether the the placeholder should load current asset representations or linked assets representations
+  - ***Builder type***: Whether the the placeholder should load current asset representations or linked assets representations
 
-    - Representation: Representation that will be loaded (ex: ma, abc, png, etc...)
+  - ***Representation***: Representation that will be loaded (ex: ma, abc, png, etc...)
 
-    - Family: Family of the representation to load (main, look, image, etc ...)
+  - ***Family***: Family of the representation to load (main, look, image, etc ...)
 
-    - Loader: Placeholder loader name that will be used to load corresponding representations
+  - ***Loader***: Placeholder loader name that will be used to load corresponding representations
 
-    - Order: Priority for current placeholder loader (priority is lowest first, highet last)
+  - ***Order***: Priority for current placeholder loader (priority is lowest first, highest last)
+
+  - ***Loader arguments***: Loader arguments dictionary can be used to pass optional data to loaders.
+  One use case is to define a custom Subset name for the animation instances created while loading Rig references.This follows the custom namespace system used by loaders.
+
+    **Example**
+      ```
+      {"animationSubsetName": "{asset_name}_animation_{subset}_##_"}
+      ```
+
 
 - **Save your template**
 


### PR DESCRIPTION
## Changelog Description
We are using the template builder to build an animation scene. All the rig placeholders are imported correctly, but the automatically created animation instances retain the rig family in their names and subsets. In our example, we need animationMain instead of rigMain, because this name will be used in the following steps like lighting.

![animation_instance (1)](https://user-images.githubusercontent.com/68907585/233339847-d55f5681-a902-49f4-8ec6-d9bd0ce46412.png)

![animation_instance](https://user-images.githubusercontent.com/68907585/233306124-75da9617-46e2-42f1-b732-0d7d58935eb3.png)

Here is the result we need. 
![image](https://user-images.githubusercontent.com/68907585/233340129-c1b9f017-d722-4507-829d-73cbb02f7d2e.png)


I checked, and it's not a template builder problem, because even if I load a rig as a reference, the result is the same. For me, since we are in the animation instance, it makes more sense to have animation instead of rig in the name. The naming is just fine if we use create from the Openpype menu.

## Testing notes:
1. In Maya, in the animation task, use the template builder to build a template that contains rig placeholders. 
2. The created animation instance has Rig in its name instead of Animation. 

Note that you should add subset in the maya costum namespace settings.  
![image](https://user-images.githubusercontent.com/68907585/233335612-135de6bb-9784-4588-9246-55a786abdf79.png)

