### PR TITLE
Nuke: Allow for more complex temp rendering paths

### DIFF
--- a/openpype/hosts/nuke/api/lib.py
+++ b/openpype/hosts/nuke/api/lib.py
@@ -1302,10 +1302,7 @@ def create_write_node(
     fdir = str(anatomy_filled["work"]["folder"]).replace("\\", "/")
     fpath = data["fpath_template"].format(
         work=fdir,
-        version=data["version"],
-        subset=data["subset"],
-        frame=data["frame"],
-        ext=ext
+        **data,
     )
 
     # create directory

--- a/openpype/hosts/nuke/api/lib.py
+++ b/openpype/hosts/nuke/api/lib.py
@@ -2051,7 +2051,7 @@ class WorkfileSettings(object):
             self._root_node["colorManagement"].setValue("OCIO")
 
         # we dont need the key anymore
-        workfile_settings.pop("customOCIOConfigPath")
+        workfile_settings.pop("customOCIOConfigPath", None)
         workfile_settings.pop("colorManagement")
         workfile_settings.pop("OCIO_config")
 


### PR DESCRIPTION
## Changelog Description
When changing the temporary rendering template (i.e., add `{asset}` to the path) to something a bit more complex the formatting was erroring due to missing keys.

## Additional info
This also adds a small bug fix that I encountered when running latest develop where `customOCIOConfigPath` key was missing from the workfile_settings. Any idea why that's the case?

## Testing notes:
1. Change the Nuke temporary render path template and add `{asset}` key somewhere
2. Create a new render instance
