### PR TITLE
Windows: Support long paths on zip updates.

### DIFF
--- a/igniter/bootstrap_repos.py
+++ b/igniter/bootstrap_repos.py
@@ -77,7 +77,6 @@ def sha256sum(filename):
 
 
 class ZipFileLongPaths(ZipFile):
-
     def _extract_member(self, member, targetpath, pwd):
         return ZipFile._extract_member(
             self, member, sanitize_long_path(targetpath), pwd

--- a/igniter/bootstrap_repos.py
+++ b/igniter/bootstrap_repos.py
@@ -34,8 +34,21 @@ LOG_WARNING = 1
 LOG_ERROR = 3
 
 
-def sanitize_long_path(path, encoding=None):
-    if platform.system().lower() == "windows":
+def sanitize_long_path(path):
+    """Sanitize long paths (260 characters) when on Windows.
+
+    Long paths are not capatible with ZipFile or reading a file, so we can
+    shorten the path to use.
+
+    Args:
+        path (str): path to either directory or file.
+
+    Returns:
+        str: sanitized path
+    """
+    if platform.system().lower() != "windows":
+        return path
+    else:
         path = os.path.abspath(path)
 
         if path.startswith("\\\\"):
@@ -44,8 +57,6 @@ def sanitize_long_path(path, encoding=None):
             path = "\\\\?\\" + path
 
         return path
-
-    return path
 
 
 def sha256sum(filename):

--- a/igniter/bootstrap_repos.py
+++ b/igniter/bootstrap_repos.py
@@ -48,15 +48,13 @@ def sanitize_long_path(path):
     """
     if platform.system().lower() != "windows":
         return path
+    path = os.path.abspath(path)
+
+    if path.startswith("\\\\"):
+        path = "\\\\?\\UNC\\" + path[2:]
     else:
-        path = os.path.abspath(path)
-
-        if path.startswith("\\\\"):
-            path = "\\\\?\\UNC\\" + path[2:]
-        else:
-            path = "\\\\?\\" + path
-
-        return path
+        path = "\\\\?\\" + path
+    return path
 
 
 def sha256sum(filename):


### PR DESCRIPTION
## Changelog Description
Support long paths for version extract on Windows.

Use case is when having long paths in for example an addon. You can install to the C drive but because the zip files are extracted in the local users folder, it'll add additional sub directories to the paths and quickly get too long paths for Windows to handle the zip updates.

## Testing notes:
1. Setup a long path in for example `addons` folder with multiple subfolders.
2. Create zip and try to update with the zip.
