### PR TITLE
Maya: fix validate frame range on review attached to other instances

### DIFF
--- a/openpype/hosts/maya/plugins/publish/collect_review.py
+++ b/openpype/hosts/maya/plugins/publish/collect_review.py
@@ -107,10 +107,8 @@ class CollectReview(pyblish.api.InstancePlugin):
             data["displayLights"] = display_lights
             data["burninDataMembers"] = burninDataMembers
 
-            publish_attributes = data.setdefault("publish_attributes", {})
             for key, value in instance.data["publish_attributes"].items():
-                if key not in publish_attributes:
-                    publish_attributes[key] = value
+                data["publish_attributes"][key] = value
 
             # The review instance must be active
             cmds.setAttr(str(instance) + '.active', 1)

--- a/openpype/hosts/maya/plugins/publish/collect_review.py
+++ b/openpype/hosts/maya/plugins/publish/collect_review.py
@@ -107,6 +107,11 @@ class CollectReview(pyblish.api.InstancePlugin):
             data["displayLights"] = display_lights
             data["burninDataMembers"] = burninDataMembers
 
+            publish_attributes = data.setdefault("publish_attributes", {})
+            for key, value in instance.data["publish_attributes"].items():
+                if key not in publish_attributes:
+                    publish_attributes[key] = value
+
             # The review instance must be active
             cmds.setAttr(str(instance) + '.active', 1)
 

--- a/openpype/settings/entities/schemas/projects_schema/schemas/schema_maya_publish.json
+++ b/openpype/settings/entities/schemas/projects_schema/schemas/schema_maya_publish.json
@@ -103,7 +103,7 @@
                 },
                 {
                     "key": "exclude_families",
-                    "label": "Families",
+                    "label": "Exclude Families",
                     "type": "list",
                     "object_type": "text"
                 }


### PR DESCRIPTION
## Changelog Description
Fixes situation where frame range validator can't be turned off on models if they are attached to reviewable camera in Maya. 

## Testing notes:
1. Create model publish instance in maya
2. create review publish instance in maya 
3. parent model maya set under the review maya set based on this **https://ayon.ynput.io/docs/artist_hosts_maya#publishing-model-with-review**
4. turn off `validate frame range` on the review in the publisher GUI. 
5. Everything should go through correctly and you should end up with review attached to the model Product. 
