### PR TITLE
Loader: Hide inactive versions in UI

### DIFF
--- a/openpype/tools/loader/model.py
+++ b/openpype/tools/loader/model.py
@@ -446,6 +446,7 @@ class SubsetsModel(BaseRepresentationModel, TreeModel):
         last_versions_by_subset_id = get_last_versions(
             project_name,
             subset_ids,
+            active=True,
             fields=["_id", "parent", "name", "type", "data", "schema"]
         )
 

--- a/openpype/tools/utils/delegates.py
+++ b/openpype/tools/utils/delegates.py
@@ -123,10 +123,14 @@ class VersionDelegate(QtWidgets.QStyledItemDelegate):
         project_name = self.dbcon.active_project()
         # Add all available versions to the editor
         parent_id = item["version_document"]["parent"]
-        version_docs = list(sorted(
-            get_versions(project_name, subset_ids=[parent_id]),
-            key=lambda item: item["name"]
-        ))
+        version_docs = [
+            version_doc
+            for version_doc in sorted(
+                get_versions(project_name, subset_ids=[parent_id]),
+                key=lambda item: item["name"]
+            )
+            if version_doc["data"].get("active", True)
+        ]
 
         hero_versions = list(
             get_hero_versions(


### PR DESCRIPTION
## Changelog Description
Hide versions with `active` set to `False` in Loader UI.

## Additional info
This required changes in next-minor release too.

## Testing notes:
There is not a function to change or set active of version in our codebase.
1. Open Loader UI
2. Choose a subset with version
3. Find the version in Mongo
4. Set it's `data.active` to `False`
5. Refresh loader UI
6. The version should disappear from UI
