### PR TITLE
Colorspace lib fix compatible python version comparison

### DIFF
--- a/openpype/pipeline/colorspace.py
+++ b/openpype/pipeline/colorspace.py
@@ -240,7 +240,7 @@ def get_data_subprocess(config_path, data_type):
 def compatible_python():
     """Only 3.9 or higher can directly use PyOpenColorIO in ocio_wrapper"""
     compatible = False
-    if sys.version[0] == 3 and sys.version[1] >= 9:
+    if sys.version_info.major == 3 and sys.version_info.minor >= 9:
         compatible = True
     return compatible
 


### PR DESCRIPTION
## Changelog Description

Fix python version comparison.

## Additional info

Resolves #5211

**Note** that this is just fixing what the code seemed to intend to do - whether the colorspace logic actually works in e.g. 3.10+ or hosts like Maya, Nuke, Fusion, Houdini, etc. with more recent Python versions I'm not sure as I'm not sure whether those actually all have access to the `PyOpenColorIO` package. As such this might need testing across all hosts also whether `import PyOpenColorIO` actually works.

## Testing notes:

Run:
```python
import sys
from openpype.pipeline import colorspace 

print(sys.version)
print(sys.version_info)
print(colorspace.compatible_python())
```
Any python 3.9+ should return True on the last print.

**NOTE** We might also want to test across different DCCs whether the check is actually accurate, e.g.:
```python
try:
    import PyOpenColorIO
    ocio = True
except Exception:
    ocio = False
from openpype.pipeline import colorspace 
compatible = colorspace.compatible_python()
print("Compatible python function:", compatible)
print("Import PyOpenColorIO works:", ocio)
print(ocio == compatible)
```
Which makes me think the compatibility check might be easier including the import check itself as well to remain fully accurate?