### PR TITLE
General: add the os library before os.environ.get

### DIFF
--- a/openpype/pipeline/create/creator_plugins.py
+++ b/openpype/pipeline/create/creator_plugins.py
@@ -1,3 +1,4 @@
+import os
 import copy
 import collections
 
@@ -660,7 +661,6 @@ def discover_convertor_plugins(*args, **kwargs):
 
 def discover_legacy_creator_plugins():
     from openpype.lib import Logger
-    import os
 
     log = Logger.get_logger("CreatorDiscover")
 

--- a/openpype/pipeline/create/creator_plugins.py
+++ b/openpype/pipeline/create/creator_plugins.py
@@ -660,6 +660,7 @@ def discover_convertor_plugins(*args, **kwargs):
 
 def discover_legacy_creator_plugins():
     from openpype.lib import Logger
+    import os
 
     log = Logger.get_logger("CreatorDiscover")
 


### PR DESCRIPTION
## Changelog Description
Adding os library into `creator_plugins.py` due to `os.environ.get` in line 667

## Additional info
n/a

## Testing notes:
1. Start Maya, or any dccs set as OP hosts
2. Load something from the loader