### PR TITLE
testing 123

### DIFF
--- a/openpype/hosts/nuke/plugins/load/load_model.py
+++ b/openpype/hosts/nuke/plugins/load/load_model.py
@@ -65,9 +65,6 @@ class AlembicModelLoader(load.LoaderPlugin):
                 inpanel=False
             )
 
-            # hide property panel
-            model_node.hideControlPanel()
-
             model_node.forceValidate()
 
             # Ensure all items are imported and selected.


### PR DESCRIPTION
This PR is meant to remove the annoyance of the UI changing focus to the properties window just for the property window of the newly created node to disappear. Instead of using node.hideControlPanel I'm implementing the concealment during the creation of the node which will not change the focus of the current window.