### PR TITLE
Houdini: Add geometry check for VDB family

### DIFF
--- a/openpype/hosts/houdini/plugins/publish/validate_vdb_output_node.py
+++ b/openpype/hosts/houdini/plugins/publish/validate_vdb_output_node.py
@@ -55,6 +55,8 @@ def get_geometry_at_frame(sop_node, frame, force=True):
     """Return geometry at frame but force a cooked value."""
     with update_mode_context(hou.updateMode.AutoUpdate):
         sop_node.cook(force=force, frame_range=(frame, frame))
+        if not hasattr(sop_node, "geometry"):
+            return
         return sop_node.geometryAtFrame(frame)
 
 

--- a/openpype/hosts/houdini/plugins/publish/validate_vdb_output_node.py
+++ b/openpype/hosts/houdini/plugins/publish/validate_vdb_output_node.py
@@ -53,10 +53,10 @@ def update_mode_context(mode):
 
 def get_geometry_at_frame(sop_node, frame, force=True):
     """Return geometry at frame but force a cooked value."""
+    if not hasattr(sop_node, "geometry"):
+        return
     with update_mode_context(hou.updateMode.AutoUpdate):
         sop_node.cook(force=force, frame_range=(frame, frame))
-        if not hasattr(sop_node, "geometry"):
-            return
         return sop_node.geometryAtFrame(frame)
 
 


### PR DESCRIPTION
## Changelog Description
When `sop_path` on Geometry ROP node points to a non SopNode, this validator `validate_vdb_output_node.py` will error and crash when this line is executed
`sop_node.geometryAtFrame(frame)`

## Additional info
The bug addressed here is the same as in this [PR](https://github.com/ynput/OpenPype/pull/5230)
