### PR TITLE
Maya: fix the register_event_callback correctly collecting workfile save after

### DIFF
--- a/openpype/hosts/maya/api/pipeline.py
+++ b/openpype/hosts/maya/api/pipeline.py
@@ -113,7 +113,7 @@ class MayaHost(HostBase, IWorkfileHost, ILoadHost):
         register_event_callback("taskChanged", on_task_changed)
         register_event_callback("workfile.open.before", before_workfile_open)
         register_event_callback("workfile.save.before", before_workfile_save)
-        register_event_callback("workfile.save.before", after_workfile_save)
+        register_event_callback("workfile.save.after", after_workfile_save)
 
     def open_workfile(self, filepath):
         return open_file(filepath)


### PR DESCRIPTION
## Changelog Description
fixing the bug of register_event_callback not being able to collect action of "workfile_save_after" for lock file action

## Additional info
n/a

## Testing notes:
1. launch maya via OP
2. enable lockfile profile for maya
3. open a file(called workfile A) via Maya
4. save a new file(called workfile B)
5. launch maya via OP
6. open workfile A
7. Should show the lock widget