### PR TITLE
Enhancement: Reduce more visual clutter for artists in new publisher reports

### DIFF
--- a/openpype/modules/ftrack/plugins/publish/collect_ftrack_family.py
+++ b/openpype/modules/ftrack/plugins/publish/collect_ftrack_family.py
@@ -71,7 +71,7 @@ class CollectFtrackFamily(pyblish.api.InstancePlugin):
             if "ftrack" not in families:
                 families.append("ftrack")
 
-        self.log.info("{} 'ftrack' family for instance with '{}'".format(
+        self.log.debug("{} 'ftrack' family for instance with '{}'".format(
             result_str, family
         ))
 

--- a/openpype/modules/ftrack/plugins/publish/integrate_ftrack_status.py
+++ b/openpype/modules/ftrack/plugins/publish/integrate_ftrack_status.py
@@ -75,7 +75,7 @@ class CollectFtrackTaskStatuses(pyblish.api.ContextPlugin):
         }
         context.data["ftrackTaskStatuses"] = task_statuses_by_type_id
         context.data["ftrackStatusByTaskId"] = {}
-        self.log.info("Collected ftrack task statuses.")
+        self.log.debug("Collected ftrack task statuses.")
 
 
 class IntegrateFtrackStatusBase(pyblish.api.InstancePlugin):
@@ -116,7 +116,7 @@ class IntegrateFtrackStatusBase(pyblish.api.InstancePlugin):
         profiles = self.get_status_profiles()
         if not profiles:
             project_name = context.data["projectName"]
-            self.log.info((
+            self.log.debug((
                 "Status profiles are not filled for project \"{}\". Skipping"
             ).format(project_name))
             return
@@ -124,7 +124,7 @@ class IntegrateFtrackStatusBase(pyblish.api.InstancePlugin):
         # Task statuses were not collected -> skip
         task_statuses_by_type_id = context.data.get("ftrackTaskStatuses")
         if not task_statuses_by_type_id:
-            self.log.info(
+            self.log.debug(
                 "Ftrack task statuses are not collected. Skipping.")
             return
 
@@ -364,12 +364,12 @@ class IntegrateFtrackTaskStatus(pyblish.api.ContextPlugin):
     def process(self, context):
         task_statuses_by_type_id = context.data.get("ftrackTaskStatuses")
         if not task_statuses_by_type_id:
-            self.log.info("Ftrack task statuses are not collected. Skipping.")
+            self.log.debug("Ftrack task statuses are not collected. Skipping.")
             return
 
         status_by_task_id = self._get_status_by_task_id(context)
         if not status_by_task_id:
-            self.log.info("No statuses to set. Skipping.")
+            self.log.debug("No statuses to set. Skipping.")
             return
 
         ftrack_session = context.data["ftrackSession"]

--- a/openpype/plugins/publish/cleanup.py
+++ b/openpype/plugins/publish/cleanup.py
@@ -86,8 +86,8 @@ class CleanUp(pyblish.api.InstancePlugin):
             return
 
         if not os.path.normpath(staging_dir).startswith(temp_root):
-            self.log.info("Skipping cleanup. Staging directory is not in the "
-                          "temp folder: %s" % staging_dir)
+            self.log.debug("Skipping cleanup. Staging directory is not in the "
+                           "temp folder: %s" % staging_dir)
             return
 
         if not os.path.exists(staging_dir):


### PR DESCRIPTION
## Changelog Description

Got this from one of our artists' reports - figured some of these logs were definitely not for the artist, reduced those logs to debug level.

![publisher_report](https://github.com/ynput/OpenPype/assets/2439881/d1eec062-8c50-4599-80fa-aef34d3b6629)

## Testing notes:

1. Read the changes
2. Test publish in new publisher hosts
