### PR TITLE
Burnins: Filter script is defined only for video streams

### DIFF
--- a/openpype/scripts/otio_burnin.py
+++ b/openpype/scripts/otio_burnin.py
@@ -442,7 +442,7 @@ class ModifiedBurnins(ffmpeg_burnins.Burnins):
             with tempfile.NamedTemporaryFile(mode="w", delete=False) as temp:
                 temp.write(filter_string)
                 filters_path = temp.name
-            filters = '-filter_script "{}"'.format(filters_path)
+            filters = '-filter_script:v "{}"'.format(filters_path)
             print("Filters:", filter_string)
             self.cleanup_paths.append(filters_path)
 


### PR DESCRIPTION
## Changelog Description
Burnins are working for inputs with audio.

## Additional info
Filters defined in file are also applied to audio streams if there is no specifier in `-filter_script`.

## Testing notes:
1. Try to make review from video with audio
2. Burnins should be added without crash
