### PR TITLE
Maya: Deadline servers

### DIFF
--- a/openpype/hosts/maya/plugins/create/create_render.py
+++ b/openpype/hosts/maya/plugins/create/create_render.py
@@ -181,16 +181,34 @@ class CreateRender(plugin.Creator):
 
         primary_pool = pool_setting["primary_pool"]
         sorted_pools = self._set_default_pool(list(pools), primary_pool)
-        cmds.addAttr(self.instance, longName="primaryPool",
-                     attributeType="enum",
-                     enumName=":".join(sorted_pools))
+        cmds.addAttr(
+            self.instance,
+            longName="primaryPool",
+            attributeType="enum",
+            enumName=":".join(sorted_pools)
+        )
+        cmds.setAttr(
+            "{}.primaryPool".format(self.instance),
+            0,
+            keyable=False,
+            channelBox=True
+        )
 
         pools = ["-"] + pools
         secondary_pool = pool_setting["secondary_pool"]
         sorted_pools = self._set_default_pool(list(pools), secondary_pool)
-        cmds.addAttr("{}.secondaryPool".format(self.instance),
-                     attributeType="enum",
-                     enumName=":".join(sorted_pools))
+        cmds.addAttr(
+            self.instance,
+            longName="secondaryPool",
+            attributeType="enum",
+            enumName=":".join(sorted_pools)
+        )
+        cmds.setAttr(
+            "{}.secondaryPool".format(self.instance),
+            0,
+            keyable=False,
+            channelBox=True
+        )
 
     def _create_render_settings(self):
         """Create instance settings."""
@@ -260,6 +278,12 @@ class CreateRender(plugin.Creator):
                                                default_priority)
             self.data["tile_priority"] = tile_priority
 
+            strict_error_checking = maya_submit_dl.get("strict_error_checking",
+                                                       True)
+            self.data["strict_error_checking"] = strict_error_checking
+
+            # Pool attributes should be last since they will be recreated when
+            # the deadline server changes.
             pool_setting = (self._project_settings["deadline"]
                                                   ["publish"]
                                                   ["CollectDeadlinePools"])
@@ -272,9 +296,6 @@ class CreateRender(plugin.Creator):
             secondary_pool = pool_setting["secondary_pool"]
             self.data["secondaryPool"] = self._set_default_pool(pool_names,
                                                                 secondary_pool)
-            strict_error_checking = maya_submit_dl.get("strict_error_checking",
-                                                       True)
-            self.data["strict_error_checking"] = strict_error_checking
 
         if muster_enabled:
             self.log.info(">>> Loading Muster credentials ...")

--- a/openpype/hosts/maya/plugins/publish/collect_render.py
+++ b/openpype/hosts/maya/plugins/publish/collect_render.py
@@ -336,7 +336,7 @@ class CollectMayaRender(pyblish.api.ContextPlugin):
                 context.data["system_settings"]["modules"]["deadline"]
             )
             if deadline_settings["enabled"]:
-                data["deadlineUrl"] = render_instance.data.get("deadlineUrl")
+                data["deadlineUrl"] = render_instance.data["deadlineUrl"]
 
             if self.sync_workfile_version:
                 data["version"] = context.data["version"]

--- a/openpype/modules/deadline/plugins/publish/collect_default_deadline_server.py
+++ b/openpype/modules/deadline/plugins/publish/collect_default_deadline_server.py
@@ -17,7 +17,8 @@ class CollectDefaultDeadlineServer(pyblish.api.ContextPlugin):
     `CollectDeadlineServerFromInstance`.
     """
 
-    order = pyblish.api.CollectorOrder + 0.410
+    # Run before collect_deadline_server_instance.
+    order = pyblish.api.CollectorOrder + 0.0025
     label = "Default Deadline Webservice"
 
     pass_mongo_url = False

--- a/openpype/modules/deadline/plugins/publish/submit_publish_job.py
+++ b/openpype/modules/deadline/plugins/publish/submit_publish_job.py
@@ -1089,6 +1089,10 @@ class ProcessSubmittedJobOnFarm(pyblish.api.InstancePlugin):
             deadline_publish_job_id = \
                 self._submit_deadline_post_job(instance, render_job, instances)
 
+            # Inject deadline url to instances.
+            for inst in instances:
+                inst["deadlineUrl"] = self.deadline_url
+
         # publish job file
         publish_job = {
             "asset": asset,


### PR DESCRIPTION
## Changelog Description
Fix working with multiple Deadline servers in Maya.

- Pools (primary and secondary) attributes were not recreated correctly.
- Order of collector plugins were wrong, so collected data was not injected into render instances.
- Server attribute was not converted to string so comparing with settings was incorrect.
- Improve debug logging for where the webservice url is getting fetched from.

## Testing notes:
1. Add multiple webservices to `modules/deadline/deadline_urls`.
2. Setup render and use non-default webservice in Maya.
3. Publish.
4. Test enabling/disabling webservices in `project_settings/deadline/deadline_servers`.
