### PR TITLE
Blender: Added setting for base unit scale

### DIFF
--- a/openpype/hosts/blender/api/pipeline.py
+++ b/openpype/hosts/blender/api/pipeline.py
@@ -26,6 +26,8 @@ from openpype.lib import (
     emit_event
 )
 import openpype.hosts.blender
+from openpype.settings import get_project_settings
+
 
 HOST_DIR = os.path.dirname(os.path.abspath(openpype.hosts.blender.__file__))
 PLUGINS_DIR = os.path.join(HOST_DIR, "plugins")
@@ -122,12 +124,23 @@ def set_start_end_frames():
     scene.render.resolution_y = resolution_y
 
 
+def set_base_file_unit_scale():
+    project = os.environ.get("AVALON_PROJECT")
+    settings = get_project_settings(project)
+
+    unit_scale = settings.get("blender").get("base_file_unit_scale")
+
+    bpy.context.scene.unit_settings.scale_length = unit_scale
+
+
 def on_new():
     set_start_end_frames()
+    set_base_file_unit_scale()
 
 
 def on_open():
     set_start_end_frames()
+    set_base_file_unit_scale()
 
 
 @bpy.app.handlers.persistent

--- a/openpype/hosts/blender/api/pipeline.py
+++ b/openpype/hosts/blender/api/pipeline.py
@@ -85,6 +85,31 @@ def uninstall():
         ops.unregister()
 
 
+def show_message(title, message):
+    from openpype.widgets.message_window import Window
+    from .ops import BlenderApplication
+
+    BlenderApplication.get_app()
+
+    Window(
+        parent=None,
+        title=title,
+        message=message,
+        level="warning")
+
+
+def message_window(title, message):
+    from .ops import (
+        MainThreadItem,
+        execute_in_main_thread,
+        _process_app_events
+    )
+
+    mti = MainThreadItem(show_message, title, message)
+    execute_in_main_thread(mti)
+    _process_app_events()
+
+
 def set_start_end_frames():
     project_name = legacy_io.active_project()
     asset_name = legacy_io.Session["AVALON_ASSET"]
@@ -153,9 +178,9 @@ def on_open():
         if unit_scale != prev_unit_scale:
             bpy.context.scene.unit_settings.scale_length = unit_scale
 
-def on_open():
-    set_start_end_frames()
-    set_base_file_unit_scale()
+            message_window(
+                "Base file unit scale changed",
+                "Base file unit scale changed to match the project settings.")
 
 
 @bpy.app.handlers.persistent

--- a/openpype/hosts/blender/api/pipeline.py
+++ b/openpype/hosts/blender/api/pipeline.py
@@ -124,19 +124,34 @@ def set_start_end_frames():
     scene.render.resolution_y = resolution_y
 
 
-def set_base_file_unit_scale():
+def on_new():
+    set_start_end_frames()
+
     project = os.environ.get("AVALON_PROJECT")
     settings = get_project_settings(project)
 
-    unit_scale = settings.get("blender").get("base_file_unit_scale")
+    unit_scale_settings = settings.get("blender").get("unit_scale_settings")
+    unit_scale_enabled = unit_scale_settings.get("enabled")
+    if unit_scale_enabled:
+        unit_scale = unit_scale_settings.get("base_file_unit_scale")
+        bpy.context.scene.unit_settings.scale_length = unit_scale
 
-    bpy.context.scene.unit_settings.scale_length = unit_scale
 
-
-def on_new():
+def on_open():
     set_start_end_frames()
-    set_base_file_unit_scale()
 
+    project = os.environ.get("AVALON_PROJECT")
+    settings = get_project_settings(project)
+
+    unit_scale_settings = settings.get("blender").get("unit_scale_settings")
+    unit_scale_enabled = unit_scale_settings.get("enabled")
+    apply_on_opening = unit_scale_settings.get("apply_on_opening")
+    if unit_scale_enabled and apply_on_opening:
+        unit_scale = unit_scale_settings.get("base_file_unit_scale")
+        prev_unit_scale = bpy.context.scene.unit_settings.scale_length
+
+        if unit_scale != prev_unit_scale:
+            bpy.context.scene.unit_settings.scale_length = unit_scale
 
 def on_open():
     set_start_end_frames()

--- a/openpype/settings/defaults/project_settings/blender.json
+++ b/openpype/settings/defaults/project_settings/blender.json
@@ -1,4 +1,5 @@
 {
+    "base_file_unit_scale": 0.01,
     "imageio": {
         "ocio_config": {
             "enabled": false,

--- a/openpype/settings/defaults/project_settings/blender.json
+++ b/openpype/settings/defaults/project_settings/blender.json
@@ -1,5 +1,9 @@
 {
-    "base_file_unit_scale": 0.01,
+    "unit_scale_settings": {
+        "enabled": true,
+        "apply_on_opening": false,
+        "base_file_unit_scale": 0.01
+    },
     "imageio": {
         "ocio_config": {
             "enabled": false,

--- a/openpype/settings/entities/schemas/projects_schema/schema_project_blender.json
+++ b/openpype/settings/entities/schemas/projects_schema/schema_project_blender.json
@@ -6,10 +6,30 @@
     "is_file": true,
     "children": [
         {
-            "key": "base_file_unit_scale",
-            "type": "number",
-            "label": "Base File Unit Scale",
-            "decimal": 2
+            "key": "unit_scale_settings",
+            "type": "dict",
+            "label": "Set Unit Scale",
+            "collapsible": true,
+            "is_group": true,
+            "checkbox_key": "enabled",
+            "children": [
+                {
+                    "type": "boolean",
+                    "key": "enabled",
+                    "label": "Enabled"
+                },
+                {
+                    "key": "apply_on_opening",
+                    "type": "boolean",
+                    "label": "Apply on Opening Existing Files"
+                },
+                {
+                    "key": "base_file_unit_scale",
+                    "type": "number",
+                    "label": "Base File Unit Scale",
+                    "decimal": 2
+                }
+            ]
         },
         {
             "key": "imageio",

--- a/openpype/settings/entities/schemas/projects_schema/schema_project_blender.json
+++ b/openpype/settings/entities/schemas/projects_schema/schema_project_blender.json
@@ -27,7 +27,7 @@
                     "key": "base_file_unit_scale",
                     "type": "number",
                     "label": "Base File Unit Scale",
-                    "decimal": 2
+                    "decimal": 10
                 }
             ]
         },

--- a/openpype/settings/entities/schemas/projects_schema/schema_project_blender.json
+++ b/openpype/settings/entities/schemas/projects_schema/schema_project_blender.json
@@ -6,6 +6,12 @@
     "is_file": true,
     "children": [
         {
+            "key": "base_file_unit_scale",
+            "type": "number",
+            "label": "Base File Unit Scale",
+            "decimal": 2
+        },
+        {
             "key": "imageio",
             "type": "dict",
             "label": "Color Management (ImageIO)",


### PR DESCRIPTION
## Changelog Description
A setting for the base unit scale has been added for Blender.
The unit scale is automatically applied when opening a file or creating a new one.

## Testing notes:
1. Set a default unit scale in Studio Settings: `project_settings/blender/base_file_unit_scale`.
2. Open any task with Blender.
3. Check if the unit scale has been applied:
![image](https://github.com/ynput/OpenPype/assets/1087869/d157c428-8840-4f2a-9323-c023e4a8564c)
