### PR TITLE
Publisher: Fix disappearing actions

### DIFF
--- a/openpype/tools/publisher/control.py
+++ b/openpype/tools/publisher/control.py
@@ -497,7 +497,9 @@ class PublishPluginsProxy:
         """
 
         return [
-            self._create_action_item(self._actions_by_id[action_id], plugin_id)
+            self._create_action_item(
+                self.get_action(plugin_id, action_id), plugin_id
+            )
             for action_id in self._action_ids_by_plugin_id[plugin_id]
         ]
 

--- a/openpype/tools/publisher/control.py
+++ b/openpype/tools/publisher/control.py
@@ -443,29 +443,29 @@ class PublishPluginsProxy:
 
     def __init__(self, plugins):
         plugins_by_id = {}
-        actions_by_id = {}
+        _actions_by_plugin_id = {}
         action_ids_by_plugin_id = {}
         for plugin in plugins:
             plugin_id = plugin.id
             plugins_by_id[plugin_id] = plugin
 
             action_ids = []
+            actions_by_id = {}
             action_ids_by_plugin_id[plugin_id] = action_ids
+            _actions_by_plugin_id[plugin_id] = actions_by_id
 
             actions = getattr(plugin, "actions", None) or []
             for action in actions:
                 action_id = action.id
-                if action_id in actions_by_id:
-                    continue
                 action_ids.append(action_id)
                 actions_by_id[action_id] = action
 
         self._plugins_by_id = plugins_by_id
-        self._actions_by_id = actions_by_id
+        self._actions_by_plugin_id = _actions_by_plugin_id
         self._action_ids_by_plugin_id = action_ids_by_plugin_id
 
-    def get_action(self, action_id):
-        return self._actions_by_id[action_id]
+    def get_action(self, plugin_id, action_id):
+        return self.__actions_by_plugin_id[plugin_id][action_id]
 
     def get_plugin(self, plugin_id):
         return self._plugins_by_id[plugin_id]
@@ -2308,7 +2308,7 @@ class PublisherController(BasePublisherController):
     def run_action(self, plugin_id, action_id):
         # TODO handle result in UI
         plugin = self._publish_plugins_proxy.get_plugin(plugin_id)
-        action = self._publish_plugins_proxy.get_action(action_id)
+        action = self._publish_plugins_proxy.get_action(plugin_id, action_id)
 
         result = pyblish.plugin.process(
             plugin, self._publish_context, None, action.id

--- a/openpype/tools/publisher/control.py
+++ b/openpype/tools/publisher/control.py
@@ -443,7 +443,7 @@ class PublishPluginsProxy:
 
     def __init__(self, plugins):
         plugins_by_id = {}
-        _actions_by_plugin_id = {}
+        actions_by_plugin_id = {}
         action_ids_by_plugin_id = {}
         for plugin in plugins:
             plugin_id = plugin.id
@@ -452,7 +452,7 @@ class PublishPluginsProxy:
             action_ids = []
             actions_by_id = {}
             action_ids_by_plugin_id[plugin_id] = action_ids
-            _actions_by_plugin_id[plugin_id] = actions_by_id
+            actions_by_plugin_id[plugin_id] = actions_by_id
 
             actions = getattr(plugin, "actions", None) or []
             for action in actions:
@@ -461,11 +461,11 @@ class PublishPluginsProxy:
                 actions_by_id[action_id] = action
 
         self._plugins_by_id = plugins_by_id
-        self._actions_by_plugin_id = _actions_by_plugin_id
+        self._actions_by_plugin_id = actions_by_plugin_id
         self._action_ids_by_plugin_id = action_ids_by_plugin_id
 
     def get_action(self, plugin_id, action_id):
-        return self.__actions_by_plugin_id[plugin_id][action_id]
+        return self._actions_by_plugin_id[plugin_id][action_id]
 
     def get_plugin(self, plugin_id):
         return self._plugins_by_id[plugin_id]


### PR DESCRIPTION
## Changelog Description
Pyblish plugin actions are visible as expected.

## Additional info
Action may not be visible in validation UI if the same action class was reused in multiple publish plugins. Store action ids by plugin ids to make sure they are stored in a different manner and store all action ids per plugin even if would already be in actions mapping.

## Source issue
The source issue came from Maya new publisher refactor where multiple pyblish plugins were using `RepairAction` but only one of them showed up in UI.

## Testing notes:
1. Have more than one validation plugin that is using `RepairAction`
2. Make both crash with validation error
3. Both should show Repair action in UI
