### PR TITLE
Unreal: Fix usage of 'get_full_path' function

### DIFF
--- a/openpype/hosts/unreal/plugins/load/load_animation.py
+++ b/openpype/hosts/unreal/plugins/load/load_animation.py
@@ -156,7 +156,7 @@ class AnimationFBXLoader(plugin.Loader):
             package_paths=[f"{root}/{hierarchy[0]}"],
             recursive_paths=False)
         levels = ar.get_assets(_filter)
-        master_level = levels[0].get_full_name()
+        master_level = levels[0].get_asset().get_path_name()
 
         hierarchy_dir = root
         for h in hierarchy:
@@ -168,7 +168,7 @@ class AnimationFBXLoader(plugin.Loader):
             package_paths=[f"{hierarchy_dir}/"],
             recursive_paths=True)
         levels = ar.get_assets(_filter)
-        level = levels[0].get_full_name()
+        level = levels[0].get_asset().get_path_name()
 
         unreal.EditorLevelLibrary.save_all_dirty_levels()
         unreal.EditorLevelLibrary.load_level(level)

--- a/openpype/hosts/unreal/plugins/load/load_camera.py
+++ b/openpype/hosts/unreal/plugins/load/load_camera.py
@@ -365,7 +365,7 @@ class CameraLoader(plugin.Loader):
         maps = ar.get_assets(filter)
 
         # There should be only one map in the list
-        EditorLevelLibrary.load_level(maps[0].get_full_name())
+        EditorLevelLibrary.load_level(maps[0].get_asset().get_path_name())
 
         level_sequence = sequences[0].get_asset()
 
@@ -513,7 +513,7 @@ class CameraLoader(plugin.Loader):
         map = maps[0]
 
         EditorLevelLibrary.save_all_dirty_levels()
-        EditorLevelLibrary.load_level(map.get_full_name())
+        EditorLevelLibrary.load_level(map.get_asset().get_path_name())
 
         # Remove the camera from the level.
         actors = EditorLevelLibrary.get_all_level_actors()
@@ -523,7 +523,7 @@ class CameraLoader(plugin.Loader):
                 EditorLevelLibrary.destroy_actor(a)
 
         EditorLevelLibrary.save_all_dirty_levels()
-        EditorLevelLibrary.load_level(world.get_full_name())
+        EditorLevelLibrary.load_level(world.get_asset().get_path_name())
 
         # There should be only one sequence in the path.
         sequence_name = sequences[0].asset_name

--- a/openpype/hosts/unreal/plugins/load/load_layout.py
+++ b/openpype/hosts/unreal/plugins/load/load_layout.py
@@ -740,7 +740,7 @@ class LayoutLoader(plugin.Loader):
         loaded_assets = self._process(self.fname, asset_dir, shot)
 
         for s in sequences:
-            EditorAssetLibrary.save_asset(s.get_full_name())
+            EditorAssetLibrary.save_asset(s.get_path_name())
 
         EditorLevelLibrary.save_current_level()
 
@@ -819,7 +819,7 @@ class LayoutLoader(plugin.Loader):
             recursive_paths=False)
         levels = ar.get_assets(filter)
 
-        layout_level = levels[0].get_full_name()
+        layout_level = levels[0].get_asset().get_path_name()
 
         EditorLevelLibrary.save_all_dirty_levels()
         EditorLevelLibrary.load_level(layout_level)
@@ -919,7 +919,7 @@ class LayoutLoader(plugin.Loader):
                 package_paths=[f"{root}/{ms_asset}"],
                 recursive_paths=False)
             levels = ar.get_assets(_filter)
-            master_level = levels[0].get_full_name()
+            master_level = levels[0].get_asset().get_path_name()
 
             sequences = [master_sequence]
 


### PR DESCRIPTION
## Changelog Description
This PR changes all the occurrences of `get_full_path` functions to alternatives to get the path of the objects.

## Additional info
`get_full_path()` returns a string that includes the name of the class of the objects. This was preventing the change of the level in most of the loaders, and to save some of the assets.
This function has been included to fix another error in PR #4938.

## Testing notes:
The function was not causing evident errors. But there were some messages in the output log that it was impossible to change level because the path was malformed.
One of the most evident problems was that updating a layout placed the new asset in the wrong level, so to test if the PR is working, try updating a layout and check if the assets are in the correct level.