### PR TITLE
Fix/mongo add certificate keyerror

### DIFF
--- a/igniter/tools.py
+++ b/igniter/tools.py
@@ -6,7 +6,7 @@ import platform
 
 from typing import Union
 from pathlib import Path
-from urllib.parse import urlparse, parse_qs
+from urllib.parse import urlparse
 
 from openpype.client import mongo
 from pymongo import MongoClient

--- a/igniter/tools.py
+++ b/igniter/tools.py
@@ -1,12 +1,14 @@
 # -*- coding: utf-8 -*-
 """Tools used in **Igniter** GUI."""
+import certifi
 import os
-from typing import Union
-from urllib.parse import urlparse, parse_qs
-from pathlib import Path
 import platform
 
-import certifi
+from typing import Union
+from pathlib import Path
+from urllib.parse import urlparse, parse_qs
+
+from openpype.client import mongo
 from pymongo import MongoClient
 from pymongo.errors import (
     ServerSelectionTimeoutError,
@@ -24,34 +26,6 @@ class OpenPypeVersionNotFound(Exception):
 class OpenPypeVersionIncompatible(Exception):
     """OpenPype version is not compatible with the installed one (build)."""
     pass
-
-
-def should_add_certificate_path_to_mongo_url(mongo_url):
-    """Check if should add ca certificate to mongo url.
-
-    Since 30.9.2021 cloud mongo requires newer certificates that are not
-    available on most of workstation. This adds path to certifi certificate
-    which is valid for it. To add the certificate path url must have scheme
-    'mongodb+srv' or has 'ssl=true' or 'tls=true' in url query.
-    """
-    parsed = urlparse(mongo_url)
-    query = parse_qs(parsed.query)
-    lowered_query_keys = set(key.lower() for key in query.keys())
-    add_certificate = False
-    # Check if url 'ssl' or 'tls' are set to 'true'
-    for key in ("ssl", "tls"):
-        if key in query and "true" in query["ssl"]:
-            add_certificate = True
-            break
-
-    # Check if url contains 'mongodb+srv'
-    if not add_certificate and parsed.scheme == "mongodb+srv":
-        add_certificate = True
-
-    # Check if url does already contain certificate path
-    if add_certificate and "tlscafile" in lowered_query_keys:
-        add_certificate = False
-    return add_certificate
 
 
 def validate_mongo_connection(cnx: str) -> (bool, str):
@@ -72,7 +46,7 @@ def validate_mongo_connection(cnx: str) -> (bool, str):
         "serverSelectionTimeoutMS": os.environ.get("AVALON_TIMEOUT", 2000)
     }
     # Add certificate path if should be required
-    if should_add_certificate_path_to_mongo_url(cnx):
+    if mongo.should_add_certificate_path_to_mongo_url(cnx):
         kwargs["ssl_ca_certs"] = certifi.where()
 
     try:
@@ -146,7 +120,7 @@ def get_openpype_global_settings(url: str) -> dict:
         dict: With settings data. Empty dictionary is returned if not found.
     """
     kwargs = {}
-    if should_add_certificate_path_to_mongo_url(url):
+    if mongo.should_add_certificate_path_to_mongo_url(url):
         kwargs["ssl_ca_certs"] = certifi.where()
 
     try:

--- a/openpype/client/mongo.py
+++ b/openpype/client/mongo.py
@@ -134,7 +134,7 @@ def should_add_certificate_path_to_mongo_url(mongo_url):
     add_certificate = False
     # Check if url 'ssl' or 'tls' are set to 'true'
     for key in ("ssl", "tls"):
-        if key in query and "true" in query["ssl"]:
+        if key in query and "true" in query.get(key):
             add_certificate = True
             break
 


### PR DESCRIPTION
## Changelog Description
get `tls` key from `should_add_certificate_path_to_mongo_url` query processing

## Additional info
see this issue https://github.com/ynput/OpenPype/issues/5027

## Testing notes:
1. connect to the database with tls option set to `true`:
mongodb://db0.example.com:27017/?tls=true&tlsCertificateKeyFile=C%3A%5CUsers%5C.certs%5Cmongodb.pem
