### PR TITLE
Tray Publisher: User can set colorspace per instance explicitly

### DIFF
--- a/openpype/hosts/traypublisher/plugins/publish/collect_explicit_colorspace.py
+++ b/openpype/hosts/traypublisher/plugins/publish/collect_explicit_colorspace.py
@@ -1,0 +1,36 @@
+import pyblish.api
+
+from openpype.pipeline import publish
+from openpype.lib import TextDef
+
+
+class CollectColorspace(pyblish.api.InstancePlugin,
+                        publish.OpenPypePyblishPluginMixin,
+                        publish.ColormanagedPyblishPluginMixin):
+    """Collect explicit user defined representation colorspaces"""
+
+    label = "Choose representation colorspace"
+    order = pyblish.api.CollectorOrder + 0.49
+    hosts = ["traypublisher"]
+
+    def process(self, instance):
+        values = self.get_attr_values_from_data(instance.data)
+        colorspace = values.get("colorspace", None)
+        if not colorspace:
+            return
+
+        context = instance.context
+        for repre in instance.data.get("representations", {}):
+            self.set_representation_colorspace(
+                representation=repre,
+                context=context,
+                colorspace=colorspace
+            )
+
+    @classmethod
+    def get_attribute_defs(cls):
+        return [
+            TextDef("colorspace",
+                    label="Override Colorspace",
+                    placeholder="")
+        ]

--- a/openpype/hosts/traypublisher/plugins/publish/validate_colorspace.py
+++ b/openpype/hosts/traypublisher/plugins/publish/validate_colorspace.py
@@ -1,0 +1,53 @@
+import pyblish.api
+
+from openpype.pipeline import (
+    publish,
+    PublishValidationError
+)
+
+from openpype.pipeline.colorspace import (
+    get_ocio_config_colorspaces
+)
+
+
+class ValidateColorspace(pyblish.api.InstancePlugin,
+                        publish.OpenPypePyblishPluginMixin,
+                        publish.ColormanagedPyblishPluginMixin):
+    """Validate representation colorspaces"""
+
+    label = "Validate representation colorspace"
+    order = pyblish.api.ValidatorOrder
+    hosts = ["traypublisher"]
+
+    def process(self, instance):
+
+        config_colorspaces = {}  # cache of colorspaces per config path
+        for repre in instance.data.get("representations", {}):
+
+            colorspace_data = repre.get("colorspaceData", {})
+            if not colorspace_data:
+                # Nothing to validate
+                continue
+
+            config_path = colorspace_data["config"]["path"]
+            if config_path not in config_colorspaces:
+                colorspaces = get_ocio_config_colorspaces(config_path)
+                config_colorspaces[config_path] = set(colorspaces)
+
+            colorspace = colorspace_data["colorspace"]
+            self.log.debug(
+                f"Validating representation '{repre['name']}' "
+                f"colorspace '{colorspace}'"
+            )
+            if colorspace not in config_colorspaces[config_path]:
+                message = (
+                    f"Representation '{repre['name']}' colorspace "
+                    f"'{colorspace}' does not exist in OCIO config: "
+                    f"{config_path}"
+                )
+
+                raise PublishValidationError(
+                    title="Representation colorspace",
+                    message=message,
+                    description=message
+                )


### PR DESCRIPTION
## Changelog Description

With this feature a user can set/override the colorspace for the representations of an instance explicitly instead of relying on the File Rules from project settings or alike. This way you can ingest any file and explicitly say "this file is colorspace X".

## Additional info

I had a few cases where I just had some files laying around or received from a client that did not adhere to any of our file rules and I didn't want to fool around with the project settings to catch that particular colorspace. I just wanted to say "These files are colorspace X"

Warning: Due to how these settings are set per instance this will set **all of the representations** of an instance to be that colorspace. Thus if an instance had both `acescg` EXRs and a preview `srgb` h264 mov you'd be overriding the colorspace for both at once and thus can not differentiate between either.

#### Screenshots

![afbeelding](https://user-images.githubusercontent.com/2439881/234218964-c9615dca-d791-4b21-bde8-f588fa1fd6be.png)
![afbeelding](https://user-images.githubusercontent.com/2439881/234219094-301b155c-4123-421f-9363-ab4dfd001879.png)

### Alternatives

Instead of this implementation a workaround could've been to still set up explicit file rules in Project Settings but then rename the input files to adhere to those file rules so the colorspace is set according to that instead.

## Testing notes:

1. Start tray publisher.
2. On the publish tab each instance should have an "Override Colorspace" attribute, type a valid colorspace name from the OCIO config set in the Project Settings.
3. On publish the colorspace name is validated.