### PR TITLE
Pack Project: Fix files packing

### DIFF
--- a/openpype/lib/project_backpack.py
+++ b/openpype/lib/project_backpack.py
@@ -125,6 +125,7 @@ def pack_project(
     if not only_documents:
         roots = project_doc["config"]["roots"]
         # Determine root directory of project
+        source_root = None
         source_root_name = None
         for root_name, root_value in roots.items():
             if source_root is not None:


### PR DESCRIPTION
## Changelog Description
Packing of project with files does work again.

## Additional info
Fixed variable value when checking for multiple roots.

## Testing notes:
1. Run pack project command on single root project
