### PR TITLE
Resolve: Use last workfile prelaunch hook

### DIFF
--- a/openpype/hooks/pre_add_last_workfile_arg.py
+++ b/openpype/hooks/pre_add_last_workfile_arg.py
@@ -22,6 +22,7 @@ class AddLastWorkfileToLaunchArgs(PreLaunchHook):
         "houdini",
         "nukestudio",
         "fusion",
+        "resolve",
         "blender",
         "photoshop",
         "tvpaint",


### PR DESCRIPTION
## Changelog Description
Added `resolve` to last workfile prelaunch hook to launch last workfile on open.

## Testing notes:
1. Select a task in a project
2. Launch Resolve on the task
3. Save the workfile using workfiles tool
4. Close resolve
5. Launch it again on the same task
6. The workfile should be opened on resolve launch
