### PR TITLE
Pack project: Raise exception with reasonable message

### DIFF
--- a/openpype/lib/project_backpack.py
+++ b/openpype/lib/project_backpack.py
@@ -141,6 +141,16 @@ def pack_project(
     if not destination_dir:
         destination_dir = root_path
 
+    if not destination_dir:
+        if only_documents:
+            raise ValueError((
+                "Destination dir must be passed."
+                " Use '--dirpath {output dir path}' if using command line."
+            ))
+        raise ValueError(
+            "Project {} does not have any roots.".format(project_name)
+        )
+
     destination_dir = os.path.normpath(destination_dir)
     if not os.path.exists(destination_dir):
         os.makedirs(destination_dir)

--- a/openpype/lib/project_backpack.py
+++ b/openpype/lib/project_backpack.py
@@ -113,6 +113,12 @@ def pack_project(
             project_name
         ))
 
+    if only_documents and not destination_dir:
+        raise ValueError((
+            "Destination directory must be defined"
+            " when only documents should be packed."
+        ))
+
     root_path = None
     source_root = {}
     project_source_path = None
@@ -142,11 +148,6 @@ def pack_project(
         destination_dir = root_path
 
     if not destination_dir:
-        if only_documents:
-            raise ValueError((
-                "Destination dir must be passed."
-                " Use '--dirpath {output dir path}' if using command line."
-            ))
         raise ValueError(
             "Project {} does not have any roots.".format(project_name)
         )

--- a/openpype/pype_commands.py
+++ b/openpype/pype_commands.py
@@ -356,6 +356,13 @@ class PypeCommands:
     def pack_project(self, project_name, dirpath, database_only):
         from openpype.lib.project_backpack import pack_project
 
+        if database_only and not dirpath:
+            raise ValueError((
+                "Destination dir must be defined when using --dbonly."
+                " Use '--dirpath {output dir path}' flag"
+                " to specify directory."
+            ))
+
         pack_project(project_name, dirpath, database_only)
 
     def unpack_project(self, zip_filepath, new_root, database_only):


### PR DESCRIPTION
## Changelog Description
Pack project crashes with relevant message when destination directory is not set.

## Additional info
It did crash with cryptic error when the logic tries to create a directory from `None`.

## Testing notes:
1. Run `pack-project --project {project name} --dbonly`
2. It should crash with more specific information what to do
