### PR TITLE
Fix: Download last workfile doesn't work if not already downloaded

### DIFF
--- a/openpype/modules/sync_server/sync_server.py
+++ b/openpype/modules/sync_server/sync_server.py
@@ -237,8 +237,7 @@ def download_last_published_workfile(
     last_published_workfile_path = get_representation_path_with_anatomy(
         workfile_representation, anatomy
     )
-    if (not last_published_workfile_path or
-            not os.path.exists(last_published_workfile_path)):
+    if not last_published_workfile_path:
         return
 
     # If representation isn't available on remote site, then return.


### PR DESCRIPTION
## Changelog Description
Some optimization condition is messing with the feature: if the published workfile is not already downloaded, it won't download it...

## Testing notes:
1. Clear all local cache in full remote configuration
2. Try to launch any file
