### PR TITLE
Maya: aligning default settings to distributed aces 1.2 config

### DIFF
--- a/openpype/settings/defaults/project_settings/maya.json
+++ b/openpype/settings/defaults/project_settings/maya.json
@@ -421,9 +421,9 @@
         },
         "workfile": {
             "enabled": false,
-            "renderSpace": "ACEScg",
-            "displayName": "sRGB",
-            "viewName": "ACES 1.0 SDR-video"
+            "renderSpace": "ACES - ACEScg",
+            "displayName": "ACES",
+            "viewName": "sRGB"
         },
         "colorManagementPreference_v2": {
             "enabled": true,


### PR DESCRIPTION
## Changelog Description
Maya colorspace setttings defaults are set the way they align our distributed ACES 1.2 config file set in global colorspace configs.

## Additional info
Workfile category is disabled by default since we don't want to damage any productions which were having configured their settings already.

## Dependency
The issue was mentioned here https://github.com/ynput/OpenPype/pull/5225