### PR TITLE
Houdini: better selection on pointcache creation 

### DIFF
--- a/openpype/hosts/houdini/plugins/create/create_pointcache.py
+++ b/openpype/hosts/houdini/plugins/create/create_pointcache.py
@@ -44,7 +44,7 @@ class CreatePointCache(plugin.HoudiniCreator):
             #   the parent type is not 'geo' like
             #   Cameras, Dopnet nodes(sop solver)
             if isinstance(selected_node, hou.SopNode) and \
-                selected_node.parent().type().name() in ['geo', 'subnet']:
+                    selected_node.parent().type().name() in ["geo", "subnet"]:
                 parms["sop_path"] = selected_node.path()
                 self.log.debug(
                    "Valid SopNode selection, 'SOP Path' in ROP will be set to '%s'."
@@ -54,7 +54,7 @@ class CreatePointCache(plugin.HoudiniCreator):
             # Allow object level paths to Geometry nodes (e.g. /obj/geo1)
             # but do not allow other object level nodes types like cameras, etc.
             elif isinstance(selected_node, hou.ObjNode) and \
-                    selected_node.type().name() in ['geo']:
+                    selected_node.type().name() in ["geo"]:
 
                 # get the output node with the minimum
                 # 'outputidx' or the node with display flag
@@ -71,7 +71,7 @@ class CreatePointCache(plugin.HoudiniCreator):
 
             if not parms.get("sop_path", None):
                 self.log.debug(
-                "Selection isn't valid. 'SOP Path' in ROP will be empty."
+                    "Selection isn't valid. 'SOP Path' in ROP will be empty."
                 )
         else:
             self.log.debug(
@@ -102,10 +102,11 @@ class CreatePointCache(plugin.HoudiniCreator):
 
         # if obj_node has one output child whether its
         # sop output node or a node with the render flag
-        elif len(outputs)==1:
+        elif len(outputs) == 1:
             return outputs[0]
 
         # if there are more than one, then it have multiple ouput nodes
         # return the one with the minimum 'outputidx'
-        else:
-            return (min(outputs, key=lambda node : node.parm('outputidx').eval()))
+        else :
+            return min(outputs,
+                        key=lambda node : node.parm('outputidx').eval())

--- a/openpype/hosts/houdini/plugins/create/create_pointcache.py
+++ b/openpype/hosts/houdini/plugins/create/create_pointcache.py
@@ -107,6 +107,6 @@ class CreatePointCache(plugin.HoudiniCreator):
 
         # if there are more than one, then it have multiple ouput nodes
         # return the one with the minimum 'outputidx'
-        else :
+        else:
             return min(outputs,
-                        key=lambda node : node.parm('outputidx').eval())
+                    key=lambda node : node.parm('outputidx').eval())

--- a/openpype/hosts/houdini/plugins/create/create_pointcache.py
+++ b/openpype/hosts/houdini/plugins/create/create_pointcache.py
@@ -108,4 +108,4 @@ class CreatePointCache(plugin.HoudiniCreator):
         # return the one with the minimum 'outputidx'
         else:
             return min(outputs,
-                       key=lambda node : node.evalParm('outputidx'))
+                       key=lambda node: node.evalParm('outputidx'))

--- a/openpype/hosts/houdini/plugins/create/create_pointcache.py
+++ b/openpype/hosts/houdini/plugins/create/create_pointcache.py
@@ -109,4 +109,4 @@ class CreatePointCache(plugin.HoudiniCreator):
         # return the one with the minimum 'outputidx'
         else:
             return min(outputs,
-                    key=lambda node : node.parm('outputidx').eval())
+                       key=lambda node : node.parm('outputidx').eval())

--- a/openpype/hosts/houdini/plugins/create/create_pointcache.py
+++ b/openpype/hosts/houdini/plugins/create/create_pointcache.py
@@ -40,11 +40,7 @@ class CreatePointCache(plugin.HoudiniCreator):
             # the ROP node we prefer it set to the SopNode path explicitly
 
             # Allow sop level paths (e.g. /obj/geo1/box1)
