### PR TITLE
Unreal: Remove Python 3.8 syntax from addon

### DIFF
--- a/openpype/hosts/unreal/addon.py
+++ b/openpype/hosts/unreal/addon.py
@@ -23,9 +23,10 @@ class UnrealAddon(OpenPypeModule, IHostAddon):
             UNREAL_ROOT_DIR, "integration", f"UE_{ue_version}", "Ayon"
         )
         if not Path(unreal_plugin_path).exists():
-            if compatible_versions := get_compatible_integration(
+            compatible_versions = get_compatible_integration(
                 ue_version, Path(UNREAL_ROOT_DIR) / "integration"
-            ):
+            )
+            if compatible_versions:
                 unreal_plugin_path = compatible_versions[-1] / "Ayon"
                 unreal_plugin_path = unreal_plugin_path.as_posix()
 


### PR DESCRIPTION
## Changelog Description
Removed Python 3.8 syntax from addon.

## Additional info
Causing crashes in older pythons inside DCCs.
