### PR TITLE
Kitsu - Add "image", "online" and "plate" to review families

### DIFF
--- a/openpype/modules/kitsu/plugins/publish/integrate_kitsu_note.py
+++ b/openpype/modules/kitsu/plugins/publish/integrate_kitsu_note.py
@@ -9,7 +9,7 @@ class IntegrateKitsuNote(pyblish.api.ContextPlugin):
 
     order = pyblish.api.IntegratorOrder
     label = "Kitsu Note and Status"
-    families = ["render", "kitsu"]
+    families = ["render", "image", "online", "plate", "kitsu"]
 
     # status settings
     set_status_note = False
@@ -52,8 +52,9 @@ class IntegrateKitsuNote(pyblish.api.ContextPlugin):
         for instance in context:
             # Check if instance is a review by checking its family
             # Allow a match to primary family or any of families
-            families = set([instance.data["family"]] +
-                           instance.data.get("families", []))
+            families = set(
+                [instance.data["family"]] + instance.data.get("families", [])
+            )
             if "review" not in families:
                 continue
 

--- a/openpype/modules/kitsu/plugins/publish/integrate_kitsu_review.py
+++ b/openpype/modules/kitsu/plugins/publish/integrate_kitsu_review.py
@@ -8,11 +8,10 @@ class IntegrateKitsuReview(pyblish.api.InstancePlugin):
 
     order = pyblish.api.IntegratorOrder + 0.01
     label = "Kitsu Review"
-    families = ["render", "kitsu"]
+    families = ["render", "image", "online", "plate", "kitsu"]
     optional = True
 
     def process(self, instance):
-
         # Check comment has been created
         comment_id = instance.data.get("kitsu_comment", {}).get("id")
         if not comment_id:

--- a/openpype/settings/defaults/project_settings/global.json
+++ b/openpype/settings/defaults/project_settings/global.json
@@ -82,7 +82,8 @@
                         "png": {
                             "ext": "png",
                             "tags": [
-                                "ftrackreview"
+                                "ftrackreview",
+                                "kitsureview"
                             ],
                             "burnins": [],
                             "ffmpeg_args": {


### PR DESCRIPTION
## Changelog Description
This PR adds "image", "online" and "plate" to the review families so they also can be uploaded to Kitsu.
It also adds the `Add review to Kitsu` tag to the default png review. Without it the user would manually need to add it for single image uploads to Kitsu and might confuse users (it confused me first for a while as movies did work).

## Testing notes:
1. Publish an image, video or image sequence as an image, online or plate and watch the review be uploaded to Kitsu
