### PR TITLE
Houdini: add select invalid action for ValidateSopOutputNode

### DIFF
--- a/openpype/hosts/houdini/api/action.py
+++ b/openpype/hosts/houdini/api/action.py
@@ -49,8 +49,7 @@ class SelectInvalidAction(pyblish.api.Action):
 class SelectROPAction(pyblish.api.Action):
     """Select ROP.
 
-    It's used to select the associated ROPs with all errored instances
-    not necessarily the ones that errored on the plugin we're running the action on.
+    It's used to select the associated ROPs with the errored instances.
     """
 
     label = "Select ROP"

--- a/openpype/hosts/houdini/api/action.py
+++ b/openpype/hosts/houdini/api/action.py
@@ -57,15 +57,12 @@ class SelectROPAction(pyblish.api.Action):
     icon = "mdi.cursor-default-click"
 
     def process(self, context, plugin):
-        errored_instances = get_errored_instances_from_context(context)
-
-        # Apply pyblish.logic to get the instances for the plug-in
-        instances = pyblish.api.instances_by_plugin(errored_instances, plugin)
+        errored_instances = get_errored_instances_from_context(context, plugin)
 
         # Get the invalid nodes for the plug-ins
         self.log.info("Finding ROP nodes..")
         rop_nodes = list()
-        for instance in instances:
+        for instance in errored_instances:
             node_path = instance.data.get("instance_node")
             if not node_path:
                 continue

--- a/openpype/hosts/houdini/api/action.py
+++ b/openpype/hosts/houdini/api/action.py
@@ -44,3 +44,46 @@ class SelectInvalidAction(pyblish.api.Action):
                 node.setCurrent(True)
         else:
             self.log.info("No invalid nodes found.")
+
+
+class SelectROPAction(pyblish.api.Action):
+    """Select ROP.
+
+    It's used to select the associated ROPs with all errored instances
+    not necessarily the ones that errored on the plugin we're running the action on.
+    """
+
+    label = "Select ROP"
+    on = "failed"  # This action is only available on a failed plug-in
+    icon = "mdi.cursor-default-click"
+
+    def process(self, context, plugin):
+        errored_instances = get_errored_instances_from_context(context)
+
+        # Apply pyblish.logic to get the instances for the plug-in
+        instances = pyblish.api.instances_by_plugin(errored_instances, plugin)
+
+        # Get the invalid nodes for the plug-ins
+        self.log.info("Finding ROP nodes..")
+        rop_nodes = list()
+        for instance in instances:
+            node_path = instance.data.get("instance_node")
+            if not node_path:
+                continue
+
+            node = hou.node(node_path)
+            if not node:
+                continue
+
+            rop_nodes.append(node)
+
+        hou.clearAllSelected()
+        if rop_nodes:
+            self.log.info("Selecting ROP nodes: {}".format(
+                ", ".join(node.path() for node in rop_nodes)
+            ))
+            for node in rop_nodes:
+                node.setSelected(True)
+                node.setCurrent(True)
+        else:
+            self.log.info("No ROP nodes found.")

--- a/openpype/hosts/houdini/plugins/publish/validate_sop_output_node.py
+++ b/openpype/hosts/houdini/plugins/publish/validate_sop_output_node.py
@@ -6,8 +6,8 @@ from openpype.pipeline.publish import RepairAction
 import hou
 
 
-class SelectInvalidAction(RepairAction):
-    label = "Select Invalid ROP"
+class SelectROPAction(RepairAction):
+    label = "Select ROP"
     icon = "mdi.cursor-default-click"
 
 class ValidateSopOutputNode(pyblish.api.InstancePlugin):
@@ -26,7 +26,7 @@ class ValidateSopOutputNode(pyblish.api.InstancePlugin):
     families = ["pointcache", "vdbcache"]
     hosts = ["houdini"]
     label = "Validate Output Node"
-    actions = [SelectInvalidAction]
+    actions = [SelectROPAction]
 
     def process(self, instance):
 
@@ -89,10 +89,10 @@ class ValidateSopOutputNode(pyblish.api.InstancePlugin):
 
     @classmethod
     def repair(cls, instance):
-        """Select Invalid ROP.
+        """Select ROP.
 
