### PR TITLE
Bug: Template builder fails when loading data without outliner representation

### DIFF
--- a/openpype/hosts/maya/api/workfile_template_builder.py
+++ b/openpype/hosts/maya/api/workfile_template_builder.py
@@ -274,7 +274,7 @@ class MayaPlaceholderLoadPlugin(PlaceholderPlugin, PlaceholderLoadMixin):
         roots = cmds.sets(container, q=True)
         ref_node = None
         try:
-           ref_node = get_reference_node(roots)
+            ref_node = get_reference_node(roots)
         except AssertionError as e:
             self.log.info(e.args[0])
 

--- a/openpype/hosts/maya/api/workfile_template_builder.py
+++ b/openpype/hosts/maya/api/workfile_template_builder.py
@@ -272,7 +272,12 @@ class MayaPlaceholderLoadPlugin(PlaceholderPlugin, PlaceholderLoadMixin):
             return
 
         roots = cmds.sets(container, q=True)
-        ref_node = get_reference_node(roots)
+        ref_node = None
+        try:
+           ref_node = get_reference_node(roots)
+        except AssertionError as e:
+            self.log.info(e.args[0])
+
         nodes_to_parent = []
         for root in roots:
             if ref_node:


### PR DESCRIPTION
## Changelog Description
I add an assertion management in case the container does not have a represention in outliner.

### Current Behavior:

If a template contains a placeholder without outliner representation it will produce this warning:
```bash
# # *** WRN: >>> { <openpype.hosts.maya.api.workfile_template_builder.MayaTemplateBuilder object at 0x7f152d504190> }: [ Failed to process placeholder |root|Production_render_template_23_5 with plugin MayaPlaceholderLoadPlugin ] 
# ==============================
# No reference node found in container
# ==============================
# Traceback (most recent call last):
#   File "/users_roaming/chector/Documents/src/OpenPype/openpype/pipeline/workfile/workfile_template_builder.py", line 727, in populate_scene_placeholders
#     placeholder_plugin.populate_placeholder(placeholder)
#   File "/users_roaming/chector/Documents/src/OpenPype/openpype/hosts/maya/api/workfile_template_builder.py", line 237, in populate_placeholder
#     self.populate_load_placeholder(placeholder)
#   File "/users_roaming/chector/Documents/src/OpenPype/openpype/pipeline/workfile/workfile_template_builder.py", line 1634, in populate_load_placeholder
#     self.load_succeed(placeholder, container)
#   File "/users_roaming/chector/Documents/src/OpenPype/openpype/hosts/maya/api/workfile_template_builder.py", line 261, in load_succeed
#     self._parent_in_hierarchy(placeholder, container)
#   File "/users_roaming/chector/Documents/src/OpenPype/openpype/hosts/maya/api/workfile_template_builder.py", line 278, in _parent_in_hierarchy
#     ref_node = get_reference_node(roots)
#   File "/users_roaming/chector/Documents/src/OpenPype/openpype/hosts/maya/api/lib.py", line 4023, in get_reference_node
#     assert references, "No reference node found in container"
```

### Steps To Reproduce:

1. Add a placeholder without ouliner representation in your template (like maya render settings)
2. Build workfile from template
3. See this error in the script editor
