### PR TITLE
General: Replace deprecated keyword argument in PyMongo

### DIFF
--- a/igniter/tools.py
+++ b/igniter/tools.py
@@ -73,7 +73,7 @@ def validate_mongo_connection(cnx: str) -> (bool, str):
     }
     # Add certificate path if should be required
     if should_add_certificate_path_to_mongo_url(cnx):
-        kwargs["ssl_ca_certs"] = certifi.where()
+        kwargs["tlsCAFile"] = certifi.where()
 
     try:
         client = MongoClient(cnx, **kwargs)
@@ -147,7 +147,7 @@ def get_openpype_global_settings(url: str) -> dict:
     """
     kwargs = {}
     if should_add_certificate_path_to_mongo_url(url):
-        kwargs["ssl_ca_certs"] = certifi.where()
+        kwargs["tlsCAFile"] = certifi.where()
 
     try:
         # Create mongo connection

--- a/openpype/client/mongo/mongo.py
+++ b/openpype/client/mongo/mongo.py
@@ -224,7 +224,7 @@ class OpenPypeMongoConnection:
             "serverSelectionTimeoutMS": timeout
         }
         if should_add_certificate_path_to_mongo_url(mongo_url):
-            kwargs["ssl_ca_certs"] = certifi.where()
+            kwargs["tlsCAFile"] = certifi.where()
 
         mongo_client = pymongo.MongoClient(mongo_url, **kwargs)
 


### PR DESCRIPTION
## Changelog Description
Use argument `tlsCAFile` instead of `ssl_ca_certs` to avoid deprecation warnings.

### Additional information
Argument `ssl_ca_certs` is marked as deprecated by `pymongo` module.

## Testing notes:
1. Connection to secure mongo server should work (e.g. cloud mongo)