### PR TITLE
Deadline: make prerender check safer

### DIFF
--- a/openpype/modules/deadline/plugins/publish/submit_publish_job.py
+++ b/openpype/modules/deadline/plugins/publish/submit_publish_job.py
@@ -825,7 +825,8 @@ class ProcessSubmittedJobOnFarm(pyblish.api.InstancePlugin):
             ).format(source))
 
         family = "render"
-        if "prerender" in instance.data["families"]:
+        if ("prerender" in instance.data["families"] or
+                "prerender.farm" in instance.data["families"]):
             family = "prerender"
         families = [family]
 


### PR DESCRIPTION
## Changelog Description
Prerender wasn't correctly recognized and was replaced with just 'render' family.

In Nuke it is correctly `prerender.farm` in families, which wasn't handled here. It resulted into using `render` in templates even if `render` and `prerender` templates were split.

## Additional info
Eventually this query should be simplified only to `prerender.farm`, but this way it is safer for now.

## Testing notes:
1. Publish `prerender` in Nuke via Deadline
2. check metadata.json in `work` folder, families need to contain `prerender`
