### PR TITLE
General: Fix new load plugins for next minor relase

### DIFF
--- a/openpype/hosts/max/plugins/load/load_model.py
+++ b/openpype/hosts/max/plugins/load/load_model.py
@@ -21,7 +21,7 @@ class ModelAbcLoader(load.LoaderPlugin):
     def load(self, context, name=None, namespace=None, data=None):
         from pymxs import runtime as rt
 
-        file_path = os.path.normpath(self.fname)
+        file_path = os.path.normpath(self.filepath_from_context(context))
 
         abc_before = {
             c for c in rt.rootNode.Children

--- a/openpype/hosts/max/plugins/load/load_model_fbx.py
+++ b/openpype/hosts/max/plugins/load/load_model_fbx.py
@@ -20,7 +20,7 @@ class FbxModelLoader(load.LoaderPlugin):
     def load(self, context, name=None, namespace=None, data=None):
         from pymxs import runtime as rt
 
-        filepath = os.path.normpath(self.fname)
+        filepath = os.path.normpath(self.filepath_from_context(context))
         rt.FBXImporterSetParam("Animation", False)
         rt.FBXImporterSetParam("Cameras", False)
         rt.FBXImporterSetParam("Preserveinstances", True)

--- a/openpype/hosts/max/plugins/load/load_model_obj.py
+++ b/openpype/hosts/max/plugins/load/load_model_obj.py
@@ -20,7 +20,7 @@ class ObjLoader(load.LoaderPlugin):
     def load(self, context, name=None, namespace=None, data=None):
         from pymxs import runtime as rt
 
-        filepath = os.path.normpath(self.fname)
+        filepath = os.path.normpath(self.filepath_from_context(context))
         self.log.debug(f"Executing command to import..")
 
         rt.execute(f'importFile @"{filepath}" #noPrompt using:ObjImp')

--- a/openpype/hosts/max/plugins/load/load_model_usd.py
+++ b/openpype/hosts/max/plugins/load/load_model_usd.py
@@ -20,7 +20,7 @@ class ModelUSDLoader(load.LoaderPlugin):
     def load(self, context, name=None, namespace=None, data=None):
         from pymxs import runtime as rt
         # asset_filepath
-        filepath = os.path.normpath(self.fname)
+        filepath = os.path.normpath(self.filepath_from_context(context))
         import_options = rt.USDImporter.CreateOptions()
         base_filename = os.path.basename(filepath)
         filename, ext = os.path.splitext(base_filename)

--- a/openpype/hosts/max/plugins/load/load_pointcloud.py
+++ b/openpype/hosts/max/plugins/load/load_pointcloud.py
@@ -19,7 +19,7 @@ class PointCloudLoader(load.LoaderPlugin):
         """load point cloud by tyCache"""
         from pymxs import runtime as rt
 
-        filepath = os.path.normpath(self.fname)
+        filepath = os.path.normpath(self.filepath_from_context(context))
         obj = rt.tyCache()
         obj.filename = filepath
 

--- a/openpype/hosts/substancepainter/plugins/load/load_mesh.py
+++ b/openpype/hosts/substancepainter/plugins/load/load_mesh.py
@@ -47,7 +47,8 @@ class SubstanceLoadProjectMesh(load.LoaderPlugin):
 
         if not substance_painter.project.is_open():
             # Allow to 'initialize' a new project
-            result = prompt_new_file_with_mesh(mesh_filepath=self.fname)
+            path = self.filepath_from_context(context)
+            result = prompt_new_file_with_mesh(mesh_filepath=path)
             if not result:
                 self.log.info("User cancelled new project prompt.")
                 return
@@ -65,7 +66,7 @@ class SubstanceLoadProjectMesh(load.LoaderPlugin):
                 else:
                     raise LoadError("Reload of mesh failed")
 
-            path = self.fname
+            path = self.filepath_from_context(context)
             substance_painter.project.reload_mesh(path,
                                                   settings,
                                                   on_mesh_reload)


### PR DESCRIPTION
## Changelog Description
Fix access to `fname` attribute which is not available on load plugin anymore.

## Additional info
Continous task of https://github.com/ynput/OpenPype/pull/4602 after develop update.

## Testing notes:
1. Max load plugins should work
2. Load mesh in substance painter should work
