### PR TITLE
Nuke: fixed broken slate workflow once published on deadline

### DIFF
--- a/openpype/plugins/publish/validate_sequence_frames.py
+++ b/openpype/plugins/publish/validate_sequence_frames.py
@@ -49,7 +49,12 @@ class ValidateSequenceFrames(pyblish.api.InstancePlugin):
             collection = collections[0]
             frames = list(collection.indexes)
 
+            if instance.data.get("slate"):
+                # Slate is not part of the frame range
+                frames = frames[1:]
+
             current_range = (frames[0], frames[-1])
+
             required_range = (instance.data["frameStart"],
                               instance.data["frameEnd"])
 

--- a/tests/unit/openpype/plugins/publish/test_validate_sequence_frames.py
+++ b/tests/unit/openpype/plugins/publish/test_validate_sequence_frames.py
@@ -180,5 +180,23 @@ class TestValidateSequenceFrames(BaseTest):
             plugin.process(instance)
         assert ("Missing frames: [1002]" in str(excinfo.value))
 
+    def test_validate_sequence_frames_slate(self, instance, plugin):
+        representations = [
+            {
+                "ext": "exr",
+                "files": [
+                    "Main_beauty.1000.exr",
+                    "Main_beauty.1001.exr",
+                    "Main_beauty.1002.exr",
+                    "Main_beauty.1003.exr"
+                ]
+            }
+        ]
+        instance.data["slate"] = True
+        instance.data["representations"] = representations
+        instance.data["frameEnd"] = 1003
+
+        plugin.process(instance)
+
 
 test_case = TestValidateSequenceFrames()


### PR DESCRIPTION
## Changelog Description
Slate workflow is now working as expected and Validate Sequence Frames is not raising the once slate frame is included.

## Additional info
Also testing routine is provided. 

## Testing notes:
1. `poetry run python .\start.py runtests <abs path>\OpenPype\tests\unit\openpype\plugins\publish\test_validate_sequence_frames.py`
