### PR TITLE
add label to matching family

### DIFF
--- a/openpype/tools/creator/model.py
+++ b/openpype/tools/creator/model.py
@@ -54,8 +54,8 @@ class CreatorsModel(QtGui.QStandardItemModel):
             item_id = index.data(ITEM_ID_ROLE)
             creator_plugin = self._creators_by_id.get(item_id)
             if creator_plugin and (
-                creator_plugin.label.lower() == family.lower() or
-                creator_plugin.family.lower() == family.lower()
+                creator_plugin.label.lower() == family.lower()
+                or creator_plugin.family.lower() == family.lower()
             ):
                 indexes.append(index)
         return indexes

--- a/openpype/tools/creator/model.py
+++ b/openpype/tools/creator/model.py
@@ -53,6 +53,9 @@ class CreatorsModel(QtGui.QStandardItemModel):
             index = self.index(row, 0)
             item_id = index.data(ITEM_ID_ROLE)
             creator_plugin = self._creators_by_id.get(item_id)
-            if creator_plugin and creator_plugin.family == family:
+            if creator_plugin and (
+                creator_plugin.label.lower() == family.lower() or
+                creator_plugin.family.lower() == family.lower()
+            ):
                 indexes.append(index)
         return indexes


### PR DESCRIPTION
## Changelog Description
I added the possibility to filter the `family smart select` with the label in addition to the family.

## Additional info
The family smart select does not work with the default settings and it is not intuitive for users to have to know the family instead of the family label.

## Testing notes:

With the default settings (to test this new add):
1. open a light task in maya
2. open the creator interface
3. if it works Render is selected

To test the legacy code change the family smart select option from `render` to `rendering`:
1. open a light task in maya
2. open the creator interface
3. if it works Render is selected
