### PR TITLE
Houdini: enhance abc publishing

### DIFF
--- a/openpype/hosts/houdini/plugins/create/create_pointcache.py
+++ b/openpype/hosts/houdini/plugins/create/create_pointcache.py
@@ -1,7 +1,6 @@
 # -*- coding: utf-8 -*-
 """Creator plugin for creating pointcache alembics."""
 from openpype.hosts.houdini.api import plugin
-# from openpype.pipeline import CreatedInstance
 
 import hou
 
@@ -58,20 +57,6 @@ class CreatePointCache(plugin.HoudiniCreator):
 
                 child_output.setDisplayFlag(1)
                 child_output.setRenderFlag(1)
-                child_output.moveToGoodPosition()
-
-            paths = child_output.geometry().findPrimAttrib("path") and \
-                      child_output.geometry().primStringAttribValues("path")
-
-            # Create default path value if missing
-            if not paths:
-                path_node = parent.createNode("name", "AUTO_PATH")
-                path_node.parm("attribname").set("path")
-                path_node.parm("name1").set('`opname("..")`/`opoutput(".", 0)`') # noqa
-
-                path_node.setFirstInput(child_output.input(0))
-                path_node.moveToGoodPosition()
-                child_output.setFirstInput(path_node)
                 child_output.moveToGoodPosition()
 
             parms["sop_path"] = child_output.path()

--- a/openpype/hosts/houdini/plugins/create/create_pointcache.py
+++ b/openpype/hosts/houdini/plugins/create/create_pointcache.py
@@ -45,15 +45,15 @@ class CreatePointCache(plugin.HoudiniCreator):
 
             # try to find output node
             for child in parent.children():
-                if child.isGenericFlagSet( hou.nodeFlag.Render):
+                if child.isGenericFlagSet(hou.nodeFlag.Render):
                     child_render = child
                 if child.type().name() == "output":
-                    child_output =  child
+                    child_output = child
                     break
 
             # create output node if not exists
             if not child_output:
-                child_output = parent.createNode("output","OUTPUT")
+                child_output = parent.createNode("output", "OUTPUT")
                 child_output.setFirstInput(child_render)
 
                 child_output.setDisplayFlag(1)
@@ -64,10 +64,10 @@ class CreatePointCache(plugin.HoudiniCreator):
                       child_output.geometry().primStringAttribValues("path")
 
             # Create default path value if missing
-            if not paths :
+            if not paths:
                 path_node = parent.createNode("name", "AUTO_PATH")
                 path_node.parm("attribname").set("path")
-                path_node.parm("name1").set('`opname("..")`/`opoutput(".", 0)`')
+                path_node.parm("name1").set('`opname("..")`/`opoutput(".", 0)`') #noqa
 
                 path_node.setFirstInput(child_output.input(0))
                 path_node.moveToGoodPosition()

--- a/openpype/hosts/houdini/plugins/create/create_pointcache.py
+++ b/openpype/hosts/houdini/plugins/create/create_pointcache.py
@@ -67,7 +67,7 @@ class CreatePointCache(plugin.HoudiniCreator):
             if not paths:
                 path_node = parent.createNode("name", "AUTO_PATH")
                 path_node.parm("attribname").set("path")
-                path_node.parm("name1").set('`opname("..")`/`opoutput(".", 0)`') #noqa
+                path_node.parm("name1").set('`opname("..")`/`opoutput(".", 0)`') # noqa
 
                 path_node.setFirstInput(child_output.input(0))
                 path_node.moveToGoodPosition()

--- a/openpype/hosts/houdini/plugins/publish/validate_abc_primitive_to_detail.py
+++ b/openpype/hosts/houdini/plugins/publish/validate_abc_primitive_to_detail.py
@@ -73,6 +73,13 @@ class ValidateAbcPrimitiveToDetail(pyblish.api.InstancePlugin):
         cls.log.debug("Checking Primitive to Detail pattern: %s" % pattern)
         cls.log.debug("Checking with path attribute: %s" % path_attr)
 
+        if not isinstance(output_node, hou.SopNode):
+            # In the case someone has explicitly set an Object
+            # node instead of a SOP node in Geometry context
+            # then for now we ignore.
+            cls.log.warning("No geometry output node found, skipping check..")
+            return
+
         # Check if the primitive attribute exists
         frame = instance.data.get("frameStart", 0)
         geo = output_node.geometryAtFrame(frame)

--- a/openpype/hosts/houdini/plugins/publish/validate_primitive_hierarchy_paths.py
+++ b/openpype/hosts/houdini/plugins/publish/validate_primitive_hierarchy_paths.py
@@ -119,9 +119,9 @@ class ValidatePrimitiveHierarchyPaths(pyblish.api.InstancePlugin):
 
         path_attr = rop_node.parm("path_attrib").eval() or "path"
         paths = geo.findPrimAttrib(path_attr) and \
-            geo.primStringAttribValues(path_attr)
+                    geo.primStringAttribValues(path_attr)
 
-        if not paths :
+        if not paths:
             output_node = instance.data.get("output_node")
             path_node = output_node.parent().createNode("name", "AUTO_PATH")
             path_node.parm("attribname").set(path_attr)

--- a/openpype/hosts/houdini/plugins/publish/validate_primitive_hierarchy_paths.py
+++ b/openpype/hosts/houdini/plugins/publish/validate_primitive_hierarchy_paths.py
@@ -1,6 +1,9 @@
 # -*- coding: utf-8 -*-
 import pyblish.api
