### PR TITLE
Maya: Looks - calculate hash for tx texture

### DIFF
--- a/openpype/hosts/maya/plugins/publish/extract_look.py
+++ b/openpype/hosts/maya/plugins/publish/extract_look.py
@@ -280,7 +280,7 @@ class MakeTX(TextureProcessor):
             # Do nothing if the source file is already a .tx file.
             return TextureResult(
                 path=source,
-                file_hash=None,     # todo: unknown texture hash?
+                file_hash=source_hash(source),
                 colorspace=colorspace,
                 transfer_mode=COPY
             )


### PR DESCRIPTION
## Changelog Description
Texture hash is calculated for textures used in published look and it is used as key in dictionary. In recent changes, this hash is not calculated for TX files, resulting in `None` value as key in dictionary, crashing publishing. This PR is adding texture hash for TX files to solve that issue.

## Additional info
In case of existing TX files the hash should be taken from TX file itself? Also, this needs to be changed anyway for AYON as we can't store hash information on version the same way we are doing it in OpenPype.

## Testing notes:
1. In Maya, create look that is using already existing TX files
2. Publish the look, it should be published ok.
