### PR TITLE
AYON: OpenPype as server addon

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,6 +37,7 @@ Temporary Items
 ###########
 /build
 /dist/
+/server_addon/package/*
 
 /vendor/bin/*
 /vendor/python/*

--- a/server_addon/README.md
+++ b/server_addon/README.md
@@ -1,0 +1,21 @@
+# OpenPype addon for AYON server
+Convert openpype into AYON addon which can be installed on AYON server. The versioning of the addon is following versioning of OpenPype.
+
+## Intro
+As you might know, OpenPype is becoming AYON, which is moving from MongoDB to dedicated server with database. For some time, we'll keep OpenPype compatible with both MongoDB and AYON. But over time we'll start to change codebase to match AYON data and separate individual parts to addons.
+
+At this moment have OpenPype codebase AYON mode, which means that OpenPype is using AYON server instead of MongoDB by under-laying conversion utils. At first, we added AYON executable next to OpenPype executables to start in AYON mode. That works, but would be hard to update new versions of code (would require new full installed build). We've decided to rather create new repository where is only base desktop application logic, for now we call it AYON launcher which will replace executables created by OpenPype build, and convert openpype code to server addon which reduce size of updates.
+
+Because the overall implementation of ayon-launcher is not fully finished yet, we'll keep both ways how to start AYON mode for some time. Once the AYON launcher is finished, we'll remove AYON executables from OpenPype codebase completely.
+
+For some time this addon will be requirement as an entry point to use AYON launcher.
+
+## How to start
+There is a `create_ayon_addon.py` python file which contains logic how to create server addon from OpenPype codebase. Just run the code.
+```shell
+./.poetry/bin/poetry run python ./server_addon/create_ayon_addon.py
+```
+
+It will create directory `./package/openpype/<OpenPype version>/*` folder with all files necessary for AYON server. You can then copy `./package/openpype/` to server addons, or zip the folder and upload it to AYON server. Restart server to update addons information, add the addon version to server bundle and set the bundle for production or staging usage.
+
+Once addon is on server and is enabled, you can just run AYON launcher. Content will be downloaded and used automatically.

--- a/server_addon/create_ayon_addon.py
+++ b/server_addon/create_ayon_addon.py
@@ -1,0 +1,117 @@
+import os
+import re
+import shutil
+import zipfile
+import collections
+from pathlib import Path
+
+
+# Patterns of directories to be skipped for server part of addon
+IGNORE_DIR_PATTERNS = [
+    re.compile(pattern)
+    for pattern in {
+        # Skip directories starting with '.'
+        r"^\.",
+        # Skip any pycache folders
+        "^__pycache__$"
+    }
+]
+
+# Patterns of files to be skipped for server part of addon
+IGNORE_FILE_PATTERNS = [
+    re.compile(pattern)
+    for pattern in {
+        # Skip files starting with '.'
+        # NOTE this could be an issue in some cases
+        r"^\.",
+        # Skip '.pyc' files
+        r"\.pyc$"
+    }
+]
+
+
+def _value_match_regexes(value, regexes):
+    for regex in regexes:
+        if regex.search(value):
+            return True
+    return False
+
+
+def find_files_in_subdir(
+    src_path,
+    ignore_file_patterns=None,
+    ignore_dir_patterns=None
+):
+    if ignore_file_patterns is None:
+        ignore_file_patterns = IGNORE_FILE_PATTERNS
+
+    if ignore_dir_patterns is None:
+        ignore_dir_patterns = IGNORE_DIR_PATTERNS
+    output = []
+
+    hierarchy_queue = collections.deque()
+    hierarchy_queue.append((src_path, []))
+    while hierarchy_queue:
+        item = hierarchy_queue.popleft()
+        dirpath, parents = item
+        for name in os.listdir(dirpath):
+            path = os.path.join(dirpath, name)
+            if os.path.isfile(path):
+                if not _value_match_regexes(name, ignore_file_patterns):
+                    items = list(parents)
+                    items.append(name)
+                    output.append((path, os.path.sep.join(items)))
+                continue
+
+            if not _value_match_regexes(name, ignore_dir_patterns):
+                items = list(parents)
+                items.append(name)
+                hierarchy_queue.append((path, items))
+
+    return output
+
+
+def main():
+    openpype_addon_dir = Path(os.path.dirname(os.path.abspath(__file__)))
+    server_dir = openpype_addon_dir / "server"
+    package_root = openpype_addon_dir / "package"
+    pyproject_path = openpype_addon_dir / "pyproject.toml"
+
+    root_dir = openpype_addon_dir.parent
+    openpype_dir = root_dir / "openpype"
+    version_path = openpype_dir / "version.py"
+
+    # Read version
+    version_content = {}
+    with open(str(version_path), "r") as stream:
+        exec(stream.read(), version_content)
+    addon_version = version_content["__version__"]
+
+    output_dir = package_root / "openpype" / addon_version
+    private_dir = output_dir / "private"
+
+    # Make sure package dir is empty
+    if package_root.exists():
+        shutil.rmtree(str(package_root))
+    # Make sure output dir is created
+    output_dir.mkdir(parents=True)
+
+    # Copy version
+    shutil.copy(str(version_path), str(output_dir))
+    for subitem in server_dir.iterdir():
+        shutil.copy(str(subitem), str(output_dir / subitem.name))
+
+    # Zip client
+    private_dir.mkdir(parents=True)
+    zip_filepath = private_dir / "client.zip"
+    with zipfile.ZipFile(zip_filepath, "w", zipfile.ZIP_DEFLATED) as zipf:
+        # Add client code content to zip
+        for path, sub_path in find_files_in_subdir(str(openpype_dir)):
+            zipf.write(path, f"{openpype_dir.name}/{sub_path}")
+
+        # Add pyproject.toml
+        zipf.write(str(pyproject_path), pyproject_path.name)
+
+
+if __name__ == "__main__":
+    main()

--- a/server_addon/pyproject.toml
+++ b/server_addon/pyproject.toml
@@ -1,0 +1,20 @@
+[tool.poetry.dependencies]
+python = ">=3.9.1,<3.10"
+aiohttp_json_rpc = "*" # TVPaint server
+aiohttp-middlewares = "^2.0.0"
+wsrpc_aiohttp = "^3.1.1" # websocket server
+clique = "1.6.*"
+shotgun_api3 = {git = "https://github.com/shotgunsoftware/python-api.git", rev = "v3.3.3"}
+gazu = "^0.9.3"
+google-api-python-client = "^1.12.8" # sync server google support (should be separate?)
+jsonschema = "^2.6.0"
+log4mongo = "^1.7"
+pathlib2= "^2.3.5" # deadline submit publish job only (single place, maybe not needed?)
+pyblish-base = "^1.8.11"
+pynput = "^1.7.2" # Timers manager - TODO replace
+"Qt.py" = "^1.3.3"
+qtawesome = "0.7.3"
+speedcopy = "^2.1"
+slack-sdk = "^3.6.0"
+pysftp = "^0.2.9"
+dropbox = "^11.20.0"

--- a/server_addon/server/__init__.py
+++ b/server_addon/server/__init__.py
@@ -1,0 +1,9 @@
+from ayon_server.addons import BaseServerAddon
+
+from .version import __version__
+
+
+class OpenPypeAddon(BaseServerAddon):
+    name = "openpype"
+    title = "OpenPype"
+    version = __version__


### PR DESCRIPTION
## Changelog Description
OpenPype repository can be converted to AYON addon for distribution. Addon has defined dependencies that are required to use it and are not in base ayon-launcher (desktop application).

## Additional info
The addon can be used with ayon-launcher or with OpenPype build with ayon executables. The logic for the addon creation is added to subfolder `./server_addon/` where is python script to create a package, pyproject.toml to define python dependencies required by the addon and server addon class definition. I'm not sure if that is the right place and if I should add helper shell/powershell scripts. If yes, should they be inside the `./server_addon/` folder or inside `./tools/`?

The README is mentioning bundles on server which are not yet available in current server develop, but will be requirement for full workflow, with installation of dependencies defined in pyproject.toml -> it won't be fully working with ayon-launcher now.

## Testing notes:
1. Create addon using `./.poetry run python ./server_addon/create_ayon_addon.py`
2. That should create `./server_addon/package/openpype/`
3. Copy `./server_addon/package/openpype/` to server addon directory
4. Restart AYON server
5. Addon should be visible in WebUI so you can enable it