### PR TITLE
Error with multiple loads from 1 placeholder

### DIFF
--- a/openpype/hosts/maya/api/workfile_template_builder.py
+++ b/openpype/hosts/maya/api/workfile_template_builder.py
@@ -254,8 +254,7 @@ class MayaPlaceholderLoadPlugin(PlaceholderPlugin, PlaceholderLoadMixin):
 
     def delete_placeholder(self, placeholder):
         """Remove placeholder if building was successful"""
-        cmds.sets(placeholder.scene_identifier, rm= PLACEHOLDER_SET )
-        print (placeholder.scene_identifier)
+        cmds.sets(placeholder.scene_identifier, rm= PLACEHOLDER_SET)
         cmds.delete(placeholder.scene_identifier)
 
     def load_succeed(self, placeholder, container):

--- a/openpype/hosts/maya/api/workfile_template_builder.py
+++ b/openpype/hosts/maya/api/workfile_template_builder.py
@@ -254,6 +254,8 @@ class MayaPlaceholderLoadPlugin(PlaceholderPlugin, PlaceholderLoadMixin):
 
     def delete_placeholder(self, placeholder):
         """Remove placeholder if building was successful"""
+        cmds.sets(placeholder.scene_identifier, rm= PLACEHOLDER_SET )
+        print (placeholder.scene_identifier)
         cmds.delete(placeholder.scene_identifier)
 
     def load_succeed(self, placeholder, container):


### PR DESCRIPTION
## Changelog Description

Bug : If we enable the set suppression, we have an error from the 2nd object because it deletes the set with it.
`TypeError: No object matches name: PLACEHOLDERS_SET`

To fixe it, we need to firstly remove the object from the set and secondly delete it, so it keeps the set.

**To test it :** 
Build workfile 
See if the rig assets linked to the shot are loaded (refer to Ftrack).