### PR TITLE
Substance Painter: Include the setting only in publish tab

### DIFF
--- a/openpype/hosts/substancepainter/plugins/create/create_textures.py
+++ b/openpype/hosts/substancepainter/plugins/create/create_textures.py
@@ -34,7 +34,6 @@ class CreateTextures(Creator):
         if not substance_painter.project.is_open():
             raise CreatorError("Can't create a Texture Set instance without "
                                "an open project.")
-
         instance = self.create_instance_in_context(subset_name,
                                                    instance_data)
         set_instance(
@@ -76,7 +75,6 @@ class CreateTextures(Creator):
         return instance
 
     def get_instance_attr_defs(self):
-
         return [
             EnumDef("exportPresetUrl",
                     items=get_export_presets(),
@@ -156,7 +154,3 @@ class CreateTextures(Creator):
             UILabelDef("*only used with "
                        "'Dilation + <x>' padding"),
         ]
-
-    def get_pre_create_attr_defs(self):
-        # Use same attributes as for instance attributes
-        return self.get_instance_attr_defs()

--- a/openpype/hosts/substancepainter/plugins/create/create_textures.py
+++ b/openpype/hosts/substancepainter/plugins/create/create_textures.py
@@ -35,6 +35,7 @@ class CreateTextures(Creator):
             raise CreatorError("Can't create a Texture Set instance without "
                                "an open project.")
         # Transfer settings from pre create to instance
+        creator_attributes = instance_data.setdefault("creator_attributes", dict())
         for key in [
             "exportPresetUrl",
             "exportFileFormat",
@@ -43,7 +44,7 @@ class CreateTextures(Creator):
             "exportDilationDistance"
         ]:
             if key in pre_create_data:
-                instance_data[key] = pre_create_data[key]
+                creator_attributes[key] = pre_create_data[key]
 
         instance = self.create_instance_in_context(subset_name,
                                                    instance_data)

--- a/openpype/hosts/substancepainter/plugins/create/create_textures.py
+++ b/openpype/hosts/substancepainter/plugins/create/create_textures.py
@@ -28,36 +28,22 @@ class CreateTextures(Creator):
     icon = "picture-o"
 
     default_variant = "Main"
-    image_format = None
-    exportPresetUrl = None
-    exportSize = None
-    exportPadding = "infinite"
-    exportDilationDistance = 16
 
     def create(self, subset_name, instance_data, pre_create_data):
 
         if not substance_painter.project.is_open():
             raise CreatorError("Can't create a Texture Set instance without "
                                "an open project.")
-        self.exportPresetUrl = pre_create_data.get("exportPresetUrl",
-                                                   self.exportPresetUrl)
-        instance_data["exportPresetUrl"] = self.exportPresetUrl
-
-        self.image_format = pre_create_data.get("exportFileFormat",
-                                                self.image_format)
-        instance_data["exportFileFormat"] = self.image_format
-
-        self.exportSize = pre_create_data.get("exportSize",
-                                              self.exportSize)
-        instance_data["exportSize"] = self.exportSize
-
-        self.exportPadding = pre_create_data.get("exportPadding",
-                                                 self.exportPadding)
-        instance_data["exportPadding"] = self.exportPadding
-
-        self.exportDilationDistance = pre_create_data.get("exportDilationDistance",
-                                                          self.exportDilationDistance)
-        instance_data["exportDilationDistance"] = self.exportDilationDistance
+        # Transfer settings from pre create to instance
+        for key in [
+            "exportPresetUrl",
+            "exportFileFormat",
+            "exportSize",
+            "exportPadding",
+            "exportDilationDistance"
+        ]:
+            if key in pre_create_data:
+                instance_data[key] = pre_create_data[key]
 
         instance = self.create_instance_in_context(subset_name,
                                                    instance_data)
@@ -104,7 +90,6 @@ class CreateTextures(Creator):
         return [
             EnumDef("exportPresetUrl",
                     items=get_export_presets(),
-                    default=self.exportPresetUrl,
                     label="Output Template"),
             BoolDef("allowSkippedMaps",
                     label="Allow Skipped Output Maps",
@@ -145,7 +130,7 @@ class CreateTextures(Creator):
                         # "psd": "psd",
                         # "sbsar": "sbsar",
                     },
-                    default=self.image_format,
+                    default=None,
                     label="File type"),
             EnumDef("exportSize",
                     items={
@@ -159,7 +144,7 @@ class CreateTextures(Creator):
                         11: "2048",
                         12: "4096"
                     },
-                    default=self.exportSize,
+                    default=None,
                     label="Size"),
 
             EnumDef("exportPadding",
@@ -170,13 +155,13 @@ class CreateTextures(Creator):
                         "color": "Dilation + default background color",
                         "diffusion": "Dilation + diffusion"
                     },
-                    default=self.exportPadding,
+                    default="infinite",
                     label="Padding"),
             NumberDef("exportDilationDistance",
                       minimum=0,
                       maximum=256,
                       decimals=0,
-                      default=self.exportDilationDistance,
+                      default=16,
                       label="Dilation Distance"),
             UILabelDef("*only used with "
                        "'Dilation + <x>' padding"),

--- a/openpype/hosts/substancepainter/plugins/create/create_textures.py
+++ b/openpype/hosts/substancepainter/plugins/create/create_textures.py
@@ -28,12 +28,37 @@ class CreateTextures(Creator):
     icon = "picture-o"
 
     default_variant = "Main"
+    image_format = None
+    exportPresetUrl = None
+    exportSize = None
+    exportPadding = "infinite"
+    exportDilationDistance = 16
 
     def create(self, subset_name, instance_data, pre_create_data):
 
         if not substance_painter.project.is_open():
             raise CreatorError("Can't create a Texture Set instance without "
                                "an open project.")
+        self.exportPresetUrl = pre_create_data.get("exportPresetUrl",
+                                                   self.exportPresetUrl)
+        instance_data["exportPresetUrl"] = self.exportPresetUrl
+
+        self.image_format = pre_create_data.get("exportFileFormat",
+                                                self.image_format)
+        instance_data["exportFileFormat"] = self.image_format
+
+        self.exportSize = pre_create_data.get("exportSize",
+                                              self.exportSize)
+        instance_data["exportSize"] = self.exportSize
+
+        self.exportPadding = pre_create_data.get("exportPadding",
+                                                 self.exportPadding)
+        instance_data["exportPadding"] = self.exportPadding
+
+        self.exportDilationDistance = pre_create_data.get("exportDilationDistance",
+                                                          self.exportDilationDistance)
+        instance_data["exportDilationDistance"] = self.exportDilationDistance
+
         instance = self.create_instance_in_context(subset_name,
                                                    instance_data)
         set_instance(
@@ -75,9 +100,11 @@ class CreateTextures(Creator):
         return instance
 
     def get_instance_attr_defs(self):
+
         return [
             EnumDef("exportPresetUrl",
                     items=get_export_presets(),
+                    default=self.exportPresetUrl,
                     label="Output Template"),
             BoolDef("allowSkippedMaps",
                     label="Allow Skipped Output Maps",
@@ -118,7 +145,7 @@ class CreateTextures(Creator):
                         # "psd": "psd",
                         # "sbsar": "sbsar",
                     },
-                    default=None,
+                    default=self.image_format,
                     label="File type"),
             EnumDef("exportSize",
                     items={
@@ -132,7 +159,7 @@ class CreateTextures(Creator):
                         11: "2048",
                         12: "4096"
                     },
-                    default=None,
+                    default=self.exportSize,
                     label="Size"),
 
             EnumDef("exportPadding",
@@ -143,14 +170,18 @@ class CreateTextures(Creator):
                         "color": "Dilation + default background color",
                         "diffusion": "Dilation + diffusion"
                     },
-                    default="infinite",
+                    default=self.exportPadding,
                     label="Padding"),
             NumberDef("exportDilationDistance",
                       minimum=0,
                       maximum=256,
                       decimals=0,
-                      default=16,
+                      default=self.exportDilationDistance,
                       label="Dilation Distance"),
             UILabelDef("*only used with "
                        "'Dilation + <x>' padding"),
         ]
