### PR TITLE
Maya: Xgen version mismatch after publish - OP-6204

### DIFF
--- a/openpype/hosts/maya/plugins/load/load_xgen.py
+++ b/openpype/hosts/maya/plugins/load/load_xgen.py
@@ -1,4 +1,5 @@
 import os
+import shutil
 
 import maya.cmds as cmds
 import xgenm
@@ -116,8 +117,8 @@ class XgenLoader(openpype.hosts.maya.api.plugin.ReferenceLoader):
     def update(self, container, representation):
         """Workflow for updating Xgen.
 
-        - Copy and potentially overwrite the workspace .xgen file.
         - Export changes to delta file.
+        - Copy and overwrite the workspace .xgen file.
         - Set collection attributes to not include delta files.
         - Update xgen maya file reference.
         - Apply the delta file changes.
@@ -130,6 +131,10 @@ class XgenLoader(openpype.hosts.maya.api.plugin.ReferenceLoader):
         There is an implicit increment of the xgen and delta files, due to
         using the workfile basename.
         """
+        # Storing current description to try and maintain later.
+        current_description = (
+            xgenm.xgGlobal.DescriptionEditor.currentDescription()
+        )
 
         container_node = container["objectName"]
         members = get_container_members(container_node)
@@ -160,6 +165,7 @@ class XgenLoader(openpype.hosts.maya.api.plugin.ReferenceLoader):
             data_path
         )
         data = {"xgProjectPath": project_path, "xgDataPath": data_path}
+        shutil.copy(new_xgen_file, xgen_file)
         write_xgen_file(data, xgen_file)
 
         attribute_data = {
@@ -171,3 +177,11 @@ class XgenLoader(openpype.hosts.maya.api.plugin.ReferenceLoader):
             super().update(container, representation)
 
             xgenm.applyDelta(xgen_palette.replace("|", ""), xgd_file)
+
+        # Restore current selected description if it exists.
+        if cmds.objExists(current_description):
+            xgenm.xgGlobal.DescriptionEditor.setCurrentDescription(
+                current_description
+            )
+        # Full UI refresh.
+        xgenm.xgGlobal.DescriptionEditor.refresh("Full")


### PR DESCRIPTION
## Changelog Description
Xgen was not updating correctly when for example adding or removing descriptions. This resolve the issue by overwritting the workspace xgen file.

## Testing notes:
1. Publish Xgen v1 with 1 description.
2. Load in a new Maya scene and save the workfile.
3. Make any changes on the description.
4. Publish Xgen v2 with 2 descriptions.
5. Update Xgen and validate both descriptions are present plus any changes.
