### PR TITLE
Update scene inventory even if any errors occurred during update

### DIFF
--- a/openpype/tools/sceneinventory/view.py
+++ b/openpype/tools/sceneinventory/view.py
@@ -844,7 +844,7 @@ class SceneInventoryView(QtWidgets.QTreeView):
 
         # Trigger update to latest
         try:
-            for item, item_version in enumerate(items, versions):
+            for item, item_version in zip(items, versions):
                 try:
                     update_container(item, item_version)
                 except AssertionError:


### PR DESCRIPTION
## Changelog Description

When selecting many items in the scene inventory to update versions and one of the items would error out the updating stops. However, before this PR the scene inventory would also NOT refresh making you think it did nothing.

Also implemented as method to allow some code deduplication.

## Additional info

We might want to change the `AssertionError` to show a popup to something more generic too to show ANY error as a dialog popup - but to remain consistent with old behavior I haven't done that. However, doing that might at least make it clearer to end user that something actually failed.

## Testing notes:

Starts updating and switching versions:
2. Update versioned containers randomly
3. Update versioned containers to explicit version (using Set version dialog)
4. Update containers to latest using top right update button
5. Update selected containers to latest using context menu "Update to latest"
5. Switch to hero versions and back
6. Use switch asset
