### PR TITLE
Publisher: Edge case fixes

### DIFF
--- a/openpype/tools/publisher/control.py
+++ b/openpype/tools/publisher/control.py
@@ -398,12 +398,22 @@ class PublishReportMaker:
         exception = result.get("error")
         if exception:
             fname, line_no, func, exc = exception.traceback
+
+            # Conversion of exception into string may crash
+            try:
+                msg = str(exception)
+            except BaseException:
+                msg = (
+                    "Publisher Controller: ERROR"
+                    " - Failed to get exception message"
+                )
+
             # Action result does not have 'is_validation_error'
             is_validation_error = result.get("is_validation_error", False)
             output.append({
                 "type": "error",
                 "is_validation_error": is_validation_error,
-                "msg": str(exception),
+                "msg": msg,
                 "filename": str(fname),
                 "lineno": str(line_no),
                 "func": str(func),

--- a/openpype/tools/publisher/publish_report_viewer/model.py
+++ b/openpype/tools/publisher/publish_report_viewer/model.py
@@ -45,8 +45,13 @@ class InstancesModel(QtGui.QStandardItemModel):
             instance_items = report_item.instance_items_by_family[family]
             all_removed = True
             for instance_item in instance_items:
-                item = QtGui.QStandardItem(instance_item.label)
-                instance_label = html_escape(instance_item.label)
+                src_instance_label = instance_item.label
+                if src_instance_label is None:
+                    # Do not cause UI crash if label is 'None'
+                    src_instance_label = "No label"
+                instance_label = html_escape(src_instance_label)
+
+                item = QtGui.QStandardItem(src_instance_label)
                 item.setData(instance_label, ITEM_LABEL_ROLE)
                 item.setData(instance_item.errored, ITEM_ERRORED_ROLE)
                 item.setData(instance_item.id, ITEM_ID_ROLE)

--- a/openpype/tools/publisher/widgets/list_view_widgets.py
+++ b/openpype/tools/publisher/widgets/list_view_widgets.py
@@ -116,7 +116,12 @@ class InstanceListItemWidget(QtWidgets.QWidget):
 
         self.instance = instance
 
-        instance_label = html_escape(instance.label)
+        instance_label = instance.label
+        if instance_label is None:
+            # Do not cause UI crash if label is 'None'
+            instance_label = "No label"
+
+        instance_label = html_escape(instance_label)
 
         subset_name_label = QtWidgets.QLabel(instance_label, self)
         subset_name_label.setObjectName("ListViewSubsetName")


### PR DESCRIPTION
## Changelog Description
Fix few edge case issues that may cause issues in Publisher UI.

## Additional info
Conversion of exception to string may cause crashes, that lead to invalid state of publisher UI without any lead -> At least show message that the exception message couldn't be converted. Missing instance label caused crashes of whole publisher UI on cryptic error -> Use default label `No label` if the source label is `None`.

## Testing notes:
Both are random edge cases, usually happening because of wrong implementation.
### Exception
- Prepare custom exception that would crash during string conversion, and raise it during publishing.
```python
class MyException(Exception):
    def __str__(self):
        self._template.format(**self._data)
```
- Report and Details page should cause error.

### Instance without label
- Prepare creator that won't fill subset and label on new instance.
- In UI should be instance with `No label` label