### PR TITLE
removing info knob from nuke creators

### DIFF
--- a/openpype/hosts/nuke/api/lib.py
+++ b/openpype/hosts/nuke/api/lib.py
@@ -1403,8 +1403,6 @@ def create_write_node(
     # adding write to read button
     add_button_clear_rendered(GN, os.path.dirname(fpath))
 
-    GN.addKnob(nuke.Text_Knob('', ''))
-
     # set tile color
     tile_color = next(
         iter(

--- a/openpype/hosts/nuke/api/pipeline.py
+++ b/openpype/hosts/nuke/api/pipeline.py
@@ -564,6 +564,7 @@ def remove_instance(instance):
     instance_node = instance.transient_data["node"]
     instance_knob = instance_node.knobs()[INSTANCE_DATA_KNOB]
     instance_node.removeKnob(instance_knob)
+    nuke.delete(instance_node)
 
 
 def select_instance(instance):

--- a/openpype/hosts/nuke/api/plugin.py
+++ b/openpype/hosts/nuke/api/plugin.py
@@ -75,20 +75,6 @@ class NukeCreator(NewCreator):
         for pass_key in keys:
             creator_attrs[pass_key] = pre_create_data[pass_key]
 
-    def add_info_knob(self, node):
-        if "OP_info" in node.knobs().keys():
-            return
-
-        # add info text
-        info_knob = nuke.Text_Knob("OP_info", "")
-        info_knob.setValue("""
-<span style=\"color:#fc0303\">
-<p>This node is maintained by <b>OpenPype Publisher</b>.</p>
-<p>To remove it use Publisher gui.</p>
-</span>
-        """)
-        node.addKnob(info_knob)
-
     def check_existing_subset(self, subset_name):
         """Make sure subset name is unique.
 
@@ -152,8 +138,6 @@ class NukeCreator(NewCreator):
             with parent_node:
                 created_node = nuke.createNode(node_type)
                 created_node["name"].setValue(node_name)
-
-                self.add_info_knob(created_node)
 
                 for key, values in node_knobs.items():
                     if key in created_node.knobs():

--- a/openpype/hosts/nuke/plugins/create/create_backdrop.py
+++ b/openpype/hosts/nuke/plugins/create/create_backdrop.py
@@ -36,8 +36,6 @@ class CreateBackdrop(NukeCreator):
             created_node["note_font_size"].setValue(24)
             created_node["label"].setValue("[{}]".format(node_name))
 
-            self.add_info_knob(created_node)
-
             return created_node
 
     def create(self, subset_name, instance_data, pre_create_data):

--- a/openpype/hosts/nuke/plugins/create/create_camera.py
+++ b/openpype/hosts/nuke/plugins/create/create_camera.py
@@ -39,8 +39,6 @@ class CreateCamera(NukeCreator):
 
             created_node["name"].setValue(node_name)
 
-            self.add_info_knob(created_node)
-
             return created_node
 
     def create(self, subset_name, instance_data, pre_create_data):

--- a/openpype/hosts/nuke/plugins/create/create_gizmo.py
+++ b/openpype/hosts/nuke/plugins/create/create_gizmo.py
@@ -40,8 +40,6 @@ class CreateGizmo(NukeCreator):
 
             created_node["name"].setValue(node_name)
 
-            self.add_info_knob(created_node)
-
             return created_node
 
     def create(self, subset_name, instance_data, pre_create_data):

--- a/openpype/hosts/nuke/plugins/create/create_model.py
+++ b/openpype/hosts/nuke/plugins/create/create_model.py
@@ -40,8 +40,6 @@ class CreateModel(NukeCreator):
 
             created_node["name"].setValue(node_name)
 
-            self.add_info_knob(created_node)
-
             return created_node
 
     def create(self, subset_name, instance_data, pre_create_data):

--- a/openpype/hosts/nuke/plugins/create/create_source.py
+++ b/openpype/hosts/nuke/plugins/create/create_source.py
@@ -32,7 +32,7 @@ class CreateSource(NukeCreator):
         read_node["tile_color"].setValue(
             int(self.node_color, 16))
         read_node["name"].setValue(node_name)
-        self.add_info_knob(read_node)
+
         return read_node
 
     def create(self, subset_name, instance_data, pre_create_data):

--- a/openpype/hosts/nuke/plugins/create/create_write_image.py
+++ b/openpype/hosts/nuke/plugins/create/create_write_image.py
@@ -86,7 +86,6 @@ class CreateWriteImage(napi.NukeWriteCreator):
                 "frame": nuke.frame()
             }
         )
-        self.add_info_knob(created_node)
 
         self._add_frame_range_limit(created_node, instance_data)
 

--- a/openpype/hosts/nuke/plugins/create/create_write_prerender.py
+++ b/openpype/hosts/nuke/plugins/create/create_write_prerender.py
@@ -74,7 +74,6 @@ class CreateWritePrerender(napi.NukeWriteCreator):
                 "height": height
             }
         )
-        self.add_info_knob(created_node)
 
         self._add_frame_range_limit(created_node)
 

--- a/openpype/hosts/nuke/plugins/create/create_write_render.py
+++ b/openpype/hosts/nuke/plugins/create/create_write_render.py
@@ -66,7 +66,6 @@ class CreateWriteRender(napi.NukeWriteCreator):
                 "height": height
             }
         )
-        self.add_info_knob(created_node)
 
         self.integrate_links(created_node, outputs=False)
 


### PR DESCRIPTION
## Changelog Description
- removing instance node if removed via publisher
- removing info knob since it is not needed any more (was there only for the transition phase)

## Testing notes:
1. nuke should create instance nodes without info message
2. Nuke should remove node once is bin icon used in Publisher on particular instance
