### PR TITLE
Addons directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -112,3 +112,9 @@ tools/run_eventserver.*
 tools/dev_*
 
 .github_changelog_generator
+
+
+# Addons
+########
+/openpype/addons/*
+!/openpype/addons/README.md

--- a/openpype/addons/README.md
+++ b/openpype/addons/README.md
@@ -1,0 +1,3 @@
+This directory is for storing external addons that needs to be included in the pipeline when distributed.
+
+The directory is ignored by Git, but included in the zip and installation files.

--- a/openpype/modules/base.py
+++ b/openpype/modules/base.py
@@ -311,6 +311,7 @@ def _load_modules():
     # Look for OpenPype modules in paths defined with `get_module_dirs`
     #   - dynamically imported OpenPype modules and addons
     module_dirs = get_module_dirs()
+
     # Add current directory at first place
     #   - has small differences in import logic
     current_dir = os.path.abspath(os.path.dirname(__file__))
@@ -318,8 +319,11 @@ def _load_modules():
     module_dirs.insert(0, hosts_dir)
     module_dirs.insert(0, current_dir)
 
+    addons_dir = os.path.join(os.path.dirname(current_dir), "addons")
+    module_dirs.append(addons_dir)
+
     processed_paths = set()
-    for dirpath in module_dirs:
+    for dirpath in frozenset(module_dirs):
         # Skip already processed paths
         if dirpath in processed_paths:
             continue


### PR DESCRIPTION
## Changelog Description
This adds a directory for Addons, for easier distribution of studio specific code.

## Additional info
Discussion about how to distribute and maintain studio specific code is going on the forums; https://community.ynput.io/t/studio-specific-code/182/11

## Testing notes:
1. Add an addon to the `openpype/addons` directory.
2. Create a build, zip and installer.
3. Validate the addon files are included with the build, zip and installer.
