### PR TITLE
AfterEffects: add review flag to each instance

### DIFF
--- a/openpype/hosts/aftereffects/plugins/create/create_render.py
+++ b/openpype/hosts/aftereffects/plugins/create/create_render.py
@@ -217,4 +217,7 @@ class RenderCreator(Creator):
             instance_data["creator_attributes"] = {"farm": is_old_farm}
             instance_data["family"] = self.family
 
+        if instance_data["creator_attributes"].get("mark_for_review") is None:
+            instance_data["creator_attributes"]["mark_for_review"] = True
+
         return instance_data

--- a/openpype/hosts/aftereffects/plugins/create/create_render.py
+++ b/openpype/hosts/aftereffects/plugins/create/create_render.py
@@ -88,16 +88,6 @@ class RenderCreator(Creator):
 
             stub.rename_item(comp.id, subset_name)
 
-    def get_instance_attr_defs(self):
-        return [
-            BoolDef("farm", label="Render on farm"),
-            BoolDef(
-                "mark_for_review",
-                label="Create separate review",
-                default=False
-            )
-        ]
-
     def get_pre_create_attr_defs(self):
         output = [
             BoolDef("use_selection", default=True, label="Use selection"),
@@ -112,6 +102,16 @@ class RenderCreator(Creator):
             )
         ]
         return output
+
+    def get_instance_attr_defs(self):
+        return [
+            BoolDef("farm", label="Render on farm"),
+            BoolDef(
+                "mark_for_review",
+                label="Review",
+                default=False
+            )
+        ]
 
     def get_icon(self):
         return resources.get_openpype_splash_filepath()

--- a/openpype/hosts/aftereffects/plugins/create/create_render.py
+++ b/openpype/hosts/aftereffects/plugins/create/create_render.py
@@ -26,12 +26,9 @@ class RenderCreator(Creator):
 
     create_allow_context_change = True
 
-    def __init__(self, project_settings, *args, **kwargs):
-        super(RenderCreator, self).__init__(project_settings, *args, **kwargs)
-        self._default_variants = (project_settings["aftereffects"]
-                                                  ["create"]
-                                                  ["RenderCreator"]
-                                                  ["defaults"])
+    # Settings
+    default_variants = []
+    mark_for_review = True
 
     def create(self, subset_name_from_ui, data, pre_create_data):
         stub = api.get_stub()  # only after After Effects is up
@@ -82,17 +79,24 @@ class RenderCreator(Creator):
                 use_farm = pre_create_data["farm"]
                 new_instance.creator_attributes["farm"] = use_farm
 
+            review = pre_create_data["mark_for_review"]
+            new_instance.creator_attributes["mark_for_review"] = review
+
             api.get_stub().imprint(new_instance.id,
                                    new_instance.data_to_store())
             self._add_instance_to_context(new_instance)
 
             stub.rename_item(comp.id, subset_name)
 
-    def get_default_variants(self):
-        return self._default_variants
-
     def get_instance_attr_defs(self):
-        return [BoolDef("farm", label="Render on farm")]
+        return [
+            BoolDef("farm", label="Render on farm"),
+            BoolDef(
+                "mark_for_review",
+                label="Create separate review",
+                default=False
+            )
+        ]
 
     def get_pre_create_attr_defs(self):
         output = [
@@ -100,7 +104,12 @@ class RenderCreator(Creator):
             BoolDef("use_composition_name",
                     label="Use composition name in subset"),
             UISeparatorDef(),
-            BoolDef("farm", label="Render on farm")
+            BoolDef("farm", label="Render on farm"),
+            BoolDef(
+                "mark_for_review",
+                label="Review",
+                default=self.mark_for_review
+            )
         ]
         return output
 
@@ -142,6 +151,13 @@ class RenderCreator(Creator):
                     new_comp_name = "dummyCompName"
                 api.get_stub().rename_item(comp_id,
                                            new_comp_name)
