### PR TITLE
Enhancement: More descriptive error messages for Loaders

### DIFF
--- a/openpype/pipeline/load/__init__.py
+++ b/openpype/pipeline/load/__init__.py
@@ -4,6 +4,8 @@ from .utils import (
     LoadError,
     IncompatibleLoaderError,
     InvalidRepresentationContext,
+    LoaderSwitchNotImplementedError,
+    LoaderNotFoundError,
 
     get_repres_contexts,
     get_contexts_for_repre_docs,
@@ -55,6 +57,8 @@ __all__ = (
     "LoadError",
     "IncompatibleLoaderError",
     "InvalidRepresentationContext",
+    "LoaderSwitchNotImplementedError",
+    "LoaderNotFoundError",
 
     "get_repres_contexts",
     "get_contexts_for_repre_docs",

--- a/openpype/pipeline/load/utils.py
+++ b/openpype/pipeline/load/utils.py
@@ -79,6 +79,16 @@ class InvalidRepresentationContext(ValueError):
     pass
 
 
+class LoaderSwitchNotImplementedError(NotImplementedError):
+    """Error when `switch` is used with Loader that has no implementation."""
+    pass
+
+
+class LoaderNotFoundError(RuntimeError):
+    """Error when Loader plugin for a loader name is not found."""
+    pass
+
+
 def get_repres_contexts(representation_ids, dbcon=None):
     """Return parenthood context for representation.
 
@@ -432,7 +442,10 @@ def remove_container(container):
 
     Loader = _get_container_loader(container)
     if not Loader:
-        raise RuntimeError("Can't remove container. See log for details.")
+        raise LoaderNotFoundError(
+            "Can't remove container because loader '{}' was not found."
+            .format(container.get("loader"))
+        )
 
     loader = Loader(get_representation_context(container["representation"]))
     return loader.remove(container)
@@ -480,7 +493,10 @@ def update_container(container, version=-1):
     # Run update on the Loader for this container
     Loader = _get_container_loader(container)
     if not Loader:
-        raise RuntimeError("Can't update container. See log for details.")
+        raise LoaderNotFoundError(
+            "Can't update container because loader '{}' was not found."
+            .format(container.get("loader"))
+        )
 
     loader = Loader(get_representation_context(container["representation"]))
     return loader.update(container, new_representation)
@@ -502,15 +518,18 @@ def switch_container(container, representation, loader_plugin=None):
         loader_plugin = _get_container_loader(container)
 
     if not loader_plugin:
-        raise RuntimeError("Can't switch container. See log for details.")
+        raise LoaderNotFoundError(
+            "Can't switch container because loader '{}' was not found."
+            .format(container.get("loader"))
+        )
 
     if not hasattr(loader_plugin, "switch"):
         # Backwards compatibility (classes without switch support
         # might be better to just have "switch" raise NotImplementedError
         # on the base class of Loader\
-        raise RuntimeError("Loader '{}' does not support 'switch'".format(
-            loader_plugin.label
-        ))
+        raise LoaderSwitchNotImplementedError(
+            "Loader {} does not support 'switch'".format(loader_plugin.label)
+        )
 
     # Get the new representation to switch to
     project_name = legacy_io.active_project()
@@ -520,7 +539,11 @@ def switch_container(container, representation, loader_plugin=None):
 
     new_context = get_representation_context(new_representation)
     if not is_compatible_loader(loader_plugin, new_context):
-        raise AssertionError("Must be compatible Loader")
+        raise IncompatibleLoaderError(
+            "Loader {} is incompatible with {}".format(
+                loader_plugin.__name__, new_context["subset"]["name"]
+            )
+        )
 
     loader = loader_plugin(new_context)
 

--- a/openpype/tools/sceneinventory/switch_dialog.py
+++ b/openpype/tools/sceneinventory/switch_dialog.py
@@ -19,6 +19,9 @@ from openpype.pipeline.load import (
     switch_container,
     get_repres_contexts,
     loaders_from_repre_context,
+    LoaderSwitchNotImplementedError,
+    IncompatibleLoaderError,
+    LoaderNotFoundError
 )
 
 from .widgets import (
@@ -1300,7 +1303,18 @@ class SwitchAssetDialog(QtWidgets.QDialog):
 
             try:
                 switch_container(container, repre_doc, loader)
-            except Exception:
+            except Exception as exc:
+                if isinstance(exc, (LoaderSwitchNotImplementedError,
+                                    IncompatibleLoaderError,
+                                    LoaderNotFoundError)):
+                    # Show error message directly
+                    text = str(exc)
+                else:
+                    text = (
+                        "Switch asset failed. "
+                        "Search console log for more details."
+                    )
+
                 msg = (
                     "Couldn't switch asset."
                     "See traceback for more information."
@@ -1308,9 +1322,7 @@ class SwitchAssetDialog(QtWidgets.QDialog):
                 log.warning(msg, exc_info=True)
                 dialog = QtWidgets.QMessageBox(self)
                 dialog.setWindowTitle("Switch asset failed")
-                dialog.setText(
-                    "Switch asset failed. Search console log for more details"
-                )
+                dialog.setText(text)
                 dialog.exec_()
 
         self.switched.emit()

--- a/openpype/tools/sceneinventory/switch_dialog.py
+++ b/openpype/tools/sceneinventory/switch_dialog.py
@@ -1301,28 +1301,28 @@ class SwitchAssetDialog(QtWidgets.QDialog):
                 else:
                     repre_doc = repres_by_name[container_repre_name]
 
+            error = None
             try:
                 switch_container(container, repre_doc, loader)
-            except Exception as exc:
-                if isinstance(exc, (LoaderSwitchNotImplementedError,
-                                    IncompatibleLoaderError,
-                                    LoaderNotFoundError)):
-                    # Show error message directly
-                    text = str(exc)
-                else:
-                    text = (
-                        "Switch asset failed. "
-                        "Search console log for more details."
-                    )
-
-                msg = (
+            except (
+                LoaderSwitchNotImplementedError,
+                IncompatibleLoaderError,
+                LoaderNotFoundError,
+            ) as exc:
+                error = str(exc)
+            except Exception:
+                error = (
+                    "Switch asset failed. "
+                    "Search console log for more details."
+                )
+            if error is not None:
+                log.warning((
                     "Couldn't switch asset."
                     "See traceback for more information."
-                )
-                log.warning(msg, exc_info=True)
+                ), exc_info=True)
                 dialog = QtWidgets.QMessageBox(self)
                 dialog.setWindowTitle("Switch asset failed")
-                dialog.setText(text)
+                dialog.setText(error)
                 dialog.exec_()
 
         self.switched.emit()


### PR DESCRIPTION
## Changelog Description

Tweak raised errors and error messages for loader errors.

## Additional info

Intends to solve #4870 

## Testing notes:

1. Try and hit the loader error cases, make sure the error message is clear.
   - perform switch asset on a loader that does not have `switch` implemented
   - change the 'loader' name on a maya container (e.g. change the attribute value to 'foobar') to something non-existent, loader messages should be clear when trying to interact with it. 