### PR TITLE
Tray: Fix restart arguments on update

### DIFF
--- a/openpype/tools/tray/pype_tray.py
+++ b/openpype/tools/tray/pype_tray.py
@@ -633,10 +633,10 @@ class TrayManager:
 
         # Create a copy of sys.argv
         additional_args = list(sys.argv)
-        # Check last argument from `get_openpype_execute_args`
-        # - when running from code it is the same as first from sys.argv
-        if args[-1] == additional_args[0]:
-            additional_args.pop(0)
+        # Remove first argument from 'sys.argv'
+        # - when running from code the first argument is 'start.py'
+        # - when running from build the first argument is executable
+        additional_args.pop(0)
 
         cleanup_additional_args = False
         if use_expected_version:
@@ -663,7 +663,6 @@ class TrayManager:
             additional_args = _additional_args
 
         args.extend(additional_args)
-
         run_detached_process(args, env=envs)
         self.exit()
 


### PR DESCRIPTION
## Changelog Description
Fix arguments on restart.

## Additional info
First argument in `sys.argv` is always removed. When running from code, it contains `start.py` script path and when running from build it contains path to openpype executable. The argument of executable can be what was passed to terminal so it could be `./openpype_console` (on linux).

## Testing notes:
Update and restart from tray should work. To replicate
1. Make sure you have at least one version in update repository
2. Choose the latest version in update repository and make sure it is not available in your local versions in local app data
3. Run openpype with different version using `--use-version={lower version}` (this version must have changes from this PR)
4. It should ask to update and restart -> condifm to update and restart
5. OpenPype should start when update finished