### PR TITLE
RepairAction and SelectInvalidAction filter instances failed on the exact plugin

### DIFF
--- a/openpype/action.py
+++ b/openpype/action.py
@@ -49,7 +49,7 @@ def deprecated(new_destination):
 
 
 @deprecated("openpype.pipeline.publish.get_errored_instances_from_context")
-def get_errored_instances_from_context(context):
+def get_errored_instances_from_context(context, plugin=None):
     """
     Deprecated:
         Since 3.14.* will be removed in 3.16.* or later.
@@ -57,7 +57,7 @@ def get_errored_instances_from_context(context):
 
     from openpype.pipeline.publish import get_errored_instances_from_context
 
-    return get_errored_instances_from_context(context)
+    return get_errored_instances_from_context(context, plugin=plugin)
 
 
 @deprecated("openpype.pipeline.publish.get_errored_plugins_from_context")
@@ -97,11 +97,9 @@ class RepairAction(pyblish.api.Action):
 
         # Get the errored instances
         self.log.info("Finding failed instances..")
-        errored_instances = get_errored_instances_from_context(context)
-
-        # Apply pyblish.logic to get the instances for the plug-in
-        instances = pyblish.api.instances_by_plugin(errored_instances, plugin)
-        for instance in instances:
+        errored_instances = get_errored_instances_from_context(context,
+                                                               plugin=plugin)
+        for instance in errored_instances:
             plugin.repair(instance)
 
 

--- a/openpype/hosts/blender/api/action.py
+++ b/openpype/hosts/blender/api/action.py
@@ -12,13 +12,13 @@ class SelectInvalidAction(pyblish.api.Action):
     icon = "search"
 
     def process(self, context, plugin):
-        errored_instances = get_errored_instances_from_context(context)
-        instances = pyblish.api.instances_by_plugin(errored_instances, plugin)
+        errored_instances = get_errored_instances_from_context(context,
+                                                               plugin=plugin)
 
         # Get the invalid nodes for the plug-ins
         self.log.info("Finding invalid nodes...")
         invalid = list()
-        for instance in instances:
+        for instance in errored_instances:
             invalid_nodes = plugin.get_invalid(instance)
             if invalid_nodes:
                 if isinstance(invalid_nodes, (list, tuple)):

--- a/openpype/hosts/fusion/api/action.py
+++ b/openpype/hosts/fusion/api/action.py
@@ -18,15 +18,13 @@ class SelectInvalidAction(pyblish.api.Action):
     icon = "search"  # Icon from Awesome Icon
 
     def process(self, context, plugin):
-        errored_instances = get_errored_instances_from_context(context)
-
-        # Apply pyblish.logic to get the instances for the plug-in
-        instances = pyblish.api.instances_by_plugin(errored_instances, plugin)
+        errored_instances = get_errored_instances_from_context(context,
+                                                               plugin=plugin)
 
         # Get the invalid nodes for the plug-ins
         self.log.info("Finding invalid nodes..")
         invalid = list()
-        for instance in instances:
+        for instance in errored_instances:
             invalid_nodes = plugin.get_invalid(instance)
             if invalid_nodes:
                 if isinstance(invalid_nodes, (list, tuple)):

--- a/openpype/hosts/houdini/api/action.py
+++ b/openpype/hosts/houdini/api/action.py
@@ -17,15 +17,13 @@ class SelectInvalidAction(pyblish.api.Action):
 
     def process(self, context, plugin):
 
-        errored_instances = get_errored_instances_from_context(context)
-
-        # Apply pyblish.logic to get the instances for the plug-in
-        instances = pyblish.api.instances_by_plugin(errored_instances, plugin)
+        errored_instances = get_errored_instances_from_context(context,
+                                                               plugin=plugin)
 
         # Get the invalid nodes for the plug-ins
         self.log.info("Finding invalid nodes..")
         invalid = list()
-        for instance in instances:
+        for instance in errored_instances:
             invalid_nodes = plugin.get_invalid(instance)
             if invalid_nodes:
                 if isinstance(invalid_nodes, (list, tuple)):

--- a/openpype/hosts/maya/api/action.py
+++ b/openpype/hosts/maya/api/action.py
@@ -111,15 +111,13 @@ class SelectInvalidAction(pyblish.api.Action):
         except ImportError:
             raise ImportError("Current host is not Maya")
 
-        errored_instances = get_errored_instances_from_context(context)
-
-        # Apply pyblish.logic to get the instances for the plug-in
-        instances = pyblish.api.instances_by_plugin(errored_instances, plugin)
+        errored_instances = get_errored_instances_from_context(context,
+                                                               plugin=plugin)
 
         # Get the invalid nodes for the plug-ins
         self.log.info("Finding invalid nodes..")
         invalid = list()
-        for instance in instances:
+        for instance in errored_instances:
             invalid_nodes = plugin.get_invalid(instance)
             if invalid_nodes:
                 if isinstance(invalid_nodes, (list, tuple)):

--- a/openpype/hosts/nuke/api/actions.py
+++ b/openpype/hosts/nuke/api/actions.py
@@ -25,15 +25,13 @@ class SelectInvalidAction(pyblish.api.Action):
         except ImportError:
             raise ImportError("Current host is not Nuke")
 
-        errored_instances = get_errored_instances_from_context(context)
-
-        # Apply pyblish.logic to get the instances for the plug-in
-        instances = pyblish.api.instances_by_plugin(errored_instances, plugin)
+        errored_instances = get_errored_instances_from_context(context,
+                                                               plugin=plugin)
 
         # Get the invalid nodes for the plug-ins
         self.log.info("Finding invalid nodes..")
         invalid = list()
-        for instance in instances:
+        for instance in errored_instances:
             invalid_nodes = plugin.get_invalid(instance)
 
             if invalid_nodes:

--- a/openpype/hosts/nuke/plugins/publish/validate_rendered_frames.py
+++ b/openpype/hosts/nuke/plugins/publish/validate_rendered_frames.py
@@ -2,6 +2,7 @@ import os
 import pyblish.api
 import clique
 from openpype.pipeline import PublishXmlValidationError
+from openpype.pipeline.publish import get_errored_instances_from_context
 
 
 class RepairActionBase(pyblish.api.Action):
@@ -11,14 +12,7 @@ class RepairActionBase(pyblish.api.Action):
     @staticmethod
     def get_instance(context, plugin):
         # Get the errored instances
-        failed = []
-        for result in context.data["results"]:
-            if (result["error"] is not None and result["instance"] is not None
-               and result["instance"] not in failed):
-                failed.append(result["instance"])
-
-        # Apply pyblish.logic to get the instances for the plug-in
-        return pyblish.api.instances_by_plugin(failed, plugin)
+        return get_errored_instances_from_context(context, plugin=plugin)
 
     def repair_knob(self, instances, state):
         for instance in instances:

--- a/openpype/hosts/resolve/api/action.py
+++ b/openpype/hosts/resolve/api/action.py
@@ -27,15 +27,13 @@ class SelectInvalidAction(pyblish.api.Action):
         except ImportError:
             raise ImportError("Current host is not Resolve")
 
-        errored_instances = get_errored_instances_from_context(context)
-
-        # Apply pyblish.logic to get the instances for the plug-in
-        instances = pyblish.api.instances_by_plugin(errored_instances, plugin)
+        errored_instances = get_errored_instances_from_context(context,
+                                                               plugin=plugin)
 
         # Get the invalid nodes for the plug-ins
         self.log.info("Finding invalid clips..")
         invalid = list()
-        for instance in instances:
+        for instance in errored_instances:
             invalid_nodes = plugin.get_invalid(instance)
             if invalid_nodes:
                 if isinstance(invalid_nodes, (list, tuple)):

--- a/openpype/pipeline/publish/lib.py
+++ b/openpype/pipeline/publish/lib.py
@@ -577,12 +577,14 @@ def remote_publish(log, close_plugin_name=None, raise_error=False):
                 raise RuntimeError(error_message)
 
 
-def get_errored_instances_from_context(context):
+def get_errored_instances_from_context(context, plugin=None):
     """Collect failed instances from pyblish context.
 
     Args:
         context (pyblish.api.Context): Publish context where we're looking
             for failed instances.
