### PR TITLE
Max: Publisher instances dont hold its enabled disabled states when Publisher reopened again

### DIFF
--- a/openpype/hosts/max/api/lib.py
+++ b/openpype/hosts/max/api/lib.py
@@ -78,13 +78,15 @@ def read(container) -> dict:
                 value.startswith(JSON_PREFIX):
             with contextlib.suppress(json.JSONDecodeError):
                 value = json.loads(value[len(JSON_PREFIX):])
-        if key.strip() == "active":
-            if value == "true":
-                data[key.strip()] = True
-            else:
-                data[key.strip()] = False
-        else:
-            data[key.strip()] = value
+
+        # default value behavior
+        # convert maxscript boolean values
+        if value == "true":
+            value = True
+        elif value == "false":
+            value = False
+
+        data[key.strip()] = value
 
     data["instance_node"] = container.Name
 

--- a/openpype/hosts/max/api/lib.py
+++ b/openpype/hosts/max/api/lib.py
@@ -78,7 +78,13 @@ def read(container) -> dict:
                 value.startswith(JSON_PREFIX):
             with contextlib.suppress(json.JSONDecodeError):
                 value = json.loads(value[len(JSON_PREFIX):])
-        data[key.strip()] = value
+        if key.strip() == "active":
+            if value == "true":
+                data[key.strip()] = True
+            else:
+                data[key.strip()] = False
+        else:
+            data[key.strip()] = value
 
     data["instance_node"] = container.Name
 

--- a/openpype/hosts/max/api/plugin.py
+++ b/openpype/hosts/max/api/plugin.py
@@ -172,7 +172,7 @@ class MaxCreator(Creator, MaxCreatorBase):
             # Setting the property
             rt.setProperty(
                 instance_node.openPypeData, "all_handles", node_list)
-
+        self.log.debug(f"{instance}")
         self._add_instance_to_context(instance)
         imprint(instance_node.name, instance.data_to_store())
 
@@ -184,6 +184,7 @@ class MaxCreator(Creator, MaxCreatorBase):
             created_instance = CreatedInstance.from_existing(
                 read(rt.GetNodeByName(instance)), self
             )
+            self.log.debug(f"{created_instance}")
             self._add_instance_to_context(created_instance)
 
     def update_instances(self, update_list):

--- a/openpype/hosts/max/api/plugin.py
+++ b/openpype/hosts/max/api/plugin.py
@@ -172,6 +172,7 @@ class MaxCreator(Creator, MaxCreatorBase):
             # Setting the property
             rt.setProperty(
                 instance_node.openPypeData, "all_handles", node_list)
+
         self._add_instance_to_context(instance)
         imprint(instance_node.name, instance.data_to_store())
 

--- a/openpype/hosts/max/api/plugin.py
+++ b/openpype/hosts/max/api/plugin.py
@@ -172,7 +172,6 @@ class MaxCreator(Creator, MaxCreatorBase):
             # Setting the property
             rt.setProperty(
                 instance_node.openPypeData, "all_handles", node_list)
-        self.log.debug(f"{instance}")
         self._add_instance_to_context(instance)
         imprint(instance_node.name, instance.data_to_store())
 
@@ -184,7 +183,6 @@ class MaxCreator(Creator, MaxCreatorBase):
             created_instance = CreatedInstance.from_existing(
                 read(rt.GetNodeByName(instance)), self
             )
-            self.log.debug(f"{created_instance}")
             self._add_instance_to_context(created_instance)
 
     def update_instances(self, update_list):


### PR DESCRIPTION
## Changelog Description
Resolve #5183, general maxscript conversion issue to python (e.g. bool conversion, true in maxscript while True in Python)
(Also resolve the ValueError when you change the subset to publish into list view menu)


## Additional info
n/a

## Testing notes:
1. Launch Max via OP
2. Openpype -> Publish...
3. Create Instance
4. Disable it
5. Close and re-open the publisher
6. It should show the instance disabled instead of enabled
