### PR TITLE
TrayPublisher: Fill missing data for instances with review

### DIFF
--- a/openpype/hosts/traypublisher/plugins/publish/collect_review_frames.py
+++ b/openpype/hosts/traypublisher/plugins/publish/collect_review_frames.py
@@ -1,0 +1,43 @@
+# -*- coding: utf-8 -*-
+import pyblish.api
+
+
+class CollectReviewInfo(pyblish.api.InstancePlugin):
+    """Collect data required for review instances.
+
+    ExtractReview plugin requires frame start/end, fps on instance data which
+    are missing on instances from TrayPublishes.
+
+    Warning:
+        This is temporary solution to "make it work". Contains removed changes
+            from https://github.com/ynput/OpenPype/pull/4383 reduced only for
+            review instances.
+    """
+
+    label = "Collect Review Info"
+    order = pyblish.api.CollectorOrder + 0.491
+    families = ["review"]
+    hosts = ["traypublisher"]
+
+    def process(self, instance):
+        asset_entity = instance.data.get("assetEntity")
+        if instance.data.get("frameStart") is not None or not asset_entity:
+            self.log.debug("Missing required data on instance")
+            return
+
+        asset_data = asset_entity["data"]
+        # Store collected data for logging
+        collected_data = {}
+        for key in (
+            "fps",
+            "frameStart",
+            "frameEnd",
+            "handleStart",
+            "handleEnd",
+        ):
+            if key in instance.data or key not in asset_data:
+                continue
+            value = asset_data[key]
+            collected_data[key] = value
+            instance.data[key] = value
+        self.log.debug("Collected data: {}".format(str(collected_data)))


### PR DESCRIPTION
## Changelog Description
Fill required data to instance in traypublisher if instance has review family. The data are required by ExtractReview and it would be complicated to do proper fix at this moment! The collector does for review instances what did https://github.com/ynput/OpenPype/pull/4383

## Additional info
Ideally we should fill frame start/end from ranges of passed files, and use frame start from asset -> calculate frame end based on range from files. There is a lot of issues connected to this approach that may break other suff. We should also collect frame ranges for image frame sequences which are not right too (e.g. in burnins).

## Testing notes:
**Simple creators**
1. Open TrayPublisher
2. Select a creator (e.g. `render`)
3. Pass files to source file input and to review input
4. Publish
5. ExtractReview should not fail on missing data on instance

**Editorial**
1. Publish via TrayPublisher editorial which should also create reviews.