+        plugin (pyblish.api.Plugin): If provided then only consider errors
+            related to that plug-in.
 
     Returns:
         List[pyblish.lib.Instance]: Instances which failed during processing.
@@ -592,6 +594,9 @@ def get_errored_instances_from_context(context):
     for result in context.data["results"]:
         if result["instance"] is None:
             # When instance is None we are on the "context" result
+            continue
+
+        if plugin is not None and result.get("plugin") != plugin:
             continue
 
         if result["error"]:

--- a/openpype/pipeline/publish/publish_plugins.py
+++ b/openpype/pipeline/publish/publish_plugins.py
@@ -234,11 +234,9 @@ class RepairAction(pyblish.api.Action):
 
         # Get the errored instances
         self.log.debug("Finding failed instances..")
-        errored_instances = get_errored_instances_from_context(context)
-
-        # Apply pyblish.logic to get the instances for the plug-in
-        instances = pyblish.api.instances_by_plugin(errored_instances, plugin)
-        for instance in instances:
+        errored_instances = get_errored_instances_from_context(context,
+                                                               plugin=plugin)
+        for instance in errored_instances:
             self.log.debug(
                 "Attempting repair for instance: {} ...".format(instance)
             )


### PR DESCRIPTION
## Changelog Description

RepairAction and SelectInvalidAction actually filter to instances that failed on the exact plugin - not on "any failure"

## Additional info

This [comment](https://github.com/ynput/OpenPype/pull/5231#discussion_r1251954530) showcased that actually the repair and select actions were running on ANY plugin that errored, not necessarily the ones that errored on the plugin we're running the action on.

I haven't tried this code - so please test. But it showcases what I think could be a solution.

I've removed the `pyblish.api.instances_by_plugin(errored_instances, plugin)` filtering because whenever an error occurred for the instance for this particular plug-in then of course the instance was related to that plugin - at least that's what I assumed.

Likely this hasn't been spotted much earlier because MOST implementations of repair and select invalid relied on a `get_invalid` action that in itself would still be checking whether the Instance was invalid for that plug-in. But it would basically be uselessly running on instances that hadn't actually errored in the first place.

## Testing notes:

1. Reproduce a scenario like described [here](https://github.com/ynput/OpenPype/pull/5231#discussion_r1251954530)
