### PR TITLE
3dsmax: Move from deprecated interface

### DIFF
--- a/openpype/hosts/max/api/pipeline.py
+++ b/openpype/hosts/max/api/pipeline.py
@@ -6,7 +6,7 @@ from operator import attrgetter
 
 import json
 
-from openpype.host import HostBase, IWorkfileHost, ILoadHost, INewPublisher
+from openpype.host import HostBase, IWorkfileHost, ILoadHost, IPublishHost
 import pyblish.api
 from openpype.pipeline import (
     register_creator_plugin_path,
@@ -28,7 +28,7 @@ CREATE_PATH = os.path.join(PLUGINS_DIR, "create")
 INVENTORY_PATH = os.path.join(PLUGINS_DIR, "inventory")
 
 
-class MaxHost(HostBase, IWorkfileHost, ILoadHost, INewPublisher):
+class MaxHost(HostBase, IWorkfileHost, ILoadHost, IPublishHost):
 
     name = "max"
     menu = None


### PR DESCRIPTION
## Changelog Description
`INewPublisher` interface is deprecated, this PR is changing the use to `IPublishHost` instead.

## Additional info
This shouldn't affect functionality and it should allow to remove `INewPublisher` from code as 3dsmax integration was its last use.

## Testing notes:
1. open 3dsmax
2. try to publish something
