### PR TITLE
Allow "inventory" actions to be supplied by a Module/Addon.

### DIFF
--- a/openpype/modules/README.md
+++ b/openpype/modules/README.md
@@ -138,7 +138,8 @@ class ClockifyModule(
  "publish": [],
  "create": [],
  "load": [],
- "actions": []
+ "actions": [],
+ "inventory": []
  }
  ```
 

--- a/openpype/modules/base.py
+++ b/openpype/modules/base.py
@@ -740,15 +740,16 @@ class ModulesManager:
         Unknown keys are logged out.
 
         Returns:
-            dict: Output is dictionary with keys "publish", "create", "load"
-                and "actions" each containing list of paths.
+            dict: Output is dictionary with keys "publish", "create", "load",
+                "actions" and "inventory" each containing list of paths.
         """
         # Output structure
         output = {
             "publish": [],
             "create": [],
             "load": [],
-            "actions": []
+            "actions": [],
+            "inventory": []
         }
         unknown_keys_by_module = {}
         for module in self.get_enabled_modules():
@@ -850,6 +851,21 @@ class ModulesManager:
 
         return self._collect_plugin_paths(
             "get_publish_plugin_paths",
+            host_name
+        )
+
+    def collect_inventory_action_paths(self, host_name):
+        """Helper to collect load plugin paths from modules.
+
+        Args:
+            host_name (str): For which host are load plugins meant.
+
+        Returns:
+            list: List of pyblish plugin paths.
+        """
+
+        return self._collect_plugin_paths(
+            "get_inventory_action_paths",
             host_name
         )
 

--- a/openpype/modules/interfaces.py
+++ b/openpype/modules/interfaces.py
@@ -33,8 +33,8 @@ class OpenPypeInterface:
 class IPluginPaths(OpenPypeInterface):
     """Module has plugin paths to return.
 
-    Expected result is dictionary with keys "publish", "create", "load" or
-    "actions" and values as list or string.
+    Expected result is dictionary with keys "publish", "create", "load",
+    "actions" or "inventory" and values as list or string.
     {
         "publish": ["path/to/publish_plugins"]
     }
@@ -108,6 +108,21 @@ class IPluginPaths(OpenPypeInterface):
         """
 
         return self._get_plugin_paths_by_type("publish")
+
+    def get_inventory_action_paths(self, host_name):
+        """Receive inventory action paths.
+
+        Give addons ability to add inventory action plugin paths.
+
+        Notes:
+           Default implementation uses 'get_plugin_paths' and always return
+               all publish plugin paths.
+
+        Args:
+           host_name (str): For which host are the plugins meant.
+        """
+
+        return self._get_plugin_paths_by_type("inventory")
 
 
 class ILaunchHookPaths(OpenPypeInterface):
@@ -397,8 +412,8 @@ class ITrayService(ITrayModule):
 class ISettingsChangeListener(OpenPypeInterface):
     """Module has plugin paths to return.
 
-    Expected result is dictionary with keys "publish", "create", "load" or
-    "actions" and values as list or string.
+    Expected result is dictionary with keys "publish", "create", "load",
+    "actions" or "inventory" and values as list or string.
     {
         "publish": ["path/to/publish_plugins"]
     }

--- a/openpype/modules/interfaces.py
+++ b/openpype/modules/interfaces.py
@@ -410,13 +410,11 @@ class ITrayService(ITrayModule):
 
 
 class ISettingsChangeListener(OpenPypeInterface):
-    """Module has plugin paths to return.
+    """Module tries to listen to settings changes.
 
-    Expected result is dictionary with keys "publish", "create", "load",
-    "actions" or "inventory" and values as list or string.
-    {
-        "publish": ["path/to/publish_plugins"]
-    }
+    Only settings changes in the current process are propagated.
+    Changes made in other processes or machines won't  trigger the callbacks.
+
     """
 
     @abstractmethod

--- a/openpype/pipeline/context_tools.py
+++ b/openpype/pipeline/context_tools.py
@@ -181,6 +181,11 @@ def install_openpype_plugins(project_name=None, host_name=None):
     for path in load_plugin_paths:
         register_loader_plugin_path(path)
 
+    inventory_action_paths = modules_manager.collect_inventory_action_paths(
+        host_name)
+    for path in inventory_action_paths:
+        register_inventory_action_path(path)
+
     if project_name is None:
         project_name = os.environ.get("AVALON_PROJECT")
 


### PR DESCRIPTION
## Changelog Description

Adds "inventory" as a possible key to the plugin paths to be returned from a module.

## Additional info

Attempts to resolve #5121
It's untested :)

## Testing notes:

See steps to reproduce in  #5121 - it should now work