### PR TITLE
Unreal: Fix missing 'object_path' property

### DIFF
--- a/openpype/hosts/unreal/plugins/load/load_animation.py
+++ b/openpype/hosts/unreal/plugins/load/load_animation.py
@@ -156,7 +156,7 @@ class AnimationFBXLoader(plugin.Loader):
             package_paths=[f"{root}/{hierarchy[0]}"],
             recursive_paths=False)
         levels = ar.get_assets(_filter)
-        master_level = levels[0].get_editor_property('object_path')
+        master_level = levels[0].get_full_name()
 
         hierarchy_dir = root
         for h in hierarchy:
@@ -168,7 +168,7 @@ class AnimationFBXLoader(plugin.Loader):
             package_paths=[f"{hierarchy_dir}/"],
             recursive_paths=True)
         levels = ar.get_assets(_filter)
-        level = levels[0].get_editor_property('object_path')
+        level = levels[0].get_full_name()
 
         unreal.EditorLevelLibrary.save_all_dirty_levels()
         unreal.EditorLevelLibrary.load_level(level)

--- a/openpype/hosts/unreal/plugins/load/load_layout.py
+++ b/openpype/hosts/unreal/plugins/load/load_layout.py
@@ -819,7 +819,7 @@ class LayoutLoader(plugin.Loader):
             recursive_paths=False)
         levels = ar.get_assets(filter)
 
-        layout_level = levels[0].get_editor_property('object_path')
+        layout_level = levels[0].get_full_name()
 
         EditorLevelLibrary.save_all_dirty_levels()
         EditorLevelLibrary.load_level(layout_level)
@@ -919,7 +919,7 @@ class LayoutLoader(plugin.Loader):
                 package_paths=[f"{root}/{ms_asset}"],
                 recursive_paths=False)
             levels = ar.get_assets(_filter)
-            master_level = levels[0].get_editor_property('object_path')
+            master_level = levels[0].get_full_name()
 
             sequences = [master_sequence]
 


### PR DESCRIPTION
## Changelog Description
Epic removed the `object_path` property from `AssetData`. This PR fixes usages of that property.

Fixes #4936 

## Testing notes:
1. In Unreal, load a layout.
2. Try changing version of the layout.
