### PR TITLE
Unreal: Added verification for Unreal app name format

### DIFF
--- a/openpype/hosts/unreal/addon.py
+++ b/openpype/hosts/unreal/addon.py
@@ -1,5 +1,7 @@
 import os
+import re
 from openpype.modules import IHostAddon, OpenPypeModule
+from openpype.widgets.message_window import Window
 
 UNREAL_ROOT_DIR = os.path.dirname(os.path.abspath(__file__))
 
@@ -18,6 +20,18 @@ class UnrealAddon(OpenPypeModule, IHostAddon):
         from pathlib import Path
 
         from .lib import get_compatible_integration
+
+        pattern = re.compile(r'^\d+-\d+$')
+
+        if not pattern.match(app.name):
+            Window(
+                parent=None,
+                title="Unreal application name format",
+                message="Unreal application name must be in format '5-0' or '5-1'",
+                level="critical")
+            raise ValueError(
+                "Unreal application name must be in format '5-0' or '5-1'"
+            )
 
         ue_version = app.name.replace("-", ".")
         unreal_plugin_path = os.path.join(

--- a/openpype/hosts/unreal/addon.py
+++ b/openpype/hosts/unreal/addon.py
@@ -24,7 +24,10 @@ class UnrealAddon(OpenPypeModule, IHostAddon):
         pattern = re.compile(r'^\d+-\d+$')
 
         if not pattern.match(app.name):
-            msg = "Unreal application name must be in format '5-0' or '5-1'"
+            msg = (
+                "Unreal application key in the settings must be in format"
+                "'5-0' or '5-1'"
+            )
             Window(
                 parent=None,
                 title="Unreal application name format",

--- a/openpype/hosts/unreal/addon.py
+++ b/openpype/hosts/unreal/addon.py
@@ -24,14 +24,13 @@ class UnrealAddon(OpenPypeModule, IHostAddon):
         pattern = re.compile(r'^\d+-\d+$')
 
         if not pattern.match(app.name):
+            msg = "Unreal application name must be in format '5-0' or '5-1'"
             Window(
                 parent=None,
                 title="Unreal application name format",
-                message="Unreal application name must be in format '5-0' or '5-1'",
+                message=msg,
                 level="critical")
-            raise ValueError(
-                "Unreal application name must be in format '5-0' or '5-1'"
-            )
+            raise ValueError(msg)
 
         ue_version = app.name.replace("-", ".")
         unreal_plugin_path = os.path.join(


### PR DESCRIPTION
## Changelog Description
The Unreal app name is used to determine the Unreal version folder, so it is necessary that if follows the format `x-x`, where `x` is any integer. This PR adds a verification that the app name follows that format.

## Additional info
Fixes #5062

## Testing notes:
1. Add a new version of Unreal in OpenPype System Settings, and add as key any string that does not respect the format.
2. Add that version to `project_anatomy/attributes/applications`.
3. Try creating a new Unreal project opening a task with that new Unreal version you added. It should show an error.
