### PR TITLE
Publisher: Fix border widget

### DIFF
--- a/openpype/tools/publisher/widgets/border_label_widget.py
+++ b/openpype/tools/publisher/widgets/border_label_widget.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from math import ceil
 from qtpy import QtWidgets, QtCore, QtGui
 
 from openpype.style import get_objected_colors

--- a/openpype/tools/publisher/widgets/border_label_widget.py
+++ b/openpype/tools/publisher/widgets/border_label_widget.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 
+from math import ceil
 from qtpy import QtWidgets, QtCore, QtGui
 
 from openpype.style import get_objected_colors
@@ -14,32 +15,44 @@ class _VLineWidget(QtWidgets.QWidget):
 
     It is expected that parent widget will set width.
     """
-    def __init__(self, color, left, parent):
+    def __init__(self, color, line_size, left, parent):
         super(_VLineWidget, self).__init__(parent)
         self._color = color
         self._left = left
+        self._line_size = line_size
+
+    def set_line_size(self, line_size):
+        self._line_size = line_size
 
     def paintEvent(self, event):
         if not self.isVisible():
             return
 
-        if self._left:
-            pos_x = 0
-        else:
-            pos_x = self.width()
+        pos_x = self._line_size * 0.5
+        if not self._left:
+            pos_x = self.width() - pos_x
+
         painter = QtGui.QPainter(self)
         painter.setRenderHints(
             QtGui.QPainter.Antialiasing
             | QtGui.QPainter.SmoothPixmapTransform
         )
+
         if self._color:
             pen = QtGui.QPen(self._color)
         else:
             pen = painter.pen()
-        pen.setWidth(1)
+        pen.setWidth(self._line_size)
         painter.setPen(pen)
         painter.setBrush(QtCore.Qt.transparent)
-        painter.drawLine(pos_x, 0, pos_x, self.height())
+        painter.drawRect(
+            QtCore.QRectF(
+                pos_x,
+                -self._line_size,
+                pos_x + (self.width() * 2),
+                self.height() + (self._line_size * 2)
+            )
+        )
         painter.end()
 
 
@@ -56,34 +69,46 @@ class _HBottomLineWidget(QtWidgets.QWidget):
 
     It is expected that parent widget will set height and radius.
     """
-    def __init__(self, color, parent):
+    def __init__(self, color, line_size, parent):
         super(_HBottomLineWidget, self).__init__(parent)
         self._color = color
         self._radius = 0
+        self._line_size = line_size
 
     def set_radius(self, radius):
         self._radius = radius
+
+    def set_line_size(self, line_size):
+        self._line_size = line_size
 
     def paintEvent(self, event):
         if not self.isVisible():
             return
 