-            # but do not allow other sop level paths when
-            #   the parent type is not 'geo' like
-            #   Cameras, Dopnet nodes(sop solver)
-            if isinstance(selected_node, hou.SopNode) and \
-                    selected_node.parent().type().name() in ["geo", "subnet"]:
+            if isinstance(selected_node, hou.SopNode):
                 parms["sop_path"] = selected_node.path()
                 self.log.debug(
                    "Valid SopNode selection, 'SOP Path' in ROP will be set to '%s'."

--- a/openpype/hosts/houdini/plugins/create/create_pointcache.py
+++ b/openpype/hosts/houdini/plugins/create/create_pointcache.py
@@ -1,7 +1,6 @@
 # -*- coding: utf-8 -*-
 """Creator plugin for creating pointcache alembics."""
 from openpype.hosts.houdini.api import plugin
-from openpype.pipeline import CreatedInstance
 
 import hou
 
@@ -14,15 +13,13 @@ class CreatePointCache(plugin.HoudiniCreator):
     icon = "gears"
 
     def create(self, subset_name, instance_data, pre_create_data):
-        import hou
-
         instance_data.pop("active", None)
         instance_data.update({"node_type": "alembic"})
 
         instance = super(CreatePointCache, self).create(
             subset_name,
             instance_data,
-            pre_create_data)  # type: CreatedInstance
+            pre_create_data)
 
         instance_node = hou.node(instance.get("instance_node"))
         parms = {
@@ -37,13 +34,50 @@ class CreatePointCache(plugin.HoudiniCreator):
         }
 
         if self.selected_nodes:
-            parms["sop_path"] = self.selected_nodes[0].path()
+            selected_node = self.selected_nodes[0]
 
-            # try to find output node
-            for child in self.selected_nodes[0].children():
-                if child.type().name() == "output":
-                    parms["sop_path"] = child.path()
-                    break
+            # Although Houdini allows ObjNode path on `sop_path`rop node
+            #  However, it's preferred to set SopNode path explicitly
+            # These checks prevent using user selecting
+
+            # Allow sop level paths (e.g. /obj/geo1/box1)
+            # but do not allow other sop level paths when
+            #   the parent type is not 'geo' like
+            #   Cameras, Dopnet nodes(sop solver)
+            if isinstance(selected_node, hou.SopNode) and \
+                selected_node.parent().type().name() == 'geo':
+                parms["sop_path"] = selected_node.path()
+                self.log.debug(
+                   "Valid SopNode selection, 'SOP Path' in ROP will be set to '%s'."
+                   % selected_node.path()
+                )
+
+            # Allow object level paths to Geometry nodes (e.g. /obj/geo1)
+            # but do not allow other object level nodes types like cameras, etc.
+            elif isinstance(selected_node, hou.ObjNode) and \
+                    selected_node.type().name() == 'geo':
+
+                # get the output node with the minimum
+                # 'outputidx' or the node with display flag
+                sop_path = self.get_obj_output(selected_node) or \
+                    selected_node.displayNode()
+
+                if sop_path:
+                    parms["sop_path"] = sop_path.path()
+                    self.log.debug(
+                        "Valid ObjNode selection, 'SOP Path' in ROP will be set to "
+                        "the child path '%s'."
+                        % sop_path.path()
+                    )
+
+            if not parms.get("sop_path", None):
+                self.log.debug(
+                "Selection isn't valid.'SOP Path' in ROP will be empty."
+                )
+        else:
+            self.log.debug(
+                "No Selection.'SOP Path' in ROP will be empty."
+            )
 
         instance_node.setParms(parms)
         instance_node.parm("trange").set(1)
@@ -57,3 +91,17 @@ class CreatePointCache(plugin.HoudiniCreator):
             hou.ropNodeTypeCategory(),
             hou.sopNodeTypeCategory()
         ]
+
+    def get_obj_output(self, obj_node):
+        """Find output node with the smallest 'outputidx'."""
+
+        outputs = dict()
+
+        for sop_node in obj_node.children():
+            if sop_node.type().name() == 'output' :
+                outputs.update({sop_node : sop_node.parm('outputidx').eval()})
+
+        if outputs:
+            return min(outputs, key = outputs.get)
+        else:
+            return

