### PR TITLE
node references to check for duplicates in Max

### DIFF
--- a/openpype/hosts/max/api/plugin.py
+++ b/openpype/hosts/max/api/plugin.py
@@ -42,6 +42,10 @@ MS_CUSTOM_ATTRIB = """attributes "openPypeData"
             (
                 handle_name = node_to_name c
                 node_ref = NodeTransformMonitor node:c
+                idx = finditem list_node.items handle_name
+                if idx do (
+                    return False
+                )
                 append temp_arr handle_name
                 append i_node_arr node_ref
             )

--- a/openpype/hosts/max/api/plugin.py
+++ b/openpype/hosts/max/api/plugin.py
@@ -44,7 +44,7 @@ MS_CUSTOM_ATTRIB = """attributes "openPypeData"
                 node_ref = NodeTransformMonitor node:c
                 idx = finditem list_node.items handle_name
                 if idx do (
-                    return False
+                    continue
                 )
                 append temp_arr handle_name
                 append i_node_arr node_ref


### PR DESCRIPTION
## Changelog Description
No duplicates for node references in Max when users trying to select nodes before publishing 

## Additional info
n/a

## Testing notes:
1. Launch Max via Openpype
2. Create Instance
3. Click "Add to Container" in OP Parameter in the created container
4. Add Items
5. And add the same items as 4
6.  The node references won't show the duplicated items anymore.