### PR TITLE
Enhancement/houdini add path action for abc validator

### DIFF
--- a/openpype/hosts/houdini/plugins/publish/validate_primitive_hierarchy_paths.py
+++ b/openpype/hosts/houdini/plugins/publish/validate_primitive_hierarchy_paths.py
@@ -150,9 +150,10 @@ class ValidatePrimitiveHierarchyPaths(pyblish.api.InstancePlugin):
             path_node, path_attr
         )
 
-        path_node.setGenericFlag(hou.nodeFlag.DisplayComment,True)
+        path_node.setGenericFlag(hou.nodeFlag.DisplayComment, True)
         path_node.setComment(
-            'Auto path node created automatically by "Add a default path attribute"'
+            'Auto path node was created automatically by '
+            '"Add a default path attribute"'
             '\nFeel free to modify or replace it.'
         )
 

--- a/openpype/hosts/houdini/plugins/publish/validate_primitive_hierarchy_paths.py
+++ b/openpype/hosts/houdini/plugins/publish/validate_primitive_hierarchy_paths.py
@@ -46,7 +46,7 @@ class ValidatePrimitiveHierarchyPaths(pyblish.api.InstancePlugin):
         if output_node is None:
             cls.log.error(
                 "SOP Output node in '%s' does not exist. "
-                "Ensure a valid SOP output path is set." % rop_node.path()
+                "Ensure a valid SOP output path is set.", rop_node.path()
             )
 
             return [rop_node]
@@ -68,7 +68,7 @@ class ValidatePrimitiveHierarchyPaths(pyblish.api.InstancePlugin):
             )
             return [rop_node]
 
-        cls.log.debug("Checking for attribute: %s" % path_attr)
+        cls.log.debug("Checking for attribute: %s", path_attr)
 
         # Check if the primitive attribute exists
         frame = instance.data.get("frameStart", 0)
@@ -91,7 +91,7 @@ class ValidatePrimitiveHierarchyPaths(pyblish.api.InstancePlugin):
         if not attrib:
             cls.log.info(
                 "Geometry Primitives are missing "
-                "path attribute: `%s`" % path_attr
+                "path attribute: `%s`", path_attr
             )
             return [output_node]
 
@@ -99,7 +99,7 @@ class ValidatePrimitiveHierarchyPaths(pyblish.api.InstancePlugin):
         if not attrib.strings():
             cls.log.info(
                 "Primitive path attribute has no "
-                "string values: %s" % path_attr
+                "string values: %s", path_attr
             )
             return [output_node]
 
@@ -111,7 +111,7 @@ class ValidatePrimitiveHierarchyPaths(pyblish.api.InstancePlugin):
             num_prims = len(geo.iterPrims())  # faster than len(geo.prims())
             cls.log.info(
                 "Prims have no value for attribute `%s` "
-                "(%s of %s prims)" % (path_attr, len(invalid_prims), num_prims)
+                "(%s of %s prims)", path_attr, len(invalid_prims), num_prims
             )
             return [output_node]
 
@@ -119,17 +119,17 @@ class ValidatePrimitiveHierarchyPaths(pyblish.api.InstancePlugin):
     def repair(cls, instance):
         """Add a default path attribute Action.
 
-        it's a helper action more than a repair action,
-        which used to add a default single value.
+        It is a helper action more than a repair action,
+        used to add a default single value for the path.
         """
 
         rop_node = hou.node(instance.data["instance_node"])
-        output_node = rop_node.parm('sop_path').evalAsNode()
+        output_node = rop_node.parm("sop_path").evalAsNode()
 
         if not output_node:
             cls.log.debug(
-                "Action isn't performed, empty SOP Path on %s"
-                % rop_node
+                "Action isn't performed, invalid SOP Path on %s",
+                rop_node
             )
             return
 
@@ -146,8 +146,8 @@ class ValidatePrimitiveHierarchyPaths(pyblish.api.InstancePlugin):
         path_node.parm("name1").set('`opname("..")`/`opname("..")`Shape')
 
         cls.log.debug(
-            "'%s' was created. It adds '%s' with a default single value"
-            % (path_node, path_attr)
+            "'%s' was created. It adds '%s' with a default single value",
+            path_node, path_attr
         )
 
         path_node.setGenericFlag(hou.nodeFlag.DisplayComment,True)
@@ -156,7 +156,7 @@ class ValidatePrimitiveHierarchyPaths(pyblish.api.InstancePlugin):
             '\nFeel free to modify or replace it.'
         )
 
-        if output_node.type().name() in ['null', 'output']:
+        if output_node.type().name() in ["null", "output"]:
             # Connect before
             path_node.setFirstInput(output_node.input(0))
             path_node.moveToGoodPosition()
@@ -165,10 +165,10 @@ class ValidatePrimitiveHierarchyPaths(pyblish.api.InstancePlugin):
         else:
             # Connect after
             path_node.setFirstInput(output_node)
-            rop_node.parm('sop_path').set(path_node.path())
+            rop_node.parm("sop_path").set(path_node.path())
             path_node.moveToGoodPosition()
 
             cls.log.debug(
-                "SOP path on '%s' updated to new output node '%s'"
-                % (rop_node, path_node)
+                "SOP path on '%s' updated to new output node '%s'",
+                rop_node, path_node
             )

