### PR TITLE
AfterEffects: allow returning stub with not saved workfile

### DIFF
--- a/openpype/hosts/aftereffects/api/pipeline.py
+++ b/openpype/hosts/aftereffects/api/pipeline.py
@@ -60,9 +60,6 @@ class AfterEffectsHost(HostBase, IWorkfileHost, ILoadHost, IPublishHost):
             print("Not connected yet, ignoring")
             return
 
-        if not stub.get_active_document_name():
-            return
-
         self._stub = stub
         return self._stub
 


### PR DESCRIPTION
## Changelog Description
Allows to use Workfile app to Save first empty workfile.

## Testing notes:
1. Open task without any workfile in AE
2. Use Save As to create first workfile
