### PR TITLE
Publisher: Do not save changes on closing of publisher

### DIFF
--- a/openpype/tools/publisher/window.py
+++ b/openpype/tools/publisher/window.py
@@ -398,8 +398,8 @@ class PublisherWindow(QtWidgets.QDialog):
         self._window_is_visible = False
         self._uninstall_app_event_listener()
         # TODO capture changes and ask user if wants to save changes on close
-        if not self._controller.host_context_has_changed:
-            self._save_changes(False)
+        # if not self._controller.host_context_has_changed:
+        #     self._save_changes(False)
         self._reset_on_show = True
         self._controller.clear_thumbnail_temp_dir_path()
         super(PublisherWindow, self).closeEvent(event)


### PR DESCRIPTION
## Changelog Description

Do not save changes on closing of publisher

## Additional info

Resolves #4863 

In the future we should still implement a pop-up saying "you are losing unsaved changes" when changes were detected.
I've just commented the lines so it's close to what it should be once we're tracking changes and can implement a pop-up to the user as described.

## Testing notes:

1. Open Publisher
2. Change e.g. publish instance active state and attributes.
3. Close publisher
4. Reopen publisher. It should now be in the state BEFORE the changes made in the step 2)
