### PR TITLE
General: Revert backward incompatible change of path to template to multiplatform

### DIFF
--- a/openpype/pipeline/workfile/workfile_template_builder.py
+++ b/openpype/pipeline/workfile/workfile_template_builder.py
@@ -13,7 +13,6 @@ about it's progress.
 
 import os
 import re
-import platform
 import collections
 import copy
 from abc import ABCMeta, abstractmethod
@@ -764,9 +763,7 @@ class AbstractTemplateBuilder(object):
                 "with host '{}'"
             ).format(task_name, task_type, host_name))
 
-        current_platform = platform.system().lower()
-        # backward compatibility for single platform version
-        path = profile["path"].get(current_platform) or profile["path"]
+        path = profile["path"]
 
         # switch to remove placeholders after they are used
         keep_placeholder = profile.get("keep_placeholder")

--- a/openpype/settings/entities/schemas/projects_schema/schemas/schema_templated_workfile_build.json
+++ b/openpype/settings/entities/schemas/projects_schema/schemas/schema_templated_workfile_build.json
@@ -26,7 +26,7 @@
                         "key": "path",
                         "label": "Path to template",
                         "type": "path",
-                        "multiplatform": true,
+                        "multiplatform": false,
                         "multipath": false
                     },
                     {


### PR DESCRIPTION
## Changelog Description
Now platformity is still handed by usage of `work[root]` (or any other root that is accessible across platforms.) 

## Additional info
Previous change would broke backward compatibility as Settings are re-saving string value to dict and losing existing values.
In the case of customer request it needs to be reworked for proper multiplatformity.

