### PR TITLE
Validate delivery action representations status

### DIFF
--- a/openpype/plugins/load/delivery.py
+++ b/openpype/plugins/load/delivery.py
@@ -155,7 +155,7 @@ class DeliveryOptionsDialog(QtWidgets.QDialog):
 
         self._update_selected_label()
         self._update_template_value()
-        
+
         btn_delivery.clicked.connect(self.deliver)
         dropdown.currentIndexChanged.connect(self._update_template_value)
 

--- a/openpype/plugins/load/delivery.py
+++ b/openpype/plugins/load/delivery.py
@@ -155,6 +155,10 @@ class DeliveryOptionsDialog(QtWidgets.QDialog):
 
         self._update_selected_label()
         self._update_template_value()
+        
+        btn_delivery.clicked.connect(self.deliver)
+        dropdown.currentIndexChanged.connect(self._update_template_value)
+
         if not self.dropdown.count():
             self.text_area.setVisible(True)
             error_message = (
@@ -163,9 +167,6 @@ class DeliveryOptionsDialog(QtWidgets.QDialog):
             )
             self.text_area.setText(error_message)
             self.log.error(error_message.replace("\n", " "))
-        else:
-            btn_delivery.clicked.connect(self.deliver)
-            dropdown.currentIndexChanged.connect(self._update_template_value)
 
     def deliver(self):
         """Main method to loop through all selected representations"""

--- a/openpype/plugins/load/delivery.py
+++ b/openpype/plugins/load/delivery.py
@@ -1,4 +1,5 @@
 import copy
+import platform
 from collections import defaultdict
 
 from qtpy import QtWidgets, QtCore, QtGui
@@ -83,6 +84,12 @@ class DeliveryOptionsDialog(QtWidgets.QDialog):
         self.templates = self._get_templates(self.anatomy)
         for name, _ in self.templates.items():
             dropdown.addItem(name)
+        if self.templates and platform.system() == "Darwin":
+            # fix macos QCombobox Style
+            dropdown.setItemDelegate(QtWidgets.QStyledItemDelegate())
+            # update combo box length to longest entry
+            longest_key = max(self.templates.keys(), key=len)
+            dropdown.setMinimumContentsLength(len(longest_key))
 
         template_label = QtWidgets.QLabel()
         template_label.setCursor(QtGui.QCursor(QtCore.Qt.IBeamCursor))
@@ -115,7 +122,7 @@ class DeliveryOptionsDialog(QtWidgets.QDialog):
         input_layout.addRow("Representations", repre_checkboxes_layout)
 
         btn_delivery = QtWidgets.QPushButton("Deliver")
-        btn_delivery.setEnabled(bool(dropdown.currentText()))
+        btn_delivery.setEnabled(False)
 
         progress_bar = QtWidgets.QProgressBar(self)
         progress_bar.setMinimum = 0
@@ -148,9 +155,17 @@ class DeliveryOptionsDialog(QtWidgets.QDialog):
 
         self._update_selected_label()
         self._update_template_value()
-
-        btn_delivery.clicked.connect(self.deliver)
-        dropdown.currentIndexChanged.connect(self._update_template_value)
+        if not self.dropdown.count():
+            self.text_area.setVisible(True)
+            error_message = (
+                "No Delivery Templates found!\n"
+                "Add Template in [project_anatomy/templates/delivery]"
+            )
+            self.text_area.setText(error_message)
+            self.log.error(error_message.replace("\n", " "))
+        else:
+            btn_delivery.clicked.connect(self.deliver)
+            dropdown.currentIndexChanged.connect(self._update_template_value)
 
     def deliver(self):
         """Main method to loop through all selected representations"""
@@ -287,14 +302,17 @@ class DeliveryOptionsDialog(QtWidgets.QDialog):
         self.files_selected, self.size_selected = \
             self._get_counts(selected_repres)
         self.selected_label.setText(self._prepare_label())
+        # update delivery button state if any templates found
+        if self.dropdown.count():
+            self.btn_delivery.setEnabled(bool(selected_repres))
 
     def _update_template_value(self, _index=None):
         """Sets template value to label after selection in dropdown."""
         name = self.dropdown.currentText()
         template_value = self.templates.get(name)
         if template_value:
-            self.btn_delivery.setEnabled(True)
             self.template_label.setText(template_value)
+            self.btn_delivery.setEnabled(bool(self._get_selected_repres()))
 
     def _update_progress(self, uploaded):
         """Update progress bar after each repre copied."""


### PR DESCRIPTION
## Changelog Description

- disable delivery button if no representations checked
- fix macos combobox layout
- add error message if no delivery templates found

## Additional info
Addressed #5162

## Testing notes:

1. Open Loader
2. Select sequence and right+click launch Deliver Versions
3. Leave it as it is. Deliver button will not be activated
4. Delete all delivery templates in `project_anatomy` and open delivery dialogue. Error message will be shown in the `text_area` with corresponding error log message.

<img width="1034" alt="image" src="https://github.com/ynput/OpenPype/assets/11698866/3fdc721f-1cc1-4f2d-8912-fc28cf74c8a6">
