### PR TITLE
Fix the reset frame range not setting up the right timeline in Max

### DIFF
--- a/openpype/hosts/max/api/lib.py
+++ b/openpype/hosts/max/api/lib.py
@@ -250,10 +250,7 @@ def reset_frame_range(fps: bool = True):
         frame_range["handleStart"]
     )
     frame_end_handle = frame_range["frameEnd"] + int(frame_range["handleEnd"])
-    frange_cmd = (
-        f"animationRange = interval {frame_start_handle} {frame_end_handle}"
-    )
-    rt.Execute(frange_cmd)
+    set_timeline(frame_start_handle, frame_end_handle)
     set_render_frame_range(frame_start_handle, frame_end_handle)
 
 
@@ -285,3 +282,11 @@ def get_max_version():
     """
     max_info = rt.MaxVersion()
     return max_info[7]
+
+
+@contextlib.contextmanager
+def set_timeline(frameStart, frameEnd):
+    """Set frame range for timeline editor in Max
+    """
+    rt.animationRange = rt.interval(frameStart, frameEnd)
+    return rt.animationRange

--- a/openpype/hosts/max/api/lib.py
+++ b/openpype/hosts/max/api/lib.py
@@ -284,7 +284,6 @@ def get_max_version():
     return max_info[7]
 
 
-@contextlib.contextmanager
 def set_timeline(frameStart, frameEnd):
     """Set frame range for timeline editor in Max
     """


### PR DESCRIPTION
## Changelog Description
Resolve #5181 

## Additional info
also resolve the timeline issue at #5001 

## Testing notes:
1. Launch Max via OP
2. Openpype... -> Set Frame Range
3. Should be setting up the right timeline regarding to the DB