### PR TITLE
Settings: Added option to nest settings templates

### DIFF
--- a/openpype/settings/entities/lib.py
+++ b/openpype/settings/entities/lib.py
@@ -323,7 +323,10 @@ class SchemasHub:
         filled_template = self._fill_template(
             schema_data, template_def
         )
-        return filled_template
+        new_template_def = []
+        for item in filled_template:
+            new_template_def.extend(self.resolve_schema_data(item))
+        return new_template_def
 
     def create_schema_object(self, schema_data, *args, **kwargs):
         """Create entity for passed schema data.


### PR DESCRIPTION
## Changelog Description
It is possible to nest settings templates in another templates.

## Additional info
Not sure if this is a bugfix or enhancement? I think it did work in past, but not really sure.

## Testing notes:
1. Nest template inside another template and use it in settings.
```
# template_1.json
[
   {"type": "boolean", "key": "test_bool"}
]

# template_2.json
[
    {"type": "template", "name": "template_1"}
]
```
2. UI Should not crash.
