### PR TITLE
Maya: Improve error feedback when no renderable cameras exist for ASS family.

### DIFF
--- a/openpype/hosts/maya/plugins/publish/collect_arnold_scene_source.py
+++ b/openpype/hosts/maya/plugins/publish/collect_arnold_scene_source.py
@@ -35,18 +35,16 @@ class CollectArnoldSceneSource(pyblish.api.InstancePlugin):
         # camera.
         cameras = cmds.ls(type="camera", long=True)
         renderable = [c for c in cameras if cmds.getAttr("%s.renderable" % c)]
-        if not renderable:
-            raise ValueError(
-                "No renderable cameras found, which is required for "
-                "publishing ASS."
-            )
-        camera = renderable[0]
-        for node in instance.data["contentMembers"]:
-            camera_shapes = cmds.listRelatives(
-                node, shapes=True, type="camera"
-            )
-            if camera_shapes:
-                camera = node
-        instance.data["camera"] = camera
+        if renderable:
+            camera = renderable[0]
+            for node in instance.data["contentMembers"]:
+                camera_shapes = cmds.listRelatives(
+                    node, shapes=True, type="camera"
+                )
+                if camera_shapes:
+                    camera = node
+            instance.data["camera"] = camera
+        else:
+            self.log.debug("No renderable cameraes found.")
 
         self.log.debug("data: {}".format(instance.data))

--- a/openpype/hosts/maya/plugins/publish/collect_arnold_scene_source.py
+++ b/openpype/hosts/maya/plugins/publish/collect_arnold_scene_source.py
@@ -45,6 +45,6 @@ class CollectArnoldSceneSource(pyblish.api.InstancePlugin):
                     camera = node
             instance.data["camera"] = camera
         else:
-            self.log.debug("No renderable cameraes found.")
+            self.log.debug("No renderable cameras found.")
 
         self.log.debug("data: {}".format(instance.data))

--- a/openpype/hosts/maya/plugins/publish/collect_arnold_scene_source.py
+++ b/openpype/hosts/maya/plugins/publish/collect_arnold_scene_source.py
@@ -37,7 +37,7 @@ class CollectArnoldSceneSource(pyblish.api.InstancePlugin):
         renderable = [c for c in cameras if cmds.getAttr("%s.renderable" % c)]
         if not renderable:
             raise ValueError(
-                "No renderable cameraes found, which is required for "
+                "No renderable cameras found, which is required for "
                 "publishing ASS."
             )
         camera = renderable[0]

--- a/openpype/hosts/maya/plugins/publish/collect_arnold_scene_source.py
+++ b/openpype/hosts/maya/plugins/publish/collect_arnold_scene_source.py
@@ -35,6 +35,11 @@ class CollectArnoldSceneSource(pyblish.api.InstancePlugin):
         # camera.
         cameras = cmds.ls(type="camera", long=True)
         renderable = [c for c in cameras if cmds.getAttr("%s.renderable" % c)]
+        if not renderable:
+            raise ValueError(
+                "No renderable cameraes found, which is required for "
+                "publishing ASS."
+            )
         camera = renderable[0]
         for node in instance.data["contentMembers"]:
             camera_shapes = cmds.listRelatives(


### PR DESCRIPTION
## Changelog Description
When collecting cameras for `ass` family, this improves the error message when no cameras are renderable.

## Testing notes:
1. Setup `ass` instance in Maya.
2. Ensure no cameras are renderable.
3. Publish and validate collection error message.