+
+    def apply_settings(self, project_settings, system_settings):
+        plugin_settings = (
+            project_settings["photoshop"]["create"]["RenderCreator"]
+        )
+
+        self.mark_for_review = plugin_settings["mark_for_review"]
 
     def get_detail_description(self):
         return """Creator for Render instances

--- a/openpype/hosts/aftereffects/plugins/create/create_render.py
+++ b/openpype/hosts/aftereffects/plugins/create/create_render.py
@@ -154,7 +154,7 @@ class RenderCreator(Creator):
 
     def apply_settings(self, project_settings, system_settings):
         plugin_settings = (
-            project_settings["photoshop"]["create"]["RenderCreator"]
+            project_settings["aftereffects"]["create"]["RenderCreator"]
         )
 
         self.mark_for_review = plugin_settings["mark_for_review"]

--- a/openpype/hosts/aftereffects/plugins/publish/collect_render.py
+++ b/openpype/hosts/aftereffects/plugins/publish/collect_render.py
@@ -88,10 +88,11 @@ class CollectAERender(publish.AbstractCollectRender):
                 raise ValueError("No file extension set in Render Queue")
             render_item = render_q[0]
 
+            instance_families = inst.data.get("families", [])
             subset_name = inst.data["subset"]
             instance = AERenderInstance(
                 family="render",
-                families=inst.data.get("families", []),
+                families=instance_families,
                 version=version,
                 time="",
                 source=current_file,
@@ -109,6 +110,7 @@ class CollectAERender(publish.AbstractCollectRender):
                 tileRendering=False,
                 tilesX=0,
                 tilesY=0,
+                review="review" in instance_families,
                 frameStart=frame_start,
                 frameEnd=frame_end,
                 frameStep=1,
@@ -220,8 +222,5 @@ class CollectAERender(publish.AbstractCollectRender):
         fam = "render.local"
         if fam not in instance.families:
             instance.families.append(fam)
-
-        if "review" in instance.families:
-            instance.review = True
 
         return instance

--- a/openpype/hosts/aftereffects/plugins/publish/collect_render.py
+++ b/openpype/hosts/aftereffects/plugins/publish/collect_render.py
@@ -139,6 +139,10 @@ class CollectAERender(publish.AbstractCollectRender):
                 instance.toBeRenderedOn = "deadline"
                 instance.renderer = "aerender"
                 instance.farm = True  # to skip integrate
+                if "review" in instance.families:
+                    # to skip ExtractReview locally
+                    instance.review = False
+                    instance.families.remove("review")
 
             instances.append(instance)
             instances_to_remove.append(inst)
@@ -218,15 +222,7 @@ class CollectAERender(publish.AbstractCollectRender):
         if fam not in instance.families:
             instance.families.append(fam)
 
-        settings = get_project_settings(os.getenv("AVALON_PROJECT"))
-        reviewable_subset_filter = (settings["deadline"]
-                                    ["publish"]
-                                    ["ProcessSubmittedJobOnFarm"]
-                                    ["aov_filter"].get(self.hosts[0]))
-        for aov_pattern in reviewable_subset_filter:
-            if re.match(aov_pattern, instance.subset):
-                instance.families.append("review")
-                instance.review = True
-                break
+        if "review" in instance.families:
+            instance.review = True
 
         return instance

--- a/openpype/hosts/aftereffects/plugins/publish/collect_render.py
+++ b/openpype/hosts/aftereffects/plugins/publish/collect_render.py
@@ -141,7 +141,6 @@ class CollectAERender(publish.AbstractCollectRender):
                 instance.farm = True  # to skip integrate
                 if "review" in instance.families:
                     # to skip ExtractReview locally
-                    instance.review = False
                     instance.families.remove("review")
 
             instances.append(instance)

--- a/openpype/hosts/aftereffects/plugins/publish/collect_review.py
+++ b/openpype/hosts/aftereffects/plugins/publish/collect_review.py
@@ -1,0 +1,32 @@
+"""
+Requires:
+    None
+
+Provides:
+    instance     -> family ("review")
+"""
+
+import os
+
+import pyblish.api
+
+from openpype.pipeline.create import get_subset_name
+
+
+class CollectReview(pyblish.api.InstancePlugin):
+    """Add review to families if instance created with 'mark_for_review' flag
+    """
+
+    label = "Collect Review"
+    label = "Review"
+    hosts = ["aftereffects"]
+    order = pyblish.api.CollectorOrder + 0.1
+
+    publish = True
+
+    def process(self, instance):
+        creator_attributes = instance.data.get("creator_attributes")
+        if (creator_attributes and
+                creator_attributes.get("mark_for_review") and
+                "review" not in instance.data["families"]):
+            instance.data["families"].append("review")

--- a/openpype/hosts/aftereffects/plugins/publish/collect_review.py
+++ b/openpype/hosts/aftereffects/plugins/publish/collect_review.py
@@ -8,20 +8,18 @@ Provides:
 import pyblish.api
 
 
-class CollectReview(pyblish.api.InstancePlugin):
+class CollectReview(pyblish.api.ContextPlugin):
     """Add review to families if instance created with 'mark_for_review' flag
     """
-
     label = "Collect Review"
-    label = "Review"
     hosts = ["aftereffects"]
     order = pyblish.api.CollectorOrder + 0.1
 
-    publish = True
-
-    def process(self, instance):
-        creator_attributes = instance.data.get("creator_attributes")
-        if (creator_attributes and
-                creator_attributes.get("mark_for_review") and
-                "review" not in instance.data["families"]):
-            instance.data["families"].append("review")
+    def process(self, context):
+        for instance in context:
+            creator_attributes = instance.data.get("creator_attributes") or {}
+            if (
+                creator_attributes.get("mark_for_review")
+                and "review" not in instance.data["families"]
+            ):
+                instance.data["families"].append("review")

--- a/openpype/hosts/aftereffects/plugins/publish/collect_review.py
+++ b/openpype/hosts/aftereffects/plugins/publish/collect_review.py
@@ -5,12 +5,7 @@ Requires:
 Provides:
     instance     -> family ("review")
 """
