### PR TITLE
AYON: Fix site sync settings

### DIFF
--- a/openpype/settings/ayon_settings.py
+++ b/openpype/settings/ayon_settings.py
@@ -278,7 +278,11 @@ def _convert_modules_system(
         if "enabled" not in value or module_name not in output_modules:
             continue
 
-        output_modules[module_name]["enabled"] = module_name in addon_versions
+        ayon_module_name = module_name
+        if module_name == "sync_server":
+            ayon_module_name = "sitesync"
+        output_modules[module_name]["enabled"] = (
+                ayon_module_name in addon_versions)
 
     # Missing modules conversions
     # - "sync_server" -> renamed to sitesync

--- a/openpype/settings/ayon_settings.py
+++ b/openpype/settings/ayon_settings.py
@@ -282,7 +282,7 @@ def _convert_modules_system(
         if module_name == "sync_server":
             ayon_module_name = "sitesync"
         output_modules[module_name]["enabled"] = (
-                ayon_module_name in addon_versions)
+            ayon_module_name in addon_versions)
 
     # Missing modules conversions
     # - "sync_server" -> renamed to sitesync


### PR DESCRIPTION
## Changelog Description
Fixed settings for AYON variant of sync server.

## Testing notes:
1. Addon ayon-sitesync should work in AYON mode.
2. Sync server should work in OpenPype mode.