### PR TITLE
Maya: Fix for explicit plugins loading.

### DIFF
--- a/openpype/hosts/maya/startup/userSetup.py
+++ b/openpype/hosts/maya/startup/userSetup.py
@@ -15,7 +15,7 @@ print("Starting OpenPype usersetup...")
 project_settings = get_project_settings(os.environ['AVALON_PROJECT'])
 
 # Loading plugins explicitly.
-explicit_plugins_loading = project_settings["maya"]["explicit_plugins_loading"]
+explicit_plugins_loading = project_settings["maya"].get("explicit_plugins_loading", False)
 if explicit_plugins_loading["enabled"]:
     def _explicit_load_plugins():
         for plugin in explicit_plugins_loading["plugins_to_load"]:


### PR DESCRIPTION
## Changelog Description
Explicit plugins loading should be optionally queried from the settings for backwards compatibility.

## Testing notes:
1. Load version of pipeline without the setting `project_settings/maya/explicit_plugins_loading`.
2. Launch Maya and validate no errors occur.
