### PR TITLE
Blender: Add support for custom path for app templates

### DIFF
--- a/openpype/hosts/blender/api/lib.py
+++ b/openpype/hosts/blender/api/lib.py
@@ -138,7 +138,18 @@ def set_app_templates_path():
     # Blender requires the app templates to be in `BLENDER_USER_SCRIPTS`.
     # After running Blender, we set that variable to our custom path, so
     # that the user can use their custom app templates.
-    app_templates_path = os.environ.get("OPENPYPE_APP_TEMPLATES_PATH")
+
+    # We look among the scripts paths for one of the paths that contains
+    # the app templates. The path must contain the subfolder
+    # `startup/bl_app_templates_user`.
+    paths = os.environ.get("OPENPYPE_BLENDER_USER_SCRIPTS").split(os.pathsep)
+
+    app_templates_path = None
+    for path in paths:
+        if os.path.isdir(
+                os.path.join(path, "startup", "bl_app_templates_user")):
+            app_templates_path = path
+            break
 
     if app_templates_path and os.path.isdir(app_templates_path):
         os.environ["BLENDER_USER_SCRIPTS"] = app_templates_path

--- a/openpype/hosts/blender/api/lib.py
+++ b/openpype/hosts/blender/api/lib.py
@@ -134,6 +134,16 @@ def append_user_scripts():
         traceback.print_exc()
 
 
+def set_app_templates_path():
+    # Blender requires the app templates to be in `BLENDER_USER_SCRIPTS`.
+    # After running Blender, we set that variable to our custom path, so
+    # that the user can use their custom app templates.
+    app_templates_path = os.environ.get("OPENPYPE_APP_TEMPLATES_PATH")
+
+    if app_templates_path and os.path.isdir(app_templates_path):
+        os.environ["BLENDER_USER_SCRIPTS"] = app_templates_path
+
+
 def imprint(node: bpy.types.bpy_struct_meta_idprop, data: Dict):
     r"""Write `data` to `node` as userDefined attributes
 

--- a/openpype/hosts/blender/api/pipeline.py
+++ b/openpype/hosts/blender/api/pipeline.py
@@ -60,6 +60,7 @@ def install():
     register_creator_plugin_path(str(CREATE_PATH))
 
     lib.append_user_scripts()
+    lib.set_app_templates_path()
 
     register_event_callback("new", on_new)
     register_event_callback("open", on_open)


### PR DESCRIPTION
## Changelog Description
This PR adds support for a custom [App Templates](https://docs.blender.org/manual/en/dev/advanced/app_templates.html) path in Blender by setting the `BLENDER_USER_SCRIPTS` environment variable to the path specified in `OPENPYPE_APP_TEMPLATES_PATH`. This allows users to use their own custom app templates in Blender.

## Testing notes:
1. Set the `OPENPYPE_APP_TEMPLATES_PATH` environment variable to a directory containing custom app templates.
2. Launch Blender and check that the custom app templates are available in the "New" menu.