### PR TITLE
Enhancement:animation family loaded as standing (abc) uses "use file sequence"

### DIFF
--- a/openpype/hosts/maya/plugins/load/load_arnold_standin.py
+++ b/openpype/hosts/maya/plugins/load/load_arnold_standin.py
@@ -16,10 +16,13 @@ from openpype.hosts.maya.api.pipeline import containerise
 
 def is_sequence(files):
     sequence = False
-    collections, remainder = clique.assemble(files)
+    print("here calling")
+    if len(files) == 1:
+        collections, remainder = clique.assemble(files, minimum_items=1)
+    else:
+        collections, remainder = clique.assemble(files)
     if collections:
         sequence = True
-
     return sequence
 
 
@@ -84,6 +87,7 @@ class ArnoldStandinLoader(load.LoaderPlugin):
             sequence = is_sequence(os.listdir(os.path.dirname(self.fname)))
             cmds.setAttr(standin_shape + ".useFrameExtension", sequence)
 
+
         nodes = [root, standin, standin_shape]
         if operator is not None:
             nodes.append(operator)
@@ -146,6 +150,10 @@ class ArnoldStandinLoader(load.LoaderPlugin):
             os.path.basename(path),
             type="string"
         )
+        print("#"*100)
+
+
+        # Object name value
 
         cmds.connectAttr(
             string_replace_operator + ".out",

--- a/openpype/hosts/maya/plugins/load/load_arnold_standin.py
+++ b/openpype/hosts/maya/plugins/load/load_arnold_standin.py
@@ -90,7 +90,7 @@ class ArnoldStandinLoader(load.LoaderPlugin):
             sequence = is_sequence(os.listdir(os.path.dirname(self.fname)))
             cmds.setAttr(standin_shape + ".useFrameExtension", sequence)
 
-            fps = float(version["data"].get("fps")) or get_current_session_fps()
+            fps = float(version["data"].get("fps"))or get_current_session_fps()
             cmds.setAttr(standin_shape + ".abcFPS", fps)
 
         nodes = [root, standin, standin_shape]

--- a/openpype/hosts/maya/plugins/load/load_arnold_standin.py
+++ b/openpype/hosts/maya/plugins/load/load_arnold_standin.py
@@ -27,6 +27,7 @@ def is_sequence(files):
         sequence = True
     return sequence
 
+
 def get_current_fps():
     session_fps = float(legacy_io.Session.get('AVALON_FPS', 25))
     return convert_to_maya_fps(session_fps)

--- a/openpype/hosts/maya/plugins/load/load_arnold_standin.py
+++ b/openpype/hosts/maya/plugins/load/load_arnold_standin.py
@@ -17,7 +17,6 @@ from openpype.hosts.maya.api.lib import (
 )
 from openpype.hosts.maya.api.pipeline import containerise
 
-
 def is_sequence(files):
     sequence = False
     if len(files) == 1:
@@ -27,13 +26,6 @@ def is_sequence(files):
     if collections:
         sequence = True
     return sequence
-
-def get_fps(standin_shape):
-
-    fps = convert_to_maya_fps(
-            float(legacy_io.Session.get("AVALON_FPS", 25))
-        )
-    return fps
 
 class ArnoldStandinLoader(load.LoaderPlugin):
     """Load as Arnold standin"""
@@ -96,9 +88,8 @@ class ArnoldStandinLoader(load.LoaderPlugin):
             sequence = is_sequence(os.listdir(os.path.dirname(self.fname)))
             cmds.setAttr(standin_shape + ".useFrameExtension", sequence)
 
-            cmds.setAttr(standin_shape + ".dso", path, type="string")
-            matching_fps = get_fps(os.listdir(os.path.dirname(self.fname)))
-            cmds.setAttr(standin_shape + ".abcFPS", matching_fps)
+            fps = float(version["data"]["fps"])
+            cmds.setAttr(standin_shape + ".abcFPS", fps)
 
         nodes = [root, standin, standin_shape]
         if operator is not None:

--- a/openpype/hosts/maya/plugins/load/load_arnold_standin.py
+++ b/openpype/hosts/maya/plugins/load/load_arnold_standin.py
@@ -90,7 +90,7 @@ class ArnoldStandinLoader(load.LoaderPlugin):
             sequence = is_sequence(os.listdir(os.path.dirname(self.fname)))
             cmds.setAttr(standin_shape + ".useFrameExtension", sequence)
 
-            fps = float(version["data"].get("fps"), get_current_fps())
+            fps = float(version["data"].get("fps")) or get_current_fps()
             cmds.setAttr(standin_shape + ".abcFPS", fps)
 
         nodes = [root, standin, standin_shape]

--- a/openpype/hosts/maya/plugins/load/load_arnold_standin.py
+++ b/openpype/hosts/maya/plugins/load/load_arnold_standin.py
@@ -6,10 +6,11 @@ import maya.cmds as cmds
 from openpype.settings import get_project_settings
 from openpype.pipeline import (
     load,
+    legacy_io,
     get_representation_path
 )
 from openpype.hosts.maya.api.lib import (
-    unique_namespace, get_attribute_input, maintained_selection
+    unique_namespace, get_attribute_input, maintained_selection, convert_to_maya_fps
 )
 from openpype.hosts.maya.api.pipeline import containerise
 
@@ -23,6 +24,17 @@ def is_sequence(files):
     if collections:
         sequence = True
     return sequence
+
+#get the fps from the project itself
+def get_fps(standin_shape):
+
+    fps = convert_to_maya_fps(
+            float(legacy_io.Session.get("AVALON_FPS", 25))
+        )
+    return fps
+
+    
+
 
 
 class ArnoldStandinLoader(load.LoaderPlugin):
@@ -85,7 +97,10 @@ class ArnoldStandinLoader(load.LoaderPlugin):
             cmds.setAttr(standin_shape + ".dso", path, type="string")
             sequence = is_sequence(os.listdir(os.path.dirname(self.fname)))
             cmds.setAttr(standin_shape + ".useFrameExtension", sequence)
-            cmds.setAttr(standin_shape + ".abcFPS", 30)
+
+            cmds.setAttr(standin_shape + ".dso", path, type="string")
+            matching_fps = get_fps(os.listdir(os.path.dirname(self.fname)))
+            cmds.setAttr(standin_shape + ".abcFPS", matching_fps)
 
         nodes = [root, standin, standin_shape]
         if operator is not None:

--- a/openpype/hosts/maya/plugins/load/load_arnold_standin.py
+++ b/openpype/hosts/maya/plugins/load/load_arnold_standin.py
@@ -25,7 +25,7 @@ def is_sequence(files):
     return sequence
 
 
-def get_current_fps():
+def get_current_session_fps():
     session_fps = float(legacy_io.Session.get('AVALON_FPS', 25))
     return convert_to_maya_fps(session_fps)
 
@@ -90,7 +90,7 @@ class ArnoldStandinLoader(load.LoaderPlugin):
             sequence = is_sequence(os.listdir(os.path.dirname(self.fname)))
             cmds.setAttr(standin_shape + ".useFrameExtension", sequence)
 
-            fps = float(version["data"].get("fps")) or get_current_fps()
+            fps = float(version["data"].get("fps")) or get_current_session_fps()
             cmds.setAttr(standin_shape + ".abcFPS", fps)
 
         nodes = [root, standin, standin_shape]

--- a/openpype/hosts/maya/plugins/load/load_arnold_standin.py
+++ b/openpype/hosts/maya/plugins/load/load_arnold_standin.py
@@ -10,7 +10,10 @@ from openpype.pipeline import (
     get_representation_path
 )
 from openpype.hosts.maya.api.lib import (
-    unique_namespace, get_attribute_input, maintained_selection, convert_to_maya_fps
+    unique_namespace, 
+    get_attribute_input, 
+    maintained_selection, 
+    convert_to_maya_fps
 )
 from openpype.hosts.maya.api.pipeline import containerise
 
@@ -25,17 +28,12 @@ def is_sequence(files):
         sequence = True
     return sequence
 
-#get the fps from the project itself
 def get_fps(standin_shape):
 
     fps = convert_to_maya_fps(
             float(legacy_io.Session.get("AVALON_FPS", 25))
         )
     return fps
-
-    
-
-
 
 class ArnoldStandinLoader(load.LoaderPlugin):
     """Load as Arnold standin"""

--- a/openpype/hosts/maya/plugins/load/load_arnold_standin.py
+++ b/openpype/hosts/maya/plugins/load/load_arnold_standin.py
@@ -27,6 +27,10 @@ def is_sequence(files):
         sequence = True
     return sequence
 
+def get_current_fps():
+    session_fps = float(legacy_io.Session.get('AVALON_FPS', 25))
+    return convert_to_maya_fps(session_fps)
+
 class ArnoldStandinLoader(load.LoaderPlugin):
     """Load as Arnold standin"""
 
@@ -88,7 +92,9 @@ class ArnoldStandinLoader(load.LoaderPlugin):
             sequence = is_sequence(os.listdir(os.path.dirname(self.fname)))
             cmds.setAttr(standin_shape + ".useFrameExtension", sequence)
 
-            fps = float(version["data"]["fps"])
+            fps = float(version["data"].get("fps"))
+            if fps is None:
+                fps = get_current_fps()
             cmds.setAttr(standin_shape + ".abcFPS", fps)
 
         nodes = [root, standin, standin_shape]

--- a/openpype/hosts/maya/plugins/load/load_arnold_standin.py
+++ b/openpype/hosts/maya/plugins/load/load_arnold_standin.py
@@ -10,9 +10,9 @@ from openpype.pipeline import (
     get_representation_path
 )
 from openpype.hosts.maya.api.lib import (
-    unique_namespace, 
-    get_attribute_input, 
-    maintained_selection, 
+    unique_namespace,
+    get_attribute_input,
+    maintained_selection,
     convert_to_maya_fps
 )
 from openpype.hosts.maya.api.pipeline import containerise

--- a/openpype/hosts/maya/plugins/load/load_arnold_standin.py
+++ b/openpype/hosts/maya/plugins/load/load_arnold_standin.py
@@ -19,10 +19,7 @@ from openpype.hosts.maya.api.pipeline import containerise
 
 def is_sequence(files):
     sequence = False
-    if len(files) == 1:
-        collections, remainder = clique.assemble(files, minimum_items=1)
-    else:
-        collections, remainder = clique.assemble(files)
+    collections, remainder = clique.assemble(files, minimum_items=1)
     if collections:
         sequence = True
     return sequence
@@ -93,9 +90,7 @@ class ArnoldStandinLoader(load.LoaderPlugin):
             sequence = is_sequence(os.listdir(os.path.dirname(self.fname)))
             cmds.setAttr(standin_shape + ".useFrameExtension", sequence)
 
-            fps = float(version["data"].get("fps"))
-            if fps is None:
-                fps = get_current_fps()
+            fps = float(version["data"].get("fps"), get_current_fps())
             cmds.setAttr(standin_shape + ".abcFPS", fps)
 
         nodes = [root, standin, standin_shape]
@@ -161,7 +156,6 @@ class ArnoldStandinLoader(load.LoaderPlugin):
             type="string"
         )
 
