### PR TITLE
Unreal: Addon Py2 compatibility

### DIFF
--- a/openpype/hosts/unreal/addon.py
+++ b/openpype/hosts/unreal/addon.py
@@ -14,6 +14,7 @@ class UnrealAddon(OpenPypeModule, IHostAddon):
     def add_implementation_envs(self, env, app):
         """Modify environments to contain all required for implementation."""
         # Set AYON_UNREAL_PLUGIN required for Unreal implementation
+        # Imports are in this method for Python 2 compatiblity of an addon
         from pathlib import Path
 
         from .lib import get_compatible_integration

--- a/openpype/hosts/unreal/addon.py
+++ b/openpype/hosts/unreal/addon.py
@@ -1,8 +1,5 @@
 import os
-from pathlib import Path
-
 from openpype.modules import IHostAddon, OpenPypeModule
-from .lib import get_compatible_integration
 
 UNREAL_ROOT_DIR = os.path.dirname(os.path.abspath(__file__))
 
@@ -17,10 +14,13 @@ class UnrealAddon(OpenPypeModule, IHostAddon):
     def add_implementation_envs(self, env, app):
         """Modify environments to contain all required for implementation."""
         # Set AYON_UNREAL_PLUGIN required for Unreal implementation
+        from pathlib import Path
+
+        from .lib import get_compatible_integration
 
         ue_version = app.name.replace("-", ".")
         unreal_plugin_path = os.path.join(
-            UNREAL_ROOT_DIR, "integration", f"UE_{ue_version}", "Ayon"
+            UNREAL_ROOT_DIR, "integration", "UE_{}".format(ue_version), "Ayon"
         )
         if not Path(unreal_plugin_path).exists():
             compatible_versions = get_compatible_integration(

--- a/openpype/hosts/unreal/lib.py
+++ b/openpype/hosts/unreal/lib.py
@@ -7,7 +7,6 @@ import json
 
 from typing import List
 
-import openpype
 from distutils import dir_util
 import subprocess
 import re


### PR DESCRIPTION
## Changelog Description
Fixed Python 2 compatibility of unreal addon.

## Additional info
Current addon implementation causes SyntaxError in Python 2 DCCs. Which is very scary for artists.

## Testing notes:
1. Unreal addon should not cause any crashes when ModulesManager is initialized in Python 2 DCC
