### PR TITLE
Maya: import workfile missing - OP-6233

### DIFF
--- a/openpype/hosts/maya/plugins/load/actions.py
+++ b/openpype/hosts/maya/plugins/load/actions.py
@@ -93,21 +93,8 @@ class ImportMayaLoader(load.LoaderPlugin):
 
     """
     representations = ["ma", "mb", "obj"]
-    families = [
-        "model",
-        "pointcache",
-        "proxyAbc",
-        "animation",
-        "mayaAscii",
-        "mayaScene",
-        "setdress",
-        "layout",
-        "camera",
-        "rig",
-        "camerarig",
-        "staticMesh",
-        "workfile"
-    ]
+    families = ["*"]
+    excluded_families = ["xgen"]
 
     label = "Import"
     order = 10

--- a/openpype/hosts/maya/plugins/load/actions.py
+++ b/openpype/hosts/maya/plugins/load/actions.py
@@ -105,7 +105,8 @@ class ImportMayaLoader(load.LoaderPlugin):
         "camera",
         "rig",
         "camerarig",
-        "staticMesh"
+        "staticMesh",
+        "workfile"
     ]
 
     label = "Import"

--- a/openpype/hosts/maya/plugins/load/actions.py
+++ b/openpype/hosts/maya/plugins/load/actions.py
@@ -93,8 +93,21 @@ class ImportMayaLoader(load.LoaderPlugin):
 
     """
     representations = ["ma", "mb", "obj"]
-    families = ["*"]
-    excluded_families = ["xgen"]
+    families = [
+        "model",
+        "pointcache",
+        "proxyAbc",
+        "animation",
+        "mayaAscii",
+        "mayaScene",
+        "setdress",
+        "layout",
+        "camera",
+        "rig",
+        "camerarig",
+        "staticMesh",
+        "workfile"
+    ]
 
     label = "Import"
     order = 10

--- a/openpype/pipeline/load/plugins.py
+++ b/openpype/pipeline/load/plugins.py
@@ -28,6 +28,7 @@ class LoaderPlugin(list):
     """
 
     families = []
+    excluded_families = []
     representations = []
     extensions = {"*"}
     order = 0
@@ -159,7 +160,10 @@ class LoaderPlugin(list):
             return False
 
         plugin_families = set(plugin_families)
-        if "*" in plugin_families:
+
+        # Return if all families are allowed and no excluded families are
+        # defined.
+        if "*" in plugin_families and not cls.excluded_families:
             return True
 
         subset_doc = context["subset"]
@@ -175,6 +179,17 @@ class LoaderPlugin(list):
 
         if not families:
             return False
+
+        # Return if there are intersections between the subsets families and
+        # the loaders excluded families.
+        if list(set(families) & set(cls.excluded_families)):
+            return False
+
+        # Return if all families are allowed since excluded families have
+        # already been considered.
+        if "*" in plugin_families:
+            return True
+
         return any(family in plugin_families for family in families)
 
     @classmethod

--- a/openpype/pipeline/load/plugins.py
+++ b/openpype/pipeline/load/plugins.py
@@ -28,7 +28,6 @@ class LoaderPlugin(list):
     """
 
     families = []
-    excluded_families = []
     representations = []
     extensions = {"*"}
     order = 0
@@ -160,10 +159,7 @@ class LoaderPlugin(list):
             return False
 
         plugin_families = set(plugin_families)
-
-        # Return if all families are allowed and no excluded families are
-        # defined.
-        if "*" in plugin_families and not cls.excluded_families:
+        if "*" in plugin_families:
             return True
 
         subset_doc = context["subset"]
@@ -179,17 +175,6 @@ class LoaderPlugin(list):
 
         if not families:
             return False
-
-        # Return if there are intersections between the subsets families and
-        # the loaders excluded families.
-        if list(set(families) & set(cls.excluded_families)):
-            return False
-
-        # Return if all families are allowed since excluded families have
-        # already been considered.
-        if "*" in plugin_families:
-            return True
-
         return any(family in plugin_families for family in families)
 
     @classmethod


### PR DESCRIPTION
## Changelog Description
Missing `workfile` family to import.

## Testing notes:
1. Publish a workfile.
2. Import the workfile through the Loader.
