### PR TITLE
 Houdini: Add geometry check for pointcache family

### DIFF
--- a/openpype/hosts/houdini/plugins/publish/validate_abc_primitive_to_detail.py
+++ b/openpype/hosts/houdini/plugins/publish/validate_abc_primitive_to_detail.py
@@ -73,6 +73,14 @@ class ValidateAbcPrimitiveToDetail(pyblish.api.InstancePlugin):
         cls.log.debug("Checking Primitive to Detail pattern: %s" % pattern)
         cls.log.debug("Checking with path attribute: %s" % path_attr)
 
+        if not hasattr(output_node, "geometry"):
+            # In the case someone has explicitly set an Object
+            # node instead of a SOP node in Geometry context
+            # then for now we ignore - this allows us to also
+            # export object transforms.
+            cls.log.warning("No geometry output node found, skipping check..")
+            return
+
         # Check if the primitive attribute exists
         frame = instance.data.get("frameStart", 0)
         geo = output_node.geometryAtFrame(frame)

--- a/openpype/hosts/houdini/plugins/publish/validate_primitive_hierarchy_paths.py
+++ b/openpype/hosts/houdini/plugins/publish/validate_primitive_hierarchy_paths.py
@@ -60,6 +60,14 @@ class ValidatePrimitiveHierarchyPaths(pyblish.api.InstancePlugin):
 
         cls.log.debug("Checking for attribute: %s" % path_attr)
 
+        if not hasattr(output_node, "geometry"):
+            # In the case someone has explicitly set an Object
+            # node instead of a SOP node in Geometry context
+            # then for now we ignore - this allows us to also
+            # export object transforms.
+            cls.log.warning("No geometry output node found, skipping check..")
+            return
+
         # Check if the primitive attribute exists
         frame = instance.data.get("frameStart", 0)
         geo = output_node.geometryAtFrame(frame)


### PR DESCRIPTION
## Changelog Description
When `sop_path`  on ABC ROP node points to a  non `SopNode`, these validators `validate_abc_primitive_to_detail.py`, `validate_primitive_hierarchy_paths.py` will error and crash when this line is executed 
`geo = output_node.geometryAtFrame(frame)`


