### PR TITLE
Keep `publisher.create_widget` variant when creating subsets

### DIFF
--- a/openpype/tools/publisher/widgets/create_widget.py
+++ b/openpype/tools/publisher/widgets/create_widget.py
@@ -828,6 +828,7 @@ class CreateWidget(QtWidgets.QWidget):
 
         if success:
             self._set_creator(self._selected_creator)
+            self.variant_input.setText(variant)
             self._controller.emit_card_message("Creation finished...")
             self._last_thumbnail_path = None
             self._thumbnail_widget.set_current_thumbnails()


### PR DESCRIPTION
Whenever a person is creating a subset to publish, the "creator" widget resets (where you choose the variant, product, etc.) so if the person is publishing several images of the a variant which is not the default one, they have to keep selecting the correct one after every "create".

This commit resets the original variant upon successful creation of a subset for publishing.

Demo:
[Screencast from 2023-06-08 10-46-40.webm](https://github.com/ynput/OpenPype/assets/1800151/ca1c91d4-b8f3-43d2-a7b7-35987f5b6a3f)

## Testing notes:
1. Launch AYON/OP
2. Launch the publisher (select a project, shot, etc.)
3. Crete a publish type (any works)
4. Choose a variant for the publish that is not the default
5. "Create >>"

The Variant fields should still have the variant you choose.


