### PR TITLE
Bug: Maya - xgen sidecar files arent moved when saving workfile as an new asset workfile changing context - OP-6222

### DIFF
--- a/openpype/hosts/maya/api/pipeline.py
+++ b/openpype/hosts/maya/api/pipeline.py
@@ -686,30 +686,6 @@ def before_workfile_save(event):
         create_workspace_mel(workdir_path, project_name)
 
 
-def prompt_warning(message, show_cancel=False):
-    """Show feedback to user.
-
-    Returns:
-        bool
-    """
-
-    accept = QtWidgets.QMessageBox.Ok
-    if show_cancel:
-        buttons = accept | QtWidgets.QMessageBox.Cancel
-    else:
-        buttons = accept
-
-    state = QtWidgets.QMessageBox.warning(
-        None,
-        "",
-        message,
-        buttons=buttons,
-        defaultButton=accept
-    )
-
-    return state == accept
-
-
 def workfile_save_before_xgen(event):
     """Manage Xgen external files when switching context.
 
@@ -778,14 +754,13 @@ def workfile_save_before_xgen(event):
 
     # Ask user about overwriting files.
     if overwrites:
-        msg = (
+        log.warning(
             "WARNING! Potential loss of data.\n\n"
-            "Found duplicate Xgen files in new context.\n"
-            "Do you want to overwrite?\n\n{}".format("\n".join(overwrites))
+            "Found duplicate Xgen files in new context.\n{}".format(
+                "\n".join(overwrites)
+            )
         )
-        accept = prompt_warning(msg, show_cancel=True)
-        if not accept:
-            return
+        return
 
     for source, destination in transfers:
         if not os.path.exists(os.path.dirname(destination)):

--- a/openpype/hosts/maya/api/pipeline.py
+++ b/openpype/hosts/maya/api/pipeline.py
@@ -8,7 +8,6 @@ from maya import utils, cmds, OpenMaya
 import maya.api.OpenMaya as om
 
 import pyblish.api
-from qtpy import QtWidgets
 
 from openpype.settings import get_project_settings
 from openpype.host import (

--- a/openpype/hosts/maya/api/pipeline.py
+++ b/openpype/hosts/maya/api/pipeline.py
@@ -8,6 +8,7 @@ from maya import utils, cmds, OpenMaya
 import maya.api.OpenMaya as om
 
 import pyblish.api
+from qtpy import QtWidgets
 
 from openpype.settings import get_project_settings
 from openpype.host import (
@@ -691,9 +692,6 @@ def prompt_warning(message, show_cancel=False):
         Returns:
             bool
         """
-
-    from qtpy import QtWidgets
-
     accept = QtWidgets.QMessageBox.Ok
     if show_cancel:
         buttons = accept | QtWidgets.QMessageBox.Cancel

--- a/openpype/hosts/maya/api/pipeline.py
+++ b/openpype/hosts/maya/api/pipeline.py
@@ -685,7 +685,7 @@ def before_workfile_save(event):
         create_workspace_mel(workdir_path, project_name)
 
 
-def display_warning(message, show_cancel=False):
+def prompt_warning(message, show_cancel=False):
     """Show feedback to user.
 
         Returns:
@@ -784,7 +784,7 @@ def workfile_save_before_xgen(event):
             "Found duplicate Xgen files in new context.\n"
             "Do you want to overwrite?\n\n{}".format("\n".join(overwrites))
         )
-        accept = display_warning(msg, show_cancel=True)
+        accept = prompt_warning(msg, show_cancel=True)
         if not accept:
             return
 

--- a/openpype/hosts/maya/api/pipeline.py
+++ b/openpype/hosts/maya/api/pipeline.py
@@ -8,6 +8,7 @@ from maya import utils, cmds, OpenMaya
 import maya.api.OpenMaya as om
 
 import pyblish.api
+from qtpy import QtWidgets
 
 from openpype.settings import get_project_settings
 from openpype.host import (

--- a/openpype/scripts/otio_burnin.py
+++ b/openpype/scripts/otio_burnin.py
@@ -442,7 +442,7 @@ class ModifiedBurnins(ffmpeg_burnins.Burnins):
             with tempfile.NamedTemporaryFile(mode="w", delete=False) as temp:
                 temp.write(filter_string)
                 filters_path = temp.name
-            filters = '-filter_script "{}"'.format(filters_path)
+            filters = '-filter_script:v "{}"'.format(filters_path)
             print("Filters:", filter_string)
             self.cleanup_paths.append(filters_path)
 


### PR DESCRIPTION
## Changelog Description
This PR manages the Xgen files when switching context in the Workfiles app.

## Testing notes:
1. Setup Xgen in Maya.
2. Switch context and validate xgen files are copied to new location.
3. Repeat steps 1-2 and validate overwrite dialog appears.
4. Load in Xgen in Maya.
5. Switch context and validate xgen still works after relaunch of Maya.