### PR TITLE
Ftrack: Limit number of ftrack events to query at once

### DIFF
--- a/openpype/modules/ftrack/ftrack_server/lib.py
+++ b/openpype/modules/ftrack/ftrack_server/lib.py
@@ -196,7 +196,7 @@ class ProcessEventHub(SocketBaseEventHub):
             {"pype_data.is_processed": False}
         ).sort(
             [("pype_data.stored", pymongo.ASCENDING)]
-        )
+        ).limit(100)
 
         found = False
         for event_data in not_processed_events:


### PR DESCRIPTION
## Changelog Description
Limit the amount of ftrack events received from mongo at once to 100.

## Additional info
We hit a limit of message length when there is a heap of events to process, which should be avoided by limiting the documents returned from mongo.

## Testing notes:
Not sure how to test? Somehow make more than 100 events at a time and validate they are processed in correct order.
