### PR TITLE
Fix no prompt for "unsaved changes" showing when opening workfile in Substance Painter

### DIFF
--- a/openpype/hosts/substancepainter/api/pipeline.py
+++ b/openpype/hosts/substancepainter/api/pipeline.py
@@ -86,7 +86,7 @@ class SubstanceHost(HostBase, IWorkfileHost, ILoadHost, IPublishHost):
         self._uninstall_menu()
         self._deregister_callbacks()
 
-    def has_unsaved_changes(self):
+    def workfile_has_unsaved_changes(self):
 
         if not substance_painter.project.is_open():
             return False

--- a/openpype/hosts/substancepainter/plugins/publish/save_workfile.py
+++ b/openpype/hosts/substancepainter/plugins/publish/save_workfile.py
@@ -20,7 +20,7 @@ class SaveCurrentWorkfile(pyblish.api.ContextPlugin):
         if context.data["currentFile"] != current:
             raise KnownPublishError("Workfile has changed during publishing!")
 
-        if host.has_unsaved_changes():
+        if host.workfile_has_unsaved_changes():
             self.log.info("Saving current file: {}".format(current))
             host.save_workfile()
         else:


### PR DESCRIPTION
## Changelog Description

Fix no prompt for "unsaved changes" showing when opening workfile in Substance Painter.

## Additional info

Equivalent of fix https://github.com/ynput/OpenPype/pull/5246 but for Substance Painter

## Testing notes:

1. Make some changes in your scene in Houdini
2. Open another file with work files tool - a "save prompt" should be shown.

