### PR TITLE
Maya: Skipping rendersetup for members.

### DIFF
--- a/openpype/hosts/maya/plugins/publish/validate_instance_has_members.py
+++ b/openpype/hosts/maya/plugins/publish/validate_instance_has_members.py
@@ -14,6 +14,11 @@ class ValidateInstanceHasMembers(pyblish.api.InstancePlugin):
     @classmethod
     def get_invalid(cls, instance):
 
+        # Allow renderlayer and workfile to be empty
+        skip_families = ["workfile", "renderlayer", "rendersetup"]
+        if instance.data.get("family") in skip_families:
+            return
+
         invalid = list()
         if not instance.data["setMembers"]:
             objectset_name = instance.data['name']

--- a/openpype/hosts/maya/plugins/publish/validate_instance_has_members.py
+++ b/openpype/hosts/maya/plugins/publish/validate_instance_has_members.py
@@ -13,12 +13,6 @@ class ValidateInstanceHasMembers(pyblish.api.InstancePlugin):
 
     @classmethod
     def get_invalid(cls, instance):
-
-        # Allow renderlayer and workfile to be empty
-        skip_families = ["workfile", "renderlayer", "rendersetup"]
-        if instance.data.get("family") in skip_families:
-            return
-
         invalid = list()
         if not instance.data["setMembers"]:
             objectset_name = instance.data['name']
@@ -27,6 +21,10 @@ class ValidateInstanceHasMembers(pyblish.api.InstancePlugin):
         return invalid
 
     def process(self, instance):
+        # Allow renderlayer and workfile to be empty
+        skip_families = ["workfile", "renderlayer", "rendersetup"]
+        if instance.data.get("family") in skip_families:
+            return
 
         invalid = self.get_invalid(instance)
         if invalid:


### PR DESCRIPTION
## Changelog Description
When publishing a `rendersetup`, the objectset is and should be empty.

## Testing notes:
1. Create `rendersetup` in Maya.
2. Publish.
