### PR TITLE
General: CLI addon command

### DIFF
--- a/openpype/cli.py
+++ b/openpype/cli.py
@@ -71,12 +71,12 @@ def tray():
 
 
 @PypeCommands.add_modules
-@main.group(help="Run command line arguments of OpenPype modules")
+@main.group(help="Run command line arguments of OpenPype addons")
 @click.pass_context
 def module(ctx):
-    """Module specific commands created dynamically.
+    """Addon specific commands created dynamically.
 
-    These commands are generated dynamically by currently loaded addon/modules.
+    These commands are generated dynamically by currently loaded addons.
     """
     pass
 

--- a/openpype/cli.py
+++ b/openpype/cli.py
@@ -5,11 +5,24 @@ import sys
 import code
 import click
 
-# import sys
 from .pype_commands import PypeCommands
 
 
-@click.group(invoke_without_command=True)
+class AliasedGroup(click.Group):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self._aliases = {}
+
+    def set_alias(self, src_name, dst_name):
+        self._aliases[dst_name] = src_name
+
+    def get_command(self, ctx, cmd_name):
+        if cmd_name in self._aliases:
+            cmd_name = self._aliases[cmd_name]
+        return super().get_command(ctx, cmd_name)
+
+
+@click.group(cls=AliasedGroup, invoke_without_command=True)
 @click.pass_context
 @click.option("--use-version",
               expose_value=False, help="use specified version")
@@ -66,6 +79,9 @@ def module(ctx):
     These commands are generated dynamically by currently loaded addon/modules.
     """
     pass
+
+# Add 'addon' as alias for module
+main.set_alias("module", "addon")
 
 
 @main.command()

--- a/openpype/cli.py
+++ b/openpype/cli.py
@@ -80,6 +80,7 @@ def module(ctx):
     """
     pass
 
+
 # Add 'addon' as alias for module
 main.set_alias("module", "addon")
 


### PR DESCRIPTION
## Changelog Description
Added `addon` alias for `module` in OpenPype cli commands.

## Testing notes:
1. Choose addon cli command of your will e.g. traypublisher
2. Replace `module` with `addon` in the command e.g. `openpype_console addon traypublisher launch`
3. It should work