### PR TITLE
275 save the filter selection for family

### DIFF
--- a/openpype/tools/loader/widgets.py
+++ b/openpype/tools/loader/widgets.py
@@ -1042,9 +1042,6 @@ class FamilyListView(QtWidgets.QListView):
         self._settings = settings
         self._last_families_setting = self._settings.value('enabled_families')
 
-        print("settings: ", settings.allKeys())
-        print("enabled_families", settings.value('enabled_families'))
-
         self.setSelectionMode(QtWidgets.QAbstractItemView.ExtendedSelection)
         self.setAlternatingRowColors(True)
         self.setContextMenuPolicy(QtCore.Qt.CustomContextMenu)
@@ -1070,7 +1067,6 @@ class FamilyListView(QtWidgets.QListView):
     def refresh(self):
         self._family_model.refresh()
         self.active_changed.emit(self.get_enabled_families())
-
         if self._last_families_setting is not None:
             self.set_last_families(self._last_families_setting)
             self._last_families_setting = None
@@ -1079,7 +1075,6 @@ class FamilyListView(QtWidgets.QListView):
         """Return the checked family items"""
         model = self._family_model
         checked_families = []
-
         for row in range(model.rowCount()):
             index = model.index(row, 0)
             checked = checkstate_int_to_enum(

--- a/openpype/tools/loader/widgets.py
+++ b/openpype/tools/loader/widgets.py
@@ -1093,8 +1093,8 @@ class FamilyListView(QtWidgets.QListView):
         for row in range(model.rowCount()):
             index = model.index(row, 0)
             family = index.data(QtCore.Qt.DisplayRole)
-            new_state = QtCore.Qt.Checked if family in families else QtCore.Qt.Unchecked 
-            index.model().setData(index, new_state, QtCore.Qt.CheckStateRole)  
+            new_state = QtCore.Qt.Checked if family in families else QtCore.Qt.Unchecked
+            index.model().setData(index, new_state, QtCore.Qt.CheckStateRole)
         self.blockSignals(False)
 
     def set_all_unchecked(self):


### PR DESCRIPTION
## Changelog Description
We implemented a code so the interface remembers the last selection of the family filtered in the loader.

## Additional info

## Testing notes:
1. Open the loader
2. Choose a project and filter families 
3. Launch the software again and go back to the loader
