### PR TITLE
Maya: Validate shader name - OP-5903

### DIFF
--- a/openpype/hosts/maya/plugins/publish/validate_shader_name.py
+++ b/openpype/hosts/maya/plugins/publish/validate_shader_name.py
@@ -50,7 +50,8 @@ class ValidateShaderName(pyblish.api.InstancePlugin):
         asset_name = instance.data.get("asset", None)
 
         # Check the number of connected shadingEngines per shape
-        r = re.compile(cls.regex)
+        regex_compile = re.compile(cls.regex)
+        error_message = "object {0} has invalid shader name {1}"
         for shape in shapes:
             shading_engines = cmds.listConnections(shape,
                                                    destination=True,
@@ -60,19 +61,18 @@ class ValidateShaderName(pyblish.api.InstancePlugin):
             )
 
             for shader in shaders:
-                m = r.match(cls.regex, shader)
+                m = re.match(cls.regex, shader)
                 if m is None:
                     invalid.append(shape)
-                    cls.log.error(
-                        "object {0} has invalid shader name {1}".format(shape,
-                                                                        shader)
-                    )
+                    cls.log.error(error_message.format(shape, shader))
                 else:
-                    if 'asset' in r.groupindex:
+                    if 'asset' in regex_compile.groupindex:
                         if m.group('asset') != asset_name:
                             invalid.append(shape)
-                            cls.log.error(("object {0} has invalid "
-                                           "shader name {1}").format(shape,
-                                                                     shader))
+                            message = error_message
+                            message += " with missing asset name \"{2}\""
+                            cls.log.error(
+                                message.format(shape, shader, asset_name)
+                            )
 
         return invalid

--- a/openpype/hosts/maya/plugins/publish/validate_shader_name.py
+++ b/openpype/hosts/maya/plugins/publish/validate_shader_name.py
@@ -61,7 +61,7 @@ class ValidateShaderName(pyblish.api.InstancePlugin):
             )
 
             for shader in shaders:
-                m = re.match(cls.regex, shader)
+                m = regex_compile.match(shader)
                 if m is None:
                     invalid.append(shape)
                     cls.log.error(error_message.format(shape, shader))

--- a/openpype/settings/defaults/project_settings/maya.json
+++ b/openpype/settings/defaults/project_settings/maya.json
@@ -734,6 +734,7 @@
         "ValidateShaderName": {
             "enabled": false,
             "optional": true,
+            "active": true,
             "regex": "(?P<asset>.*)_(.*)_SHD"
         },
         "ValidateShadingEngine": {

--- a/openpype/settings/entities/schemas/projects_schema/schemas/schema_maya_publish.json
+++ b/openpype/settings/entities/schemas/projects_schema/schemas/schema_maya_publish.json
@@ -127,6 +127,11 @@
                     "label": "Optional"
                 },
                 {
+                    "type": "boolean",
+                    "key": "active",
+                    "label": "Active"
+                },
+                {
                     "type": "label",
                     "label": "Shader name regex can use named capture group <b>asset</b> to validate against current asset name.<p><b>Example:</b><br/><code>^.*(?P=&lt;asset&gt;.+)_SHD</code></p>"
                 },


### PR DESCRIPTION
## Changelog Description
Running the plugin would error with:
```
// TypeError: 'str' object cannot be interpreted as an integer
```

Fixed and added setting `active`.

## Testing notes:
1. Enable `project_settings/maya/publish/ValidateShaderName`
2. Launch Maya, create a look and publish.
3. Validation should fail with information about naming of shader.
