### PR TITLE
Houdini: Collect `currentFile` context data separate from workfile instance

### DIFF
--- a/openpype/hosts/houdini/plugins/publish/collect_current_file.py
+++ b/openpype/hosts/houdini/plugins/publish/collect_current_file.py
@@ -4,15 +4,14 @@ import hou
 import pyblish.api
 
 
-class CollectHoudiniCurrentFile(pyblish.api.InstancePlugin):
+class CollectHoudiniCurrentFile(pyblish.api.ContextPlugin):
     """Inject the current working file into context"""
 
-    order = pyblish.api.CollectorOrder - 0.01
+    order = pyblish.api.CollectorOrder - 0.1
     label = "Houdini Current File"
     hosts = ["houdini"]
-    families = ["workfile"]
 
-    def process(self, instance):
+    def process(self, context):
         """Inject the current working file"""
 
         current_file = hou.hipFile.path()
@@ -34,26 +33,5 @@ class CollectHoudiniCurrentFile(pyblish.api.InstancePlugin):
                 "saved correctly."
             )
 
-        instance.context.data["currentFile"] = current_file
-
-        folder, file = os.path.split(current_file)
-        filename, ext = os.path.splitext(file)
-
-        instance.data.update({
-            "setMembers": [current_file],
-            "frameStart": instance.context.data['frameStart'],
-            "frameEnd": instance.context.data['frameEnd'],
-            "handleStart": instance.context.data['handleStart'],
-            "handleEnd": instance.context.data['handleEnd']
-        })
-
-        instance.data['representations'] = [{
-            'name': ext.lstrip("."),
-            'ext': ext.lstrip("."),
-            'files': file,
-            "stagingDir": folder,
-        }]
-
-        self.log.info('Collected instance: {}'.format(file))
-        self.log.info('Scene path: {}'.format(current_file))
-        self.log.info('staging Dir: {}'.format(folder))
+        context.data["currentFile"] = current_file
+        self.log.info('Current workfile path: {}'.format(current_file))

--- a/openpype/hosts/houdini/plugins/publish/collect_workfile.py
+++ b/openpype/hosts/houdini/plugins/publish/collect_workfile.py
@@ -1,0 +1,36 @@
+import os
+
+import pyblish.api
+
+
+class CollectWorkfile(pyblish.api.InstancePlugin):
+    """Inject workfile representation into instance"""
+
+    order = pyblish.api.CollectorOrder - 0.01
+    label = "Houdini Workfile Data"
+    hosts = ["houdini"]
+    families = ["workfile"]
+
+    def process(self, instance):
+
+        current_file = instance.context.data["currentFile"]
+        folder, file = os.path.split(current_file)
+        filename, ext = os.path.splitext(file)
+
+        instance.data.update({
+            "setMembers": [current_file],
+            "frameStart": instance.context.data['frameStart'],
+            "frameEnd": instance.context.data['frameEnd'],
+            "handleStart": instance.context.data['handleStart'],
+            "handleEnd": instance.context.data['handleEnd']
+        })
+
+        instance.data['representations'] = [{
+            'name': ext.lstrip("."),
+            'ext': ext.lstrip("."),
+            'files': file,
+            "stagingDir": folder,
+        }]
+
+        self.log.info('Collected instance: {}'.format(file))
+        self.log.info('staging Dir: {}'.format(folder))


### PR DESCRIPTION
## Changelog Description

Fix publishing without an active workfile instance due to missing `currentFile` data.
Now collect `currentFile` into context in houdini through context plugin no matter the active instances.

## Additional info

Resolves #4860 

## Testing notes:

1. Start Houdini
2. Create a review instance and/or pointcache instance
3. Publish should work fine
4. Disable workfile instance
5. Publish should still work fine