### PR TITLE
OCIO: Support working with single frame renders

### DIFF
--- a/openpype/plugins/publish/extract_color_transcode.py
+++ b/openpype/plugins/publish/extract_color_transcode.py
@@ -184,6 +184,11 @@ class ExtractOIIOTranscode(publish.Extractor):
                     if tag == "review":
                         added_review = True
 
+                # If there is only 1 file outputted then convert list to
+                # string, cause that'll indicate that its not a sequence.
+                if len(new_repre["files"]) == 1:
+                    new_repre["files"] = new_repre["files"][0]
+
                 new_representations.append(new_repre)
                 added_representations = True
 


### PR DESCRIPTION
## Changelog Description
When there is only 1 file, the datamember `files` on the representation should be a string.

## Testing notes:
1. Setup a profile for Maya in `project_settings/global/publish/ExtractOIIOTranscode/profiles`.
2. Setup a `render` in Maya and publish.
