### PR TITLE
Feature: Download last published workfile specify version

### DIFF
--- a/openpype/modules/sync_server/launch_hooks/pre_copy_last_published_workfile.py
+++ b/openpype/modules/sync_server/launch_hooks/pre_copy_last_published_workfile.py
@@ -119,6 +119,18 @@ class CopyLastPublishedWorkfile(PreLaunchHook):
             "task": {"name": task_name, "type": task_type}
         }
 
+        # Add version filter
+        workfile_version = self.launch_context.data.get("workfile_version", -1)
+        if workfile_version > 0 and workfile_version not in {None, "last"}:
+            context_filters["version"] = self.launch_context.data[
+                "workfile_version"
+            ]
+
+            # Only one version will be matched
+            version_index = 0
+        else:
+            version_index = workfile_version
+
         workfile_representations = list(get_representations(
             project_name,
             context_filters=context_filters
@@ -136,9 +148,10 @@ class CopyLastPublishedWorkfile(PreLaunchHook):
             lambda r: r["context"].get("version") is not None,
             workfile_representations
         )
-        workfile_representation = max(
+        # Get workfile version
+        workfile_representation = sorted(
             filtered_repres, key=lambda r: r["context"]["version"]
-        )
+        )[version_index]
 
         # Copy file and substitute path
         last_published_workfile_path = download_last_published_workfile(


### PR DESCRIPTION
## Changelog Description
Setting `workfile_version` key to hook's `self.launch_context.data` allow you to specify the workfile version you want sync service to download if none is matched locally. This is helpful if the last version hasn't been correctly published/synchronized, and you want to recover the previous one (or some you'd like).  
Version could be set in two ways:
- OP's absolute version, matching the `version` index in DB.
- Relative version in reverse order from the last one: `-2`, `-3`...

I don't know where I should write documentation about that.

## Testing notes:
1. Clear your local workfile.
2. Create a hook to set the version you'd like: `self.launch_context.data["workfile_version"] = 1` or `self.launch_context.data["workfile_version"] = -2`.
3. Launch the task, you'll get the required workfile.