### PR TITLE
Publish: Enhance automated publish plugin settings

### DIFF
--- a/openpype/pipeline/publish/__init__.py
+++ b/openpype/pipeline/publish/__init__.py
@@ -36,6 +36,9 @@ from .lib import (
     context_plugin_should_run,
     get_instance_staging_dir,
     get_publish_repre_path,
+
+    apply_plugin_settings_automatically,
+    get_plugin_settings,
 )
 
 from .abstract_expected_files import ExpectedFiles
@@ -79,6 +82,9 @@ __all__ = (
     "context_plugin_should_run",
     "get_instance_staging_dir",
     "get_publish_repre_path",
+
+    "apply_plugin_settings_automatically",
+    "get_plugin_settings",
 
     "ExpectedFiles",
 

--- a/openpype/pipeline/publish/lib.py
+++ b/openpype/pipeline/publish/lib.py
@@ -374,9 +374,9 @@ def get_plugin_settings(plugin, project_settings, log, category=None):
     """
 
     # Plugin can define settings category by class attribute
-    #   - it's impossible to set `settings_category` via settings because 
-    #       obviously settings are not applied before it.
-    #   - if `settings_category` is set the fallback category method is ignored
+    # - it's impossible to set `settings_category` via settings because
+    #     obviously settings are not applied before it.
+    # - if `settings_category` is set the fallback category method is ignored
     settings_category = getattr(plugin, "settings_category", None)
     if settings_category:
         try:

--- a/openpype/pipeline/publish/lib.py
+++ b/openpype/pipeline/publish/lib.py
@@ -374,9 +374,9 @@ def get_plugin_settings(plugin, project_settings, log, category=None):
     """
 
     # Plugin can define settings category by class attribute
-    #   - do not try to set the key using settings!
-    #   - if attribute is available it won't try other ways how to get
-    #       the settings
+    #   - it's impossible to set `settings_category` via settings because 
+    #       obviously settings are not applied before it.
+    #   - if `settings_category` is set the fallback category method is ignored
     settings_category = getattr(plugin, "settings_category", None)
     if settings_category:
         try:

--- a/openpype/pipeline/publish/lib.py
+++ b/openpype/pipeline/publish/lib.py
@@ -373,6 +373,26 @@ def get_plugin_settings(plugin, project_settings, log, category=None):
         dict[str, Any]: Plugin settings {'attribute': 'value'}.
     """
 
+    # Plugin can define settings category by class attribute
+    #   - do not try to set the key using settings!
+    #   - if attribute is available it won't try other ways how to get
+    #       the settings
+    settings_category = getattr(plugin, "settings_category", None)
+    if settings_category:
+        try:
+            return (
+                project_settings
+                [settings_category]
+                ["publish"]
+                [plugin.__name__]
+            )
+        except KeyError:
+            log.warning((
+                "Couldn't find plugin '{}' settings"
+                " under settings category '{}'"
+            ).format(plugin.__name__, settings_category))
+            return {}
+
     # Use project settings based on a category name
     if category:
         try:


### PR DESCRIPTION
## Changelog Description
Added plugins option to define settings category where to look for settings of a plugin and added public helper functions to apply settings `get_plugin_settings` and `apply_plugin_settings_automatically`.

## Additional info
Plugin has no way how to tell automated settings apply function where to look for it's settings. We allow 2 options, one is to look for settings into current host (we should maybe remove that completelly?), second is to use 3rd parent folder name from plugin file -> we're lucky it somehow worked.

We already have option to implement `apply_settings` class method, but then developer looses the option to automatically apply the settings -> that's why those functions were made as public, so it is at least possible to reuse them.

In most of cases all we need to define is the first level of settings where to look, for that cases was added option to add `settings_category` attribute on a plugin, which tell where to look for settings. Other ways where to look for settings are ignored if this attribute is available on a plugin.
```python
class MyDeadlinePlugin(pyblish.api.ContextPlugin):
    settings_category = "deadline"
```
In this example values from `project_settings["deadline"]["plugins"]["publish"][MyDeadlinePlugin]` would be applied automatically.

### Why we need this
In AYON the folder of an addon does not match key in settings (e.g. addon is `ayon_ftrack` but key in settings is `"ftrack"`).

## Testing notes:
Nothing should really change in this PR.
- Change settings of any publish plugin and check if they are applied.
