### PR TITLE
Nuke: Remote existing frames

### DIFF
--- a/openpype/hosts/nuke/api/plugin.py
+++ b/openpype/hosts/nuke/api/plugin.py
@@ -311,6 +311,7 @@ class NukeWriteCreator(NukeCreator):
         }
         if ("farm_rendering" in self.instance_attributes):
             rendering_targets["farm"] = "Farm rendering"
+            rendering_targets["farm_frames"] = "Existing frames farm rendering"
 
         return EnumDef(
             "render_target",
@@ -669,7 +670,7 @@ class ExporterReviewLut(ExporterReview):
         self.ext = ext or "cube"
         self.cube_size = cube_size or 32
         self.lut_size = lut_size or 1024
-        self.lut_style = lut_style or "linear"
+        self.lut_style = lut_style or "scene_linear"
 
         # set frame start / end and file name to self
         self.get_file_info()

--- a/openpype/hosts/nuke/api/plugin.py
+++ b/openpype/hosts/nuke/api/plugin.py
@@ -670,7 +670,7 @@ class ExporterReviewLut(ExporterReview):
         self.ext = ext or "cube"
         self.cube_size = cube_size or 32
         self.lut_size = lut_size or 1024
-        self.lut_style = lut_style or "scene_linear"
+        self.lut_style = lut_style or "linear"
 
         # set frame start / end and file name to self
         self.get_file_info()

--- a/openpype/hosts/nuke/plugins/publish/collect_writes.py
+++ b/openpype/hosts/nuke/plugins/publish/collect_writes.py
@@ -29,6 +29,9 @@ class CollectNukeWrites(pyblish.api.InstancePlugin,
         instance.data["families"].append(
             "{}.{}".format(family, render_target)
         )
+        self.log.debug("Appending render target to families: {}.{}".format(
+            family, render_target)
+        )
         if instance.data.get("review"):
             instance.data["families"].append("review")
 
@@ -73,7 +76,7 @@ class CollectNukeWrites(pyblish.api.InstancePlugin,
 
         self.log.debug('output dir: {}'.format(output_dir))
 
-        if render_target == "frames":
+        if render_target in ["frames", "farm_frames"]:
             representation = {
                 'name': ext,
                 'ext': ext,
@@ -141,6 +144,22 @@ class CollectNukeWrites(pyblish.api.InstancePlugin,
 
             instance.data["representations"].append(representation)
             self.log.info("Publishing rendered frames ...")
+
+            if render_target == "farm_frames":
+                # Farm rendering
+                instance.data["toBeRenderedOn"] = "deadline"
+                instance.data["transfer"] = False
+                instance.data["farm"] = True # to skip integrate
+                self.log.info("Farm rendering ON ...")
+
+                self.log.info(
+                    "Adding collected files %s to expectedFiles instance.data",
+                    collected_frames
+                )
+                if "expectedFiles" not in instance.data:
+                    instance.data["expectedFiles"] = list()
+                    for source_file in collected_frames:
+                        instance.data["expectedFiles"].append(os.path.join(output_dir, source_file))
 
         elif render_target == "farm":
             farm_keys = ["farm_chunk", "farm_priority", "farm_concurrency"]

--- a/openpype/hosts/nuke/plugins/publish/collect_writes.py
+++ b/openpype/hosts/nuke/plugins/publish/collect_writes.py
@@ -149,7 +149,7 @@ class CollectNukeWrites(pyblish.api.InstancePlugin,
                 # Farm rendering
                 instance.data["toBeRenderedOn"] = "deadline"
                 instance.data["transfer"] = False
-                instance.data["farm"] = True # to skip integrate
+                instance.data["farm"] = True  # to skip integrate
                 self.log.info("Farm rendering ON ...")
 
                 self.log.info(
@@ -159,7 +159,9 @@ class CollectNukeWrites(pyblish.api.InstancePlugin,
                 if "expectedFiles" not in instance.data:
                     instance.data["expectedFiles"] = list()
                     for source_file in collected_frames:
-                        instance.data["expectedFiles"].append(os.path.join(output_dir, source_file))
+                        instance.data["expectedFiles"].append(
+                            os.path.join(output_dir, source_file)
+                        )
 
         elif render_target == "farm":
             farm_keys = ["farm_chunk", "farm_priority", "farm_concurrency"]

--- a/openpype/hosts/nuke/plugins/publish/extract_camera.py
+++ b/openpype/hosts/nuke/plugins/publish/extract_camera.py
@@ -11,9 +11,9 @@ from openpype.hosts.nuke.api.lib import maintained_selection
 
 
 class ExtractCamera(publish.Extractor):
-    """ 3D camera exctractor
+    """ 3D camera extractor
     """
-    label = 'Exctract Camera'
+    label = 'Extract Camera'
     order = pyblish.api.ExtractorOrder
     families = ["camera"]
     hosts = ["nuke"]

--- a/openpype/hosts/nuke/plugins/publish/extract_model.py
+++ b/openpype/hosts/nuke/plugins/publish/extract_model.py
@@ -11,9 +11,9 @@ from openpype.hosts.nuke.api.lib import (
 
 
 class ExtractModel(publish.Extractor):
-    """ 3D model exctractor
+    """ 3D model extractor
     """
-    label = 'Exctract Model'
+    label = 'Extract Model'
     order = pyblish.api.ExtractorOrder
     families = ["model"]
     hosts = ["nuke"]

--- a/openpype/modules/deadline/plugins/publish/submit_nuke_deadline.py
+++ b/openpype/modules/deadline/plugins/publish/submit_nuke_deadline.py
@@ -32,7 +32,7 @@ class NukeSubmitDeadline(pyblish.api.InstancePlugin,
     label = "Submit Nuke to Deadline"
     order = pyblish.api.IntegratorOrder + 0.1
     hosts = ["nuke"]
-    families = ["render", "prerender"]
+    families = ["render.farm", "prerender.farm"]
     optional = True
     targets = ["local"]
 

--- a/openpype/modules/deadline/plugins/publish/submit_nuke_deadline.py
+++ b/openpype/modules/deadline/plugins/publish/submit_nuke_deadline.py
@@ -32,7 +32,7 @@ class NukeSubmitDeadline(pyblish.api.InstancePlugin,
     label = "Submit Nuke to Deadline"
     order = pyblish.api.IntegratorOrder + 0.1
     hosts = ["nuke"]
-    families = ["render.farm", "prerender.farm"]
+    families = ["render", "prerender"]
     optional = True
     targets = ["local"]
 

--- a/openpype/modules/deadline/plugins/publish/submit_publish_job.py
+++ b/openpype/modules/deadline/plugins/publish/submit_publish_job.py
@@ -872,7 +872,6 @@ class ProcessSubmittedJobOnFarm(pyblish.api.InstancePlugin,
             "multipartExr": data.get("multipartExr", False),
             "jobBatchName": data.get("jobBatchName", ""),
             "useSequenceForReview": data.get("useSequenceForReview", True),
-            "colorspace": data.get("colorspace"),
             # map inputVersions `ObjectId` -> `str` so json supports it
             "inputVersions": list(map(str, data.get("inputVersions", []))),
             "colorspace": instance.data.get("colorspace")
@@ -886,7 +885,6 @@ class ProcessSubmittedJobOnFarm(pyblish.api.InstancePlugin,
         # transfer specific families from original instance to new render
         for item in self.families_transfer:
             if item in instance.data.get("families", []):
-                self.log.debug("Transfering '%s' family to instance.", item)
                 instance_skeleton_data["families"] += [item]
 
         # transfer specific properties from original instance based on
@@ -894,7 +892,6 @@ class ProcessSubmittedJobOnFarm(pyblish.api.InstancePlugin,
         for key, values in self.instance_transfer.items():
             if key in instance.data.get("families", []):
                 for v in values:
-                    self.log.debug("Transfering '%s' property to instance.", v)
                     instance_skeleton_data[v] = instance.data.get(v)
 
         # look into instance data if representations are not having any

--- a/openpype/modules/deadline/plugins/publish/submit_publish_job.py
+++ b/openpype/modules/deadline/plugins/publish/submit_publish_job.py
@@ -1121,7 +1121,7 @@ class ProcessSubmittedJobOnFarm(pyblish.api.InstancePlugin,
             "fps": context.data.get("fps", None),
             "source": source,
             "user": context.data["user"],
-            "version": context.data.get("version"),  # this is workfile version
+            "version": context.data["version"],  # this is workfile version
             "intent": context.data.get("intent"),
             "comment": context.data.get("comment"),
             "job": render_job or None,

--- a/openpype/modules/deadline/plugins/publish/validate_expected_and_rendered_files.py
+++ b/openpype/modules/deadline/plugins/publish/validate_expected_and_rendered_files.py
@@ -21,6 +21,10 @@ class ValidateExpectedFiles(pyblish.api.InstancePlugin):
 
     def process(self, instance):
         self.instance = instance
+        # TODO: Find a better way to check whether a job has been submitted with
+        # existing frames
+        if not instance.data["render_job_id"]:
+            return
         frame_list = self._get_frame_list(instance.data["render_job_id"])
 
         for repre in instance.data["representations"]:

--- a/openpype/modules/deadline/plugins/publish/validate_expected_and_rendered_files.py
+++ b/openpype/modules/deadline/plugins/publish/validate_expected_and_rendered_files.py
@@ -21,8 +21,8 @@ class ValidateExpectedFiles(pyblish.api.InstancePlugin):
 
     def process(self, instance):
         self.instance = instance
-        # TODO: Find a better way to check whether a job has been submitted with
-        # existing frames
+        # TODO: Find a better way to check whether a job has been submitted
+        # with existing frames
         if not instance.data["render_job_id"]:
             return
         frame_list = self._get_frame_list(instance.data["render_job_id"])


### PR DESCRIPTION
## Changelog Description
This adds initial support to submit existing frames to the farm in Nuke to run the publish plugins.

## Additional info
I did these changes together with the ones on https://github.com/ynput/OpenPype/pull/5195 so there might be some things I touched there that were required here and viceversa.

## Testing notes:
1. Create a write render instance and render locally some frames
2. Go to the publisher and choose "Existing frames farm rendering"
3. Hit publish