### PR TITLE
Publisher: UI works with instances without label

### DIFF
--- a/openpype/pipeline/publish/__init__.py
+++ b/openpype/pipeline/publish/__init__.py
@@ -39,6 +39,7 @@ from .lib import (
 
     apply_plugin_settings_automatically,
     get_plugin_settings,
+    get_publish_instance_label,
 )
 
 from .abstract_expected_files import ExpectedFiles
@@ -85,6 +86,7 @@ __all__ = (
 
     "apply_plugin_settings_automatically",
     "get_plugin_settings",
+    "get_publish_instance_label",
 
     "ExpectedFiles",
 

--- a/openpype/pipeline/publish/lib.py
+++ b/openpype/pipeline/publish/lib.py
@@ -30,6 +30,8 @@ from .contants import (
     TRANSIENT_DIR_TEMPLATE
 )
 
+_ARG_PLACEHOLDER = object()
+
 
 def get_template_name_profiles(
     project_name, project_settings=None, logger=None
@@ -866,3 +868,33 @@ def add_repre_files_for_cleanup(instance, repre):
     for file_name in files:
         expected_file = os.path.join(staging_dir, file_name)
         instance.context.data["cleanupFullPaths"].append(expected_file)
+
+
+def get_publish_instance_label(instance, default=_ARG_PLACEHOLDER):
+    """Try to get label from pyblish instance.
+
+    First are checked 'label' and 'name' keys in instance data. If are not set
+    a default value is returned. Instance object is converted to string
+    if default value is not specific.
+
+    Todos:
+        Maybe 'subset' key could be used too.
+
+    Args:
+        instance (pyblish.api.Instance): Pyblish instance.
+        default (Optional[Any]): Default value to return if any
+
+    Returns:
+        Union[Any]: Instance label or default label.
+    """
+
+    label = (
+        instance.data.get("label")
+        or instance.data.get("name")
+    )
+    if label:
+        return label
+
+    if default is _ARG_PLACEHOLDER:
+        return str(instance)
+    return default

--- a/openpype/plugins/publish/extract_review.py
+++ b/openpype/plugins/publish/extract_review.py
@@ -23,7 +23,10 @@ from openpype.lib.transcoding import (
     convert_input_paths_for_ffmpeg,
     get_transcode_temp_directory,
 )
-from openpype.pipeline.publish import KnownPublishError
+from openpype.pipeline.publish import (
+    KnownPublishError,
+    get_publish_instance_label,
+)
 from openpype.pipeline.publish.lib import add_repre_files_for_cleanup
 
 
@@ -203,17 +206,8 @@ class ExtractReview(pyblish.api.InstancePlugin):
 
         return filtered_defs
 
-    @staticmethod
-    def get_instance_label(instance):
-        return (
-            getattr(instance, "label", None)
-            or instance.data.get("label")
-            or instance.data.get("name")
-            or str(instance)
-        )
-
     def main_process(self, instance):
-        instance_label = self.get_instance_label(instance)
+        instance_label = get_publish_instance_label(instance)
         self.log.debug("Processing instance \"{}\"".format(instance_label))
         profile_outputs = self._get_outputs_for_instance(instance)
         if not profile_outputs:

--- a/openpype/plugins/publish/integrate_thumbnail.py
+++ b/openpype/plugins/publish/integrate_thumbnail.py
@@ -20,6 +20,7 @@ import pyblish.api
 
 from openpype.client import get_versions
 from openpype.client.operations import OperationsSession, new_thumbnail_doc
+from openpype.pipeline.publish import get_publish_instance_label
 
 InstanceFilterResult = collections.namedtuple(
     "InstanceFilterResult",
@@ -133,7 +134,7 @@ class IntegrateThumbnails(pyblish.api.ContextPlugin):
 
         filtered_instances = []
         for instance in context:
-            instance_label = self._get_instance_label(instance)
+            instance_label = get_publish_instance_label(instance)
             # Skip instances without published representations
             # - there is no place where to put the thumbnail
             published_repres = instance.data.get("published_representations")
@@ -248,7 +249,7 @@ class IntegrateThumbnails(pyblish.api.ContextPlugin):
 
         for instance_item in filtered_instance_items:
             instance, thumbnail_path, version_id = instance_item
-            instance_label = self._get_instance_label(instance)
+            instance_label = get_publish_instance_label(instance)
             version_doc = version_docs_by_str_id.get(version_id)
             if not version_doc:
                 self.log.warning((
@@ -339,10 +340,3 @@ class IntegrateThumbnails(pyblish.api.ContextPlugin):
             ))
 
         op_session.commit()
-
-    def _get_instance_label(self, instance):
-        return (
-            instance.data.get("label")
-            or instance.data.get("name")
-            or "N/A"
-        )

--- a/openpype/tools/publisher/control.py
+++ b/openpype/tools/publisher/control.py
@@ -40,6 +40,7 @@ from openpype.pipeline.create.context import (
     CreatorsOperationFailed,
     ConvertorsOperationFailed,
 )
+from openpype.pipeline.publish import get_publish_instance_label
 
 # Define constant for plugin orders offset
 PLUGIN_ORDER_OFFSET = 0.5
@@ -346,7 +347,7 @@ class PublishReportMaker:
     def _extract_instance_data(self, instance, exists):
         return {
             "name": instance.data.get("name"),
-            "label": instance.data.get("label"),
+            "label": get_publish_instance_label(instance),
             "family": instance.data["family"],
             "families": instance.data.get("families") or [],
             "exists": exists,


### PR DESCRIPTION
## Changelog Description
Publisher UI does not crash if instance don't have filled 'label' key in instance data.

## Additional info
Issue was added with publish instances view in [this PR](https://github.com/ynput/OpenPype/pull/4915). Reported in UE where are instances without filled `"label"` key. Implemented helper function 'get_publish_instance_label' in publish lib, to get label from pyblish instance.

### Screenshot
![image](https://github.com/ynput/OpenPype/assets/43494761/2a43d1fe-0099-48fd-96ba-3457a6a5ec1d)

## Testing notes:
1. Make sure you have publish instance without label filled
2. Use publisher UI to publish
3. Wait for successfull publishing, or stop publishing in middle
4. On left side should be instances view without any major issues
