### PR TITLE
Houdini: Fix `get_color_management_preferences`

### DIFF
--- a/openpype/hosts/houdini/api/lib.py
+++ b/openpype/hosts/houdini/api/lib.py
@@ -633,23 +633,8 @@ def evalParmNoFrame(node, parm, pad_character="#"):
 
 def get_color_management_preferences():
     """Get default OCIO preferences"""
-    data = {
-        "config": hou.Color.ocio_configPath()
-
+    return {
+        "config": hou.Color.ocio_configPath(),
+        "display": hou.Color.ocio_defaultDisplay(),
+        "view": hou.Color.ocio_defaultView()
     }
-
-    # Get default display and view from OCIO
-    display = hou.Color.ocio_defaultDisplay()
-    disp_regex = re.compile(r"^(?P<name>.+-)(?P<display>.+)$")
-    disp_match = disp_regex.match(display)
-
-    view = hou.Color.ocio_defaultView()
-    view_regex = re.compile(r"^(?P<name>.+- )(?P<view>.+)$")
-    view_match = view_regex.match(view)
-    data.update({
-        "display": disp_match.group("display"),
-        "view": view_match.group("view")
-
-    })
-
-    return data


### PR DESCRIPTION
## Changelog Description

Fix the issue described [here](https://github.com/ynput/OpenPype/pull/4825#discussion_r1217793100) where the logic for retrieving the current OCIO display and view was incorrectly trying to apply a regex to it.

## Testing notes:

1. Publish renders from Houdini with different OCIO configs - preferably with colorspace prefs set to something without a `-` in the colorspace name.