-
-import os
-
 import pyblish.api
-
-from openpype.pipeline.create import get_subset_name
 
 
 class CollectReview(pyblish.api.InstancePlugin):

--- a/openpype/hosts/aftereffects/plugins/publish/extract_local_render.py
+++ b/openpype/hosts/aftereffects/plugins/publish/extract_local_render.py
@@ -66,33 +66,9 @@ class ExtractLocalRender(publish.Extractor):
             first_repre = not representations
             if instance.data["review"] and first_repre:
                 repre_data["tags"] = ["review"]
+                thumbnail_path = os.path.join(staging_dir, files[0])
+                instance.data["thumbnailSource"] = thumbnail_path
 
             representations.append(repre_data)
 
         instance.data["representations"] = representations
-
-        ffmpeg_path = get_ffmpeg_tool_path("ffmpeg")
-        # Generate thumbnail.
-        thumbnail_path = os.path.join(staging_dir, "thumbnail.jpg")
-
-        args = [
-            ffmpeg_path, "-y",
-            "-i", first_file_path,
-            "-vf", "scale=300:-1",
-            "-vframes", "1",
-            thumbnail_path
-        ]
-        self.log.debug("Thumbnail args:: {}".format(args))
-        try:
-            output = run_subprocess(args)
-        except TypeError:
-            self.log.warning("Error in creating thumbnail")
-            six.reraise(*sys.exc_info())
-
-        instance.data["representations"].append({
-            "name": "thumbnail",
-            "ext": "jpg",
-            "files": os.path.basename(thumbnail_path),
-            "stagingDir": staging_dir,
-            "tags": ["thumbnail"]
-        })

--- a/openpype/modules/deadline/plugins/publish/submit_publish_job.py
+++ b/openpype/modules/deadline/plugins/publish/submit_publish_job.py
@@ -438,7 +438,7 @@ class ProcessSubmittedJobOnFarm(pyblish.api.InstancePlugin):
             "Finished copying %i files" % len(resource_files))
 
     def _create_instances_for_aov(
-        self, instance_data, exp_files, additional_data
+        self, instance_data, exp_files, additional_data, do_not_add_review
     ):
         """Create instance for each AOV found.
 
@@ -449,6 +449,8 @@ class ProcessSubmittedJobOnFarm(pyblish.api.InstancePlugin):
             instance_data (pyblish.plugin.Instance): skeleton data for instance
                 (those needed) later by collector
             exp_files (list): list of expected files divided by aovs
+            additional_data (dict):
+            do_not_add_review (bool): explicitly skip review
 
         Returns:
             list of instances
@@ -514,8 +516,6 @@ class ProcessSubmittedJobOnFarm(pyblish.api.InstancePlugin):
 
             app = os.environ.get("AVALON_APP", "")
 
-            preview = False
-
             if isinstance(col, list):
                 render_file_name = os.path.basename(col[0])
             else:
@@ -532,6 +532,8 @@ class ProcessSubmittedJobOnFarm(pyblish.api.InstancePlugin):
             new_instance = deepcopy(instance_data)
             new_instance["subset"] = subset_name
             new_instance["subsetGroup"] = group_name
+
+            preview = preview and not do_not_add_review
             if preview:
                 new_instance["review"] = True
 
@@ -591,7 +593,7 @@ class ProcessSubmittedJobOnFarm(pyblish.api.InstancePlugin):
             self.log.debug("instances:{}".format(instances))
         return instances
 
-    def _get_representations(self, instance, exp_files):
+    def _get_representations(self, instance, exp_files, do_not_add_review):
         """Create representations for file sequences.
 
         This will return representations of expected files if they are not
