### PR TITLE
Publisher: Small style changes

### DIFF
--- a/openpype/pipeline/publish/publish_plugins.py
+++ b/openpype/pipeline/publish/publish_plugins.py
@@ -45,7 +45,7 @@ class PublishValidationError(Exception):
 
     def __init__(self, message, title=None, description=None, detail=None):
         self.message = message
-        self.title = title or "< Missing title >"
+        self.title = title
         self.description = description or message
         self.detail = detail
         super(PublishValidationError, self).__init__(message)

--- a/openpype/style/data.json
+++ b/openpype/style/data.json
@@ -48,7 +48,7 @@
         "bg-view-selection-hover": "rgba(92, 173, 214, .8)",
 
         "border": "#373D48",
-        "border-hover": "rgba(168, 175, 189, .3)",
+        "border-hover": "rgb(92, 99, 111)",
         "border-focus": "rgb(92, 173, 214)",
 
         "restart-btn-bg": "#458056",

--- a/openpype/style/style.css
+++ b/openpype/style/style.css
@@ -35,6 +35,11 @@ QWidget:disabled {
     color: {color:font-disabled};
 }
 
+/* Some DCCs have set borders to solid color */
+QScrollArea {
+    border: none;
+}
+
 QLabel {
     background: transparent;
 }
@@ -474,7 +479,6 @@ QAbstractItemView:disabled{
 }
 
 QAbstractItemView::item:hover {
-    /* color: {color:bg-view-hover}; */
     background: {color:bg-view-hover};
 }
 

--- a/openpype/style/style.css
+++ b/openpype/style/style.css
@@ -42,7 +42,7 @@ QLabel {
 /* Inputs */
 QAbstractSpinBox, QLineEdit, QPlainTextEdit, QTextEdit {
     border: 1px solid {color:border};
-    border-radius: 0.3em;
+    border-radius: 0.2em;
     background: {color:bg-inputs};
     padding: 0.1em;
 }
@@ -226,7 +226,7 @@ QMenu::separator {
 /* Combobox */
 QComboBox {
     border: 1px solid {color:border};
-    border-radius: 3px;
+    border-radius: 0.2em;
     padding: 1px 3px 1px 3px;
     background: {color:bg-inputs};
 }
@@ -743,7 +743,7 @@ OverlayMessageWidget QWidget {
 
 #TypeEditor, #ToolEditor, #NameEditor, #NumberEditor {
     background: transparent;
-    border-radius: 0.3em;
+    border-radius: 0.2em;
 }
 
 #TypeEditor:focus, #ToolEditor:focus, #NameEditor:focus, #NumberEditor:focus {
@@ -1072,7 +1072,7 @@ ValidationArtistMessage QLabel {
 #AssetNameInputWidget {
     background: {color:bg-inputs};
     border: 1px solid {color:border};
-    border-radius: 0.3em;
+    border-radius: 0.2em;
 }
 
 #AssetNameInputWidget QWidget {

--- a/openpype/style/style.css
+++ b/openpype/style/style.css
@@ -948,6 +948,7 @@ PixmapButton:disabled {
     border-top-left-radius: 0px;
     padding-top: 0.5em;
     padding-bottom: 0.5em;
+    width: 0.5em;
 }
 #VariantInput[state="new"], #VariantInput[state="new"]:focus, #VariantInput[state="new"]:hover {
     border-color: {color:publisher:success};

--- a/openpype/style/style.css
+++ b/openpype/style/style.css
@@ -864,7 +864,13 @@ OverlayMessageWidget QWidget {
     background: {color:bg-view-hover};
 }
 
-/* New Create/Publish UI */
+/* Publisher UI (Create/Publish) */
+#PublishWindow QAbstractSpinBox, QLineEdit, QPlainTextEdit, QTextEdit {
+    padding: 1px;
+}
+#PublishWindow QComboBox {
+    padding: 1px 1px 1px 0.2em;
+}
 PublisherTabsWidget {
     background: {color:publisher:tab-bg};
 }
@@ -1470,6 +1476,12 @@ CreateNextPageOverlay {
 }
 
 /* Attribute Definition widgets */
+AttributeDefinitionsWidget QAbstractSpinBox, QLineEdit, QPlainTextEdit, QTextEdit {
+    padding: 1px;
+}
+AttributeDefinitionsWidget QComboBox {
+    padding: 1px 1px 1px 0.2em;
+}
 InViewButton, InViewButton:disabled {
     background: transparent;
 }

