### PR TITLE
Maya: Minor refactoring and code cleanup

### DIFF
--- a/openpype/hosts/maya/api/lib.py
+++ b/openpype/hosts/maya/api/lib.py
@@ -2811,19 +2811,22 @@ def get_attr_in_layer(attr, layer):
 
 def fix_incompatible_containers():
     """Backwards compatibility: old containers to use new ReferenceLoader"""
-
+    old_loaders = {
+        "MayaAsciiLoader",
+        "AbcLoader",
+        "ModelLoader",
+        "CameraLoader",
+        "RigLoader",
+        "FBXLoader"
+    }
     host = registered_host()
     for container in host.ls():
         loader = container['loader']
-
-        print(container['loader'])
-
-        if loader in ["MayaAsciiLoader",
-                      "AbcLoader",
-                      "ModelLoader",
-                      "CameraLoader",
-                      "RigLoader",
-                      "FBXLoader"]:
+        if loader in old_loaders:
+            log.info(
+                "Converting legacy container loader {} to "
+                "ReferenceLoader: {}".format(loader, container["objectName"])
+            )
             cmds.setAttr(container["objectName"] + ".loader",
                          "ReferenceLoader", type="string")
 

--- a/openpype/hosts/maya/api/lib.py
+++ b/openpype/hosts/maya/api/lib.py
@@ -2954,7 +2954,7 @@ def _get_render_instances():
         list: list of instances
 
     """
-    objectset = cmds.ls("*.id", long=True, type="objectSet",
+    objectset = cmds.ls("*.id", long=True, exactType="objectSet",
                         recursive=True, objectsOnly=True)
 
     instances = []

--- a/openpype/hosts/maya/api/lib.py
+++ b/openpype/hosts/maya/api/lib.py
@@ -3,7 +3,6 @@
 import os
 from pprint import pformat
 import sys
-import platform
 import uuid
 import re
 

--- a/openpype/hosts/maya/api/pipeline.py
+++ b/openpype/hosts/maya/api/pipeline.py
@@ -569,7 +569,6 @@ def _update_render_layer_observers():
 def on_open():
     """On scene open let's assume the containers have changed."""
 
-    from qtpy import QtWidgets
     from openpype.widgets import popup
 
     utils.executeDeferred(_update_render_layer_observers)
@@ -583,10 +582,7 @@ def on_open():
         log.warning("Scene has outdated content.")
 
         # Find maya main window
-        top_level_widgets = {w.objectName(): w for w in
-                             QtWidgets.QApplication.topLevelWidgets()}
-        parent = top_level_widgets.get("MayaWindow", None)
-
+        parent = lib.get_main_window()
         if parent is None:
             log.info("Skipping outdated content pop-up "
                      "because Maya window can't be found.")

--- a/openpype/hosts/maya/api/pipeline.py
+++ b/openpype/hosts/maya/api/pipeline.py
@@ -563,21 +563,20 @@ def on_save():
         lib.set_id(node, new_id, overwrite=False)
 
 
+def _update_render_layer_observers():
+    # Helper to trigger update for all renderlayer observer logic
+    lib.remove_render_layer_observer()
+    lib.add_render_layer_observer()
+    lib.add_render_layer_change_observer()
+
+
 def on_open():
     """On scene open let's assume the containers have changed."""
 
     from qtpy import QtWidgets
     from openpype.widgets import popup
 
-    cmds.evalDeferred(
-        "from openpype.hosts.maya.api import lib;"
-        "lib.remove_render_layer_observer()")
-    cmds.evalDeferred(
-        "from openpype.hosts.maya.api import lib;"
-        "lib.add_render_layer_observer()")
-    cmds.evalDeferred(
-        "from openpype.hosts.maya.api import lib;"
-        "lib.add_render_layer_change_observer()")
+    utils.executeDeferred(_update_render_layer_observers)
     # # Update current task for the current scene
     # update_task_from_path(cmds.file(query=True, sceneName=True))
 
@@ -618,16 +617,9 @@ def on_new():
     """Set project resolution and fps when create a new file"""
     log.info("Running callback on new..")
     with lib.suspended_refresh():
-        cmds.evalDeferred(
-            "from openpype.hosts.maya.api import lib;"
-            "lib.remove_render_layer_observer()")
-        cmds.evalDeferred(
-            "from openpype.hosts.maya.api import lib;"
-            "lib.add_render_layer_observer()")
-        cmds.evalDeferred(
-            "from openpype.hosts.maya.api import lib;"
-            "lib.add_render_layer_change_observer()")
         lib.set_context_settings()
+
+    utils.executeDeferred(_update_render_layer_observers)
     _remove_workfile_lock()
 
 

