### PR TITLE
Enhancement: Fix PySide 6.5 support for loader

### DIFF
--- a/openpype/tools/loader/model.py
+++ b/openpype/tools/loader/model.py
@@ -123,7 +123,7 @@ class BaseRepresentationModel(object):
         self.remote_provider = remote_provider
 
 
-class SubsetsModel(TreeModel, BaseRepresentationModel):
+class SubsetsModel(BaseRepresentationModel, TreeModel):
     doc_fetched = QtCore.Signal()
     refreshed = QtCore.Signal(bool)
 

--- a/openpype/tools/publisher/widgets/list_view_widgets.py
+++ b/openpype/tools/publisher/widgets/list_view_widgets.py
@@ -1039,7 +1039,8 @@ class InstanceListView(AbstractInstanceView):
             proxy_index = proxy_model.mapFromSource(select_indexes[0])
             selection_model.setCurrentIndex(
                 proxy_index,
-                selection_model.ClearAndSelect | selection_model.Rows
+                QtCore.QItemSelectionModel.ClearAndSelect
+                | QtCore.QItemSelectionModel.Rows
             )
             return
 


### PR DESCRIPTION
## Changelog Description

Fixes PySide 6.5 support in Loader.

## Additional info

There's a bug in PySide 6.5 it seems with multiple inheritance:
- https://bugreports.qt.io/browse/PYSIDE-2294
- https://bugreports.qt.io/browse/PYSIDE-2304
- https://forum.qt.io/topic/144262/typeerror-with-pyside-6-5-0-for-multiple-inheritance-of-mainwindow/7?_=1682360495905&lang=nl

In [this USD PR the inheritance order is reversed](https://github.com/PixarAnimationStudios/USD/pull/2392) to solve the issue, which also works in our case.

---

This PR also fixes an issue with the Publisher when switching list view mode when having a single instance selected - which is an issue I believe from PySide6+ not PySide6.5.

## Testing notes:

1. Launch Loader in PySide 6.5
2. Toggle list view mode in new publisher with a single instance selected.