--- a/openpype/tools/attribute_defs/widgets.py
+++ b/openpype/tools/attribute_defs/widgets.py
@@ -1,4 +1,3 @@
-import uuid
 import copy
 
 from qtpy import QtWidgets, QtCore
@@ -126,7 +125,7 @@ class AttributeDefinitionsWidget(QtWidgets.QWidget):
 
         row = 0
         for attr_def in attr_defs:
-            if not isinstance(attr_def, UIDef):
+            if attr_def.is_value_def:
                 if attr_def.key in self._current_keys:
                     raise KeyError(
                         "Duplicated key \"{}\"".format(attr_def.key))
@@ -144,7 +143,7 @@ class AttributeDefinitionsWidget(QtWidgets.QWidget):
 
             col_num = 2 - expand_cols
 
-            if attr_def.label:
+            if attr_def.is_value_def and attr_def.label:
                 label_widget = QtWidgets.QLabel(attr_def.label, self)
                 tooltip = attr_def.tooltip
                 if tooltip:

--- a/openpype/tools/attribute_defs/widgets.py
+++ b/openpype/tools/attribute_defs/widgets.py
@@ -148,6 +148,11 @@ class AttributeDefinitionsWidget(QtWidgets.QWidget):
                 tooltip = attr_def.tooltip
                 if tooltip:
                     label_widget.setToolTip(tooltip)
+                if attr_def.is_label_horizontal:
+                    label_widget.setAlignment(
+                        QtCore.Qt.AlignRight
+                        | QtCore.Qt.AlignVCenter
+                    )
                 layout.addWidget(
                     label_widget, row, 0, 1, expand_cols
                 )

--- a/openpype/tools/publisher/constants.py
+++ b/openpype/tools/publisher/constants.py
@@ -2,7 +2,7 @@ from qtpy import QtCore, QtGui
 
 # ID of context item in instance view
 CONTEXT_ID = "context"
-CONTEXT_LABEL = "Options"
+CONTEXT_LABEL = "Context"
 # Not showed anywhere - used as identifier
 CONTEXT_GROUP = "__ContextGroup__"
 

--- a/openpype/tools/publisher/constants.py
+++ b/openpype/tools/publisher/constants.py
@@ -15,6 +15,9 @@ VARIANT_TOOLTIP = (
     "\nnumerical characters (0-9) dot (\".\") or underscore (\"_\")."
 )
 
+INPUTS_LAYOUT_HSPACING = 4
+INPUTS_LAYOUT_VSPACING = 2
+
 # Roles for instance views
 INSTANCE_ID_ROLE = QtCore.Qt.UserRole + 1
 SORT_VALUE_ROLE = QtCore.Qt.UserRole + 2

--- a/openpype/tools/publisher/control.py
+++ b/openpype/tools/publisher/control.py
@@ -163,7 +163,7 @@ class AssetDocsCache:
         return copy.deepcopy(self._full_asset_docs_by_name[asset_name])
 
 
