### PR TITLE
Workfile Builder UI: Workfile builder window is not modal

### DIFF
--- a/openpype/hosts/maya/api/workfile_template_builder.py
+++ b/openpype/hosts/maya/api/workfile_template_builder.py
@@ -14,7 +14,7 @@ from openpype.tools.workfile_template_build import (
     WorkfileBuildPlaceholderDialog,
 )
 
-from .lib import read, imprint
+from .lib import read, imprint, get_main_window
 
 PLACEHOLDER_SET = "PLACEHOLDERS_SET"
 
@@ -319,8 +319,9 @@ def update_workfile_template(*args):
 def create_placeholder(*args):
     host = registered_host()
     builder = MayaTemplateBuilder(host)
-    window = WorkfileBuildPlaceholderDialog(host, builder)
-    window.exec_()
+    window = WorkfileBuildPlaceholderDialog(host, builder,
+                                            parent=get_main_window())
+    window.show()
 
 
 def update_placeholder(*args):
@@ -343,6 +344,7 @@ def update_placeholder(*args):
         raise ValueError("Too many selected nodes")
 
     placeholder_item = placeholder_items[0]
-    window = WorkfileBuildPlaceholderDialog(host, builder)
+    window = WorkfileBuildPlaceholderDialog(host, builder,
+                                            parent=get_main_window())
     window.set_update_mode(placeholder_item)
     window.exec_()

--- a/openpype/hosts/maya/api/workfile_template_builder.py
+++ b/openpype/hosts/maya/api/workfile_template_builder.py
@@ -226,7 +226,7 @@ class MayaPlaceholderLoadPlugin(PlaceholderPlugin, PlaceholderLoadMixin):
             if placeholder_data.get("plugin_identifier") != self.identifier:
                 continue
 
-            # TODO do data validations and maybe updgrades if are invalid
+            # TODO do data validations and maybe upgrades if they are invalid
             output.append(
                 LoadPlaceholderItem(node_name, placeholder_data, self)
             )

--- a/openpype/hosts/maya/api/workfile_template_builder.py
+++ b/openpype/hosts/maya/api/workfile_template_builder.py
@@ -173,44 +173,37 @@ class MayaPlaceholderLoadPlugin(PlaceholderPlugin, PlaceholderLoadMixin):
 
     def create_placeholder(self, placeholder_data):
         selection = cmds.ls(selection=True)
-        if not selection:
-            raise ValueError("Nothing is selected")
         if len(selection) > 1:
             raise ValueError("More then one item are selected")
+
+        parent = selection[0] if selection else None
 
         placeholder_data["plugin_identifier"] = self.identifier
 
         placeholder_name = self._create_placeholder_name(placeholder_data)
 
         placeholder = cmds.spaceLocator(name=placeholder_name)[0]
-        # TODO: this can crash if selection can't be used
-        cmds.parent(placeholder, selection[0])
+        if parent:
+            placeholder = cmds.parent(placeholder, selection[0])[0]
 
-        # get the long name of the placeholder (with the groups)
-        placeholder_full_name = (
-            cmds.ls(selection[0], long=True)[0]
-            + "|"
-            + placeholder.replace("|", "")
-        )
-
-        imprint(placeholder_full_name, placeholder_data)
+        imprint(placeholder, placeholder_data)
 
         # Add helper attributes to keep placeholder info
         cmds.addAttr(
-            placeholder_full_name,
+            placeholder,
             longName="parent",
             hidden=True,
             dataType="string"
         )
         cmds.addAttr(
-            placeholder_full_name,
+            placeholder,
             longName="index",
             hidden=True,
             attributeType="short",
             defaultValue=-1
         )
 
-        cmds.setAttr(placeholder_full_name + ".parent", "", type="string")
+        cmds.setAttr(placeholder + ".parent", "", type="string")
 
     def update_placeholder(self, placeholder_item, placeholder_data):
         node_name = placeholder_item.scene_identifier

--- a/openpype/hosts/nuke/api/workfile_template_builder.py
+++ b/openpype/hosts/nuke/api/workfile_template_builder.py
@@ -25,6 +25,7 @@ from .lib import (
     select_nodes,
     duplicate_node,
     node_tempfile,
+    get_main_window
 )
 
 PLACEHOLDER_SET = "PLACEHOLDERS_SET"
@@ -963,8 +964,9 @@ def update_workfile_template(*args):
 def create_placeholder(*args):
     host = registered_host()
     builder = NukeTemplateBuilder(host)
-    window = WorkfileBuildPlaceholderDialog(host, builder)
-    window.exec_()
+    window = WorkfileBuildPlaceholderDialog(host, builder,
+                                            parent=get_main_window())
+    window.show()
 
 
 def update_placeholder(*args):
@@ -988,6 +990,7 @@ def update_placeholder(*args):
         raise ValueError("Too many selected nodes")
 
     placeholder_item = placeholder_items[0]
-    window = WorkfileBuildPlaceholderDialog(host, builder)
+    window = WorkfileBuildPlaceholderDialog(host, builder,
+                                            parent=get_main_window())
     window.set_update_mode(placeholder_item)
     window.exec_()

--- a/openpype/tools/workfile_template_build/window.py
+++ b/openpype/tools/workfile_template_build/window.py
@@ -220,7 +220,6 @@ class WorkfileBuildPlaceholderDialog(QtWidgets.QDialog):
         # TODO much better error handling
         try:
             plugin.create_placeholder(options)
-            self.accept()
         except Exception:
             self.log.warning("Something went wrong", exc_info=True)
             dialog = QtWidgets.QMessageBox(self)


### PR DESCRIPTION
## Changelog Description

Workfile Templates Builder:

1. Create dialog is not a modal dialog
2. Create dialog remains open after create, so you can directly create a new placeholder with similar settings 
3. In Maya allow to create root level placeholders (no selection during create) - **this felt more like a bugfix than anything else.**

## Additional info

Minor tweaks to workfile template creation.

## Testing notes:

1. Test creating and using of workfile templates (in particular in Maya and Nuke)