### PR TITLE
Houdini: fix typo error in collect arnold rop

### DIFF
--- a/openpype/hosts/houdini/plugins/publish/collect_arnold_rop.py
+++ b/openpype/hosts/houdini/plugins/publish/collect_arnold_rop.py
@@ -50,7 +50,7 @@ class CollectArnoldROPRenderProducts(pyblish.api.InstancePlugin):
         num_aovs = rop.evalParm("ar_aovs")
         for index in range(1, num_aovs + 1):
             # Skip disabled AOVs
-            if not rop.evalParm("ar_enable_aovP{}".format(index)):
+            if not rop.evalParm("ar_enable_aov{}".format(index)):
                 continue
 
             if rop.evalParm("ar_aov_exr_enable_layer_name{}".format(index)):


### PR DESCRIPTION
## Changelog Description
Fixing a typo error in `collect_arnold_rop.py`

Reference: [#5280](https://github.com/ynput/OpenPype/issues/5280)