-from openpype.pipeline.publish import ValidateContentsOrder
+from openpype.pipeline.publish import (
+    ValidateContentsOrder,
+    RepairAction
+)
 from openpype.pipeline import PublishValidationError
 import hou
 
@@ -18,6 +21,7 @@ class ValidatePrimitiveHierarchyPaths(pyblish.api.InstancePlugin):
     families = ["pointcache"]
     hosts = ["houdini"]
     label = "Validate Prims Hierarchy Path"
+    actions = [RepairAction]
 
     def process(self, instance):
         invalid = self.get_invalid(instance)
@@ -104,3 +108,26 @@ class ValidatePrimitiveHierarchyPaths(pyblish.api.InstancePlugin):
                 "(%s of %s prims)" % (path_attr, len(invalid_prims), num_prims)
             )
             return [output_node.path()]
+
+    @classmethod
+    def repair(cls, instance):
+        output_node = instance.data.get("output_node")
+        rop_node = hou.node(instance.data["instance_node"])
+
+        frame = instance.data.get("frameStart", 0)
+        geo = output_node.geometryAtFrame(frame)
+
+        path_attr = rop_node.parm("path_attrib").eval() or "path"
+        paths = geo.findPrimAttrib(path_attr) and \
+            geo.primStringAttribValues(path_attr)
+
+        if not paths :
+            output_node = instance.data.get("output_node")
+            path_node = output_node.parent().createNode("name", "AUTO_PATH")
+            path_node.parm("attribname").set(path_attr)
+            path_node.parm("name1").set('`opname("..")`/`opoutput(".", 0)`')
+
+            path_node.setFirstInput(output_node.input(0))
+            path_node.moveToGoodPosition()
+            output_node.setFirstInput(path_node)
+            output_node.moveToGoodPosition()


### PR DESCRIPTION
## Changelog Description
1) On point cache creation in Houdini :  Create plugin will 
      -  if `output` node doesn't exist , create one

2) On Publishing: `Validate Prims Hierarchy Path` 
    - added a repair action
      - if  `path` attribute doesn't exist,  create it with  a default path value `"{parent_node_name}/{output_node_name}"`
      - it will use the same path attribute  name as in the `ROP alembic node` 
      - it skips checking if output node is not a `SOP Output node`
    > This doesn't enforce a certain path attribute value, artists are free to use any values they would preferer.

3) On Publishing: `Validate Output Node`
    - added a repair action if `sop_path` in  the `ROP alembic node` doesn't point to a `SOP Output node`

4) On Publishing: `Validate Primitive to Detail (Abc)`
     I added a condition to skip this validation if  `output node` is not a sop node 
     it cause validator not to error at this line `geo = output_node.geometryAtFrame(frame)`


## tests


### Case 1: create point cache 
create any object (e.g. a sphere)
create point cache while use selection toggle `ON`

it adds only an output node 
if artist adds no path attribute, then on publishing it will redirect to Case 2

### Case 2: ROP's sop_path is set to a sop output node with no path attribute 
These validators will error: 
- `Validate Primitive to Detail (Abc)`
- `Validate Prims Hierarchy Path`

Repair Actions Response: 
- `Validate Prims Hierarchy Path`
  - log: *DEBUG - 'path' attribute was not found!*
  - it creats a `name` node, change `attribute` to the ROP's `path_attrib` parameter and set a default path value
  - log: *DEBUG - 'AUTO_PATH' was created, It adds 'path' with a default single value*


### case 3: Empty ROP 
These validators will error: 
- `Validate Output Node`
- `Validate Primitive to Detail (Abc)`
- `Validate Input Node (Abc)`
- `Validate Prims Hierarchy Path`

Repair Actions Response : 
- `Validate Output Node` 
  - log: *DEBUG - This ROP {rop path} has empty SOP Path*
  - log: *DEBUG - Try Setting SOP path to selected node*
- `Validate Prims Hierarchy Path`
  - log: *WARNING - No geometry output node found, skipping Repair Action..*

### case 4: ROP's sop_path is set to an Obj node
These validators will error: 
- `Validate Output Node`

Repair Actions Response : 
- `Validate Output Node` 
  - log: *DEBUG - SOP Path points to an Obj node*
  - It creates an output node and connects it to the node with render flag
  - log: *DEBUG - SOP Output node created and set.*

### case 5: ROP's sop_path is set to a sop node and it isn't a SOP Output node
it can happens when sop_path points to any sop node that isn't sop output node
whether the sop output node exists or not 

These validators will error: 
- `Validate Output Node`
- `Validate Primitive to Detail (Abc)`
- `Validate Prims Hierarchy Path`

Repair Actions Response : 
- `Validate Output Node` 
  - log: *DEBUG - SOP Path points to an Sop node and it isn't a SOP Output node*
  - It creates an output node and connects it to the sop node in the ROP's `sop_path` parameter
  - log: *DEBUG - SOP Output node created and set.*
- `Validate Prims Hierarchy Path`
  - log: *WARNING - No geometry output node found, skipping Repair Action..*


### Case 6: ROP's sop_path is set to a non existed node
A more general case of case 5 

Repair Actions Response : 
- `Validate Output Node` 
  - log: *DEBUG - '{output node}' doesn't exist*
  - log: *DEBUG - Trying setting sop path to the parent '{parent node}'*
  - if it isn't valid
    - log: *DEBUG - '{parent node}' is not valid or it doesn't exist!*
    - log: *DEBUG - Resetting SOP Path of this ROP '{rop node}'*
      - redirect to case case 3: Empty ROP