### PR TITLE
Maya: Fix collecting arnold prefix when none

### DIFF
--- a/openpype/hosts/maya/api/lib_renderproducts.py
+++ b/openpype/hosts/maya/api/lib_renderproducts.py
@@ -274,12 +274,14 @@ class ARenderProducts:
                 "Unsupported renderer {}".format(self.renderer)
             )
 
+        # Note: When this attribute is never set (e.g. on maya launch) then
+        # this can return None even though it is a string attribute
         prefix = self._get_attr(prefix_attr)
 
         if not prefix:
             # Fall back to scene name by default
-            log.debug("Image prefix not set, using <Scene>")
-            file_prefix = "<Scene>"
+            log.warning("Image prefix not set, using <Scene>")
+            prefix = "<Scene>"
 
         return prefix
 

--- a/openpype/hosts/maya/api/lib_renderproducts.py
+++ b/openpype/hosts/maya/api/lib_renderproducts.py
@@ -528,9 +528,6 @@ class RenderProductsArnold(ARenderProducts):
     def get_renderer_prefix(self):
 
         prefix = super(RenderProductsArnold, self).get_renderer_prefix()
-        if prefix is None:
-            return ""
-
         merge_aovs = self._get_attr("defaultArnoldDriver.mergeAOVs")
         if not merge_aovs and "<renderpass>" not in prefix.lower():
             # When Merge AOVs is disabled and <renderpass> token not present

--- a/openpype/hosts/maya/api/lib_renderproducts.py
+++ b/openpype/hosts/maya/api/lib_renderproducts.py
@@ -528,6 +528,9 @@ class RenderProductsArnold(ARenderProducts):
     def get_renderer_prefix(self):
 
         prefix = super(RenderProductsArnold, self).get_renderer_prefix()
+        if prefix is None:
+            return ""
+
         merge_aovs = self._get_attr("defaultArnoldDriver.mergeAOVs")
         if not merge_aovs and "<renderpass>" not in prefix.lower():
             # When Merge AOVs is disabled and <renderpass> token not present


### PR DESCRIPTION
## Changelog Description
When no prefix is specified in render settings, the renderlayer collector would error.

## Testing notes:
1. Setup `render` in Maya.
2. Ensure no prefix is specified in render settings.
3. Publish and verify no errors occur at the collection stage.
