### PR TITLE
Maya: Fix for explicit plugins loading.

### DIFF
--- a/openpype/hosts/maya/startup/userSetup.py
+++ b/openpype/hosts/maya/startup/userSetup.py
@@ -15,7 +15,7 @@ print("Starting OpenPype usersetup...")
 project_settings = get_project_settings(os.environ['AVALON_PROJECT'])
 
 # Loading plugins explicitly.
-explicit_plugins_loading = project_settings["maya"]["explicit_plugins_loading"]
+explicit_plugins_loading = project_settings["maya"].get("explicit_plugins_loading", False)
 if explicit_plugins_loading["enabled"]:
     def _explicit_load_plugins():
         for plugin in explicit_plugins_loading["plugins_to_load"]:

--- a/openpype/hosts/maya/startup/userSetup.py
+++ b/openpype/hosts/maya/startup/userSetup.py
@@ -15,7 +15,9 @@ print("Starting OpenPype usersetup...")
 project_settings = get_project_settings(os.environ['AVALON_PROJECT'])
 
 # Loading plugins explicitly.
-explicit_plugins_loading = project_settings["maya"].get("explicit_plugins_loading", False)
+explicit_plugins_loading = project_settings["maya"].get(
+    "explicit_plugins_loading", False
+)
 if explicit_plugins_loading["enabled"]:
     def _explicit_load_plugins():
         for plugin in explicit_plugins_loading["plugins_to_load"]:
@@ -32,6 +34,8 @@ if explicit_plugins_loading["enabled"]:
         _explicit_load_plugins,
         lowestPriority=True
     )
+else:
+    print("Explicit Plugins Loading could not be loaded from settings.")
 
 # Open Workfile Post Initialization.
 key = "OPENPYPE_OPEN_WORKFILE_POST_INITIALIZATION"


### PR DESCRIPTION
## Changelog Description
Explicit plugins loading should be optionally queried from the settings for backwards compatibility.

## Testing notes:
1. Setup OpenPype with AYON backend. This should load the pipeline without the setting `project_settings/maya/explicit_plugins_loading`.
3. Launch Maya and validate no errors occur.
