### PR TITLE
3dsmax: make code compatible with 3dsmax 2022

### DIFF
--- a/openpype/hosts/max/api/plugin.py
+++ b/openpype/hosts/max/api/plugin.py
@@ -207,7 +207,9 @@ class MaxCreator(Creator, MaxCreatorBase):
 
         """
         for instance in instances:
-            if instance_node := rt.GetNodeByName(instance.data.get("instance_node")):  # noqa
+            instance_node = rt.GetNodeByName(
+                instance.data.get("instance_node"))
+            if instance_node:
                 count = rt.custAttributes.count(instance_node)
                 rt.custAttributes.delete(instance_node, count)
                 rt.Delete(instance_node)

--- a/openpype/hosts/max/plugins/create/create_render.py
+++ b/openpype/hosts/max/plugins/create/create_render.py
@@ -24,7 +24,8 @@ class CreateRender(plugin.MaxCreator):
             instance_data,
             pre_create_data)
         container_name = instance.data.get("instance_node")
-        if sel_obj := self.selected_nodes:
+        sel_obj = self.selected_nodes
+        if sel_obj:
             # set viewport camera for rendering(mandatory for deadline)
             RenderSettings(self.project_settings).set_render_camera(sel_obj)
         # set output paths for rendering(mandatory for deadline)

--- a/openpype/hosts/max/plugins/publish/validate_camera_contents.py
+++ b/openpype/hosts/max/plugins/publish/validate_camera_contents.py
@@ -18,7 +18,8 @@ class ValidateCameraContent(pyblish.api.InstancePlugin):
                    "$Physical_Camera", "$Target"]
 
     def process(self, instance):
-        if invalid := self.get_invalid(instance):  # noqa
+        invalid = self.get_invalid(instance)
+        if invalid:
             raise PublishValidationError(("Camera instance must only include"
                                           "camera (and camera target). "
                                           f"Invalid content {invalid}"))

--- a/openpype/hosts/max/plugins/publish/validate_model_contents.py
+++ b/openpype/hosts/max/plugins/publish/validate_model_contents.py
@@ -18,7 +18,8 @@ class ValidateModelContent(pyblish.api.InstancePlugin):
     label = "Model Contents"
 
     def process(self, instance):
-        if invalid := self.get_invalid(instance):  # noqa
+        invalid = self.get_invalid(instance)
+        if invalid:
             raise PublishValidationError(("Model instance must only include"
                                           "Geometry and Editable Mesh. "
                                           f"Invalid types on: {invalid}"))

--- a/openpype/hosts/max/plugins/publish/validate_pointcloud.py
+++ b/openpype/hosts/max/plugins/publish/validate_pointcloud.py
@@ -35,12 +35,16 @@ class ValidatePointCloud(pyblish.api.InstancePlugin):
 
         """
         report = []
-        if invalid := self.get_tyflow_object(instance):  # noqa
-            report.append(f"Non tyFlow object found: {invalid}")
 
-        if invalid := self.get_tyflow_operator(instance):  # noqa
-            report.append(
-                f"tyFlow ExportParticle operator not found: {invalid}")
+        invalid_object = self.get_tyflow_object(instance)
+        if invalid_object:
+            report.append(f"Non tyFlow object found: {invalid_object}")
+
+        invalid_operator = self.get_tyflow_operator(instance)
+        if invalid_operator:
+            report.append((
+                "tyFlow ExportParticle operator not "
+                f"found: {invalid_operator}"))
 
         if self.validate_export_mode(instance):
             report.append("The export mode is not at PRT")
@@ -49,9 +53,10 @@ class ValidatePointCloud(pyblish.api.InstancePlugin):
             report.append(("tyFlow Partition setting is "
                            "not at the default value"))
 
-        if invalid := self.validate_custom_attribute(instance):  # noqa
+        invalid_attribute = self.validate_custom_attribute(instance)
+        if invalid_attribute:
             report.append(("Custom Attribute not found "
-                           f":{invalid}"))
+                           f":{invalid_attribute}"))
 
         if report:
             raise PublishValidationError(f"{report}")


### PR DESCRIPTION
## Changelog Description
Python 3.7 in 3dsmax 2022 is not supporting walrus operator. This is removing it from the code for the sake of compatibility

## Testing notes:
3dsmax functionality should work the same in 2022 and 2023