-        It's used to select invalid ROP which tells the
-        artist which ROP node need to be fixed!
+        It's used to select the associated ROP for the selected instance
+        which tells the artist which ROP node need to be fixed!
         """
 
         rop_node = hou.node(instance.data["instance_node"])

--- a/openpype/hosts/houdini/plugins/publish/validate_sop_output_node.py
+++ b/openpype/hosts/houdini/plugins/publish/validate_sop_output_node.py
@@ -2,6 +2,7 @@
 import pyblish.api
 from openpype.pipeline import PublishValidationError
 from openpype.pipeline.publish import RepairAction
+from openpype.hosts.houdini.api.action import SelectInvalidAction
 
 import hou
 
@@ -26,7 +27,7 @@ class ValidateSopOutputNode(pyblish.api.InstancePlugin):
     families = ["pointcache", "vdbcache"]
     hosts = ["houdini"]
     label = "Validate Output Node"
-    actions = [SelectROPAction]
+    actions = [SelectROPAction, SelectInvalidAction]
 
     def process(self, instance):
 
@@ -48,7 +49,7 @@ class ValidateSopOutputNode(pyblish.api.InstancePlugin):
                 "Ensure a valid SOP output path is set." % node.path()
             )
 
-            return [node.path()]
+            return [node]
 
         # Output node must be a Sop node.
         if not isinstance(output_node, hou.SopNode):
@@ -58,7 +59,7 @@ class ValidateSopOutputNode(pyblish.api.InstancePlugin):
                 "instead found category type: %s"
                 % (output_node.path(), output_node.type().category().name())
             )
-            return [output_node.path()]
+            return [output_node]
 
         # For the sake of completeness also assert the category type
         # is Sop to avoid potential edge case scenarios even though
@@ -78,14 +79,14 @@ class ValidateSopOutputNode(pyblish.api.InstancePlugin):
             except hou.Error as exc:
                 cls.log.error("Cook failed: %s" % exc)
                 cls.log.error(output_node.errors()[0])
-                return [output_node.path()]
+                return [output_node]
 
         # Ensure the output node has at least Geometry data
         if not output_node.geometry():
             cls.log.error(
                 "Output node `%s` has no geometry data." % output_node.path()
             )
-            return [output_node.path()]
+            return [output_node]
 
     @classmethod
     def repair(cls, instance):

--- a/openpype/hosts/houdini/plugins/publish/validate_sop_output_node.py
+++ b/openpype/hosts/houdini/plugins/publish/validate_sop_output_node.py
@@ -1,15 +1,13 @@
 # -*- coding: utf-8 -*-
 import pyblish.api
 from openpype.pipeline import PublishValidationError
-from openpype.pipeline.publish import RepairAction
-from openpype.hosts.houdini.api.action import SelectInvalidAction
+from openpype.hosts.houdini.api.action import (
+    SelectInvalidAction,
+    SelectROPAction,
+)
 
 import hou
 
-
-class SelectROPAction(RepairAction):
-    label = "Select ROP"
-    icon = "mdi.cursor-default-click"
 
 class ValidateSopOutputNode(pyblish.api.InstancePlugin):
     """Validate the instance SOP Output Node.
@@ -87,19 +85,3 @@ class ValidateSopOutputNode(pyblish.api.InstancePlugin):
                 "Output node `%s` has no geometry data." % output_node.path()
             )
             return [output_node]
-
-    @classmethod
-    def repair(cls, instance):
-        """Select ROP.
-
-        It's used to select the associated ROP for the selected instance
-        which tells the artist which ROP node need to be fixed!
-        """
-
-        rop_node = hou.node(instance.data["instance_node"])
-        rop_node.setSelected(True, clear_all_selected=True)
-
-        cls.log.debug(
-            '%s has been selected'
-            % rop_node.path()
-        )

--- a/openpype/hosts/houdini/plugins/publish/validate_sop_output_node.py
+++ b/openpype/hosts/houdini/plugins/publish/validate_sop_output_node.py
@@ -1,7 +1,13 @@
 # -*- coding: utf-8 -*-
 import pyblish.api
 from openpype.pipeline import PublishValidationError
+from openpype.pipeline.publish import RepairAction
 
+import hou
+
+class SelectInvalidAction(RepairAction):
+    label = "Select Invalid ROP"
+    icon = "mdi.cursor-default-click"
 
 class ValidateSopOutputNode(pyblish.api.InstancePlugin):
     """Validate the instance SOP Output Node.
@@ -19,6 +25,7 @@ class ValidateSopOutputNode(pyblish.api.InstancePlugin):
     families = ["pointcache", "vdbcache"]
     hosts = ["houdini"]
     label = "Validate Output Node"
+    actions = [SelectInvalidAction]
 
     def process(self, instance):
 
@@ -31,9 +38,6 @@ class ValidateSopOutputNode(pyblish.api.InstancePlugin):
 
     @classmethod
     def get_invalid(cls, instance):
-
-        import hou
-
         output_node = instance.data.get("output_node")
 
         if output_node is None:
@@ -81,3 +85,19 @@ class ValidateSopOutputNode(pyblish.api.InstancePlugin):
                 "Output node `%s` has no geometry data." % output_node.path()
             )
             return [output_node.path()]
+
+    @classmethod
+    def repair(cls, instance):
+        """Select Invalid ROP.
+
+        It's used to select invalid ROP which tells the
+        artist which ROP node need to be fixed!
+        """
+
+        rop_node = hou.node(instance.data["instance_node"])
+        rop_node.setSelected(True, clear_all_selected=True)
+
+        cls.log.debug(
+            '%s has been selected'
+            % rop_node.path()
+        )

--- a/openpype/hosts/houdini/plugins/publish/validate_sop_output_node.py
+++ b/openpype/hosts/houdini/plugins/publish/validate_sop_output_node.py
@@ -5,6 +5,7 @@ from openpype.pipeline.publish import RepairAction
 
 import hou
 
+
 class SelectInvalidAction(RepairAction):
     label = "Select Invalid ROP"
     icon = "mdi.cursor-default-click"


### PR DESCRIPTION
## Changelog Description
This PR adds `SelectROPAction` action to `houdini\api\action.py`
and it's used in `Validate Output Node` 

`SelectROPAction` is used to select the associated ROPs with the errored instances.

## Additional info
Testing this PR requires merging these [PR](https://github.com/ynput/OpenPype/pull/5230) and [PR](https://github.com/ynput/OpenPype/pull/5232)
Alternatively, you can add these lines before `geo = output_node.geometryAtFrame(frame)`
```
if not hasattr(output_node, "geometry"):
  # In the case someone has explicitly set an Object
  # node instead of a SOP node in Geometry context
  # then for now we ignore - this allows us to also
  # export object transforms.
  cls.log.warning("No geometry output node found, skipping check..")
  return
```
