### PR TITLE
Nuke: fixed missing files key in representation

### DIFF
--- a/openpype/hosts/nuke/plugins/publish/collect_writes.py
+++ b/openpype/hosts/nuke/plugins/publish/collect_writes.py
@@ -133,7 +133,6 @@ class CollectNukeWrites(pyblish.api.InstancePlugin,
                 else:
                     representation['files'] = collected_frames
 
-                self.log.debug("_ representation: {}".format(representation))
                 # inject colorspace data
                 self.set_representation_colorspace(
                     representation, instance.context,

--- a/openpype/hosts/nuke/plugins/publish/collect_writes.py
+++ b/openpype/hosts/nuke/plugins/publish/collect_writes.py
@@ -133,11 +133,12 @@ class CollectNukeWrites(pyblish.api.InstancePlugin,
                 else:
                     representation['files'] = collected_frames
 
-            # inject colorspace data
-            self.set_representation_colorspace(
-                representation, instance.context,
-                colorspace=colorspace
-            )
+                self.log.debug("_ representation: {}".format(representation))
+                # inject colorspace data
+                self.set_representation_colorspace(
+                    representation, instance.context,
+                    colorspace=colorspace
+                )
 
             instance.data["representations"].append(representation)
             self.log.info("Publishing rendered frames ...")


### PR DESCRIPTION
## Changelog Description
Issue with missing keys once rendering target set to existing frames is fixed. Instance has to be evaluated in validation for missing files.

## Testing notes:
1. Open nuke workfile and create new Render family instance on any selected node. 
2. Do not render any frames and set instance's render target to Existing frames
3. hit Publish button and notice that Validate Rendered frames is popping up. 
4. This is correct behaviour.