### PR TITLE
Ftrack: Role names are not case sensitive in ftrack event server status action

### DIFF
--- a/openpype/modules/ftrack/scripts/sub_event_status.py
+++ b/openpype/modules/ftrack/scripts/sub_event_status.py
@@ -296,9 +296,9 @@ def server_activity_validate_user(event):
     if not user_ent:
         return False
 
-    role_list = ["Pypeclub", "Administrator"]
+    role_list = {"pypeclub", "administrator"}
     for role in user_ent["user_security_roles"]:
-        if role["security_role"]["name"] in role_list:
+        if role["security_role"]["name"].lower() in role_list:
             return True
     return False
 


### PR DESCRIPTION
## Changelog Description
Event server status action is not case sensitive for role names of user.

## Testing notes:
1. Change role name of `pypeclub` to e.g. `PyPeCLuB` in ftrack
2. Run event server
3. Status action should be visible in actions list
