### PR TITLE
Colorspace: check PyOpenColorIO rather then python version

### DIFF
--- a/openpype/pipeline/colorspace.py
+++ b/openpype/pipeline/colorspace.py
@@ -240,7 +240,7 @@ def compatibility_check():
     """Making sure PyOpenColorIO is importable"""
     try:
         import PyOpenColorIO  # noqa: F401
-    except (ImportError, ModuleNotFoundError):
+    except ImportError:
         return False
     return True
 

--- a/openpype/pipeline/colorspace.py
+++ b/openpype/pipeline/colorspace.py
@@ -1,7 +1,6 @@
 from copy import deepcopy
 import re
 import os
-import sys
 import json
 import platform
 import contextlib
@@ -237,12 +236,13 @@ def get_data_subprocess(config_path, data_type):
         return json.loads(return_json_data)
 
 
-def compatible_python():
-    """Only 3.9 or higher can directly use PyOpenColorIO in ocio_wrapper"""
-    compatible = False
-    if sys.version_info.major == 3 and sys.version_info.minor >= 9:
-        compatible = True
-    return compatible
+def compatibility_check():
+    """Making sure PyOpenColorIO is importable"""
+    try:
+        import PyOpenColorIO
+    except (ImportError, ModuleNotFoundError):
+        return False
+    return True
 
 
 def get_ocio_config_colorspaces(config_path):
@@ -257,11 +257,14 @@ def get_ocio_config_colorspaces(config_path):
     Returns:
         dict: colorspace and family in couple
     """
-    if compatible_python():
-        from ..scripts.ocio_wrapper import _get_colorspace_data
-        return _get_colorspace_data(config_path)
-    else:
+    if not compatibility_check():
+        # python environment is not compatible with PyOpenColorIO
+        # needs to be run in subprocess
         return get_colorspace_data_subprocess(config_path)
+
+    from openpype.scripts.ocio_wrapper import _get_colorspace_data
+
+    return _get_colorspace_data(config_path)
 
 
 def get_colorspace_data_subprocess(config_path):
@@ -290,11 +293,14 @@ def get_ocio_config_views(config_path):
     Returns:
         dict: `display/viewer` and viewer data
     """
-    if compatible_python():
-        from ..scripts.ocio_wrapper import _get_views_data
-        return _get_views_data(config_path)
-    else:
+    if not compatibility_check():
+        # python environment is not compatible with PyOpenColorIO
+        # needs to be run in subprocess
         return get_views_data_subprocess(config_path)
+
+    from openpype.scripts.ocio_wrapper import _get_views_data
+
+    return _get_views_data(config_path)
 
 
 def get_views_data_subprocess(config_path):

--- a/openpype/pipeline/colorspace.py
+++ b/openpype/pipeline/colorspace.py
@@ -239,7 +239,7 @@ def get_data_subprocess(config_path, data_type):
 def compatibility_check():
     """Making sure PyOpenColorIO is importable"""
     try:
-        import PyOpenColorIO
+        import PyOpenColorIO  # noqa: F401
     except (ImportError, ModuleNotFoundError):
         return False
     return True


### PR DESCRIPTION
## Changelog Description
Fixing previously merged PR (https://github.com/ynput/OpenPype/pull/5212) And applying better way to check compatibility with PyOpenColorIO python api.

## Additional info
- implementing suggestion from https://github.com/ynput/OpenPype/pull/5212#issuecomment-1614651292

## Testing notes:
1. Colorspace features should now work again in any host
