### PR TITLE
Nuke: removing deprecated settings in baking

### DIFF
--- a/openpype/hosts/nuke/api/plugin.py
+++ b/openpype/hosts/nuke/api/plugin.py
@@ -824,41 +824,6 @@ class ExporterReviewMov(ExporterReview):
         add_tags = []
         self.publish_on_farm = farm
         read_raw = kwargs["read_raw"]
-
-        # TODO: remove this when `reformat_nodes_config`
-        # is changed in settings
-        reformat_node_add = kwargs["reformat_node_add"]
-        reformat_node_config = kwargs["reformat_node_config"]
-
-        # TODO: make this required in future
-        reformat_nodes_config = kwargs.get("reformat_nodes_config", {})
-
-        # TODO: remove this once deprecated is removed
-        # make sure only reformat_nodes_config is used in future
-        if reformat_node_add and reformat_nodes_config.get("enabled"):
-            self.log.warning(
-                "`reformat_node_add` is deprecated. "
-                "Please use only `reformat_nodes_config` instead.")
-            reformat_nodes_config = None
-
-        # TODO: reformat code when backward compatibility is not needed
-        # warning if reformat_nodes_config is not set
-        if not reformat_nodes_config:
-            self.log.warning(
-                "Please set `reformat_nodes_config` in settings. "
-                "Using `reformat_node_config` instead."
-            )
-            reformat_nodes_config = {
-                "enabled": reformat_node_add,
-                "reposition_nodes": [
-                    {
-                        "node_class": "Reformat",
-                        "knobs": reformat_node_config
-                    }
-                ]
-            }
-
-
         bake_viewer_process = kwargs["bake_viewer_process"]
         bake_viewer_input_process_node = kwargs[
             "bake_viewer_input_process"]
@@ -897,6 +862,7 @@ class ExporterReviewMov(ExporterReview):
         self._shift_to_previous_node_and_temp(subset, r_node, "Read...   `{}`")
 
         # add reformat node
+        reformat_nodes_config = kwargs["reformat_nodes_config"]
         if reformat_nodes_config["enabled"]:
             reposition_nodes = reformat_nodes_config["reposition_nodes"]
             for reposition_node in reposition_nodes:


### PR DESCRIPTION
## Changelog Description
Removing deprecated settings for baking with reformat. This option was only for single reformat node and it had been substituted with multiple reposition nodes.

# Dependency:
https://github.com/ynput/ayon-addons-settings/pull/18