### PR TITLE
Maya: bug fix on repair action in Arnold Scene Source CBID Validator

### DIFF
--- a/openpype/hosts/maya/plugins/publish/validate_arnold_scene_source_cbid.py
+++ b/openpype/hosts/maya/plugins/publish/validate_arnold_scene_source_cbid.py
@@ -70,5 +70,5 @@ class ValidateArnoldSceneSourceCbid(pyblish.api.InstancePlugin):
 
     @classmethod
     def repair(cls, instance):
-        for content_node, proxy_node in cls.get_invalid_couples(cls, instance):
-            lib.set_id(proxy_node, lib.get_id(content_node), overwrite=False)
+        for content_node, proxy_node in cls.get_invalid_couples(instance):
+            lib.set_id(proxy_node, lib.get_id(content_node), overwrite=True)


### PR DESCRIPTION
## Changelog Description
Fix the bug of not being able to use repair action  in Arnold Scene Source CBID Validator

## Additional info
n/a

## Testing notes:
1. Launch Maya via OP
2. Create Arnold Scene Source Instance with Content mesh and proxy mesh.
3. Run the publisher
4. If it triggers the Arnold Scene Source CBID Validator, right-click to repair it.
5. Run the publisher again
6. It will pass the validation.