### PR TITLE
Colorspace: host config path backward compatibility

### DIFF
--- a/openpype/hosts/nuke/api/lib.py
+++ b/openpype/hosts/nuke/api/lib.py
@@ -2069,6 +2069,35 @@ class WorkfileSettings(object):
                 log.debug("nuke.root()['{}'] changed to: {}".format(
                     knob, value_))
 
+        # set ocio config path
+        if config_data:
+            current_ocio_path = os.getenv("OCIO")
+            if current_ocio_path != config_data["path"]:
+                message = """
+It seems like there's a mismatch between the OCIO config path set in your Nuke
+settings and the actual path set in your OCIO environment.
+
+To resolve this, please follow these steps:
+1. Close Nuke if it's currently open.
+2. Reopen Nuke.
+
+Please note the paths for your reference:
+
+- The OCIO environment path currently set:
+  `{env_path}`
+
+- The path in your current Nuke settings:
+  `{settings_path}`
+
+Reopening Nuke should synchronize these paths and resolve any discrepancies.
+"""
+                nuke.message(
+                    message.format(
+                        env_path=current_ocio_path,
+                        settings_path=config_data["path"]
+                    )
+                )
+
     def set_writes_colorspace(self):
         ''' Adds correct colorspace to write node dict
 

--- a/openpype/pipeline/colorspace.py
+++ b/openpype/pipeline/colorspace.py
@@ -375,7 +375,7 @@ def get_imageio_config(
     # This is for backward compatibility.
     # TODO: in future rewrite this to be more explicit
     activate_host_color_management = imageio_host.get(
-        "activate_host_color_management", True)
+        "activate_host_color_management")
 
     # TODO: remove this in future - backward compatibility
     if activate_host_color_management is None:

--- a/openpype/pipeline/colorspace.py
+++ b/openpype/pipeline/colorspace.py
@@ -377,6 +377,10 @@ def get_imageio_config(
     activate_host_color_management = imageio_host.get(
         "activate_host_color_management", True)
 
+    # TODO: remove this in future - backward compatibility
+    if activate_host_color_management is None:
+        activate_host_color_management = host_ocio_config.get("enabled", False)
+
     if not activate_host_color_management:
         # if host settings are disabled return False because
         # it is expected that no colorspace management is needed


### PR DESCRIPTION
## Changelog Description
Old project settings overrides are now fully backward compatible. The issue with host config paths overrides were solved and now once a project used to be set to ocio_config **enabled** with found filepaths - this is now considered as activated host ocio_config paths overrides.

Nuke is having an popup dialogue which is letting know to a user that settings for config path were changed. 

## Additional info
We are having issue in hosts using prelaunch hook for OCIO environment hosts and also having Set colorspace in OpenPype menu. In case were production will change ocio config path and users are having opened hosts - they will not know about the change since we are not able to flush environment variable under running instance of host. In Nuke I was able to at least let know to artists with the popup, but we will need to do it  with more generic way. 


## Testing notes:
1. you will need to save project settings overrides on a host in commit just before the release tag 3.15.10 (97203d193abe3277cb0e95b6392667aea5490130) so you are having old settings. 
Make sure`project_settings/<host>/imageio/ocio_config/enabled` is activated and some path is added (different than the global)  
2. then close OpenPype and change branch to latest develop and open your host. 
3. notice that the OCIO config path was set via prelaunch hook and see the path in terminal 
example:
```
>>> [  Setting OCIO environment to config path: C:\projects\OP02_VFX_demo\shots\sq001\sh010\config\aces_1.2\config.ocio  ]
```