-        # Object name value
         cmds.connectAttr(
             string_replace_operator + ".out",
             "{}.inputs[{}]".format(

--- a/openpype/hosts/maya/plugins/load/load_arnold_standin.py
+++ b/openpype/hosts/maya/plugins/load/load_arnold_standin.py
@@ -16,7 +16,6 @@ from openpype.hosts.maya.api.pipeline import containerise
 
 def is_sequence(files):
     sequence = False
-    print("here calling")
     if len(files) == 1:
         collections, remainder = clique.assemble(files, minimum_items=1)
     else:
@@ -86,7 +85,7 @@ class ArnoldStandinLoader(load.LoaderPlugin):
             cmds.setAttr(standin_shape + ".dso", path, type="string")
             sequence = is_sequence(os.listdir(os.path.dirname(self.fname)))
             cmds.setAttr(standin_shape + ".useFrameExtension", sequence)
-
+            cmds.setAttr(standin_shape + ".abcFPS", 30)
 
         nodes = [root, standin, standin_shape]
         if operator is not None:
@@ -150,11 +149,8 @@ class ArnoldStandinLoader(load.LoaderPlugin):
             os.path.basename(path),
             type="string"
         )
-        print("#"*100)
-
 
         # Object name value
-
         cmds.connectAttr(
             string_replace_operator + ".out",
             "{}.inputs[{}]".format(


### PR DESCRIPTION
## Changelog Description
The changes are the following. We started by updating the the is_sequence(files) function allowing it to return True for a list of files which has only one file, since our animation in this provides just one alembic file. For the correct FPS number, we got the fps from the published ass/abc from the version data.


## Testing notes:
Load the animation with abc format with Maya


