### PR TITLE
Unreal: get current project settings not using unreal project name

### DIFF
--- a/openpype/hosts/unreal/hooks/pre_workfile_preparation.py
+++ b/openpype/hosts/unreal/hooks/pre_workfile_preparation.py
@@ -34,6 +34,7 @@ class UnrealPrelaunchHook(PreLaunchHook):
         super().__init__(*args, **kwargs)
 
         self.signature = f"( {self.__class__.__name__} )"
+        self.project_name = self.data["project_name"]
 
     def _get_work_filename(self):
         # Use last workfile if was found
@@ -111,6 +112,7 @@ class UnrealPrelaunchHook(PreLaunchHook):
         ue_project_worker = UEProjectGenerationWorker()
         ue_project_worker.setup(
             engine_version,
+            self.project_name,
             unreal_project_name,
             engine_path,
             project_dir

--- a/openpype/hosts/unreal/hooks/pre_workfile_preparation.py
+++ b/openpype/hosts/unreal/hooks/pre_workfile_preparation.py
@@ -112,7 +112,7 @@ class UnrealPrelaunchHook(PreLaunchHook):
         ue_project_worker = UEProjectGenerationWorker()
         ue_project_worker.setup(
             engine_version,
-            self.project_name,
+            self.data["project_name"],
             unreal_project_name,
             engine_path,
             project_dir

--- a/openpype/hosts/unreal/hooks/pre_workfile_preparation.py
+++ b/openpype/hosts/unreal/hooks/pre_workfile_preparation.py
@@ -34,7 +34,6 @@ class UnrealPrelaunchHook(PreLaunchHook):
         super().__init__(*args, **kwargs)
 
         self.signature = f"( {self.__class__.__name__} )"
-        self.project_name = self.data["project_name"]
 
     def _get_work_filename(self):
         # Use last workfile if was found

--- a/openpype/hosts/unreal/lib.py
+++ b/openpype/hosts/unreal/lib.py
@@ -1,18 +1,17 @@
 # -*- coding: utf-8 -*-
 """Unreal launching and project tools."""
 
+import json
 import os
 import platform
-import json
-
+import re
+import subprocess
+from collections import OrderedDict
+from distutils import dir_util
+from pathlib import Path
 from typing import List
 
-from distutils import dir_util
-import subprocess
-import re
-from pathlib import Path
-from collections import OrderedDict
-from openpype.settings import get_project_settings
+from openpype.settings import get_current_project_settings
 
 
 def get_engine_versions(env=None):
@@ -213,7 +212,8 @@ def create_unreal_project(project_name: str,
 
     """
     env = env or os.environ
-    preset = get_project_settings(project_name)["unreal"]["project_setup"]
+
+    preset = get_current_project_settings()["unreal"]["project_setup"]
     ue_id = ".".join(ue_version.split(".")[:2])
     # get unreal engine identifier
     # -------------------------------------------------------------------------

--- a/openpype/hosts/unreal/ue_workers.py
+++ b/openpype/hosts/unreal/ue_workers.py
@@ -3,15 +3,16 @@ import os
 import platform
 import re
 import subprocess
+import tempfile
 from distutils import dir_util
+from distutils.dir_util import copy_tree
 from pathlib import Path
 from typing import List, Union
-import tempfile
-from distutils.dir_util import copy_tree
-
-import openpype.hosts.unreal.lib as ue_lib
 
 from qtpy import QtCore
+
+import openpype.hosts.unreal.lib as ue_lib
+from openpype.settings import get_current_project_settings
 
 
 def parse_comp_progress(line: str, progress_signal: QtCore.Signal(int)):
@@ -54,7 +55,7 @@ class UEProjectGenerationWorker(QtCore.QObject):
     dev_mode = False
 
     def setup(self, ue_version: str,
-              project_name,
+              unreal_project_name,
               engine_path: Path,
               project_dir: Path,
               dev_mode: bool = False,
@@ -64,14 +65,12 @@ class UEProjectGenerationWorker(QtCore.QObject):
         self.project_dir = project_dir
         self.env = env or os.environ
 
-        preset = ue_lib.get_project_settings(
-            project_name
-        )["unreal"]["project_setup"]
+        preset = get_current_project_settings()["unreal"]["project_setup"]
 
         if dev_mode or preset["dev_mode"]:
             self.dev_mode = True
 
-        self.project_name = project_name
+        self.project_name = unreal_project_name
         self.engine_path = engine_path
 
     def run(self):

--- a/openpype/hosts/unreal/ue_workers.py
+++ b/openpype/hosts/unreal/ue_workers.py
@@ -12,7 +12,7 @@ from typing import List, Union
 from qtpy import QtCore
 
 import openpype.hosts.unreal.lib as ue_lib
-from openpype.settings import get_current_project_settings
+from openpype.settings import get_project_settings
 
 
 def parse_comp_progress(line: str, progress_signal: QtCore.Signal(int)):
@@ -55,17 +55,31 @@ class UEProjectGenerationWorker(QtCore.QObject):
     dev_mode = False
 
     def setup(self, ue_version: str,
+              project_name: str,
               unreal_project_name,
               engine_path: Path,
               project_dir: Path,
               dev_mode: bool = False,
               env: dict = None):
+        """Set the worker with necessary parameters.
+
+        Args:
+            ue_version (str): Unreal Engine version.
+            project_name (str): Name of the project in AYON.
+            unreal_project_name (str): Name of the project in Unreal.
+            engine_path (Path): Path to the Unreal Engine.
+            project_dir (Path): Path to the project directory.
+            dev_mode (bool, optional): Whether to run the project in dev mode.
+                Defaults to False.
+            env (dict, optional): Environment variables. Defaults to None.
+
+        """
 
         self.ue_version = ue_version
         self.project_dir = project_dir
         self.env = env or os.environ
 
-        preset = get_current_project_settings()["unreal"]["project_setup"]
+        preset = get_project_settings(project_name)["unreal"]["project_setup"]
 
         if dev_mode or preset["dev_mode"]:
             self.dev_mode = True


### PR DESCRIPTION
## Changelog Description
There was a bug where Unreal project name was used to query project settings. But Unreal project name can differ from the "real" one because of naming convention rules set by Unreal. This is fixing it by asking for current project settings.

## Testing notes:
Creatiing new Unreal project via AYON with different name from the main project should work as expected
