### PR TITLE
Publisher: Call explicitly prepared tab methods

### DIFF
--- a/openpype/tools/publisher/window.py
+++ b/openpype/tools/publisher/window.py
@@ -676,7 +676,15 @@ class PublisherWindow(QtWidgets.QDialog):
         self._tabs_widget.set_current_tab(identifier)
 
     def set_current_tab(self, tab):
-        self._set_current_tab(tab)
+        if tab == "create":
+            self._go_to_create_tab()
+        elif tab == "publish":
+            self._go_to_publish_tab()
+        elif tab == "report":
+            self._go_to_report_tab()
+        elif tab == "details":
+            self._go_to_details_tab()
+
         if not self._window_is_visible:
             self.set_tab_on_reset(tab)
 

--- a/openpype/tools/publisher/window.py
+++ b/openpype/tools/publisher/window.py
@@ -694,6 +694,12 @@ class PublisherWindow(QtWidgets.QDialog):
     def _go_to_create_tab(self):
         if self._create_tab.isEnabled():
             self._set_current_tab("create")
+            return
+
+        self._overlay_object.add_message(
+            "Can't switch to Create tab because publishing is paused.",
+            message_type="info"
+        )
 
     def _go_to_publish_tab(self):
         self._set_current_tab("publish")


### PR DESCRIPTION
## Changelog Description
It is not possible to go to Create tab during publishing from OpenPype menu.

## Additional info
Public method `set_current_tab` does not use directly `_set_current_tab` but one of prepared methods. There are two ways how to handle this. One is this, the other is to move the condition from `_go_to_create_tab` to `_set_current_tab`. I don't have preference.

## Testing notes:
1. Make sure you're in host where `Create` action in OpenPype menu opens publisher on Create tab
1. Open publisher
2. Start publishing
3. Pause publishing (or just validate)
4. Click on the `Create` action in menu
5. The UI should not change to `Create` tab
