### PR TITLE
Maya: Bugfix look update nodes by id with non-unique shape names (query with `fullPath`)

### DIFF
--- a/openpype/hosts/maya/plugins/load/load_look.py
+++ b/openpype/hosts/maya/plugins/load/load_look.py
@@ -113,8 +113,8 @@ class LookLoader(openpype.hosts.maya.api.plugin.ReferenceLoader):
 
         # region compute lookup
         nodes_by_id = defaultdict(list)
-        for n in nodes:
-            nodes_by_id[lib.get_id(n)].append(n)
+        for node in nodes:
+            nodes_by_id[lib.get_id(node)].append(node)
         lib.apply_attributes(attributes, nodes_by_id)
 
     def _get_nodes_with_shader(self, shader_nodes):

--- a/openpype/hosts/maya/plugins/load/load_look.py
+++ b/openpype/hosts/maya/plugins/load/load_look.py
@@ -29,7 +29,7 @@ class LookLoader(openpype.hosts.maya.api.plugin.ReferenceLoader):
     color = "orange"
 
     def process_reference(self, context, name, namespace, options):
-        import maya.cmds as cmds
+        from maya import cmds
 
         with lib.maintained_selection():
             file_url = self.prepare_root_value(self.fname,
@@ -125,7 +125,7 @@ class LookLoader(openpype.hosts.maya.api.plugin.ReferenceLoader):
         Returns
             <list> node names
         """
-        import maya.cmds as cmds
+        from maya import cmds
 
         for shader in shader_nodes:
             future = cmds.listHistory(shader, future=True)

--- a/openpype/hosts/maya/plugins/load/load_look.py
+++ b/openpype/hosts/maya/plugins/load/load_look.py
@@ -127,12 +127,14 @@ class LookLoader(openpype.hosts.maya.api.plugin.ReferenceLoader):
         """
         import maya.cmds as cmds
 
-        nodes_list = []
         for shader in shader_nodes:
-            connections = cmds.listConnections(cmds.listHistory(shader, f=1),
+            future = cmds.listHistory(shader, future=True)
+            connections = cmds.listConnections(future,
                                                type='mesh')
             if connections:
-                for connection in connections:
-                    nodes_list.extend(cmds.listRelatives(connection,
-                                                         shapes=True))
-        return nodes_list
+                # Ensure unique entries only to optimize query and results
+                connections = list(set(connections))
+                return cmds.listRelatives(connections,
+                                          shapes=True,
+                                          fullPath=True) or []
+        return []


### PR DESCRIPTION
## Changelog Description

Fixes a bug where updating attributes on nodes with assigned shader if shape name existed more than once in the scene due to `cmds.listRelatives` call not being done with the `fullPath=True` flag.

Original error:
```python
# Traceback (most recent call last):
#   File "E:\openpype\OpenPype\openpype\tools\sceneinventory\view.py", line 264, in <lambda>
#     lambda: self._show_version_dialog(items))
#   File "E:\openpype\OpenPype\openpype\tools\sceneinventory\view.py", line 722, in _show_version_dialog
#     self._update_containers(items, version)
#   File "E:\openpype\OpenPype\openpype\tools\sceneinventory\view.py", line 849, in _update_containers
#     update_container(item, item_version)
#   File "E:\openpype\OpenPype\openpype\pipeline\load\utils.py", line 502, in update_container
#     return loader.update(container, new_representation)
#   File "E:\openpype\OpenPype\openpype\hosts\maya\plugins\load\load_look.py", line 119, in update
#     nodes_by_id[lib.get_id(n)].append(n)
#   File "E:\openpype\OpenPype\openpype\hosts\maya\api\lib.py", line 1420, in get_id
#     sel.add(node)
```

## Additional info

Also optimized the query a bit by doing a single `listRelatives` query.

## Testing notes:

1. Update looks in Maya