--- a/openpype/hosts/houdini/plugins/create/create_pointcache.py
+++ b/openpype/hosts/houdini/plugins/create/create_pointcache.py
@@ -109,4 +109,4 @@ class CreatePointCache(plugin.HoudiniCreator):
         # return the one with the minimum 'outputidx'
         else:
             return min(outputs,
-                       key=lambda node : node.parm('outputidx').eval())
+                       key=lambda node : node.evalParm('outputidx'))

--- a/openpype/hosts/houdini/plugins/create/create_pointcache.py
+++ b/openpype/hosts/houdini/plugins/create/create_pointcache.py
@@ -45,7 +45,7 @@ class CreatePointCache(plugin.HoudiniCreator):
             #   the parent type is not 'geo' like
             #   Cameras, Dopnet nodes(sop solver)
             if isinstance(selected_node, hou.SopNode) and \
-                selected_node.parent().type().name() == 'geo':
+                selected_node.parent().type().name() in ['geo', 'subnet']:
                 parms["sop_path"] = selected_node.path()
                 self.log.debug(
                    "Valid SopNode selection, 'SOP Path' in ROP will be set to '%s'."
@@ -55,7 +55,7 @@ class CreatePointCache(plugin.HoudiniCreator):
             # Allow object level paths to Geometry nodes (e.g. /obj/geo1)
             # but do not allow other object level nodes types like cameras, etc.
             elif isinstance(selected_node, hou.ObjNode) and \
-                    selected_node.type().name() == 'geo':
+                    selected_node.type().name() in ['geo']:
 
                 # get the output node with the minimum
                 # 'outputidx' or the node with display flag

--- a/openpype/hosts/houdini/plugins/create/create_pointcache.py
+++ b/openpype/hosts/houdini/plugins/create/create_pointcache.py
@@ -58,8 +58,7 @@ class CreatePointCache(plugin.HoudiniCreator):
 
                 # get the output node with the minimum
                 # 'outputidx' or the node with display flag
-                sop_path = self.get_obj_output(selected_node) or \
-                    selected_node.displayNode()
+                sop_path = self.get_obj_output(selected_node)
 
                 if sop_path:
                     parms["sop_path"] = sop_path.path()


### PR DESCRIPTION
## Changelog Description
Houdini  allows `ObjNode` path as `sop_path` in the `ROP` unlike OP/ Ayon require `sop_path` to be set to a sop node path explicitly 
In this code, better selection is used to filter out invalid selections from OP/ Ayon  point of view
Valid selections are 
- `SopNode` that has parent of type `geo` or `subnet`
- `ObjNode` of type `geo` that has 
   -  `SopNode` of type `output` 
   - `SopNode` with render flag `on` (if no `Sopnode` of type `output`)

this effectively  filter 
- empty `ObjNode` 
- `ObjNode`(s) of other types like `cam` and `dopnet` 
-  `SopNode`(s) that thier parents of other types like `cam` and `sop solver` 

## Additional info
This PR is one of several PRs made for this [issue](https://github.com/ynput/OpenPype/issues/3431)

## Testing notes:
Create `pointcache` instance while selecting:
Case    ->    Result 
1. empty geo `ObjNode`  -> empty `sop_path`  in ROP
2. geo  `ObjNode`  with one node inside ->  `sop_path` will be set to that sop node inside
3. geo  `ObjNode`  with multiple nodes inside ->  `sop_path` will be set to that sop node inside with render flag `on` 
4. geo `OjNode` with multiple nodes of type `output` inside ->  `sop_path` will be set to that `output` node with smallest `outputidx` 
5. any `SopNode`  that's inside a geo `ObjNode` -> `sop_path` will be set to that sop node
6. any `SopNode`  that's inside a subnet `SopNode` -> `sop_path` will be set to that sop node
7.  `SopNode`  that's inside a cam `ObjNode` -> empty `sop_path`  in ROP
8. `SopNode`  that's inside a sop solver `ObjNode` -> empty `sop_path`  in ROP
