### PR TITLE
Unreal: Fix sequence frames validator to use correct data

### DIFF
--- a/openpype/hosts/unreal/plugins/publish/validate_sequence_frames.py
+++ b/openpype/hosts/unreal/plugins/publish/validate_sequence_frames.py
@@ -31,8 +31,8 @@ class ValidateSequenceFrames(pyblish.api.InstancePlugin):
             frames = list(collection.indexes)
 
             current_range = (frames[0], frames[-1])
-            required_range = (data["frameStart"],
-                              data["frameEnd"])
+            required_range = (data["clipIn"],
+                              data["clipOut"])
 
             if current_range != required_range:
                 raise ValueError(f"Invalid frame range: {current_range} - "


### PR DESCRIPTION
## Changelog Description
Fix sequence frames validator to use clipIn and clipOut data instead of frameStart and frameEnd.

## Testing notes:
1. In Unreal, create a Render instance.
2. Render the sequence.
3. Try publishing. The validator should pass if data is correct in the Project Manager.
