### PR TITLE
Maya: Include handles - OP-6236

### DIFF
--- a/openpype/hosts/maya/api/lib.py
+++ b/openpype/hosts/maya/api/lib.py
@@ -2297,8 +2297,8 @@ def reset_frame_range(playback=True, render=True, fps=True):
         cmds.currentTime(frame_start)
 
     if render:
-        cmds.setAttr("defaultRenderGlobals.startFrame", frame_start)
-        cmds.setAttr("defaultRenderGlobals.endFrame", frame_end)
+        cmds.setAttr("defaultRenderGlobals.startFrame", animation_start)
+        cmds.setAttr("defaultRenderGlobals.endFrame", animation_end)
 
 
 def reset_scene_resolution():


### PR DESCRIPTION
## Changelog Description
Render range was missing the handles.

## Testing notes:
1. Setup shot with handles.
2. Enable `project_settings/maya/include_handles/include_handles_default`.
3. Set frame range in Maya and validate it includes handles.
