### PR TITLE
Maya: Include disabled plugins

### DIFF
--- a/openpype/hosts/maya/plugins/create/convert_legacy.py
+++ b/openpype/hosts/maya/plugins/create/convert_legacy.py
@@ -51,7 +51,7 @@ class MayaLegacyConvertor(SubsetConvertorPlugin,
         # From all current new style manual creators find the mapping
         # from family to identifier
         family_to_id = {}
-        for identifier, creator in self.create_context.manual_creators.items():
+        for identifier, creator in self.create_context.creators.items():
             family = getattr(creator, "family", None)
             if not family:
                 continue
@@ -70,7 +70,6 @@ class MayaLegacyConvertor(SubsetConvertorPlugin,
         # logic was thus to be live to the current task to begin with.
         data = dict()
         data["task"] = self.create_context.get_current_task_name()
-
         for family, instance_nodes in legacy.items():
             if family not in family_to_id:
                 self.log.warning(
@@ -81,7 +80,7 @@ class MayaLegacyConvertor(SubsetConvertorPlugin,
                 continue
 
             creator_id = family_to_id[family]
-            creator = self.create_context.manual_creators[creator_id]
+            creator = self.create_context.creators[creator_id]
             data["creator_identifier"] = creator_id
 
             if isinstance(creator, plugin.RenderlayerCreator):

--- a/openpype/pipeline/create/context.py
+++ b/openpype/pipeline/create/context.py
@@ -1804,10 +1804,10 @@ class CreateContext:
                 self,
                 self.headless
             )
+            creators[creator_identifier] = creator
             if not creator.enabled:
                 disabled_creators[creator_identifier] = creator
                 continue
-            creators[creator_identifier] = creator
             if isinstance(creator, AutoCreator):
                 autocreators[creator_identifier] = creator
             elif isinstance(creator, Creator):


### PR DESCRIPTION
## Changelog Description
When converting `animation` family or loading a `rig` family, need to include the disabled `animation` creator.

## Testing notes:
1. Convert legacy `animation` instances.
2. Verify no errors occur.
3. Load `rig` family.
4. Verify no errors occur.
