### PR TITLE
Maya: Xgen export of Abc's during Render Publishing - OP-6206

### DIFF
--- a/openpype/hosts/maya/plugins/publish/extract_workfile_xgen.py
+++ b/openpype/hosts/maya/plugins/publish/extract_workfile_xgen.py
@@ -57,7 +57,7 @@ class ExtractWorkfileXgen(publish.Extractor):
                 continue
 
             render_start_frame = instance.data["frameStart"]
-            render_end_frame = instance.data["frameStart"]
+            render_end_frame = instance.data["frameEnd"]
 
             if start_frame is None:
                 start_frame = render_start_frame

--- a/openpype/hosts/maya/plugins/publish/extract_xgen.py
+++ b/openpype/hosts/maya/plugins/publish/extract_xgen.py
@@ -88,6 +88,18 @@ class ExtractXgen(publish.Extractor):
 
             delete_bin.append(palette)
 
+            # Copy shading assignments.
+            nodes = (
+                instance.data["xgmDescriptions"] +
+                instance.data["xgmSubdPatches"]
+            )
+            for node in nodes:
+                target_node = node.split(":")[-1]
+                shading_engine = cmds.listConnections(
+                    node, type="shadingEngine"
+                )[0]
+                cmds.sets(target_node, edit=True, forceElement=shading_engine)
+
             # Export duplicated palettes.
             xgenm.exportPalette(palette, xgen_path)
 


### PR DESCRIPTION
## Changelog Description
Shading assignments was missing duplicating the setup for Xgen publishing and the exporting of patches was getting the end frame incorrectly.

## Testing notes:
1. Setup Xgen with material assignments.
3. Publish.
4. Load Xgen and animation and connect geometry.
5. Create render instance.
6. Publish.
