### PR TITLE
Add library in builder type for template builder

### DIFF
--- a/openpype/pipeline/workfile/workfile_template_builder.py
+++ b/openpype/pipeline/workfile/workfile_template_builder.py
@@ -759,7 +759,7 @@ class AbstractTemplateBuilder(object):
         """
 
         host_name = self.host_name
-        project_name = self.project_name
+        project_name = self.current_project_name
         task_name = self.current_task_name
         task_type = self.current_task_type
 

--- a/openpype/pipeline/workfile/workfile_template_builder.py
+++ b/openpype/pipeline/workfile/workfile_template_builder.py
@@ -1262,14 +1262,13 @@ class PlaceholderLoadMixin(object):
         ]
 
         loader_items = list(sorted(loader_items, key=lambda i: i["label"]))
-        libraries_project_items = list()
-        for library in get_libraries_project_names():
-            libraries_project_items.append(
-                {
-                    "label": "From Library : {}".format(library),
-                    "value": library
-                }
-            )
+        libraries_project_items = [
+            {
+                "label": "From Library : {}".format(project_name),
+                "value": project_name
+            }
+            for project_name in get_library_project_names()
+        ]
 
         options = options or {}
 
@@ -1471,18 +1470,9 @@ class PlaceholderLoadMixin(object):
                 "representation": [placeholder.data["representation"]],
                 "family": [placeholder.data["family"]],
             }
-
-        elif builder_type == "all_assets":
-            context_filters = {
-                "asset": [re.compile(placeholder.data["asset"])],
-                "subset": [re.compile(placeholder.data["subset"])],
-                "hierarchy": [re.compile(placeholder.data["hierarchy"])],
-                "representation": [placeholder.data["representation"]],
-                "family": [placeholder.data["family"]]
-            }
-
         else:
-            project_name = builder_type
+            if builder_type != "all_assets":
+                project_name = builder_type
             context_filters = {
                 "asset": [re.compile(placeholder.data["asset"])],
                 "subset": [re.compile(placeholder.data["subset"])],
@@ -1897,7 +1887,7 @@ class CreatePlaceholderItem(PlaceholderItem):
         self._failed_created_publish_instances.append(creator_data)
 
 
-def get_libraries_project_names():
+def get_library_project_names():
     libraries = list()
 
     for project in get_projects(fields=["name", "data.library_project"]):

--- a/openpype/pipeline/workfile/workfile_template_builder.py
+++ b/openpype/pipeline/workfile/workfile_template_builder.py
@@ -159,7 +159,9 @@ class AbstractTemplateBuilder(object):
     @property
     def project_settings(self):
         if self._project_settings is None:
-            self._project_settings = get_project_settings(self.current_project_name)
+            self._project_settings = get_project_settings(
+                self.current_project_name
+            )
         return self._project_settings
 
     @property

--- a/openpype/pipeline/workfile/workfile_template_builder.py
+++ b/openpype/pipeline/workfile/workfile_template_builder.py
@@ -159,14 +159,14 @@ class AbstractTemplateBuilder(object):
     @property
     def project_settings(self):
         if self._project_settings is None:
-            self._project_settings = get_project_settings(self.project_name)
+            self._project_settings = get_project_settings(self.current_project_name)
         return self._project_settings
 
     @property
     def current_asset_doc(self):
         if self._current_asset_doc is None:
             self._current_asset_doc = get_asset_by_name(
-                self.project_name, self.current_asset_name
+                self.current_project_name, self.current_asset_name
             )
         return self._current_asset_doc
 
@@ -174,7 +174,7 @@ class AbstractTemplateBuilder(object):
     def linked_asset_docs(self):
         if self._linked_asset_docs is None:
             self._linked_asset_docs = get_linked_assets(
-                self.project_name, self.current_asset_doc
+                self.current_project_name, self.current_asset_doc
             )
         return self._linked_asset_docs
 
@@ -1561,7 +1561,7 @@ class PlaceholderLoadMixin(object):
             return
 
         repre_load_contexts = get_contexts_for_repre_docs(
-            self.project_name, filtered_representations
+            self.current_project_name, filtered_representations
         )
         loaders_by_name = self.builder.get_loaders_by_name()
         for repre_load_context in repre_load_contexts.values():

--- a/openpype/pipeline/workfile/workfile_template_builder.py
+++ b/openpype/pipeline/workfile/workfile_template_builder.py
@@ -1481,10 +1481,7 @@ class PlaceholderLoadMixin(object):
             }
         else:
             if builder_type != "all_assets":
-                print(97, self)
-                print(98, builder_type)
                 self.project_name = builder_type
-                print(99, self.project_name, self.builder.project_name)
             context_filters = {
                 "asset": [re.compile(placeholder.data["asset"])],
                 "subset": [re.compile(placeholder.data["subset"])],

--- a/openpype/pipeline/workfile/workfile_template_builder.py
+++ b/openpype/pipeline/workfile/workfile_template_builder.py
@@ -1308,7 +1308,7 @@ class PlaceholderLoadMixin(object):
                     " field \"inputLinks\""
                     "\nAll assets : Template loader will look for all assets"
                     " in database."
-                    "\nLibraries assets : Template loader will look for assets "
+                    "\nLibraries assets : Template loader will look for assets"
                     "in libraries."
                 )
             ),
@@ -1895,6 +1895,7 @@ class CreatePlaceholderItem(PlaceholderItem):
 
     def create_failed(self, creator_data):
         self._failed_created_publish_instances.append(creator_data)
+
 
 def get_libraries_project_names():
     libraries = list()


### PR DESCRIPTION
We would like to be able to add an asset from a Library type project.

## Changelog Description
I made a concept to verify that this addition in the interface seems logical for users.  I added the list of libraries available in builder typer, by the way I renamed builder type by builder source which seems more precise to me.

![image](https://user-images.githubusercontent.com/7068597/237034477-a39cab6c-1da3-4c87-ace9-7fce5175877b.png)

## Testing notes:
1. open maya
2. click on create placeholder
![image](https://user-images.githubusercontent.com/7068597/237036152-23b46c4b-7ad0-401f-b19b-570ad9eb5660.png)