--- a/openpype/hosts/houdini/plugins/publish/validate_primitive_hierarchy_paths.py
+++ b/openpype/hosts/houdini/plugins/publish/validate_primitive_hierarchy_paths.py
@@ -133,6 +133,7 @@ class ValidatePrimitiveHierarchyPaths(pyblish.api.InstancePlugin):
         paths = geo.findPrimAttrib(path_attr) and \
                     geo.primStringAttribValues(path_attr)
 
+        # This check to prevent the action from running multiple times.
         if paths:
             return
 

--- a/openpype/hosts/houdini/plugins/publish/validate_primitive_hierarchy_paths.py
+++ b/openpype/hosts/houdini/plugins/publish/validate_primitive_hierarchy_paths.py
@@ -116,6 +116,12 @@ class ValidatePrimitiveHierarchyPaths(pyblish.api.InstancePlugin):
 
     @classmethod
     def repair(cls, instance):
+        """Add a default path attribute Action.
+
+        it's a helper action more than a repair action,
+        which used to add a default single value.
+        """
+
         output_node = instance.data.get("output_node")
         rop_node = hou.node(instance.data["instance_node"])
 

--- a/openpype/hosts/houdini/plugins/publish/validate_primitive_hierarchy_paths.py
+++ b/openpype/hosts/houdini/plugins/publish/validate_primitive_hierarchy_paths.py
@@ -159,6 +159,13 @@ class ValidatePrimitiveHierarchyPaths(pyblish.api.InstancePlugin):
             output_node.moveToGoodPosition()
         else:
             # Connect after
-            output_node.setFirstInput(path_node)
+            path_node.setFirstInput(output_node)
             rop_node.parm('sop_path').set(path_node.path())
             path_node.moveToGoodPosition()
+            instance.data.update({"output_node" : path_node })
+
+            cls.log.debug(
+            "'%s' has set as the output node, "
+            "'%s' has updated"
+            % (path_node, rop_node)
+            )

--- a/openpype/hosts/houdini/plugins/publish/validate_primitive_hierarchy_paths.py
+++ b/openpype/hosts/houdini/plugins/publish/validate_primitive_hierarchy_paths.py
@@ -141,8 +141,8 @@ class ValidatePrimitiveHierarchyPaths(pyblish.api.InstancePlugin):
         path_node.parm("name1").set('`opname("..")`/`opname("..")`Shape')
 
         cls.log.debug(
-            '%s node has been created'
-            % path_node
+            "'%s' was created. It adds '%s' with a default single value"
+            % (path_node, path_attr)
         )
 
         path_node.setGenericFlag(hou.nodeFlag.DisplayComment,True)

--- a/openpype/hosts/houdini/plugins/publish/validate_primitive_hierarchy_paths.py
+++ b/openpype/hosts/houdini/plugins/publish/validate_primitive_hierarchy_paths.py
@@ -136,7 +136,7 @@ class ValidatePrimitiveHierarchyPaths(pyblish.api.InstancePlugin):
         # This check to prevent the action from running multiple times.
         # git_invalid only returns [output_node] when
         #   path attribute is the problem
-        if  cls.get_invalid(instance) != [output_node]:
+        if cls.get_invalid(instance) != [output_node]:
             return
 
         path_attr = rop_node.parm("path_attrib").eval()
@@ -169,6 +169,6 @@ class ValidatePrimitiveHierarchyPaths(pyblish.api.InstancePlugin):
             path_node.moveToGoodPosition()
 
             cls.log.debug(
-            "SOP path on '%s' updated to new output node '%s'"
-            % (rop_node, path_node)
+                "SOP path on '%s' updated to new output node '%s'"
+                % (rop_node, path_node)
             )


### PR DESCRIPTION
## Changelog Description
Add a default path attribute Action.
it's a helper action more than a repair action, which used to add a default single value.


## Additional info
This validator is going to be skipped if the `sop_path` in the ROP doesn't point to a `SopNode` after merging this [PR](https://github.com/ynput/OpenPype/pull/5230)
otherwise the publisher will error 

## Testing notes:
use `pointcache` to export these examples, set the sop path explicitly
- test 1 : create `AUTO_PATH` node before `null` node 
- test 2 : create `AUTO_PATH` node before `output` node 
- test 3 : create `AUTO_PATH` node after `sphere` node and set it as output node and update ROP node
- test 4 :  create `AUTO_PATH` node after `merge` node and set it as output node and update ROP node
- test 5 :  create `AUTO_PATH` node after `copy` node and set it as output node and update ROP node
- test 6 : set `sop_path` explicitly to the parent geo node  of these nodes in screenshot, publish will crash
- test 6 : after merging the mentioned PR, publisher will only show `Validate Output Node` error 

![Screenshot 2023-07-04 100221](https://github.com/ynput/OpenPype/assets/20871534/3046c396-847c-4b98-8876-e03b76161554)


![Untitled](https://github.com/ynput/OpenPype/assets/20871534/08ce4baf-71ed-4ec3-908a-f3d4b86fa174)
