### PR TITLE
Deadline: OPENPYPE_VERSION should only be added when running from build

### DIFF
--- a/openpype/modules/deadline/plugins/publish/submit_publish_job.py
+++ b/openpype/modules/deadline/plugins/publish/submit_publish_job.py
@@ -146,7 +146,6 @@ class ProcessSubmittedJobOnFarm(pyblish.api.InstancePlugin,
         "FTRACK_SERVER",
         "AVALON_APP_NAME",
         "OPENPYPE_USERNAME",
-        "OPENPYPE_VERSION",
         "OPENPYPE_SG_USER"
     ]
 


### PR DESCRIPTION
## Changelog Description
When running from source the environment variable `OPENPYPE_VERSION` should not be added. This is a bugfix for the feature #4489

## Testing notes:
1. Run OP from source.
2. Setup render in Maya.
3. Submit to Deadline and verify there is no `OPENPYPE_VERSION` environment variable on the publish job.
