### PR TITLE
General: Remove default windowFlags from publisher

### DIFF
--- a/openpype/tools/publisher/window.py
+++ b/openpype/tools/publisher/window.py
@@ -66,8 +66,7 @@ class PublisherWindow(QtWidgets.QDialog):
             on_top_flag = QtCore.Qt.Dialog
 
         self.setWindowFlags(
-            self.windowFlags()
-            | QtCore.Qt.WindowTitleHint
+            QtCore.Qt.WindowTitleHint
             | QtCore.Qt.WindowMaximizeButtonHint
             | QtCore.Qt.WindowMinimizeButtonHint
             | QtCore.Qt.WindowCloseButtonHint


### PR DESCRIPTION
## Changelog Description
The default windowFlags is making the publisher window (in Linux at least) only show the close button and it's frustrating as many times you just want to minimize the window and get back to the validation after. Removing that line I get what I'd expect.

**Before:**
![image](https://github.com/ynput/OpenPype/assets/4348536/c7d10416-2449-4d61-a0ce-c047768d64c0)

**After:**
![image](https://github.com/ynput/OpenPype/assets/4348536/c984712a-6105-4246-aa18-dbbb2970554a)

## Testing notes:
1. Open publisher window
