### PR TITLE
Scene inventory: Model refresh fix with cherry picking

### DIFF
--- a/openpype/tools/sceneinventory/window.py
+++ b/openpype/tools/sceneinventory/window.py
@@ -107,8 +107,8 @@ class SceneInventoryWindow(QtWidgets.QDialog):
         view.hierarchy_view_changed.connect(
             self._on_hierarchy_view_change
         )
-        view.data_changed.connect(self.refresh)
-        refresh_button.clicked.connect(self.refresh)
+        view.data_changed.connect(self._refresh_callback)
+        refresh_button.clicked.connect(self._refresh_callback)
         update_all_button.clicked.connect(self._on_update_all)
 
         self._update_all_button = update_all_button
@@ -138,6 +138,11 @@ class SceneInventoryWindow(QtWidgets.QDialog):
         whilst trying to name an instance.
 
         """
+
+    def _refresh_callback(self):
+        """Signal callback to trigger 'refresh' without any arguments."""
+
+        self.refresh()
 
     def refresh(self, items=None):
         with preserve_expanded_rows(

--- a/openpype/tools/sceneinventory/window.py
+++ b/openpype/tools/sceneinventory/window.py
@@ -107,8 +107,8 @@ class SceneInventoryWindow(QtWidgets.QDialog):
         view.hierarchy_view_changed.connect(
             self._on_hierarchy_view_change
         )
-        view.data_changed.connect(self._refresh_callback)
-        refresh_button.clicked.connect(self._refresh_callback)
+        view.data_changed.connect(self._on_refresh_request)
+        refresh_button.clicked.connect(self._on_refresh_request)
         update_all_button.clicked.connect(self._on_update_all)
 
         self._update_all_button = update_all_button
@@ -139,7 +139,7 @@ class SceneInventoryWindow(QtWidgets.QDialog):
 
         """
 
-    def _refresh_callback(self):
+    def _on_refresh_request(self):
         """Signal callback to trigger 'refresh' without any arguments."""
 
         self.refresh()


### PR DESCRIPTION
## Changelog Description
Fix cherry pick issue in scene inventory.

## Additional info
As described in [source issue](https://github.com/ynput/OpenPype/issues/4593), the functionality is implemented only in blender. I didn't find out what it actually does?

### Traceback
```
Traceback (most recent call last):
  File "S:\openpype\OpenPype\openpype\tools\sceneinventory\window.py", line 156, in refresh
    self._model.refresh(**kwargs)
  File "S:\openpype\OpenPype\openpype\tools\sceneinventory\model.py", line 211, in refresh
    if not hasattr(host.pipeline, "update_hierarchy"):
AttributeError: 'FusionHost' object has no attribute 'pipeline'
```

## Testing notes:
1. Open scene inventory
2. Cherry pick an item there