### PR TITLE
Global: Move PyOpenColorIO to vendor/python 

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -71,7 +71,6 @@ pysftp = "^0.2.9"
 dropbox = "^11.20.0"
 aiohttp-middlewares = "^2.0.0"
 ayon-python-api = "^0.1"
-opencolorio = "^2.2.0"
 Unidecode = "^1.2"
 
 [tool.poetry.dev-dependencies]
@@ -130,6 +129,11 @@ version = "6.4.3"
 [openpype.qtbinding.linux]
 package = "PySide2"
 version = "5.15.2"
+
+# DCC packages supply their own opencolorio, lets not interfere with theirs
+[openpype.opencolorio]
+package = "opencolorio"
+version = "2.2.1"
 
 # TODO: we will need to handle different linux flavours here and
 #       also different macos versions too.

--- a/tools/fetch_thirdparty_libs.py
+++ b/tools/fetch_thirdparty_libs.py
@@ -67,39 +67,42 @@ def _print(msg: str, message_type: int = 0) -> None:
     print(f"{header}{msg}")
 
 
-def install_qtbinding(pyproject, openpype_root, platform_name):
-    _print("Handling Qt binding framework ...")
-    qtbinding_def = pyproject["openpype"]["qtbinding"][platform_name]
-    package = qtbinding_def["package"]
-    version = qtbinding_def.get("version")
-
-    qtbinding_arg = None
+def _pip_install(openpype_root, package, version=None):
+    arg = None
     if package and version:
-        qtbinding_arg = f"{package}=={version}"
+        arg = f"{package}=={version}"
     elif package:
-        qtbinding_arg = package
+        arg = package
 
-    if not qtbinding_arg:
-        _print("Didn't find Qt binding to install")
+    if not arg:
+        _print("Couldn't find package to install")
         sys.exit(1)
 
-    _print(f"We'll install {qtbinding_arg}")
+    _print(f"We'll install {arg}")
 
     python_vendor_dir = openpype_root / "vendor" / "python"
     try:
         subprocess.run(
             [
                 sys.executable,
-                "-m", "pip", "install", "--upgrade", qtbinding_arg,
+                "-m", "pip", "install", "--upgrade", arg,
                 "-t", str(python_vendor_dir)
             ],
             check=True,
             stdout=subprocess.DEVNULL
         )
     except subprocess.CalledProcessError as e:
-        _print("Error during PySide2 installation.", 1)
+        _print(f"Error during {package} installation.", 1)
         _print(str(e), 1)
         sys.exit(1)
+
+
+def install_qtbinding(pyproject, openpype_root, platform_name):
+    _print("Handling Qt binding framework ...")
+    qtbinding_def = pyproject["openpype"]["qtbinding"][platform_name]
+    package = qtbinding_def["package"]
+    version = qtbinding_def.get("version")
+    _pip_install(openpype_root, package, version)
 
     # Remove libraries for QtSql which don't have available libraries
     #   by default and Postgre library would require to modify rpath of
@@ -110,6 +113,14 @@ def install_qtbinding(pyproject, openpype_root, platform_name):
         )
         for filepath in sqldrivers_dir.iterdir():
             os.remove(str(filepath))
+
+
+def install_opencolorio(pyproject, openpype_root):
+    _print("Installing PyOpenColorIO")
+    opencolorio_def = pyproject["openpype"]["opencolorio"]
+    package = opencolorio_def["package"]
+    version = opencolorio_def.get("version")
+    _pip_install(openpype_root, package, version)
 
 
 def install_thirdparty(pyproject, openpype_root, platform_name):
@@ -221,6 +232,7 @@ def main():
     pyproject = toml.load(openpype_root / "pyproject.toml")
     platform_name = platform.system().lower()
     install_qtbinding(pyproject, openpype_root, platform_name)
+    install_opencolorio(pyproject, openpype_root)
     install_thirdparty(pyproject, openpype_root, platform_name)
     end_time = time.time_ns()
     total_time = (end_time - start_time) / 1000000000


### PR DESCRIPTION
So that DCCs don't conflict with their own.

See https://github.com/ynput/OpenPype/pull/4267#issuecomment-1537153263 for the issue with Gaffer.

I'm not sure if this is the correct approach, but I assume PySide/Shiboken is under `vendor/python` for this reason as well...