### PR TITLE
Unreal: Fix camera frame range

### DIFF
--- a/openpype/hosts/unreal/plugins/load/load_camera.py
+++ b/openpype/hosts/unreal/plugins/load/load_camera.py
@@ -268,8 +268,8 @@ class CameraLoader(plugin.Loader):
         data = get_asset_by_name(project_name, asset)["data"]
         cam_seq.set_display_rate(
             unreal.FrameRate(data.get("fps"), 1.0))
-        cam_seq.set_playback_start(0)
-        cam_seq.set_playback_end(data.get('clipOut') - data.get('clipIn') + 1)
+        cam_seq.set_playback_start(data.get('clipIn'))
+        cam_seq.set_playback_end(data.get('clipOut') + 1)
         self._set_sequence_hierarchy(
             sequences[-1], cam_seq,
             data.get('clipIn'), data.get('clipOut'))


### PR DESCRIPTION
## Changelog Description
Fix the frame range of the level sequence for the Camera in Unreal.

## Testing notes:
1. Load a camera in Unreal.
2. Open the level sequence that has been created.
3. Check if the frame range of the sequence is the one set in the project manager.
