### PR TITLE
Fusion: Simplify creator icons code

### DIFF
--- a/openpype/hosts/fusion/plugins/create/create_saver.py
+++ b/openpype/hosts/fusion/plugins/create/create_saver.py
@@ -26,7 +26,7 @@ class CreateSaver(Creator):
     family = "render"
     default_variants = ["Main", "Mask"]
     description = "Fusion Saver to generate image sequence"
-    icon = "eye"
+    icon = "fa5.eye"
 
     instance_attributes = ["reviewable"]
 

--- a/openpype/hosts/fusion/plugins/create/create_saver.py
+++ b/openpype/hosts/fusion/plugins/create/create_saver.py
@@ -1,7 +1,5 @@
 import os
 
-import qtawesome
-
 from openpype.hosts.fusion.api import (
     get_current_comp,
     comp_lock_and_undo_chunk,
@@ -28,6 +26,7 @@ class CreateSaver(Creator):
     family = "render"
     default_variants = ["Main", "Mask"]
     description = "Fusion Saver to generate image sequence"
+    icon = "eye"
 
     instance_attributes = ["reviewable"]
 
@@ -88,9 +87,6 @@ class CreateSaver(Creator):
             created_instance.transient_data["tool"] = tool
 
             self._add_instance_to_context(created_instance)
-
-    def get_icon(self):
-        return qtawesome.icon("fa.eye", color="white")
 
     def update_instances(self, update_list):
         for created_inst, _changes in update_list:

--- a/openpype/hosts/fusion/plugins/create/create_workfile.py
+++ b/openpype/hosts/fusion/plugins/create/create_workfile.py
@@ -13,7 +13,7 @@ class FusionWorkfileCreator(AutoCreator):
     identifier = "workfile"
     family = "workfile"
     label = "Workfile"
-    icon = "file-o"
+    icon = "fa5.file"
 
     default_variant = "Main"
 

--- a/openpype/hosts/fusion/plugins/create/create_workfile.py
+++ b/openpype/hosts/fusion/plugins/create/create_workfile.py
@@ -1,5 +1,3 @@
-import qtawesome
-
 from openpype.hosts.fusion.api import (
     get_current_comp
 )
@@ -15,6 +13,7 @@ class FusionWorkfileCreator(AutoCreator):
     identifier = "workfile"
     family = "workfile"
     label = "Workfile"
+    icon = "file-o"
 
     default_variant = "Main"
 
@@ -104,6 +103,3 @@ class FusionWorkfileCreator(AutoCreator):
             existing_instance["asset"] = asset_name
             existing_instance["task"] = task_name
             existing_instance["subset"] = subset_name
-
-    def get_icon(self):
-        return qtawesome.icon("fa.file-o", color="white")


### PR DESCRIPTION
## Changelog Description

Simplify code for setting the icons for the Fusion creators

## Additional info

Icons look like before:
![afbeelding](https://user-images.githubusercontent.com/2439881/234027039-04997a88-9cec-4470-ba89-dbef7d2e375a.png)

There was no need to reimplement `get_icon` methods.

## Testing notes:

1. Open Publisher in Fusion
2. Icons should still look beautiful for the instances