--- a/openpype/hosts/maya/api/pipeline.py
+++ b/openpype/hosts/maya/api/pipeline.py
@@ -549,13 +549,9 @@ def on_save():
     Any transform of a mesh, without an existing ID, is given one
     automatically on file save.
     """
-
     log.info("Running callback on save..")
     # remove lockfile if users jumps over from one scene to another
     _remove_workfile_lock()
-
-    # # Update current task for the current scene
-    # update_task_from_path(cmds.file(query=True, sceneName=True))
 
     # Generate ids of the current context on nodes in the scene
     nodes = lib.get_id_required_nodes(referenced_nodes=False)
@@ -577,8 +573,6 @@ def on_open():
     from openpype.widgets import popup
 
     utils.executeDeferred(_update_render_layer_observers)
-    # # Update current task for the current scene
-    # update_task_from_path(cmds.file(query=True, sceneName=True))
 
     # Validate FPS after update_task_from_path to
     # ensure it is using correct FPS for the asset

--- a/openpype/hosts/maya/api/pipeline.py
+++ b/openpype/hosts/maya/api/pipeline.py
@@ -480,18 +480,16 @@ def on_init():
     # Force load objExport plug-in (requested by artists)
     cmds.loadPlugin("objExport", quiet=True)
 
-    from .customize import (
-        override_component_mask_commands,
-        override_toolbox_ui
-    )
-    safe_deferred(override_component_mask_commands)
-
-    launch_workfiles = os.environ.get("WORKFILES_STARTUP")
-
-    if launch_workfiles:
-        safe_deferred(host_tools.show_workfiles)
-
     if not lib.IS_HEADLESS:
+        launch_workfiles = os.environ.get("WORKFILES_STARTUP")
+        if launch_workfiles:
+            safe_deferred(host_tools.show_workfiles)
+
+        from .customize import (
+            override_component_mask_commands,
+            override_toolbox_ui
+        )
+        safe_deferred(override_component_mask_commands)
         safe_deferred(override_toolbox_ui)
 
 

--- a/openpype/hosts/maya/api/plugin.py
+++ b/openpype/hosts/maya/api/plugin.py
@@ -1,5 +1,4 @@
 import os
-import re
 
 from maya import cmds
 

--- a/openpype/hosts/maya/api/render_setup_tools.py
+++ b/openpype/hosts/maya/api/render_setup_tools.py
@@ -15,7 +15,6 @@ import contextlib
 from maya import cmds
 from maya.app.renderSetup.model import renderSetup
 
-# from colorbleed.maya import lib
 from .lib import pairwise
 
 

--- a/openpype/hosts/maya/plugins/publish/extract_obj.py
+++ b/openpype/hosts/maya/plugins/publish/extract_obj.py
@@ -2,7 +2,6 @@
 import os
 
 from maya import cmds
-# import maya.mel as mel
 import pyblish.api
 from openpype.pipeline import publish
 from openpype.hosts.maya.api import lib

--- a/openpype/hosts/maya/tools/mayalookassigner/app.py
+++ b/openpype/hosts/maya/tools/mayalookassigner/app.py
@@ -8,7 +8,10 @@ from openpype.client import get_last_version_by_subset_id
 from openpype import style
 from openpype.pipeline import legacy_io
 from openpype.tools.utils.lib import qt_app_context
-from openpype.hosts.maya.api.lib import assign_look_by_version
+from openpype.hosts.maya.api.lib import (
+    assign_look_by_version,
+    get_main_window
+)
 
 from maya import cmds
 # old api for MFileIO
@@ -297,9 +300,7 @@ def show():
         pass
 
     # Get Maya main window
-    top_level_widgets = QtWidgets.QApplication.topLevelWidgets()
-    mainwindow = next(widget for widget in top_level_widgets
-                      if widget.objectName() == "MayaWindow")
+    mainwindow = get_main_window()
 
     with qt_app_context():
         window = MayaLookAssignerWindow(parent=mainwindow)

--- a/openpype/pipeline/create/legacy_create.py
+++ b/openpype/pipeline/create/legacy_create.py
@@ -74,12 +74,12 @@ class LegacyCreator(object):
         if not plugin_settings:
             return
 
-        print(">>> We have preset for {}".format(plugin_name))
+        cls.log.debug(">>> We have preset for {}".format(plugin_name))
         for option, value in plugin_settings.items():
             if option == "enabled" and value is False:
-                print("  - is disabled by preset")
+                cls.log.debug("  - is disabled by preset")
             else:
-                print("  - setting `{}`: `{}`".format(option, value))
+                cls.log.debug("  - setting `{}`: `{}`".format(option, value))
             setattr(cls, option, value)
 
     def process(self):


### PR DESCRIPTION
## Changelog Description

Some small cleanup and refactoring of logic. Removing old comments, unused imports and some minor optimization. Also removed the prints of the loader names of each container the scene in `fix_incompatible_containers` + optimizing by using `set` and defining only once. Moved some UI related code/tweaks to run `on_init` only if not in headless mode. Removed an empty `obj.py` file.

Each commit message kind of describes why the change was made.

## Additional info

Even though these are mostly cosmetic changes they might introduce subtle bugs (of course). So do a quick test run please.

## Testing notes:

1. Maya Look assigner should still open
2. Maya Creator UI should still work
3. Render Setup observers should still work, create a render instance - ensure it correctly catches adding new renderlayers or removing old ones and test the publishing of it.
4. Extracting `.obj` should still work.