### PR TITLE
General: fix build_workfile get_linked_assets missing project_name arg

### DIFF
--- a/openpype/pipeline/workfile/build_workfile.py
+++ b/openpype/pipeline/workfile/build_workfile.py
@@ -186,7 +186,7 @@ class BuildWorkfile:
 
         if link_context_profiles:
             # Find and append linked assets if preset has set linked mapping
-            link_assets = get_linked_assets(current_asset_entity)
+            link_assets = get_linked_assets(project_name, current_asset_entity)
             if link_assets:
                 assets.extend(link_assets)
 


### PR DESCRIPTION
## Changelog Description
Linked assets collection don't work within `build_workfile` because `get_linked_assets` function call has a missing `project_name `argument.
 - Added the `project_name` arg to the `get_linked_assets` function call.
