### PR TITLE
Tweak profiles logging to debug level

### DIFF
--- a/openpype/lib/profiles_filtering.py
+++ b/openpype/lib/profiles_filtering.py
@@ -167,7 +167,7 @@ def filter_profiles(profiles_data, key_values, keys_order=None, logger=None):
         for item in key_values.items()
     ])
 
-    logger.info(
+    logger.debug(
         "Looking for matching profile for: {}".format(log_parts)
     )
 
@@ -209,19 +209,19 @@ def filter_profiles(profiles_data, key_values, keys_order=None, logger=None):
             matching_profiles.append((profile, profile_scores))
 
     if not matching_profiles:
-        logger.info(
+        logger.debug(
             "None of profiles match your setup. {}".format(log_parts)
         )
         return None
 
     if len(matching_profiles) > 1:
-        logger.info(
+        logger.debug(
             "More than one profile match your setup. {}".format(log_parts)
         )
 
     profile = _profile_exclusion(matching_profiles, logger)
     if profile:
-        logger.info(
+        logger.debug(
             "Profile selected: {}".format(profile)
         )
     return profile


### PR DESCRIPTION
## Changelog Description

Tweak profiles logging to debug level since they aren't artist facing logs.

## Additional info

Before:

![before](https://github.com/ynput/OpenPype/assets/2439881/ef3ec848-75cf-4e39-8699-7d33e587bfb4)

After:

![image](https://github.com/ynput/OpenPype/assets/2439881/9c587360-99da-425b-a3ae-7c3cf6070ec3)

## Testing notes:

1. Publish from some hosts using the new publisher
2. Artist facing logs should now be much clearer (less clutter)