-class PublishReport:
+class PublishReportMaker:
     """Report for single publishing process.
 
     Report keeps current state of publishing and currently processed plugin.
@@ -784,6 +784,13 @@ class PublishValidationErrors:
 
         # Make sure the cached report is cleared
         plugin_id = self._plugins_proxy.get_plugin_id(plugin)
+        if not error.title:
+            if hasattr(plugin, "label") and plugin.label:
+                plugin_label = plugin.label
+            else:
+                plugin_label = plugin.__name__
+            error.title = plugin_label
+
         self._error_items.append(
             ValidationErrorItem.from_result(plugin_id, error, instance)
         )
@@ -1674,7 +1681,7 @@ class PublisherController(BasePublisherController):
         # pyblish.api.Context
         self._publish_context = None
         # Pyblish report
-        self._publish_report = PublishReport(self)
+        self._publish_report = PublishReportMaker(self)
         # Store exceptions of validation error
         self._publish_validation_errors = PublishValidationErrors()
 

--- a/openpype/tools/publisher/widgets/card_view_widgets.py
+++ b/openpype/tools/publisher/widgets/card_view_widgets.py
@@ -332,7 +332,7 @@ class ContextCardWidget(CardWidget):
         icon_layout.addWidget(icon_widget)
 
         layout = QtWidgets.QHBoxLayout(self)
-        layout.setContentsMargins(0, 5, 10, 5)
+        layout.setContentsMargins(0, 2, 10, 2)
         layout.addLayout(icon_layout, 0)
         layout.addWidget(label_widget, 1)
 
@@ -363,7 +363,7 @@ class ConvertorItemCardWidget(CardWidget):
         icon_layout.addWidget(icon_widget)
 
         layout = QtWidgets.QHBoxLayout(self)
-        layout.setContentsMargins(0, 5, 10, 5)
+        layout.setContentsMargins(0, 2, 10, 2)
         layout.addLayout(icon_layout, 0)
         layout.addWidget(label_widget, 1)
 
@@ -424,7 +424,7 @@ class InstanceCardWidget(CardWidget):
         top_layout.addWidget(expand_btn, 0)
 
         layout = QtWidgets.QHBoxLayout(self)
-        layout.setContentsMargins(0, 5, 10, 5)
+        layout.setContentsMargins(0, 2, 10, 2)
         layout.addLayout(top_layout)
         layout.addWidget(detail_widget)
 

--- a/openpype/tools/publisher/widgets/card_view_widgets.py
+++ b/openpype/tools/publisher/widgets/card_view_widgets.py
@@ -9,7 +9,7 @@ Only one item can be selected at a time.
 ```
 <i> : Icon. Can have Warning icon when context is not right
 ┌──────────────────────┐
-│  Options             │
+│  Context             │
 │ <Group 1> ────────── │
 │ <i> <Instance 1>  [x]│
 │ <i> <Instance 2>  [x]│
@@ -202,7 +202,7 @@ class ConvertorItemsGroupWidget(BaseGroupWidget):
 class InstanceGroupWidget(BaseGroupWidget):
     """Widget wrapping instances under group."""
 
-    active_changed = QtCore.Signal()
+    active_changed = QtCore.Signal(str, str, bool)
 
     def __init__(self, group_icons, *args, **kwargs):
         super(InstanceGroupWidget, self).__init__(*args, **kwargs)
@@ -253,12 +253,15 @@ class InstanceGroupWidget(BaseGroupWidget):
                         instance, group_icon, self
                     )
                     widget.selected.connect(self._on_widget_selection)
-                    widget.active_changed.connect(self.active_changed)
+                    widget.active_changed.connect(self._on_active_changed)
                     self._widgets_by_id[instance.id] = widget
                     self._content_layout.insertWidget(widget_idx, widget)
                 widget_idx += 1
 
         self._update_ordered_item_ids()
+
+    def _on_active_changed(self, instance_id, value):
+        self.active_changed.emit(self.group_name, instance_id, value)
 
 
 class CardWidget(BaseClickableFrame):
@@ -377,7 +380,7 @@ class ConvertorItemCardWidget(CardWidget):
 class InstanceCardWidget(CardWidget):
     """Card widget representing instance."""
 
-    active_changed = QtCore.Signal()
+    active_changed = QtCore.Signal(str, bool)
 
     def __init__(self, instance, group_icon, parent):
         super(InstanceCardWidget, self).__init__(parent)
@@ -444,6 +447,10 @@ class InstanceCardWidget(CardWidget):
 
     def set_active_toggle_enabled(self, enabled):
         self._active_checkbox.setEnabled(enabled)
+
+    @property
+    def is_active(self):
+        return self._active_checkbox.isChecked()
 
     def set_active(self, new_value):
         """Set instance as active."""
@@ -515,7 +522,7 @@ class InstanceCardWidget(CardWidget):
             return
 
         self.instance["active"] = new_value
-        self.active_changed.emit()
+        self.active_changed.emit(self._id, new_value)
 
     def _on_expend_clicked(self):
         self._set_expanded()
@@ -583,6 +590,45 @@ class InstanceCardView(AbstractInstanceView):
         result = super(InstanceCardView, self).sizeHint()
         result.setWidth(width)
         return result
+
+    def _toggle_instances(self, value):
+        if not self._active_toggle_enabled:
+            return
+
+        widgets = self._get_selected_widgets()
+        changed = False
+        for widget in widgets:
+            if not isinstance(widget, InstanceCardWidget):
+                continue
+
+            is_active = widget.is_active
+            if value == -1:
+                widget.set_active(not is_active)
+                changed = True
+                continue
+
+            _value = bool(value)
+            if is_active is not _value:
+                widget.set_active(_value)
+                changed = True
+
+        if changed:
+            self.active_changed.emit()
+
+    def keyPressEvent(self, event):
+        if event.key() == QtCore.Qt.Key_Space:
+            self._toggle_instances(-1)
+            return True
+
+        elif event.key() == QtCore.Qt.Key_Backspace:
+            self._toggle_instances(0)
+            return True
+
+        elif event.key() == QtCore.Qt.Key_Return:
+            self._toggle_instances(1)
+            return True
+
+        return super(InstanceCardView, self).keyPressEvent(event)
 
     def _get_selected_widgets(self):
         output = []
@@ -742,7 +788,15 @@ class InstanceCardView(AbstractInstanceView):
         for widget in self._widgets_by_group.values():
             widget.update_instance_values()
 
-    def _on_active_changed(self):
+    def _on_active_changed(self, group_name, instance_id, value):
+        group_widget = self._widgets_by_group[group_name]
+        instance_widget = group_widget.get_widget_by_item_id(instance_id)
+        if instance_widget.is_selected:
+            for widget in self._get_selected_widgets():
+                if isinstance(widget, InstanceCardWidget):
+                    widget.set_active(value)
+        else:
+            self._select_item_clear(instance_id, group_name, instance_widget)
         self.active_changed.emit()
 
     def _on_widget_selection(self, instance_id, group_name, selection_type):

--- a/openpype/tools/publisher/widgets/create_widget.py
+++ b/openpype/tools/publisher/widgets/create_widget.py
@@ -22,6 +22,8 @@ from ..constants import (
     CREATOR_IDENTIFIER_ROLE,
     CREATOR_THUMBNAIL_ENABLED_ROLE,
     CREATOR_SORT_ROLE,
+    INPUTS_LAYOUT_HSPACING,
+    INPUTS_LAYOUT_VSPACING,
 )
 
 SEPARATORS = ("---separator---", "---")
@@ -198,6 +200,8 @@ class CreateWidget(QtWidgets.QWidget):
 
         variant_subset_layout = QtWidgets.QFormLayout(variant_subset_widget)
         variant_subset_layout.setContentsMargins(0, 0, 0, 0)
+        variant_subset_layout.setHorizontalSpacing(INPUTS_LAYOUT_HSPACING)
+        variant_subset_layout.setVerticalSpacing(INPUTS_LAYOUT_VSPACING)
         variant_subset_layout.addRow("Variant", variant_widget)
         variant_subset_layout.addRow("Subset", subset_name_input)
 

--- a/openpype/tools/publisher/widgets/list_view_widgets.py
+++ b/openpype/tools/publisher/widgets/list_view_widgets.py
@@ -486,6 +486,9 @@ class InstanceListView(AbstractInstanceView):
             group_widget.set_expanded(expanded)
 
     def _on_toggle_request(self, toggle):
+        if not self._active_toggle_enabled:
+            return
+
         selected_instance_ids = self._instance_view.get_selected_instance_ids()
         if toggle == -1:
             active = None

--- a/openpype/tools/publisher/widgets/list_view_widgets.py
+++ b/openpype/tools/publisher/widgets/list_view_widgets.py
@@ -11,7 +11,7 @@ selection can be enabled disabled using checkbox or keyboard key presses:
 - Backspace - disable selection
 
 ```
-|- Options
+|- Context
 |- <Group 1> [x]
 |  |- <Instance 1> [x]
 |  |- <Instance 2> [x]

--- a/openpype/tools/publisher/widgets/precreate_widget.py
+++ b/openpype/tools/publisher/widgets/precreate_widget.py
@@ -117,8 +117,11 @@ class AttributesWidget(QtWidgets.QWidget):
 
             col_num = 2 - expand_cols
 
-            if attr_def.label:
+            if attr_def.is_value_def and attr_def.label:
                 label_widget = QtWidgets.QLabel(attr_def.label, self)
+                tooltip = attr_def.tooltip
+                if tooltip:
+                    label_widget.setToolTip(tooltip)
                 self._layout.addWidget(
                     label_widget, row, 0, 1, expand_cols
                 )

--- a/openpype/tools/publisher/widgets/precreate_widget.py
+++ b/openpype/tools/publisher/widgets/precreate_widget.py
@@ -2,6 +2,8 @@ from qtpy import QtWidgets, QtCore
 
 from openpype.tools.attribute_defs import create_widget_for_attr_def
 
+from ..constants import INPUTS_LAYOUT_HSPACING, INPUTS_LAYOUT_VSPACING
+
 
 class PreCreateWidget(QtWidgets.QWidget):
     def __init__(self, parent):
@@ -81,6 +83,8 @@ class AttributesWidget(QtWidgets.QWidget):
 
         layout = QtWidgets.QGridLayout(self)
         layout.setContentsMargins(0, 0, 0, 0)
+        layout.setHorizontalSpacing(INPUTS_LAYOUT_HSPACING)
+        layout.setVerticalSpacing(INPUTS_LAYOUT_VSPACING)
 
         self._layout = layout
 

--- a/openpype/tools/publisher/widgets/precreate_widget.py
+++ b/openpype/tools/publisher/widgets/precreate_widget.py
@@ -126,6 +126,11 @@ class AttributesWidget(QtWidgets.QWidget):
                 tooltip = attr_def.tooltip
                 if tooltip:
                     label_widget.setToolTip(tooltip)
+                if attr_def.is_label_horizontal:
+                    label_widget.setAlignment(
+                        QtCore.Qt.AlignRight
+                        | QtCore.Qt.AlignVCenter
+                    )
                 self._layout.addWidget(
                     label_widget, row, 0, 1, expand_cols
                 )

--- a/openpype/tools/publisher/widgets/widgets.py
+++ b/openpype/tools/publisher/widgets/widgets.py
@@ -36,6 +36,8 @@ from .icons import (
 from ..constants import (
     VARIANT_TOOLTIP,
     ResetKeySequence,
+    INPUTS_LAYOUT_HSPACING,
+    INPUTS_LAYOUT_VSPACING,
 )
 
 
@@ -1098,6 +1100,8 @@ class GlobalAttrsWidget(QtWidgets.QWidget):
         btns_layout.addWidget(cancel_btn)
 
         main_layout = QtWidgets.QFormLayout(self)
+        main_layout.setHorizontalSpacing(INPUTS_LAYOUT_HSPACING)
+        main_layout.setVerticalSpacing(INPUTS_LAYOUT_VSPACING)
         main_layout.addRow("Variant", variant_input)
         main_layout.addRow("Asset", asset_value_widget)
         main_layout.addRow("Task", task_value_widget)
@@ -1346,6 +1350,8 @@ class CreatorAttrsWidget(QtWidgets.QWidget):
         content_layout.setColumnStretch(0, 0)
         content_layout.setColumnStretch(1, 1)
         content_layout.setAlignment(QtCore.Qt.AlignTop)
+        content_layout.setHorizontalSpacing(INPUTS_LAYOUT_HSPACING)
+        content_layout.setVerticalSpacing(INPUTS_LAYOUT_VSPACING)
 
         row = 0
         for attr_def, attr_instances, values in result:
@@ -1479,6 +1485,8 @@ class PublishPluginAttrsWidget(QtWidgets.QWidget):
         attr_def_layout = QtWidgets.QGridLayout(attr_def_widget)
         attr_def_layout.setColumnStretch(0, 0)
         attr_def_layout.setColumnStretch(1, 1)
+        attr_def_layout.setHorizontalSpacing(INPUTS_LAYOUT_HSPACING)
+        attr_def_layout.setVerticalSpacing(INPUTS_LAYOUT_VSPACING)
 
         content_layout = QtWidgets.QVBoxLayout(content_widget)
         content_layout.addWidget(attr_def_widget, 0)

--- a/openpype/tools/publisher/widgets/widgets.py
+++ b/openpype/tools/publisher/widgets/widgets.py
@@ -1385,6 +1385,11 @@ class CreatorAttrsWidget(QtWidgets.QWidget):
                 tooltip = attr_def.tooltip
                 if tooltip:
                     label_widget.setToolTip(tooltip)
+                if attr_def.is_label_horizontal:
+                    label_widget.setAlignment(
+                        QtCore.Qt.AlignRight
+                        | QtCore.Qt.AlignVCenter
+                    )
                 content_layout.addWidget(
                     label_widget, row, 0, 1, expand_cols
                 )
@@ -1522,6 +1527,11 @@ class PublishPluginAttrsWidget(QtWidgets.QWidget):
                         tooltip = attr_def.tooltip
                         if tooltip:
                             label_widget.setToolTip(tooltip)
+                        if attr_def.is_label_horizontal:
+                            label_widget.setAlignment(
+                                QtCore.Qt.AlignRight
+                                | QtCore.Qt.AlignVCenter
+                            )
                         attr_def_layout.addWidget(
                             label_widget, row, 0, 1, expand_cols
                         )

--- a/openpype/tools/publisher/widgets/widgets.py
+++ b/openpype/tools/publisher/widgets/widgets.py
@@ -9,7 +9,7 @@ import collections
 from qtpy import QtWidgets, QtCore, QtGui
 import qtawesome
 
-from openpype.lib.attribute_definitions import UnknownDef, UIDef
+from openpype.lib.attribute_definitions import UnknownDef
 from openpype.tools.attribute_defs import create_widget_for_attr_def
 from openpype.tools import resources
 from openpype.tools.flickcharm import FlickCharm
@@ -1371,9 +1371,14 @@ class CreatorAttrsWidget(QtWidgets.QWidget):
 
             col_num = 2 - expand_cols
 
-            label = attr_def.label or attr_def.key
+            label = None
+            if attr_def.is_value_def:
+                label = attr_def.label or attr_def.key
             if label:
                 label_widget = QtWidgets.QLabel(label, self)
+                tooltip = attr_def.tooltip
+                if tooltip:
+                    label_widget.setToolTip(tooltip)
                 content_layout.addWidget(
                     label_widget, row, 0, 1, expand_cols
                 )
@@ -1501,7 +1506,9 @@ class PublishPluginAttrsWidget(QtWidgets.QWidget):
                         expand_cols = 1
 
                     col_num = 2 - expand_cols
-                    label = attr_def.label or attr_def.key
+                    label = None
+                    if attr_def.is_value_def:
+                        label = attr_def.label or attr_def.key
                     if label:
                         label_widget = QtWidgets.QLabel(label, content_widget)
                         tooltip = attr_def.tooltip
@@ -1517,7 +1524,7 @@ class PublishPluginAttrsWidget(QtWidgets.QWidget):
                     )
                     row += 1
 
-                if isinstance(attr_def, UIDef):
+                if not attr_def.is_value_def:
                     continue
 
                 widget.value_changed.connect(self._input_value_changed)

--- a/openpype/tools/publisher/window.py
+++ b/openpype/tools/publisher/window.py
@@ -450,16 +450,15 @@ class PublisherWindow(QtWidgets.QDialog):
 
         # PySide6 Support
         if hasattr(event, "keyCombination"):
-            match_result = ResetKeySequence.matches(
+            reset_match_result = ResetKeySequence.matches(
                 QtGui.QKeySequence(event.keyCombination())
             )
-            reset_pressed = match_result == QtGui.QKeySequence.ExactMatch
         else:
-            reset_pressed = ResetKeySequence.matches(
+            reset_match_result = ResetKeySequence.matches(
                 QtGui.QKeySequence(event.modifiers() | event.key())
             )
 
-        if reset_pressed:
+        if reset_match_result == QtGui.QKeySequence.ExactMatch:
             if not self.controller.publish_is_running:
                 self.reset()
             event.accept()

--- a/openpype/tools/publisher/window.py
+++ b/openpype/tools/publisher/window.py
@@ -442,7 +442,8 @@ class PublisherWindow(QtWidgets.QDialog):
             event.accept()
             return
 
-        if event.matches(QtGui.QKeySequence.Save):
+        save_match = event.matches(QtGui.QKeySequence.Save)
+        if save_match == QtGui.QKeySequence.ExactMatch:
             if not self._controller.publish_has_started:
                 self._save_changes(True)
             event.accept()

--- a/openpype/tools/publisher/window.py
+++ b/openpype/tools/publisher/window.py
@@ -448,9 +448,18 @@ class PublisherWindow(QtWidgets.QDialog):
             event.accept()
             return
 
-        if ResetKeySequence.matches(
-            QtGui.QKeySequence(event.key() | event.modifiers())
-        ):
+        # PySide6 Support
+        if hasattr(event, "keyCombination"):
+            match_result = ResetKeySequence.matches(
+                QtGui.QKeySequence(event.keyCombination())
+            )
+            reset_pressed = match_result == QtGui.QKeySequence.ExactMatch
+        else:
+            reset_pressed = ResetKeySequence.matches(
+                QtGui.QKeySequence(event.modifiers() | event.key())
+            )
+
+        if reset_pressed:
             if not self.controller.publish_is_running:
                 self.reset()
             event.accept()

--- a/openpype/tools/publisher/window.py
+++ b/openpype/tools/publisher/window.py
@@ -46,6 +46,8 @@ class PublisherWindow(QtWidgets.QDialog):
     def __init__(self, parent=None, controller=None, reset_on_show=None):
         super(PublisherWindow, self).__init__(parent)
 
+        self.setObjectName("PublishWindow")
+
         self.setWindowTitle("OpenPype publisher")
 
         icon = QtGui.QIcon(resources.get_openpype_icon_filepath())

--- a/openpype/tools/utils/__init__.py
+++ b/openpype/tools/utils/__init__.py
@@ -1,6 +1,7 @@
 from .widgets import (
     FocusSpinBox,
     FocusDoubleSpinBox,
+    ComboBox,
     CustomTextComboBox,
     PlaceholderLineEdit,
     BaseClickableFrame,
@@ -38,6 +39,7 @@ from .overlay_messages import (
 __all__ = (
     "FocusSpinBox",
     "FocusDoubleSpinBox",
+    "ComboBox",
     "CustomTextComboBox",
     "PlaceholderLineEdit",
     "BaseClickableFrame",

--- a/openpype/tools/utils/widgets.py
+++ b/openpype/tools/utils/widgets.py
@@ -274,6 +274,9 @@ class PixmapLabel(QtWidgets.QLabel):
         self._empty_pixmap = QtGui.QPixmap(0, 0)
         self._source_pixmap = pixmap
 
+        self._last_width = 0
+        self._last_height = 0
+
     def set_source_pixmap(self, pixmap):
         """Change source image."""
         self._source_pixmap = pixmap
@@ -283,6 +286,12 @@ class PixmapLabel(QtWidgets.QLabel):
         size = self.fontMetrics().height()
         size += size % 2
         return size, size
+
+    def minimumSizeHint(self):
+        width, height = self._get_pix_size()
+        if width != self._last_width or height != self._last_height:
+            self._set_resized_pix()
+        return QtCore.QSize(width, height)
 
     def _set_resized_pix(self):
         if self._source_pixmap is None:
@@ -297,6 +306,8 @@ class PixmapLabel(QtWidgets.QLabel):
                 QtCore.Qt.SmoothTransformation
             )
         )
+        self._last_width = width
+        self._last_height = height
 
     def resizeEvent(self, event):
         self._set_resized_pix()

--- a/openpype/tools/utils/widgets.py
+++ b/openpype/tools/utils/widgets.py
@@ -41,7 +41,28 @@ class FocusDoubleSpinBox(QtWidgets.QDoubleSpinBox):
             super(FocusDoubleSpinBox, self).wheelEvent(event)
 
 
-class CustomTextComboBox(QtWidgets.QComboBox):
+class ComboBox(QtWidgets.QComboBox):
+    """Base of combobox with pre-implement changes used in tools.
+
+    Combobox is using styled delegate by default so stylesheets are propagated.
+
+    Items are not changed on scroll until the combobox is in focus.
+    """
+
+    def __init__(self, *args, **kwargs):
+        super(ComboBox, self).__init__(*args, **kwargs)
+        delegate = QtWidgets.QStyledItemDelegate()
+        self.setItemDelegate(delegate)
+        self.setFocusPolicy(QtCore.Qt.StrongFocus)
+
+        self._delegate = delegate
+
+    def wheelEvent(self, event):
+        if self.hasFocus():
+            return super(ComboBox, self).wheelEvent(event)
+
+
+class CustomTextComboBox(ComboBox):
     """Combobox which can have different text showed."""
 
     def __init__(self, *args, **kwargs):


### PR DESCRIPTION
## Changelog Description
Small changes in styles and form of publisher UI.

## Additional info
- Attribute definitions have smaller spacing and padding, their labels are aligned to right.
- Cards in card view are a little bit smaller (6px).
- Icons on cards should have unified size -> pixmaps are not sometimes resized correctly but card size is unified.
- Change of active states on card view works the same as in list view.
- Renamed `Options` to `Context`.
- Border radius on inputs is a little bit smaller.
- Scroll area have explicitly set borders to none -> in Houdini were black.
- Implemente combobox which ignores mouse wheel event until has active focus (avoid accidental change of values)

## Testing notes:
1. Open Publisher in different DCCs
2. Validate it is not broken