@@ -602,6 +604,7 @@ class ProcessSubmittedJobOnFarm(pyblish.api.InstancePlugin):
             instance (dict): instance data for which we are
                              setting representations
             exp_files (list): list of expected files
+            do_not_add_review (bool): explicitly skip review
 
         Returns:
             list of representations
@@ -651,6 +654,7 @@ class ProcessSubmittedJobOnFarm(pyblish.api.InstancePlugin):
             if instance.get("slate"):
                 frame_start -= 1
 
+            preview = preview and not do_not_add_review
             rep = {
                 "name": ext,
                 "ext": ext,
@@ -705,6 +709,7 @@ class ProcessSubmittedJobOnFarm(pyblish.api.InstancePlugin):
             preview = match_aov_pattern(
                 host_name, self.aov_filter, remainder
             )
+            preview = preview and not do_not_add_review
             if preview:
                 rep.update({
                     "fps": instance.get("fps"),
@@ -820,8 +825,12 @@ class ProcessSubmittedJobOnFarm(pyblish.api.InstancePlugin):
         families = [family]
 
         # pass review to families if marked as review
+        do_not_add_review = False
         if data.get("review"):
             families.append("review")
+        elif data.get("review") == False:
+            self.log.debug("Instance has review explicitly disabled.")
+            do_not_add_review = True
 
         instance_skeleton_data = {
             "family": family,
@@ -977,7 +986,8 @@ class ProcessSubmittedJobOnFarm(pyblish.api.InstancePlugin):
             instances = self._create_instances_for_aov(
                 instance_skeleton_data,
                 data.get("expectedFiles"),
-                additional_data
+                additional_data,
+                do_not_add_review
             )
             self.log.info("got {} instance{}".format(
                 len(instances),
@@ -986,7 +996,8 @@ class ProcessSubmittedJobOnFarm(pyblish.api.InstancePlugin):
         else:
             representations = self._get_representations(
                 instance_skeleton_data,
-                data.get("expectedFiles")
+                data.get("expectedFiles"),
+                do_not_add_review
             )
 
             if "representations" not in instance_skeleton_data.keys():

--- a/openpype/pipeline/publish/abstract_collect_render.py
+++ b/openpype/pipeline/publish/abstract_collect_render.py
@@ -58,7 +58,7 @@ class RenderInstance(object):
     # With default values
     # metadata
     renderer = attr.ib(default="")  # renderer - can be used in Deadline
-    review = attr.ib(default=False)  # generate review from instance (bool)
+    review = attr.ib(default=None)  # False - explicitly skip review
     priority = attr.ib(default=50)  # job priority on farm
 
     family = attr.ib(default="renderlayer")

--- a/openpype/settings/defaults/project_settings/aftereffects.json
+++ b/openpype/settings/defaults/project_settings/aftereffects.json
@@ -13,10 +13,14 @@
         "RenderCreator": {
             "defaults": [
                 "Main"
-            ]
+            ],
+            "mark_for_review": true
         }
     },
     "publish": {
+        "CollectReview": {
+            "enabled": true
+        },
         "ValidateSceneSettings": {
             "enabled": true,
             "optional": true,

--- a/openpype/settings/defaults/project_settings/deadline.json
+++ b/openpype/settings/defaults/project_settings/deadline.json
@@ -103,6 +103,9 @@
                 "maya": [
                     ".*([Bb]eauty).*"
                 ],
+                "aftereffects": [
+                    ".*"
+                ],
                 "celaction": [
                     ".*"
                 ],

--- a/openpype/settings/defaults/project_settings/deadline.json
+++ b/openpype/settings/defaults/project_settings/deadline.json
@@ -103,9 +103,6 @@
                 "maya": [
                     ".*([Bb]eauty).*"
                 ],
-                "aftereffects": [
-                    ".*"
-                ],
                 "celaction": [
                     ".*"
                 ],

--- a/openpype/settings/entities/schemas/projects_schema/schema_project_aftereffects.json
+++ b/openpype/settings/entities/schemas/projects_schema/schema_project_aftereffects.json
@@ -40,7 +40,13 @@
                             "label": "Default Variants",
                             "object_type": "text",
                             "docstring": "Fill default variant(s) (like 'Main' or 'Default') used in subset name creation."
-                        }
+                        },
+                        {
+                            "type": "boolean",
+                            "key": "mark_for_review",
+                            "label": "Review",
+                            "default": true
+                         }
                     ]
                 }
             ]
@@ -51,6 +57,21 @@
             "key": "publish",
             "label": "Publish plugins",
             "children": [
+                {
+                    "type": "dict",
+                    "collapsible": true,
+                    "key": "CollectReview",
+                    "label": "Collect Review",
+                    "checkbox_key": "enabled",
+                    "children": [
+                        {
+                            "type": "boolean",
+                            "key": "enabled",
+                            "label": "Enabled",
+                            "default": true
+                        }
+                    ]
+                },
                 {
                     "type": "dict",
                     "collapsible": true,

--- a/tests/integration/hosts/aftereffects/test_deadline_publish_in_aftereffects_multicomposition.py
+++ b/tests/integration/hosts/aftereffects/test_deadline_publish_in_aftereffects_multicomposition.py
@@ -9,6 +9,9 @@ log = logging.getLogger("test_publish_in_aftereffects")
 class TestDeadlinePublishInAfterEffectsMultiComposition(AEDeadlinePublishTestClass):  # noqa
     """est case for DL publishing in AfterEffects with multiple compositions.
 
+        Workfile contains 2 prepared `render` instances. First has review set,
+        second doesn't.
+
         Uses generic TestCase to prepare fixtures for test data, testing DBs,
         env vars.
 
@@ -68,7 +71,7 @@ class TestDeadlinePublishInAfterEffectsMultiComposition(AEDeadlinePublishTestCla
                                     name="renderTest_taskMain2"))
 
         failures.append(
-            DBAssert.count_of_types(dbcon, "representation", 7))
+            DBAssert.count_of_types(dbcon, "representation", 5))
 
         additional_args = {"context.subset": "workfileTest_task",
                            "context.ext": "aep"}
@@ -105,13 +108,13 @@ class TestDeadlinePublishInAfterEffectsMultiComposition(AEDeadlinePublishTestCla
         additional_args = {"context.subset": "renderTest_taskMain2",
                            "name": "thumbnail"}
         failures.append(
-            DBAssert.count_of_types(dbcon, "representation", 1,
+            DBAssert.count_of_types(dbcon, "representation", 0,
                                     additional_args=additional_args))
 
         additional_args = {"context.subset": "renderTest_taskMain2",
                            "name": "png_exr"}
         failures.append(
-            DBAssert.count_of_types(dbcon, "representation", 1,
+            DBAssert.count_of_types(dbcon, "representation", 0,
                                     additional_args=additional_args))
 
         assert not any(failures)


### PR DESCRIPTION
## Changelog Description
Adds `mark_for_review` flag to the Creator to allow artists to disable review if necessary.

Exposed this flag in Settings, by default set to True (eg. same behavior as previously).

## Additional info
Not sure if `CollectReview` should be separate plugin and exposed in Settings. I matched state from Photoshop to be the same.
Adding 'review' family from `creator_attributes` could be easily moved to `collect_render.py` and whole `collect_review.py` removed.

## Testing notes:
1. toggle `Review` flag in created `render` instance in AE 
2. publish locally
3. publish on Deadline
