### PR TITLE
Enhancement/publisher: Remove "hit play to continue" label on continue

### DIFF
--- a/openpype/tools/publisher/widgets/publish_frame.py
+++ b/openpype/tools/publisher/widgets/publish_frame.py
@@ -331,6 +331,7 @@ class PublishFrame(QtWidgets.QWidget):
         self._set_success_property(3)
         self._set_progress_visibility(True)
         self._set_main_label("Publishing...")
+        self._message_label_top.setText("")  # clear text
 
         self._reset_btn.setEnabled(False)
         self._stop_btn.setEnabled(True)

--- a/openpype/tools/publisher/widgets/publish_frame.py
+++ b/openpype/tools/publisher/widgets/publish_frame.py
@@ -310,7 +310,7 @@ class PublishFrame(QtWidgets.QWidget):
         self._set_success_property()
         self._set_progress_visibility(True)
 
-        self._main_label.setText("Hit publish (play button)! If you want")
+        self._main_label.setText("")
         self._message_label_top.setText("")
 
         self._reset_btn.setEnabled(True)


### PR DESCRIPTION
## Changelog Description

Remove "hit play to continue" message on continue so that it doesn't show anymore when play was clicked.

## Additional info

Resolve issue described [here](https://github.com/ynput/OpenPype/pull/4915#issuecomment-1559957492)

## Testing notes:

1. Click validate
2. Wait for it to finish validation successfully
3. Click publish
4. Now while it is publishing it will be expanded (that's correct) and it should **not** show the subtitle (second line in the message) **Hit publish (play button) to continue)** because it's currently playing/publishing. 

This can also be reproduced by:

1. Click validate
2. Stop/Pause the validation
3. Continue the validation or publishing
4. Now while it is publishing it will be expanded (that's correct) and it should **not** show the subtitle (second line in the message) **Hit publish (play button) to continue)** because it's currently playing/publishing. 