### PR TITLE
Substance Painter: Fix default color management settings

### DIFF
--- a/openpype/settings/defaults/project_settings/substancepainter.json
+++ b/openpype/settings/defaults/project_settings/substancepainter.json
@@ -2,11 +2,11 @@
     "imageio": {
         "activate_host_color_management": true,
         "ocio_config": {
-            "override_global_config": true,
+            "override_global_config": false,
             "filepath": []
         },
         "file_rules": {
-            "activate_host_rules": true,
+            "activate_host_rules": false,
             "rules": {}
         }
     },


### PR DESCRIPTION
## Changelog Description

The default settings for color management for Substance Painter were invalid, it was set to override the global config by default but specified no valid config paths of its own - and thus errored that the paths were not correct.

This sets the defaults correctly to match other hosts.

_I quickly checked - this seems to be the only host with the wrong default settings_

## Additional info

Resolves #5241

## Testing notes:

1. Enable global color management in settings `project_settings/global/imageio/activate_global_color_management`

![image](https://github.com/ynput/OpenPype/assets/2439881/8822969d-6d55-4f64-bb00-7652b23c0a87)

2. Launch Substance Painter


For sake of testing it would also be good to confirm the OCIO config works in Substance Painter and that publishing also works as expected with it.
