### PR TITLE
Drop-down menu to list all representations by family in create placeholder

### DIFF
--- a/openpype/pipeline/workfile/workfile_template_builder.py
+++ b/openpype/pipeline/workfile/workfile_template_builder.py
@@ -47,7 +47,6 @@ from openpype.pipeline.load import (
 
 from openpype.pipeline.create import (
     discover_legacy_creator_plugins,
-    discover_creator_plugins,
     CreateContext,
 )
 
@@ -1250,16 +1249,15 @@ class PlaceholderLoadMixin(object):
         loader_items = list(sorted(loader_items, key=lambda i: i["label"]))
         options = options or {}
 
-        # Get families and sort them alphabetically
+        # Get families from all loaders excluding "*"
         all_loaders = discover_loader_plugins()
-        families = []
+        families = set()
         for loader in all_loaders:
-            families.extend(loader.families)
+            families.update(loader.families)
+        families.discard("*")
 
-        families = list(set(families))
-        if "*" in families:
-            families.remove("*")
-        families.sort()
+        # Sort for readability
+        families = list(sorted(families))
 
         return [
             attribute_definitions.UISeparatorDef(),

--- a/openpype/pipeline/workfile/workfile_template_builder.py
+++ b/openpype/pipeline/workfile/workfile_template_builder.py
@@ -24,6 +24,7 @@ from openpype.client import (
     get_linked_assets,
     get_representations,
 )
+from openpype.pipeline.load.plugins import discover_loader_plugins
 from openpype.settings import (
     get_project_settings,
     get_system_settings,
@@ -1250,11 +1251,14 @@ class PlaceholderLoadMixin(object):
         options = options or {}
 
         # Get families and sort them alphabetically
-        families = (
-            discover_legacy_creator_plugins() or
-            discover_creator_plugins()
-        )
-        families = [f.family for f in families]
+        all_loaders = discover_loader_plugins()
+        families = []
+        for loader in all_loaders:
+            families.extend(loader.families)
+
+        families = list(set(families))
+        if "*" in families:
+            families.remove("*")
         families.sort()
 
         return [

--- a/openpype/pipeline/workfile/workfile_template_builder.py
+++ b/openpype/pipeline/workfile/workfile_template_builder.py
@@ -1292,11 +1292,11 @@ class PlaceholderLoadMixin(object):
                 default=options.get("family"),
                 items=families
             ),
-            attribute_definitions.TextDef(
+            attribute_definitions.EnumDef(
                 "representation",
                 label="Representation name",
                 default=options.get("representation"),
-                placeholder="ma, abc, ..."
+                items=representations['animation']
             ),
             attribute_definitions.EnumDef(
                 "loader",

--- a/openpype/pipeline/workfile/workfile_template_builder.py
+++ b/openpype/pipeline/workfile/workfile_template_builder.py
@@ -38,7 +38,7 @@ from openpype.lib import (
     attribute_definitions,
 )
 from openpype.lib.attribute_definitions import get_attributes_keys
-from openpype.pipeline import legacy_io, Anatomy, discover_loader_plugins
+from openpype.pipeline import legacy_io, Anatomy
 from openpype.pipeline.load import (
     get_loaders_by_name,
     get_contexts_for_repre_docs,

--- a/openpype/pipeline/workfile/workfile_template_builder.py
+++ b/openpype/pipeline/workfile/workfile_template_builder.py
@@ -38,7 +38,7 @@ from openpype.lib import (
     attribute_definitions,
 )
 from openpype.lib.attribute_definitions import get_attributes_keys
-from openpype.pipeline import legacy_io, Anatomy
+from openpype.pipeline import legacy_io, Anatomy, discover_loader_plugins
 from openpype.pipeline.load import (
     get_loaders_by_name,
     get_contexts_for_repre_docs,
@@ -47,6 +47,7 @@ from openpype.pipeline.load import (
 
 from openpype.pipeline.create import (
     discover_legacy_creator_plugins,
+    discover_creator_plugins,
     CreateContext,
 )
 

--- a/openpype/pipeline/workfile/workfile_template_builder.py
+++ b/openpype/pipeline/workfile/workfile_template_builder.py
@@ -47,7 +47,6 @@ from openpype.pipeline.load import (
 
 from openpype.pipeline.create import (
     discover_legacy_creator_plugins,
-    discover_creator_plugins,
     CreateContext,
 )
 
@@ -1267,7 +1266,7 @@ class PlaceholderLoadMixin(object):
 
         for loader in all_loaders:
             for family in loader.families:
-                if family == families[0]:
+                if family == (options.get('family') or families[0]):
                     representations.extend(loader.representations)
 
         representations = list(set(representations))

--- a/openpype/pipeline/workfile/workfile_template_builder.py
+++ b/openpype/pipeline/workfile/workfile_template_builder.py
@@ -1249,28 +1249,26 @@ class PlaceholderLoadMixin(object):
         loader_items = list(sorted(loader_items, key=lambda i: i["label"]))
         options = options or {}
 
-        # Get families and sort them alphabetically
+        # Get families from all loaders excluding "*"
         all_loaders = discover_loader_plugins()
-        families = []
-        representations = []
-
+        families = set()
+        representations = set()
         for loader in all_loaders:
-            for family in loader.families:
-                if family == "*":
-                    continue
+            families.update(loader.families)
+        families.discard("*")
 
-                if family not in families:
-                    families.append(family)
+        # Sort for readability
+        families = list(sorted(families))
 
-        families.sort()
-
+        # Get representations for the default family,
+        # or the first one if no default
         for loader in all_loaders:
             for family in loader.families:
                 if family == (options.get('family') or families[0]):
-                    representations.extend(loader.representations)
+                    representations.update(loader.representations)
+        representations.discard("*")
 
-        representations = list(set(representations))
-        representations.sort()
+        representations = list(sorted(representations))
 
         return [
             attribute_definitions.UISeparatorDef(),

--- a/openpype/pipeline/workfile/workfile_template_builder.py
+++ b/openpype/pipeline/workfile/workfile_template_builder.py
@@ -1250,15 +1250,28 @@ class PlaceholderLoadMixin(object):
         loader_items = list(sorted(loader_items, key=lambda i: i["label"]))
         options = options or {}
 
-        # Get families from all loaders excluding "*"
+        # Get families and sort them alphabetically
         all_loaders = discover_loader_plugins()
-        families = set()
-        for loader in all_loaders:
-            families.update(loader.families)
-        families.discard("*")
+        families = []
+        representations = []
 
-        # Sort for readability
-        families = list(sorted(families))
+        for loader in all_loaders:
+            for family in loader.families:
+                if family == "*":
+                    continue
+
+                if family not in families:
+                    families.append(family)
+
+        families.sort()
+
+        for loader in all_loaders:
+            for family in loader.families:
+                if family == families[0]:
+                    representations.extend(loader.representations)
+
+        representations = list(set(representations))
+        representations.sort()
 
         return [
             attribute_definitions.UISeparatorDef(),
@@ -1296,7 +1309,7 @@ class PlaceholderLoadMixin(object):
                 "representation",
                 label="Representation name",
                 default=options.get("representation"),
-                items=representations['animation']
+                items=representations
             ),
             attribute_definitions.EnumDef(
                 "loader",

--- a/openpype/pipeline/workfile/workfile_template_builder.py
+++ b/openpype/pipeline/workfile/workfile_template_builder.py
@@ -792,7 +792,6 @@ class AbstractTemplateBuilder(object):
             "code": anatomy["attributes"]["code"]
         }
 
-
         result = StringTemplate.format_template(path, fill_data)
         if result.solved:
             path = result.normalized()
@@ -1262,12 +1261,15 @@ class PlaceholderLoadMixin(object):
 
         # Get representations for the default family,
         # or the first one if no default
+        attributes = ['representations', 'extensions', 'extension']
         for loader in all_loaders:
             for family in loader.families:
                 if family == (options.get('family') or families[0]):
-                    representations.update(loader.representations)
-        representations.discard("*")
+                    for attribute in attributes:
+                        if hasattr(loader, attribute):
+                            representations.update(getattr(loader, attribute))
 
+        representations.discard("*")
         representations = list(sorted(representations))
 
         return [

--- a/openpype/pipeline/workfile/workfile_template_builder.py
+++ b/openpype/pipeline/workfile/workfile_template_builder.py
@@ -43,8 +43,10 @@ from openpype.pipeline.load import (
     get_contexts_for_repre_docs,
     load_with_repre_context,
 )
+
 from openpype.pipeline.create import (
     discover_legacy_creator_plugins,
+    discover_creator_plugins,
     CreateContext,
 )
 
@@ -1246,6 +1248,15 @@ class PlaceholderLoadMixin(object):
 
         loader_items = list(sorted(loader_items, key=lambda i: i["label"]))
         options = options or {}
+
+        # Get families and sort them alphabetically
+        families = (
+            discover_legacy_creator_plugins() or
+            discover_creator_plugins()
+        )
+        families = [f.family for f in families]
+        families.sort()
+
         return [
             attribute_definitions.UISeparatorDef(),
             attribute_definitions.UILabelDef("Main attributes"),
@@ -1272,11 +1283,11 @@ class PlaceholderLoadMixin(object):
                     " field \"inputLinks\""
                 )
             ),
-            attribute_definitions.TextDef(
+            attribute_definitions.EnumDef(
                 "family",
                 label="Family",
                 default=options.get("family"),
-                placeholder="model, look, ..."
+                items=families
             ),
             attribute_definitions.TextDef(
                 "representation",

--- a/openpype/tools/workfile_template_build/window.py
+++ b/openpype/tools/workfile_template_build/window.py
@@ -295,23 +295,26 @@ class WorkfileBuildPlaceholderDialog(QtWidgets.QDialog):
         self._attr_defs_widget = widget
 
     def get_representation_by_family(self, family):
-        representations_by_family = []
+        representations_by_family = set()
         representations = []
         all_loaders = discover_loader_plugins()
+        attributes = ['representations', 'extensions', 'extension']
 
         for loader in all_loaders:
             for loader_family in loader.families:
                 if loader_family == family:
-                    representations_by_family.extend(loader.representations)
+                    for attribute in attributes:
+                        if hasattr(loader, attribute):
+                            repre = getattr(loader, attribute)
+                            representations_by_family.update(repre)
 
-        representations_by_family = list(set(representations_by_family))
+        representations_by_family.discard("*")
+        representations_by_family = list(sorted(representations_by_family))
 
         for repre in representations_by_family:
             representations.append({
                 'label': repre,
                 'value': repre
             })
-
-        representations = sorted(representations, key=lambda x: x['label'])
 
         return representations


### PR DESCRIPTION
## Changelog Description
Currently in the create placeholder window, we need to write the representation manually. This replace the text field by an enum field which updates himself each time the family enum is changed. The new representation enum then contain all the representations for the selected family.
The representations are collected from the loaders of the software.

## Additional info
Here's an example on Maya.
For the "animation" family:
![image](https://github.com/ynput/OpenPype/assets/51854004/c884ae8a-c85c-4961-b346-e73862ea3b9c)
For the "render" family:
![image](https://github.com/ynput/OpenPype/assets/51854004/8b3c51b1-353d-426b-b4a6-2e19e068e2ab)