+
+    def get_pre_create_attr_defs(self):
+        # Use same attributes as for instance attributes
+        return self.get_instance_attr_defs()

--- a/openpype/hosts/substancepainter/plugins/create/create_textures.py
+++ b/openpype/hosts/substancepainter/plugins/create/create_textures.py
@@ -35,7 +35,8 @@ class CreateTextures(Creator):
             raise CreatorError("Can't create a Texture Set instance without "
                                "an open project.")
         # Transfer settings from pre create to instance
-        creator_attributes = instance_data.setdefault("creator_attributes", dict())
+        creator_attributes = instance_data.setdefault(
+            "creator_attributes", dict())
         for key in [
             "exportPresetUrl",
             "exportFileFormat",

--- a/openpype/hosts/substancepainter/plugins/publish/collect_textureset_images.py
+++ b/openpype/hosts/substancepainter/plugins/publish/collect_textureset_images.py
@@ -114,7 +114,7 @@ class CollectTextureSet(pyblish.api.InstancePlugin):
         # Clone the instance
         image_instance = context.create_instance(image_subset)
         image_instance[:] = instance[:]
-        image_instance.data.update(copy.deepcopy(instance.data))
+        image_instance.data.update(copy.deepcopy(dict(instance.data)))
         image_instance.data["name"] = image_subset
         image_instance.data["label"] = image_subset
         image_instance.data["subset"] = image_subset
@@ -157,9 +157,7 @@ class CollectTextureSet(pyblish.api.InstancePlugin):
             dict: Export config
 
         """
-
-        creator_attrs = instance.data["creator_attributes"]
-        preset_url = creator_attrs["exportPresetUrl"]
+        preset_url = instance.data["exportPresetUrl"]
         self.log.debug(f"Exporting using preset: {preset_url}")
 
         # See: https://substance3d.adobe.com/documentation/ptpy/api/substance_painter/export  # noqa
@@ -172,10 +170,10 @@ class CollectTextureSet(pyblish.api.InstancePlugin):
             "exportParameters": [
                 {
                     "parameters": {
-                        "fileFormat": creator_attrs["exportFileFormat"],
-                        "sizeLog2": creator_attrs["exportSize"],
-                        "paddingAlgorithm": creator_attrs["exportPadding"],
-                        "dilationDistance": creator_attrs["exportDilationDistance"]  # noqa
+                        "fileFormat": instance.data["exportFileFormat"],
+                        "sizeLog2": instance.data["exportSize"],
+                        "paddingAlgorithm": instance.data["exportPadding"],
+                        "dilationDistance": instance.data["exportDilationDistance"]  # noqa
                     }
                 }
             ]

--- a/openpype/hosts/substancepainter/plugins/publish/collect_textureset_images.py
+++ b/openpype/hosts/substancepainter/plugins/publish/collect_textureset_images.py
@@ -114,7 +114,7 @@ class CollectTextureSet(pyblish.api.InstancePlugin):
         # Clone the instance
         image_instance = context.create_instance(image_subset)
         image_instance[:] = instance[:]
-        image_instance.data.update(copy.deepcopy(dict(instance.data)))
+        image_instance.data.update(copy.deepcopy(instance.data))
         image_instance.data["name"] = image_subset
         image_instance.data["label"] = image_subset
         image_instance.data["subset"] = image_subset
@@ -157,7 +157,9 @@ class CollectTextureSet(pyblish.api.InstancePlugin):
             dict: Export config
 
         """
-        preset_url = instance.data["exportPresetUrl"]
+
+        creator_attrs = instance.data["creator_attributes"]
+        preset_url = creator_attrs["exportPresetUrl"]
         self.log.debug(f"Exporting using preset: {preset_url}")
 
         # See: https://substance3d.adobe.com/documentation/ptpy/api/substance_painter/export  # noqa
@@ -170,10 +172,10 @@ class CollectTextureSet(pyblish.api.InstancePlugin):
             "exportParameters": [
                 {
                     "parameters": {
-                        "fileFormat": instance.data["exportFileFormat"],
-                        "sizeLog2": instance.data["exportSize"],
-                        "paddingAlgorithm": instance.data["exportPadding"],
-                        "dilationDistance": instance.data["exportDilationDistance"]  # noqa
+                        "fileFormat": creator_attrs["exportFileFormat"],
+                        "sizeLog2": creator_attrs["exportSize"],
+                        "paddingAlgorithm": creator_attrs["exportPadding"],
+                        "dilationDistance": creator_attrs["exportDilationDistance"]  # noqa
                     }
                 }
             ]


### PR DESCRIPTION
## Changelog Description
Instead of having two settings in both create and publish tab, there is solely one setting in the publish tab for users to set up the parameters.
Resolve #5172

## Additional info
n/a

## Testing notes:
1. Launch SP via OP
2. Open project file
3. Create Texture Set
4. Go to Publish Tab -> Click TextureSetMain
5. It would show all the settings