-        rect = QtCore.QRect(
-            0, -self._radius, self.width(), self.height() + self._radius
+        x_offset = self._line_size * 0.5
+        rect = QtCore.QRectF(
+            x_offset,
+            -self._radius,
+            self.width() - (2 * x_offset),
+            (self.height() + self._radius) - x_offset
         )
         painter = QtGui.QPainter(self)
         painter.setRenderHints(
             QtGui.QPainter.Antialiasing
             | QtGui.QPainter.SmoothPixmapTransform
         )
+
         if self._color:
             pen = QtGui.QPen(self._color)
         else:
             pen = painter.pen()
-        pen.setWidth(1)
+        pen.setWidth(self._line_size)
         painter.setPen(pen)
         painter.setBrush(QtCore.Qt.transparent)
-        painter.drawRoundedRect(rect, self._radius, self._radius)
+        if self._radius:
+            painter.drawRoundedRect(rect, self._radius, self._radius)
+        else:
+            painter.drawRect(rect)
         painter.end()
 
 
@@ -102,30 +127,38 @@ class _HTopCornerLineWidget(QtWidgets.QWidget):
 
     It is expected that parent widget will set height and radius.
     """
-    def __init__(self, color, left_side, parent):
+
+    def __init__(self, color, line_size, left_side, parent):
         super(_HTopCornerLineWidget, self).__init__(parent)
         self._left_side = left_side
+        self._line_size = line_size
         self._color = color
         self._radius = 0
 
     def set_radius(self, radius):
         self._radius = radius
 
+    def set_line_size(self, line_size):
+        self._line_size = line_size
+
     def paintEvent(self, event):
         if not self.isVisible():
             return
 
-        pos_y = self.height() / 2
-
+        pos_y = self.height() * 0.5
+        x_offset = self._line_size * 0.5
         if self._left_side:
-            rect = QtCore.QRect(
-                0, pos_y, self.width() + self._radius, self.height()
+            rect = QtCore.QRectF(
+                x_offset,
+                pos_y,
+                self.width() + self._radius + x_offset,
+                self.height()
             )
         else:
-            rect = QtCore.QRect(
-                -self._radius,
+            rect = QtCore.QRectF(
+                (-self._radius),
                 pos_y,
-                self.width() + self._radius,
+                (self.width() + self._radius) - x_offset,
                 self.height()
             )
 
@@ -138,10 +171,13 @@ class _HTopCornerLineWidget(QtWidgets.QWidget):
             pen = QtGui.QPen(self._color)
         else:
             pen = painter.pen()
-        pen.setWidth(1)
+        pen.setWidth(self._line_size)
         painter.setPen(pen)
         painter.setBrush(QtCore.Qt.transparent)
-        painter.drawRoundedRect(rect, self._radius, self._radius)
+        if self._radius:
+            painter.drawRoundedRect(rect, self._radius, self._radius)
+        else:
+            painter.drawRect(rect)
         painter.end()
 
 
@@ -163,8 +199,10 @@ class BorderedLabelWidget(QtWidgets.QFrame):
         if color_value:
             color = color_value.get_qcolor()
 
-        top_left_w = _HTopCornerLineWidget(color, True, self)
-        top_right_w = _HTopCornerLineWidget(color, False, self)
+        line_size = 1
+
+        top_left_w = _HTopCornerLineWidget(color, line_size, True, self)
+        top_right_w = _HTopCornerLineWidget(color, line_size, False, self)
 
         label_widget = QtWidgets.QLabel(label, self)
 
@@ -175,10 +213,10 @@ class BorderedLabelWidget(QtWidgets.QFrame):
         top_layout.addWidget(label_widget, 0)
         top_layout.addWidget(top_right_w, 1)
 
-        left_w = _VLineWidget(color, True, self)
-        right_w = _VLineWidget(color, False, self)
+        left_w = _VLineWidget(color, line_size, True, self)
+        right_w = _VLineWidget(color, line_size, False, self)
 
-        bottom_w = _HBottomLineWidget(color, self)
+        bottom_w = _HBottomLineWidget(color, line_size, self)
 
         center_layout = QtWidgets.QHBoxLayout()
         center_layout.setContentsMargins(5, 5, 5, 5)
@@ -201,6 +239,7 @@ class BorderedLabelWidget(QtWidgets.QFrame):
         self._widget = None
 
         self._radius = 0
+        self._line_size = line_size
 
         self._top_left_w = top_left_w
         self._top_right_w = top_right_w
@@ -216,14 +255,38 @@ class BorderedLabelWidget(QtWidgets.QFrame):
             value, value, value, value
         )
 
+    def set_line_size(self, line_size):
+        if self._line_size == line_size:
+            return
+        self._line_size = line_size
+        for widget in (
+            self._top_left_w,
+            self._top_right_w,
+            self._left_w,
+            self._right_w,
+            self._bottom_w
+        ):
+            widget.set_line_size(line_size)
+        self._recalculate_sizes()
+
     def showEvent(self, event):
         super(BorderedLabelWidget, self).showEvent(event)
+        self._recalculate_sizes()
 
+    def _recalculate_sizes(self):
         height = self._label_widget.height()
-        radius = (height + (height % 2)) / 2
+        radius = int((height + (height % 2)) / 2)
         self._radius = radius
 
-        side_width = 1 + radius
+        radius_size = self._line_size + 1
+        if radius_size < radius:
+            radius_size = radius
+
+        if radius:
+            side_width = self._line_size + radius
+        else:
+            side_width = self._line_size + 1
+
         # Don't use fixed width/height as that would set also set
         #   the other size (When fixed width is set then is also set
         #   fixed height).
@@ -231,8 +294,8 @@ class BorderedLabelWidget(QtWidgets.QFrame):
         self._left_w.setMaximumWidth(side_width)
         self._right_w.setMinimumWidth(side_width)
         self._right_w.setMaximumWidth(side_width)
-        self._bottom_w.setMinimumHeight(radius)
-        self._bottom_w.setMaximumHeight(radius)
+        self._bottom_w.setMinimumHeight(radius_size)
+        self._bottom_w.setMaximumHeight(radius_size)
         self._bottom_w.set_radius(radius)
         self._top_right_w.set_radius(radius)
         self._top_left_w.set_radius(radius)


### PR DESCRIPTION
## Changelog Description
Fixed border lines in Publisher UI to be painted correctly with correct indentation and size.

## Screenshots
### Before
![image](https://github.com/ynput/OpenPype/assets/43494761/3f5cf5ce-313d-4e68-9a5f-562aa4cc52de)

### After
![image](https://github.com/ynput/OpenPype/assets/43494761/f01cbab6-ea5c-4291-bedd-7e16c5665a6c)

## Testing notes:
If this did not happen to you before this PR, you're can't validate the change much.
1. Open Publisher
2. Check the painted borders visible in Create and Publish pages
