### PR TITLE
nuke: callback for dirmapping is on demand

### DIFF
--- a/openpype/hosts/nuke/api/pipeline.py
+++ b/openpype/hosts/nuke/api/pipeline.py
@@ -151,6 +151,7 @@ class NukeHost(
 def add_nuke_callbacks():
     """ Adding all available nuke callbacks
     """
+    nuke_settings = get_current_project_settings()["nuke"]
     workfile_settings = WorkfileSettings()
     # Set context settings.
     nuke.addOnCreate(
@@ -169,7 +170,10 @@ def add_nuke_callbacks():
     # # set apply all workfile settings on script load and save
     nuke.addOnScriptLoad(WorkfileSettings().set_context_settings)
 
-    nuke.addFilenameFilter(dirmap_file_name_filter)
+    if nuke_settings["nuke-dirmap"]["enabled"]:
+        log.info("Added Nuke's dirmaping callback ...")
+        # Add dirmap for file paths.
+        nuke.addFilenameFilter(dirmap_file_name_filter)
 
     log.info("Added Nuke callbacks ...")
 


### PR DESCRIPTION
## Changelog Description
Nuke was slowed down on processing due this callback. Since it is disabled by default it made sense to add it only on demand. 

## Testing notes:
It is very difficult to measure the difference in performance. It could be noticeable in multitude of image sequence Readers with higher resolution merged together into one viewer and played. The framerate during loading could identify the difference. Good benchmark is to compare it with Nuke session started from OpenPype and then the same nuke script opened with Nuke without OpenPype.

1. you shell enable or disable it from here `project_settings/nuke/nuke-dirmap/enabled`
2. See the difference in cashing and playback performance.
