### PR TITLE
Maya: Support same attribute names on different node types.

### DIFF
--- a/openpype/hosts/maya/plugins/publish/validate_rendersettings.py
+++ b/openpype/hosts/maya/plugins/publish/validate_rendersettings.py
@@ -274,16 +274,18 @@ class ValidateRenderSettings(pyblish.api.InstancePlugin):
 
         # go through definitions and test if such node.attribute exists.
         # if so, compare its value from the one required.
-        for attribute, data in cls.get_nodes(instance, renderer).items():
+        for data in cls.get_nodes(instance, renderer):
             for node in data["nodes"]:
                 try:
                     render_value = cmds.getAttr(
-                        "{}.{}".format(node, attribute)
+                        "{}.{}".format(node, data["attribute"])
                     )
                 except RuntimeError:
                     invalid = True
                     cls.log.error(
-                        "Cannot get value of {}.{}".format(node, attribute)
+                        "Cannot get value of {}.{}".format(
+                            node, data["attribute"]
+                        )
                     )
                 else:
                     if render_value not in data["values"]:
@@ -291,7 +293,10 @@ class ValidateRenderSettings(pyblish.api.InstancePlugin):
                         cls.log.error(
                             "Invalid value {} set on {}.{}. Expecting "
                             "{}".format(
-                                render_value, node, attribute, data["values"]
+                                render_value,
+                                node,
+                                data["attribute"],
+                                data["values"]
                             )
                         )
 
@@ -305,7 +310,7 @@ class ValidateRenderSettings(pyblish.api.InstancePlugin):
                 "{}_render_attributes".format(renderer)
             ) or []
         )
-        result = {}
+        result = []
         for attr, values in OrderedDict(validation_settings).items():
             values = [convert_to_int_or_float(v) for v in values if v]
 
@@ -335,7 +340,13 @@ class ValidateRenderSettings(pyblish.api.InstancePlugin):
                 )
                 continue
 
-            result[attribute_name] = {"nodes": nodes, "values": values}
+            result.append(
+                {
+                    "attribute": attribute_name,
+                    "nodes": nodes,
+                    "values": values
+                }
+            )
 
         return result
 
@@ -350,11 +361,11 @@ class ValidateRenderSettings(pyblish.api.InstancePlugin):
             "{aov_separator}", instance.data.get("aovSeparator", "_")
         )
 
-        for attribute, data in cls.get_nodes(instance, renderer).items():
+        for data in cls.get_nodes(instance, renderer):
             if not data["values"]:
                 continue
             for node in data["nodes"]:
-                lib.set_attribute(attribute, data["values"][0], node)
+                lib.set_attribute(data["attribute"], data["values"][0], node)
 
         with lib.renderlayer(layer_node):
             default = lib.RENDER_ATTRS['default']


### PR DESCRIPTION
## Changelog Description
When validating render settings attributes, support same attribute names on different node types.

## Testing notes:
1. Add the following settings to `project_settings/maya/publish/ValidateRenderSettings/arnold_render_attributes`:
- aiAOVDriver.exrCompression = 8
- renderGlobals.exrCompression = 2
2. Setup render in Maya with Arnold and Publish.
