### PR TITLE
Maya: Refactor imports to `lib.get_reference_node` since the other function…

### DIFF
--- a/openpype/hosts/maya/plugins/inventory/import_reference.py
+++ b/openpype/hosts/maya/plugins/inventory/import_reference.py
@@ -1,7 +1,7 @@
 from maya import cmds
 
 from openpype.pipeline import InventoryAction
-from openpype.hosts.maya.api.plugin import get_reference_node
+from openpype.hosts.maya.api.lib import get_reference_node
 
 
 class ImportReference(InventoryAction):

--- a/openpype/hosts/maya/plugins/load/load_look.py
+++ b/openpype/hosts/maya/plugins/load/load_look.py
@@ -14,7 +14,7 @@ import openpype.hosts.maya.api.plugin
 from openpype.hosts.maya.api import lib
 from openpype.widgets.message_window import ScrollMessageBox
 
-from openpype.hosts.maya.api.plugin import get_reference_node
+from openpype.hosts.maya.api.lib import get_reference_node
 
 
 class LookLoader(openpype.hosts.maya.api.plugin.ReferenceLoader):


### PR DESCRIPTION
## Changelog Description
Refactor imports to `lib.get_reference_node` since the other function is deprecated.

## Testing notes:

1. Import a reference via scene manager / inventory action
2. Load/update a look