### PR TITLE
Resolve: Make sure scripts dir exists

### DIFF
--- a/openpype/hosts/resolve/utils.py
+++ b/openpype/hosts/resolve/utils.py
@@ -29,6 +29,10 @@ def setup(env):
     log.info("Utility Scripts Dir: `{}`".format(util_scripts_paths))
     log.info("Utility Scripts: `{}`".format(scripts))
 
+    # Make sure scripts dir exists
+    if not os.path.exists(util_scripts_dir):
+        os.makedirs(util_scripts_dir)
+
     # make sure no script file is in folder
     for script in os.listdir(util_scripts_dir):
         path = os.path.join(util_scripts_dir, script)

--- a/openpype/hosts/resolve/utils.py
+++ b/openpype/hosts/resolve/utils.py
@@ -30,8 +30,7 @@ def setup(env):
     log.info("Utility Scripts: `{}`".format(scripts))
 
     # Make sure scripts dir exists
-    if not os.path.exists(util_scripts_dir):
-        os.makedirs(util_scripts_dir)
+    os.makedirs(util_scripts_dir, exist_ok=True)
 
     # make sure no script file is in folder
     for script in os.listdir(util_scripts_dir):


### PR DESCRIPTION
## Changelog Description
Make sure the scripts directory exists before looping over it's content.

## Additional info
The issue appeared to me on first launch.

## Testing notes:
1. Remove utils script dir on your workstation
2. Launch Resolve -> That should not crash