### PR TITLE
Ftrack: Fix ignore sync filter

### DIFF
--- a/openpype/modules/ftrack/lib/avalon_sync.py
+++ b/openpype/modules/ftrack/lib/avalon_sync.py
@@ -890,7 +890,7 @@ class SyncEntitiesFactory:
             else:
                 parent_dict = self.entities_dict.get(parent_id, {})
 
-            for child_id in parent_dict.get("children", []):
+            for child_id in list(parent_dict.get("children", [])):
                 # keep original `remove` value for all children
                 _remove = (remove is True)
                 if not _remove:


### PR DESCRIPTION
## Changelog Description
Ftrack ignore filter does not crash because of dictionary modifications during it's iteration.

### Detailed description
When we trigger ftrack action **Sync to Avalon** (local or server) and we have some folders with the custom attr `avalon_ignore_sync=True`, a part of this folders are not ignore in the process.

Because we have `self.entities_dict[parent_id]["children"].remove` in the loop `for child_id in parent_dict.get("children", []):` we could missed indexes in the process.

To prevent modification of the list inside its loop we can just create a new list from `parent_dict["children"]`.