### PR TITLE
AYON: Global environments key fix

### DIFF
--- a/openpype/settings/ayon_settings.py
+++ b/openpype/settings/ayon_settings.py
@@ -155,7 +155,7 @@ def _convert_general(ayon_settings, output, default_settings):
         "log_to_server": False,
         "studio_name": core_settings["studio_name"],
         "studio_code": core_settings["studio_code"],
-        "environments": environments
+        "environment": environments
     })
     output["general"] = general
 


### PR DESCRIPTION
## Changelog Description
Seems that when converting ayon settings to OP settings the `environments` setting is put under the `environments` key in `general` however when populating the environment the `environment` key gets picked up, which does not contain the environment variables from the `core/environments` setting

![image](https://github.com/ynput/OpenPype/assets/72554834/4e0fbb3c-57f5-493b-a567-f1c2582c7575)

