### PR TITLE
AfterEffects - add container check validator to AE settings

### DIFF
--- a/openpype/settings/defaults/project_settings/aftereffects.json
+++ b/openpype/settings/defaults/project_settings/aftereffects.json
@@ -32,6 +32,11 @@
             "skip_timelines_check": [
                 ".*"
             ]
+        },
+        "ValidateContainers": {
+            "enabled": true,
+            "optional": true,
+            "active": true
         }
     },
     "workfile_builder": {

--- a/openpype/settings/entities/schemas/projects_schema/schema_project_aftereffects.json
+++ b/openpype/settings/entities/schemas/projects_schema/schema_project_aftereffects.json
@@ -107,6 +107,17 @@
                             "label": "Skip Timeline Check  for Tasks"
                         }
                     ]
+                },
+                {
+                    "type": "schema_template",
+                    "name": "template_publish_plugin",
+                    "template_data": [
+                        {
+                            "docstring": "Check if loaded container in scene are latest versions.",
+                            "key": "ValidateContainers",
+                            "label": "ValidateContainers"
+                        }
+                    ]
                 }
             ]
         },


### PR DESCRIPTION
## Changelog Description
Adds check if scene contains only latest version of loaded containers.

## Testing notes:
1. Disable `Validate Containers` in AE section and try to publish