### PR TITLE
Maya: Removed unnecessary import of pyblish.cli

### DIFF
--- a/openpype/tests/lib.py
+++ b/openpype/tests/lib.py
@@ -5,7 +5,6 @@ import tempfile
 import contextlib
 
 import pyblish
-import pyblish.cli
 import pyblish.plugin
 from pyblish.vendor import six
 


### PR DESCRIPTION
## Changelog Description
This import resulted in adding additional logging handler which lead to duplication of logs in hosts with plugins containing `is_in_tests` method. Import is unnecessary for testing functionality.

