### PR TITLE
Fusion: Add USD loader

### DIFF
--- a/openpype/hosts/fusion/plugins/load/load_usd.py
+++ b/openpype/hosts/fusion/plugins/load/load_usd.py
@@ -1,0 +1,73 @@
+from openpype.pipeline import (
+    load,
+    get_representation_path,
+)
+from openpype.hosts.fusion.api import (
+    imprint_container,
+    get_current_comp,
+    comp_lock_and_undo_chunk
+)
+
+
+class FusionLoadAlembicMesh(load.LoaderPlugin):
+    """Load USD into Fusion
+
+    Support for USD was added since Fusion 18.5
+    """
+
+    families = ["*"]
+    representations = ["*"]
+    extensions = {"usd", "usda", "usdz"}
+
+    label = "Load USD"
+    order = -10
+    icon = "code-fork"
+    color = "orange"
+
+    tool_type = "uLoader"
+
+    def load(self, context, name, namespace, data):
+        # Fallback to asset name when namespace is None
+        if namespace is None:
+            namespace = context['asset']['name']
+
+        # Create the Loader with the filename path set
+        comp = get_current_comp()
+        with comp_lock_and_undo_chunk(comp, "Create tool"):
+
+            path = self.fname
+
+            args = (-32768, -32768)
+            tool = comp.AddTool(self.tool_type, *args)
+            tool["Filename"] = path
+
+            imprint_container(tool,
+                              name=name,
+                              namespace=namespace,
+                              context=context,
+                              loader=self.__class__.__name__)
+
+    def switch(self, container, representation):
+        self.update(container, representation)
+
+    def update(self, container, representation):
+
+        tool = container["_tool"]
+        assert tool.ID == self.tool_type, f"Must be {self.tool_type}"
+        comp = tool.Comp()
+
+        path = get_representation_path(representation)
+
+        with comp_lock_and_undo_chunk(comp, "Update tool"):
+            tool["Filename"] = path
+
+            # Update the imprinted representation
+            tool.SetData("avalon.representation", str(representation["_id"]))
+
+    def remove(self, container):
+        tool = container["_tool"]
+        assert tool.ID == self.tool_type, f"Must be {self.tool_type}"
+        comp = tool.Comp()
+
+        with comp_lock_and_undo_chunk(comp, "Remove tool"):
+            tool.Delete()


### PR DESCRIPTION
## Changelog Description

Add an OpenPype managed USD loader (`uLoader`) for Fusion. 

## Additional info

Fusion 18.5 beta adds USD tools, including a USD loader tool (`uLoader`).

_Note Fusion 18.5+ is currently still in public beta, so I'll keep this around as a draft for the time being._

## Testing notes:

1. Start Fusion 18.5 beta or a newer release once it's out
2. Load published USD files.
3. Also test whether updating and removing works with manage.. (scene inventory)