### PR TITLE
Maya: Xgen multiple descriptions on single shape - OP-6039

### DIFF
--- a/openpype/hosts/maya/plugins/publish/collect_xgen.py
+++ b/openpype/hosts/maya/plugins/publish/collect_xgen.py
@@ -35,8 +35,7 @@ class CollectXgen(pyblish.api.InstancePlugin):
             connected_transform = get_attribute_input(
                 node + ".transform"
             ).split(".")[0]
-            if connected_transform not in data["xgenConnections"]:
-                data["xgenConnections"].add(connected_transform)
+            data["xgenConnections"].add(connected_transform)
 
         # Collect all files under palette root as resources.
         import xgenm

--- a/openpype/hosts/maya/plugins/publish/collect_xgen.py
+++ b/openpype/hosts/maya/plugins/publish/collect_xgen.py
@@ -30,12 +30,13 @@ class CollectXgen(pyblish.api.InstancePlugin):
         if data["xgmPalettes"]:
             data["xgmPalette"] = data["xgmPalettes"][0]
 
-        data["xgenConnections"] = {}
+        data["xgenConnections"] = []
         for node in data["xgmSubdPatches"]:
-            data["xgenConnections"][node] = {}
-            for attr in ["transform", "geometry"]:
-                input = get_attribute_input("{}.{}".format(node, attr))
-                data["xgenConnections"][node][attr] = input
+            connected_transform = get_attribute_input(
+                node + ".transform"
+            ).split(".")[0]
+            if connected_transform not in data["xgenConnections"]:
+                data["xgenConnections"].append(connected_transform)
 
         # Collect all files under palette root as resources.
         import xgenm

--- a/openpype/hosts/maya/plugins/publish/collect_xgen.py
+++ b/openpype/hosts/maya/plugins/publish/collect_xgen.py
@@ -30,7 +30,7 @@ class CollectXgen(pyblish.api.InstancePlugin):
         if data["xgmPalettes"]:
             data["xgmPalette"] = data["xgmPalettes"][0]
 
-        data["xgenConnections"] = []
+        data["xgenConnections"] = set()
         for node in data["xgmSubdPatches"]:
             connected_transform = get_attribute_input(
                 node + ".transform"

--- a/openpype/hosts/maya/plugins/publish/collect_xgen.py
+++ b/openpype/hosts/maya/plugins/publish/collect_xgen.py
@@ -36,7 +36,7 @@ class CollectXgen(pyblish.api.InstancePlugin):
                 node + ".transform"
             ).split(".")[0]
             if connected_transform not in data["xgenConnections"]:
-                data["xgenConnections"].append(connected_transform)
+                data["xgenConnections"].add(connected_transform)
 
         # Collect all files under palette root as resources.
         import xgenm

--- a/openpype/hosts/maya/plugins/publish/extract_xgen.py
+++ b/openpype/hosts/maya/plugins/publish/extract_xgen.py
@@ -51,11 +51,9 @@ class ExtractXgen(publish.Extractor):
         with delete_after() as delete_bin:
             duplicate_nodes = []
             # Collect nodes to export.
-            for _, connections in instance.data["xgenConnections"].items():
-                transform_name = connections["transform"].split(".")[0]
-
+            for node in instance.data["xgenConnections"]:
                 # Duplicate_transform subd patch geometry.
-                duplicate_transform = cmds.duplicate(transform_name)[0]
+                duplicate_transform = cmds.duplicate(node)[0]
                 delete_bin.append(duplicate_transform)
 
                 # Discard the children.

--- a/openpype/hosts/maya/plugins/publish/validate_xgen.py
+++ b/openpype/hosts/maya/plugins/publish/validate_xgen.py
@@ -61,9 +61,7 @@ class ValidateXgen(pyblish.api.InstancePlugin):
         # We need a namespace else there will be a naming conflict when
         # extracting because of stripping namespaces and parenting to world.
         node_names = [instance.data["xgmPalette"]]
-        for _, connections in instance.data["xgenConnections"].items():
-            node_names.append(connections["transform"].split(".")[0])
-
+        node_names.extend(instance.data["xgenConnections"])
         non_namespaced_nodes = [n for n in node_names if ":" not in n]
         if non_namespaced_nodes:
             raise PublishValidationError(


### PR DESCRIPTION
## Changelog Description
When having multiple descriptions on the same geometry, the extraction would produce redundant duplicate geometries.

## Testing notes:
1. Setup Maya Xgen scene with multiple descriptions on the same geometry. See below for outliner example.
![Capture](https://github.com/ynput/OpenPype/assets/1860085/48d04eb8-4d95-415d-b8bb-b4123b21fbd8)
2. Publish.
3. Load in Xgen into a new scene and validate no duplicate geometries are present.
