### PR TITLE
Remove new lines from the delivery template string

### DIFF
--- a/openpype/pipeline/delivery.py
+++ b/openpype/pipeline/delivery.py
@@ -157,6 +157,8 @@ def deliver_single_file(
     delivery_path = delivery_path.replace("..", ".")
     # Make sure path is valid for all platforms
     delivery_path = os.path.normpath(delivery_path.replace("\\", "/"))
+    # Remove newlines from the end of the string to avoid OSError during copy
+    delivery_path = delivery_path.rstrip()
 
     delivery_folder = os.path.dirname(delivery_path)
     if not os.path.exists(delivery_folder):


### PR DESCRIPTION
## Changelog Description
If the delivery template has a new line symbol at the end, say it was copied from the text editor, the delivery process will fail with `OSError` due to incorrect destination path. To avoid that I added `rstrip()` to the `delivery_path` processing.

## Testing notes:
1. Create a delivery template with a newline at the end (copy the template string from the text editor including the newline)
2. Delivery now will not fail.
