### PR TITLE
Save the filter selection for family in loader interface  only 

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -35,6 +35,7 @@ body:
       label: Version
       description: What version are you running? Look to OpenPype Tray
       options:
+        - 3.15.10
         - 3.15.10-nightly.2
         - 3.15.10-nightly.1
         - 3.15.9
@@ -134,7 +135,6 @@ body:
         - 3.14.3-nightly.4
         - 3.14.3-nightly.3
         - 3.14.3-nightly.2
-        - 3.14.3-nightly.1
     validations:
       required: true
   - type: dropdown

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -35,6 +35,7 @@ body:
       label: Version
       description: What version are you running? Look to OpenPype Tray
       options:
+        - 3.15.11-nightly.1
         - 3.15.10
         - 3.15.10-nightly.2
         - 3.15.10-nightly.1
@@ -134,7 +135,6 @@ body:
         - 3.14.3-nightly.5
         - 3.14.3-nightly.4
         - 3.14.3-nightly.3
-        - 3.14.3-nightly.2
     validations:
       required: true
   - type: dropdown

--- a/openpype/tools/loader/widgets.py
+++ b/openpype/tools/loader/widgets.py
@@ -1057,12 +1057,8 @@ class FamilyListView(QtWidgets.QListView):
         family_model.dataChanged.connect(self._on_data_change)
         self.customContextMenuRequested.connect(self._on_context_menu)
 
-
         self._family_model = family_model
         self._proxy_model = proxy_model
-
-        # self.set_last_families(self._last_families_setting)
-
 
     def set_enabled_families(self, families):
         self._proxy_model.set_enabled_families(families)
@@ -1132,8 +1128,6 @@ class FamilyListView(QtWidgets.QListView):
         else:
             state = QtCore.Qt.Unchecked
 
-        # self.blockSignals(True)
-
         for index in indexes:
             index_state = checkstate_int_to_enum(
                 index.data(QtCore.Qt.CheckStateRole)
@@ -1149,8 +1143,6 @@ class FamilyListView(QtWidgets.QListView):
                     new_state = QtCore.Qt.Checked
 
             index.model().setData(index, new_state, QtCore.Qt.CheckStateRole)
-
-        # self.blockSignals(False)
 
         self.active_changed.emit(self.get_enabled_families())
 

--- a/openpype/tools/loader/widgets.py
+++ b/openpype/tools/loader/widgets.py
@@ -1040,7 +1040,7 @@ class FamilyListView(QtWidgets.QListView):
             settings = None
 
         self._settings = settings
-        self._last_families_setting = self._settings.value('enabled_families') or []
+        self._last_families_setting = self._settings.value('enabled_families')
 
         print("settings: ", settings.allKeys())
         print("enabled_families", settings.value('enabled_families'))
@@ -1099,8 +1099,7 @@ class FamilyListView(QtWidgets.QListView):
             index = model.index(row, 0)
             family = index.data(QtCore.Qt.DisplayRole)
             new_state = QtCore.Qt.Checked if family in families else QtCore.Qt.Unchecked 
-            index.model().setData(index, new_state, QtCore.Qt.CheckStateRole)
-            
+            index.model().setData(index, new_state, QtCore.Qt.CheckStateRole)  
         self.blockSignals(False)
 
     def set_all_unchecked(self):

--- a/openpype/tools/loader/widgets.py
+++ b/openpype/tools/loader/widgets.py
@@ -1033,7 +1033,6 @@ class FamilyListView(QtWidgets.QListView):
     def __init__(self, dbcon, family_config_cache, parent=None):
         super(FamilyListView, self).__init__(parent=parent)
 
-        from Qt import QtCore, QtWidgets
         try:
             settings = QtCore.QSettings("OpenPype", "FamilyList")
         except Exception:
@@ -1041,9 +1040,6 @@ class FamilyListView(QtWidgets.QListView):
 
         self._settings = settings
         self._last_families_setting = self._settings.value('enabled_families')
-
-        print("settings: ", settings.allKeys())
-        print("enabled_families", settings.value('enabled_families'))
 
         self.setSelectionMode(QtWidgets.QAbstractItemView.ExtendedSelection)
         self.setAlternatingRowColors(True)
@@ -1093,13 +1089,14 @@ class FamilyListView(QtWidgets.QListView):
     def set_last_families(self, families):
         if not families:
             return
+        self.blockSignals(True)
 
         model = self._family_model
         for row in range(model.rowCount()):
             index = model.index(row, 0)
             family = index.data(QtCore.Qt.DisplayRole)
-            new_state = QtCore.Qt.Checked if family in families else QtCore.Qt.Unchecked 
-            index.model().setData(index, new_state, QtCore.Qt.CheckStateRole)  
+            new_state = QtCore.Qt.Checked if family in families else QtCore.Qt.Unchecked
+            index.model().setData(index, new_state, QtCore.Qt.CheckStateRole)
         self.blockSignals(False)
 
     def set_all_unchecked(self):


### PR DESCRIPTION
## Changelog Description
We have changed the following file widgets.py to save the filter selection whenever you exit the OpenPype or the loader window. Using QSettings we save the user's last filter selection. We implemented as well a setter for the remaining checked families.


## Additional info
We set the new family list in the refresh method (i.e when we open the interface back up)
However, this new implementation only works on OpenPype and not on Maya as requested.

## Testing notes:
1. Open the OpenPype software, a loader window.
2. Choose a project and filter the family you want
3. Exit the software
4. Repeat step 1.