### PR TITLE
Bug: Local settings don't open on 3.14.7 

### DIFF
--- a/openpype/tools/settings/local_settings/projects_widget.py
+++ b/openpype/tools/settings/local_settings/projects_widget.py
@@ -285,7 +285,7 @@ class SitesWidget(QtWidgets.QWidget):
                 continue
 
             site_inputs = []
-            site_config = site_configs[site_name]
+            site_config = site_configs.get(site_name, {})
             for root_name, path_entity in site_config.get("root", {}).items():
                 if not path_entity:
                     continue


### PR DESCRIPTION
### Before posting a new ticket, have you looked through the documentation to find an answer?

Yes I have

### Have you looked through the existing tickets to find any related issues ?

Not yet

### Author of the bug

@FadyFS

### Version

3.15.11-nightly.3

### What platform you are running OpenPype on?

Linux / Centos

### Current Behavior:

the previous behavior (bug) : 
![image](https://github.com/quadproduction/OpenPype/assets/135602303/09bff9d5-3f8b-4339-a1e5-30c04ade828c)


### Expected Behavior:

![image](https://github.com/quadproduction/OpenPype/assets/135602303/c505a103-7965-4796-bcdf-73bcc48a469b)


### What type of bug is it ?

Happened only once in a particular configuration

### Which project / workfile / asset / ...

open settings with 3.14.7 

### Steps To Reproduce:

1. Run openpype on the 3.15.11-nightly.3 version 
2. Open settings in 3.14.7 version

### Relevant log output:

_No response_

### Additional context:

_No response_
