### PR TITLE
Maya: Repair RenderPass token when merging AOVs.

### DIFF
--- a/openpype/hosts/maya/plugins/publish/validate_rendersettings.py
+++ b/openpype/hosts/maya/plugins/publish/validate_rendersettings.py
@@ -364,6 +364,17 @@ class ValidateRenderSettings(pyblish.api.InstancePlugin):
             cmds.setAttr("defaultRenderGlobals.animation", True)
 
             # Repair prefix
+            if renderer == "arnold":
+                multipart = cmds.getAttr("defaultArnoldDriver.mergeAOVs")
+                if multipart:
+                    separator_variations = [
+                        "_<RenderPass>",
+                        "<RenderPass>_",
+                        "<RenderPass>",
+                    ]
+                    for variant in separator_variations:
+                        default_prefix = default_prefix.replace(variant, "")
+
             if renderer != "renderman":
                 node = render_attrs["node"]
                 prefix_attr = render_attrs["prefix"]


### PR DESCRIPTION
## Changelog Description
Validator was flagging that `<RenderPass>` was in the image prefix, but did not repair the issue.

## Testing notes:
1. Setup render in Maya with `Merge AOV` enabled.
2. Ensure `<RenderPass>` token is in image prefix.
3. Publish and repair.
