### PR TITLE
Maya: fix save file prompt on launch last workfile with color management enabled + restructure `set_colorspace`

### DIFF
--- a/openpype/hosts/maya/api/lib.py
+++ b/openpype/hosts/maya/api/lib.py
@@ -3238,36 +3238,21 @@ def iter_shader_edits(relationships, shader_nodes, nodes_by_id, label=None):
 
 
 def set_colorspace():
-    """Set Colorspace from project configuration
-    """
+    """Set Colorspace from project configuration"""
 
-    # set color spaces for rendering space and view transforms
-    def _colormanage(**kwargs):
-        """Wrapper around `cmds.colorManagementPrefs`.
-
-        This logs errors instead of raising an error so color management
-        settings get applied as much as possible.
-
-        """
-        assert len(kwargs) == 1, "Must receive one keyword argument"
-        try:
-            cmds.colorManagementPrefs(edit=True, **kwargs)
-            log.debug("Setting Color Management Preference: {}".format(kwargs))
-        except RuntimeError as exc:
-            log.error(exc)
-
-    project_name = os.getenv("AVALON_PROJECT")
+    project_name = get_current_project_name()
     imageio = get_project_settings(project_name)["maya"]["imageio"]
 
     # ocio compatibility variables
     ocio_v2_maya_version = 2022
     maya_version = int(cmds.about(version=True))
     ocio_v2_support = use_ocio_v2 = maya_version >= ocio_v2_maya_version
+    is_ocio_set = bool(os.environ.get("OCIO"))
 
-    root_dict = {}
     use_workfile_settings = imageio.get("workfile", {}).get("enabled")
-
     if use_workfile_settings:
+        root_dict = imageio["workfile"]
+    else:
         # TODO: deprecated code from 3.15.5 - remove
         # Maya 2022+ introduces new OCIO v2 color management settings that
         # can override the old color management preferences. OpenPype has
@@ -3290,40 +3275,63 @@ def set_colorspace():
         if not isinstance(root_dict, dict):
             msg = "set_colorspace(): argument should be dictionary"
             log.error(msg)
+            return
 
-    else:
-        root_dict = imageio["workfile"]
+    # backward compatibility
+    # TODO: deprecated code from 3.15.5 - remove with deprecated code above
+    view_name = root_dict.get("viewTransform")
+    if view_name is None:
+        view_name = root_dict.get("viewName")
 
     log.debug(">> root_dict: {}".format(pformat(root_dict)))
+    if not root_dict:
+        return
 
-    if root_dict:
-        # enable color management
-        cmds.colorManagementPrefs(e=True, cmEnabled=True)
-        cmds.colorManagementPrefs(e=True, ocioRulesEnabled=True)
+    # set color spaces for rendering space and view transforms
+    def _colormanage(**kwargs):
+        """Wrapper around `cmds.colorManagementPrefs`.
 
-        # backward compatibility
-        # TODO: deprecated code from 3.15.5 - refactor to use new settings
-        view_name = root_dict.get("viewTransform")
-        if view_name is None:
-            view_name = root_dict.get("viewName")
+        This logs errors instead of raising an error so color management
+        settings get applied as much as possible.
 
-        if use_ocio_v2:
-            # Use Maya 2022+ default OCIO v2 config
+        """
+        assert len(kwargs) == 1, "Must receive one keyword argument"
+        try:
+            cmds.colorManagementPrefs(edit=True, **kwargs)
+            log.debug("Setting Color Management Preference: {}".format(kwargs))
+        except RuntimeError as exc:
+            log.error(exc)
+
+    # enable color management
+    cmds.colorManagementPrefs(edit=True, cmEnabled=True)
+    cmds.colorManagementPrefs(edit=True, ocioRulesEnabled=True)
+
+    if use_ocio_v2:
+        log.info("Using Maya OCIO v2")
+        if not is_ocio_set:
+            # Set the Maya 2022+ default OCIO v2 config file path
             log.info("Setting default Maya OCIO v2 config")
-            cmds.colorManagementPrefs(edit=True, configFilePath="")
+            # Note: Setting "" as value also sets this default however
+            # introduces a bug where launching a file on startup will prompt
+            # to save the empty scene before it, so we set using the path.
+            # This value has been the same for 2022, 2023 and 2024
+            path = "<MAYA_RESOURCES>/OCIO-configs/Maya2022-default/config.ocio"
+            cmds.colorManagementPrefs(edit=True, configFilePath=path)
 
-            # set rendering space and view transform
-            _colormanage(renderingSpaceName=root_dict["renderSpace"])
-            _colormanage(viewName=view_name)
-            _colormanage(displayName=root_dict["displayName"])
-        else:
+        # set rendering space and view transform
+        _colormanage(renderingSpaceName=root_dict["renderSpace"])
+        _colormanage(viewName=view_name)
+        _colormanage(displayName=root_dict["displayName"])
+    else:
+        log.info("Using Maya OCIO v1 (legacy)")
+        if not is_ocio_set:
             # Set the Maya default config file path
             log.info("Setting default Maya OCIO v1 legacy config")
             cmds.colorManagementPrefs(edit=True, configFilePath="legacy")
 
-            # set rendering space and view transform
-            _colormanage(renderingSpaceName=root_dict["renderSpace"])
-            _colormanage(viewTransformName=view_name)
+        # set rendering space and view transform
+        _colormanage(renderingSpaceName=root_dict["renderSpace"])
+        _colormanage(viewTransformName=view_name)
 
 
 @contextlib.contextmanager


### PR DESCRIPTION
## Changelog Description

- Only set `configFilePath` when OCIO env var is not set since it doesn't do anything if OCIO var is set anyway.
- Set the Maya 2022+ default OCIO path using the resources path instead of "" to avoid Maya Save File on new file after launch
   - **Bugfix: This is what fixes the Save prompt on open last workfile feature with Global color management enabled**
- Move all code related to applying the maya settings together after querying the settings
- Swap around the `if use_workfile_settings` since the check was reversed
- Use `get_current_project_name()` instead of environment vars

## Additional info

**Please note** that with the default settings **and** global color management enabled that you will after this PR now get logged errors on New Scene due to the default settings with color management setting OCIO configs using the `OCIO` env var:

![image](https://github.com/ynput/OpenPype/assets/2439881/0d0a4e65-7b4f-4369-a30a-064988506c93)

However the default colorspaces for Maya do not existing in those configs (but they are based on the default OCIO configs of Maya):

![image](https://github.com/ynput/OpenPype/assets/2439881/b0bcdc45-c7a9-493a-a323-57c2ae805e2b)

Before this PR those values ALSO wouldn't be set however no error would have been logged due to the `colorManagementPrefs` config path to be set to Maya's default JUST before those calls and maya finding the views and displays there - however the OCIO env var takes precedence over it and thus overrides those prefs - and with that thus resets those settings again.

To avoid this you'll need to tweak the settings from the second screenshot into colorspaces that actually exist in the one from OpenPype.

## Testing notes:

1. Enable the global color management setting `project_settings/global/imageio/activate_global_color_management`
2. Open Maya 2022 and 2023 and 2024 with last workfile - it should not prompt to save the empty file for before opening the file on launch.
3. Color management should continue to work as expected in maya
    - As such, it might be good to also publish a look with some color management

Note: All this should also still continue to work with `project_settings/global/imageio/activate_global_color_management` disabled.