### PR TITLE
General: fix Scene Inventory switch version error dialog missing parent arg on init

### DIFF
--- a/openpype/tools/sceneinventory/view.py
+++ b/openpype/tools/sceneinventory/view.py
@@ -791,7 +791,7 @@ class SceneInventoryView(QtWidgets.QTreeView):
         else:
             version_str = version
 
-        dialog = QtWidgets.QMessageBox()
+        dialog = QtWidgets.QMessageBox(self)
         dialog.setIcon(QtWidgets.QMessageBox.Warning)
         dialog.setStyleSheet(style.load_stylesheet())
         dialog.setWindowTitle("Update failed")


### PR DESCRIPTION
## Changelog Description
QuickFix for the switch version error dialog to set inventory widget as parent.
