### PR TITLE
General: Sort launcher actions alphabetically

### DIFF
--- a/openpype/tools/launcher/models.py
+++ b/openpype/tools/launcher/models.py
@@ -273,7 +273,7 @@ class ActionModel(QtGui.QStandardItemModel):
         # Sort by order and name
         return sorted(
             compatible,
-            key=lambda action: (action.order, action.name)
+            key=lambda action: (action.order, lib.get_action_label(action))
         )
 
     def update_force_not_open_workfile_settings(self, is_checked, action_id):


### PR DESCRIPTION
## Changelog Description
The launcher actions weren't being sorted by its label but its name (which on the case of the apps it's the version number) and thus the order wasn't consistent and we kept getting a different order on every launch. From my debugging session, this was the result of what the `actions` variable held after the `filter_compatible_actions` function before these changes:
```
(Pdb) for p in actions: print(p.order, p.name)
0 14-02
0 14-02
0 14-02
0 14-02
0 14-02
0 19-5-493
0 2023
0 3-41
0 6-01
```
This caused already a couple bugs from our artists thinking they had launched Nuke X and instead launched Nuke and telling us their Nuke was missing nodes

**Before:**
![image](https://github.com/ynput/OpenPype/assets/4348536/66ef4b3a-37ed-4a62-bdcc-40e92cab37cb)

**After:**
<img width="259" alt="image" src="https://github.com/ynput/OpenPype/assets/4348536/7aa0f439-a36a-489e-9718-08aa4b074488">

## Testing notes:
1. Start the launcher and check the order of the apps
