### PR TITLE
Publisher: Fix save shortcut

### DIFF
--- a/openpype/tools/publisher/window.py
+++ b/openpype/tools/publisher/window.py
@@ -453,7 +453,11 @@ class PublisherWindow(QtWidgets.QDialog):
             return
 
         save_match = event.matches(QtGui.QKeySequence.Save)
-        if save_match == QtGui.QKeySequence.ExactMatch:
+        # PySide2 and PySide6 support
+        if not isinstance(save_match, bool):
+            save_match = save_match == QtGui.QKeySequence.ExactMatch
+
+        if save_match:
             if not self._controller.publish_has_started:
                 self._save_changes(True)
             event.accept()


### PR DESCRIPTION
## Changelog Description
Save shortcut should work for both PySide2 and PySide6.

## Additional info
Event key sequence match returns differnet type in PySide2 and PySide6. For PySide2 returns boolean whereas for PySide6 it is enum item (type of match).

## Testing notes:
Save in publisher using Ctrl + S should work in PySide2 and PySide6.
