### PR TITLE
Maya Load References - Add Display Handle Setting

### DIFF
--- a/openpype/hosts/maya/plugins/load/load_reference.py
+++ b/openpype/hosts/maya/plugins/load/load_reference.py
@@ -162,9 +162,12 @@ class ReferenceLoader(openpype.hosts.maya.api.plugin.ReferenceLoader):
                     with parent_nodes(roots, parent=None):
                         cmds.xform(group_name, zeroTransformPivots=True)
 
-                cmds.setAttr("{}.displayHandle".format(group_name), 1)
-
                 settings = get_project_settings(os.environ['AVALON_PROJECT'])
+
+                display_handle = settings['maya']['load'].get('reference_loader', {}).get(
+                    'display_handle', True)
+                cmds.setAttr("{}.displayHandle".format(group_name), display_handle)
+
                 colors = settings['maya']['load']['colors']
                 c = colors.get(family)
                 if c is not None:
@@ -174,7 +177,7 @@ class ReferenceLoader(openpype.hosts.maya.api.plugin.ReferenceLoader):
                                  (float(c[1]) / 255),
                                  (float(c[2]) / 255))
 
-                cmds.setAttr("{}.displayHandle".format(group_name), 1)
+                cmds.setAttr("{}.displayHandle".format(group_name), display_handle)
                 # get bounding box
                 bbox = cmds.exactWorldBoundingBox(group_name)
                 # get pivot position on world space

--- a/openpype/hosts/maya/plugins/load/load_reference.py
+++ b/openpype/hosts/maya/plugins/load/load_reference.py
@@ -165,9 +165,11 @@ class ReferenceLoader(openpype.hosts.maya.api.plugin.ReferenceLoader):
                 settings = get_project_settings(os.environ['AVALON_PROJECT'])
 
                 display_handle = settings['maya']['load'].get(
-                    'reference_loader', {}).get('display_handle', True)
+                    'reference_loader', {}
+                ).get('display_handle', True)
                 cmds.setAttr(
-                    "{}.displayHandle".format(group_name), display_handle)
+                    "{}.displayHandle".format(group_name), display_handle
+                )
 
                 colors = settings['maya']['load']['colors']
                 c = colors.get(family)
@@ -179,7 +181,8 @@ class ReferenceLoader(openpype.hosts.maya.api.plugin.ReferenceLoader):
                                  (float(c[2]) / 255))
 
                 cmds.setAttr(
-                    "{}.displayHandle".format(group_name), display_handle)
+                    "{}.displayHandle".format(group_name), display_handle
+                )
                 # get bounding box
                 bbox = cmds.exactWorldBoundingBox(group_name)
                 # get pivot position on world space

--- a/openpype/hosts/maya/plugins/load/load_reference.py
+++ b/openpype/hosts/maya/plugins/load/load_reference.py
@@ -164,9 +164,10 @@ class ReferenceLoader(openpype.hosts.maya.api.plugin.ReferenceLoader):
 
                 settings = get_project_settings(os.environ['AVALON_PROJECT'])
 
-                display_handle = settings['maya']['load'].get('reference_loader', {}).get(
-                    'display_handle', True)
-                cmds.setAttr("{}.displayHandle".format(group_name), display_handle)
+                display_handle = settings['maya']['load'].get(
+                    'reference_loader', {}).get('display_handle', True)
+                cmds.setAttr(
+                    "{}.displayHandle".format(group_name), display_handle)
 
                 colors = settings['maya']['load']['colors']
                 c = colors.get(family)
@@ -177,7 +178,8 @@ class ReferenceLoader(openpype.hosts.maya.api.plugin.ReferenceLoader):
                                  (float(c[1]) / 255),
                                  (float(c[2]) / 255))
 
-                cmds.setAttr("{}.displayHandle".format(group_name), display_handle)
+                cmds.setAttr(
+                    "{}.displayHandle".format(group_name), display_handle)
                 # get bounding box
                 bbox = cmds.exactWorldBoundingBox(group_name)
                 # get pivot position on world space

--- a/openpype/settings/defaults/project_settings/maya.json
+++ b/openpype/settings/defaults/project_settings/maya.json
@@ -1460,7 +1460,8 @@
         },
         "reference_loader": {
             "namespace": "{asset_name}_{subset}_##_",
-            "group_name": "_GRP"
+            "group_name": "_GRP",
+            "display_handle": true
         }
     },
     "workfile_build": {

--- a/openpype/settings/entities/schemas/projects_schema/schemas/schema_maya_load.json
+++ b/openpype/settings/entities/schemas/projects_schema/schemas/schema_maya_load.json
@@ -111,6 +111,14 @@
                 {
                     "type": "label",
                     "label": "Here's a link to the doc where you can find explanations about customing the naming of referenced assets: https://openpype.io/docs/admin_hosts_maya#load-plugins"
+                },
+                {
+                    "type": "separator"
+                },
+                {
+                    "type": "boolean",
+                    "key": "display_handle",
+                    "label": "Display Handle On Load References"
                 }
             ]
         }


### PR DESCRIPTION
## Changelog Description
When we load a reference in Maya using OpenPype loader, display handle is checked by default and prevent us to select easily the object in the viewport. 
![image](https://user-images.githubusercontent.com/68907585/234317963-09b1d537-43a5-4715-bf3f-8cd8cc4568e1.png)

I understand that some productions like to keep this option, so I propose to add display handle to the reference loader settings. 
![image](https://user-images.githubusercontent.com/68907585/234317353-e05678a8-e297-4f12-9234-46c4de781542.png)

## Testing notes:
1. Using Openpype loader in Maya, load an asset as reference. 
2. Verify that Display Handle is following the settings. 



