### PR TITLE
Hiero: fixing otio current project and cosmetics

### DIFF
--- a/openpype/hosts/hiero/api/__init__.py
+++ b/openpype/hosts/hiero/api/__init__.py
@@ -21,8 +21,13 @@ from .pipeline import (
     reset_selection
 )
 
+from .constants import (
+    OPENPYPE_TAG_NAME,
+    DEFAULT_SEQUENCE_NAME,
+    DEFAULT_BIN_NAME
+)
+
 from .lib import (
-    pype_tag_name,
     flatten,
     get_track_items,
     get_current_project,
@@ -82,8 +87,12 @@ __all__ = [
     "file_extensions",
     "work_root",
 
+    # Constants
+    "OPENPYPE_TAG_NAME",
+    "DEFAULT_SEQUENCE_NAME",
+    "DEFAULT_BIN_NAME",
+
     # Lib functions
-    "pype_tag_name",
     "flatten",
     "get_track_items",
     "get_current_project",

--- a/openpype/hosts/hiero/api/constants.py
+++ b/openpype/hosts/hiero/api/constants.py
@@ -1,0 +1,3 @@
+OPENPYPE_TAG_NAME = "openpypeData"
+DEFAULT_SEQUENCE_NAME = "openpypeSequence"
+DEFAULT_BIN_NAME = "openpypeBin"

--- a/openpype/hosts/hiero/plugins/publish/precollect_instances.py
+++ b/openpype/hosts/hiero/plugins/publish/precollect_instances.py
@@ -310,7 +310,7 @@ class PrecollectInstances(pyblish.api.ContextPlugin):
 
                 # add pypedata marker to otio_clip metadata
                 for marker in otio_clip.markers:
-                    if phiero.pype_tag_name in marker.name:
+                    if phiero.OPENPYPE_TAG_NAME in marker.name:
                         otio_clip.metadata.update(marker.metadata)
                 return {"otioClip": otio_clip}
 

--- a/openpype/hosts/hiero/plugins/publish/precollect_workfile.py
+++ b/openpype/hosts/hiero/plugins/publish/precollect_workfile.py
@@ -8,7 +8,6 @@ from qtpy.QtGui import QPixmap
 import hiero.ui
 
 from openpype.pipeline import legacy_io
-from openpype.hosts.hiero import api as phiero
 from openpype.hosts.hiero.api.otio import hiero_export
 
 
@@ -22,8 +21,8 @@ class PrecollectWorkfile(pyblish.api.ContextPlugin):
 
         asset = legacy_io.Session["AVALON_ASSET"]
         subset = "workfile"
-        project = phiero.get_current_project()
         active_timeline = hiero.ui.activeSequence()
+        project = active_timeline.project()
         fps = active_timeline.framerate().toFloat()
 
         # adding otio timeline to context


### PR DESCRIPTION
## Changelog Description
Otio were not returning correct current project once additional Untitled project was open in project manager stack. 

## Additional info
- creating constants module for api wide constants
- creating CTX class for passing module wide variables instead of using fake self

## Testing notes:
1.open your testing project in hiero
2. create Untitled project so you can see two projects in project manager
3. make sure a sequence is open with testing publishable clips
4. Open puplisher and see all is working as expected - instances are created.

