### PR TITLE
Maya: soft-fail when pan/zoom locked on camera when playblasting

### DIFF
--- a/openpype/hosts/maya/plugins/publish/extract_playblast.py
+++ b/openpype/hosts/maya/plugins/publish/extract_playblast.py
@@ -217,7 +217,11 @@ class ExtractPlayblast(publish.Extractor):
                 instance.data["panel"], edit=True, **viewport_defaults
             )
 
-        cmds.setAttr("{}.panZoomEnabled".format(preset["camera"]), pan_zoom)
+        try:
+            cmds.setAttr(
+                "{}.panZoomEnabled".format(preset["camera"]), pan_zoom)
+        except RuntimeError:
+            self.log.warning("Cannot restore Pan/Zoom settings.")
 
         collected_files = os.listdir(stagingdir)
         patterns = [clique.PATTERNS["frames"]]


### PR DESCRIPTION
## Changelog Description
When pan/zoom enabled attribute on camera is locked, playblasting with pan/zoom fails because it is trying to restore it. This is fixing it by skipping over with warning.

## Testing notes:
1. Create camera, lock pan/zoom attribute
2. Publish review from it
3. Publishing shouldn't fail
