### PR TITLE
Fix no prompt for "unsaved changes" showing when opening workfile in Houdini

### DIFF
--- a/openpype/hosts/houdini/api/pipeline.py
+++ b/openpype/hosts/houdini/api/pipeline.py
@@ -93,7 +93,7 @@ class HoudiniHost(HostBase, IWorkfileHost, ILoadHost, IPublishHost):
             import hdefereval # noqa, hdefereval is only available in ui mode
             hdefereval.executeDeferred(creator_node_shelves.install)
 
-    def has_unsaved_changes(self):
+    def workfile_has_unsaved_changes(self):
         return hou.hipFile.hasUnsavedChanges()
 
     def get_workfile_extensions(self):

--- a/openpype/hosts/houdini/plugins/publish/save_scene.py
+++ b/openpype/hosts/houdini/plugins/publish/save_scene.py
@@ -19,7 +19,7 @@ class SaveCurrentScene(pyblish.api.ContextPlugin):
             "Collected filename from current scene name."
         )
 
-        if host.has_unsaved_changes():
+        if host.workfile_has_unsaved_changes():
             self.log.info("Saving current file: {}".format(current_file))
             host.save_workfile(current_file)
         else:


### PR DESCRIPTION
## Changelog Description

Fix no prompt for "unsaved changes" showing when opening workfile in Houdini.

## Additional info

@iLLiCiTiT It seems there has been some refactoring of `host.has_unsaved_changes` to `host.workfile_has_unsaved_changes` but the **refactoring actually wasn't done in a backwards compatible way**. It seems the new default does this:

```python
    def workfile_has_unsaved_changes(self):
        """Currently opened scene is saved.

        Not all hosts can know if current scene is saved because the API of
        DCC does not support it.

        Returns:
            bool: True if scene is saved and False if has unsaved
                modifications.
            None: Can't tell if workfiles has modifications.
        """
        return None

    def has_unsaved_changes(self):
        """Deprecated variant of 'workfile_has_unsaved_changes'.

        Todo:
            Remove when all usages are replaced.
        """

        return self.workfile_has_unsaved_changes()
```

Even though I suspect it should've done the reverse where the default behavior for `workfile_has_unsaved_changes` would call the backwards compatible `has_unsaved_changes` like:
```python
    def workfile_has_unsaved_changes(self):
        """Currently opened scene is saved.

        Not all hosts can know if current scene is saved because the API of
        DCC does not support it.

        Returns:
            bool: True if scene is saved and False if has unsaved
                modifications.
            None: Can't tell if workfiles has modifications.
        """
        # backwards compatibility: Originally `has_unsaved_changes` was implemented on hosts
        #   so if `workfile_has_unsaved_changes` is not overridden (yet) on the host implementation
        #   then we fall back to the old method name
        return self.has_unsaved_changes()

    def has_unsaved_changes(self):
        """Deprecated variant of 'workfile_has_unsaved_changes'.

        Todo:
            Remove when all usages are replaced.
        """
        return None
```

Without the backwards compatibility tweak described here I suspect the "save prompt" is also broken in Substance Painter currently since it only implements `has_unsaved_changes` on the host.

So it might make sense to still make that backwards compatible tweak somewhere?

## Testing notes:

1. Make some changes in your scene in Houdini
2. Open another file with work files tool - a "save prompt" should be shown.
