### PR TITLE
Nuke: Pre-render and missing review flag on instance causing crash

### DIFF
--- a/openpype/hosts/nuke/plugins/publish/collect_writes.py
+++ b/openpype/hosts/nuke/plugins/publish/collect_writes.py
@@ -190,7 +190,7 @@ class CollectNukeWrites(pyblish.api.InstancePlugin,
 
         # make sure rendered sequence on farm will
         # be used for extract review
-        if not instance.data["review"]:
+        if not instance.data.get("review"):
             instance.data["useSequenceForReview"] = False
 
         self.log.debug("instance.data: {}".format(pformat(instance.data)))


### PR DESCRIPTION
## Changelog Description
If instance created in nuke was missing `review` flag, collector crashed.

## Testing notes:
1. try publishing prerender in nuke
