### PR TITLE
Publisher: Keep track about current context and fix context selection widget

### DIFF
--- a/openpype/tools/publisher/widgets/create_widget.py
+++ b/openpype/tools/publisher/widgets/create_widget.py
@@ -418,7 +418,10 @@ class CreateWidget(QtWidgets.QWidget):
             prereq_available = False
             creator_btn_tooltips.append("Creator is not selected")
 
-        if self._context_change_is_enabled() and self._asset_name is None:
+        if (
+            self._context_change_is_enabled()
+            and self._get_asset_name() is None
+        ):
             # QUESTION how to handle invalid asset?
             prereq_available = False
             creator_btn_tooltips.append("Context is not selected")

--- a/openpype/tools/publisher/widgets/create_widget.py
+++ b/openpype/tools/publisher/widgets/create_widget.py
@@ -316,6 +316,9 @@ class CreateWidget(QtWidgets.QWidget):
         self._first_show = True
         self._last_thumbnail_path = None
 
+        self._last_current_context_asset = None
+        self._last_current_context_task = None
+
     @property
     def current_asset_name(self):
         return self._controller.current_asset_name
@@ -357,10 +360,27 @@ class CreateWidget(QtWidgets.QWidget):
             self._invalidate_prereq()
 
     def refresh(self):
+        current_asset_name = self._controller.current_asset_name
+        current_task_name = self._controller.current_task_name
+
         # Get context before refresh to keep selection of asset and
         #   task widgets
         asset_name = self._get_asset_name()
         task_name = self._get_task_name()
+        # Replace by current context if last loaded context was
+        #   'current context' before reset
+        if (
+            self._last_current_context_asset
+            and (
+                asset_name == self._last_current_context_asset
+                and task_name == self._last_current_context_task
+            )
+        ):
+            asset_name = current_asset_name
+            task_name = current_task_name
+
+        self._last_current_context_asset = current_asset_name
+        self._last_current_context_task = current_task_name
 
         self._prereq_available = False
 

--- a/openpype/tools/publisher/widgets/create_widget.py
+++ b/openpype/tools/publisher/widgets/create_widget.py
@@ -283,6 +283,9 @@ class CreateWidget(QtWidgets.QWidget):
         thumbnail_widget.thumbnail_cleared.connect(self._on_thumbnail_clear)
 
         controller.event_system.add_callback(
+            "main.window.closed", self._on_main_window_close
+        )
+        controller.event_system.add_callback(
             "plugins.refresh.finished", self._on_plugins_refresh
         )
 
@@ -318,6 +321,7 @@ class CreateWidget(QtWidgets.QWidget):
 
         self._last_current_context_asset = None
         self._last_current_context_task = None
+        self._use_current_context = True
 
     @property
     def current_asset_name(self):
@@ -359,6 +363,12 @@ class CreateWidget(QtWidgets.QWidget):
         if check_prereq:
             self._invalidate_prereq()
 
+    def _on_main_window_close(self):
+        """Publisher window was closed."""
+
+        # Use current context on next refresh
+        self._use_current_context = True
+
     def refresh(self):
         current_asset_name = self._controller.current_asset_name
         current_task_name = self._controller.current_task_name
@@ -367,20 +377,24 @@ class CreateWidget(QtWidgets.QWidget):
         #   task widgets
         asset_name = self._get_asset_name()
         task_name = self._get_task_name()
+
         # Replace by current context if last loaded context was
         #   'current context' before reset
         if (
-            self._last_current_context_asset
-            and (
-                asset_name == self._last_current_context_asset
+            self._use_current_context
+            or (
+                self._last_current_context_asset
+                and asset_name == self._last_current_context_asset
                 and task_name == self._last_current_context_task
             )
         ):
             asset_name = current_asset_name
             task_name = current_task_name
 
+        # Store values for future refresh
         self._last_current_context_asset = current_asset_name
         self._last_current_context_task = current_task_name
+        self._use_current_context = False
 
         self._prereq_available = False
 

--- a/openpype/tools/publisher/window.py
+++ b/openpype/tools/publisher/window.py
@@ -406,6 +406,9 @@ class PublisherWindow(QtWidgets.QDialog):
         self._comment_input.setText("")  # clear comment
         self._reset_on_show = True
         self._controller.clear_thumbnail_temp_dir_path()
+        # Trigger custom event that should be captured only in UI
+        #   - backend (controller) must not be dependent on this event topic!!!
+        self._controller.event_system.emit("main.window.closed", {}, "window")
         super(PublisherWindow, self).closeEvent(event)
 
     def leaveEvent(self, event):


### PR DESCRIPTION
## Changelog Description
Change selected context to current context on reset. Fix bug when context widget is re-enabled.

## Additional info
Update of current context happens only if current context was selected in context widget before reset. We could clear the cache on window close too. 

## Testing notes:
**Context change update**
1. Open Publisher in a host
2. Change context using workfiles tool
3. Reset publisher
4. Context should change selection to new context
5. Close publisher
6. Change context using workfiles tool
7. Open Publisher
8. Current context should be selected

**Selection bug**
1. Open TrayPublisher
2. Select an asset and task
3. Select a simple creator -> variant can be changed and subset name is calculated
4. Select BatchMov creator  -> context selection should be disabled
5. Select a simple creator -> variant can be changed and subset name is calculated