### PR TITLE
Testing: improving logging during testing

### DIFF
--- a/openpype/pype_commands.py
+++ b/openpype/pype_commands.py
@@ -291,7 +291,14 @@ class PypeCommands:
             folder = "../tests"
 
         # disable warnings and show captured stdout even if success
-        args = ["--disable-pytest-warnings", "-rP", folder]
+        args = [
+            "--disable-pytest-warnings",
+            "--capture=sys",
+            "--print",
+            "-W ignore::DeprecationWarning",
+            "-rP",
+            folder
+        ]
 
         if mark:
             args.extend(["-m", mark])


### PR DESCRIPTION
## Changelog Description
Unit testing logging was crashing on more then one nested layers of inherited loggers.

## Additional info
- Also muting Deprecated warnings. 
- adding printing during testing rather then waiting for the test results

## Testing notes:
1. run any of your favourite tests in terminal to see the difference
