### PR TITLE
Substance Painter: Fix Collect Texture Set Images unable to copy.deepcopy due to QMenu

### DIFF
--- a/openpype/hosts/substancepainter/plugins/publish/collect_textureset_images.py
+++ b/openpype/hosts/substancepainter/plugins/publish/collect_textureset_images.py
@@ -114,7 +114,7 @@ class CollectTextureSet(pyblish.api.InstancePlugin):
         # Clone the instance
         image_instance = context.create_instance(image_subset)
         image_instance[:] = instance[:]
-        image_instance.data.update(copy.deepcopy(instance.data))
+        image_instance.data.update(copy.deepcopy(dict(instance.data)))
         image_instance.data["name"] = image_subset
         image_instance.data["label"] = image_subset
         image_instance.data["subset"] = image_subset


### PR DESCRIPTION
## Changelog Description

Fix `copy.deepcopy` of `instance.data`.

## Additional info

Resolves https://github.com/ynput/OpenPype/issues/5171 and issue reported on forum https://community.ynput.io/t/substance-painter-error-in-op-3-15-11/443/2

## Testing notes:

1. Start Substance Painter
2. Publish a texture set
