### PR TITLE
Nuke: slates are published with old publisher comment

### DIFF
--- a/openpype/hosts/nuke/plugins/publish/extract_slate_frame.py
+++ b/openpype/hosts/nuke/plugins/publish/extract_slate_frame.py
@@ -298,7 +298,10 @@ class ExtractSlateFrame(publish.Extractor):
 
     def add_comment_slate_node(self, instance, node):
 
-        comment = instance.data["comment"]
+        comment = (
+            instance.context.data.get("comment")
+            or instance.data["comment"]
+        )
         intent = instance.context.data.get("intent")
         if not isinstance(intent, dict):
             intent = {


### PR DESCRIPTION
## Changelog Description
Older publisher was storing comment on context level.

## Testing notes:
1. publishing should be working as it was
