### PR TITLE
Allow to open with djv by extension instead of representation name

### DIFF
--- a/openpype/plugins/load/open_djv.py
+++ b/openpype/plugins/load/open_djv.py
@@ -19,7 +19,8 @@ class OpenInDJV(load.LoaderPlugin):
 
     djv_list = existing_djv_path()
     families = ["*"] if djv_list else []
-    representations = [
+    representations = ["*"]
+    extensions = [
         "cin", "dpx", "avi", "dv", "gif", "flv", "mkv", "mov", "mpg", "mpeg",
         "mp4", "m4v", "mxf", "iff", "z", "ifl", "jpeg", "jpg", "jfif", "lut",
         "1dl", "exr", "pic", "png", "ppm", "pnm", "pgm", "pbm", "rla", "rpf",


### PR DESCRIPTION
## Changelog Description

Filter open in djv action by extension instead of representation.

## Additional info

Came up on [Ynput discord here](https://discordapp.com/channels/517362899170230292/1110185294596149328)

## Testing notes:

1. Ensure to configure the DJV application in Studio Settings > System > Applications > djvview
2. Open Loader
3. Try the open in djv view loader on any of the extensions
4. In particular test on a representation like `h264_png` or alike where representation name != extension.
