### PR TITLE
AYON: Missing files on representations

### DIFF
--- a/openpype/client/server/conversion_utils.py
+++ b/openpype/client/server/conversion_utils.py
@@ -125,7 +125,7 @@ def _get_default_template_name(templates):
             return "default"
 
         if default_template is None:
-            default_template = template["name"]
+            default_template = name
 
     return default_template
 

--- a/openpype/client/server/conversion_utils.py
+++ b/openpype/client/server/conversion_utils.py
@@ -913,7 +913,7 @@ def convert_create_representation_to_v4(representation, con):
         new_file_item = {
             key: value
             for key, value in file_item.items()
-            if key != "_id"
+            if key in ("hash", "path", "size")
         }
         new_file_item.update({
             "id": create_entity_id(),
@@ -1231,7 +1231,9 @@ def convert_update_representation_to_v4(
             new_files = list(new_files.values())
 
         for item in new_files:
-            item.pop("_id")
+            for key in tuple(item.keys()):
+                if key not in ("hash", "path", "size"):
+                    item.pop(key)
             item.update({
                 "id": create_entity_id(),
                 "name": os.path.basename(item["path"]),

--- a/openpype/client/server/conversion_utils.py
+++ b/openpype/client/server/conversion_utils.py
@@ -664,10 +664,12 @@ def convert_v4_representation_to_v3(representation):
                 file_info["_id"] = file_id
                 new_files.append(file_info)
 
-        if not new_files:
-            new_files.append({
-                "name": "studio"
-            })
+        for file_info in new_files:
+            if not file_info.get("sites"):
+                file_info["sites"] = [{
+                    "name": "studio"
+                }]
+
         output["files"] = new_files
 
     if representation.get("active") is False:

--- a/openpype/client/server/operations.py
+++ b/openpype/client/server/operations.py
@@ -359,8 +359,7 @@ def prepare_hero_version_update_data(old_doc, new_doc, replace=True):
     """
 
     changes = _prepare_update_data(old_doc, new_doc, replace)
-    if "version_id" in changes:
-        changes.pop("version_id")
+    changes.pop("version_id", None)
     return changes
 
 

--- a/openpype/client/server/operations.py
+++ b/openpype/client/server/operations.py
@@ -358,7 +358,10 @@ def prepare_hero_version_update_data(old_doc, new_doc, replace=True):
         Dict[str, Any]: Changes between old and new document.
     """
 
-    return _prepare_update_data(old_doc, new_doc, replace)
+    changes = _prepare_update_data(old_doc, new_doc, replace)
+    if "version_id" in changes:
+        changes.pop("version_id")
+    return changes
 
 
 def prepare_representation_update_data(old_doc, new_doc, replace=True):


### PR DESCRIPTION
## Changelog Description
Fix integration of files into representation in server database.

## Additional info
The `files` were not integrated correctly. They were added to representation data instead of representation itself and the structure of files data were not right. Fixed the structure and fixed missing sites that were already handled, but not correctly. Also fixed update of hero version, where `"version_id"` change is skipped.

## Testing notes:
1. Integration in AYON mode should work and representations on server should have files
2. Update of representations should work
3. Update of hero version should work

NOTE: To test hero version enable the plugin in settings and add family you want to test to families filter in settings.