### PR TITLE
AYON: Make appdirs case sensitive

### DIFF
--- a/common/ayon_common/utils.py
+++ b/common/ayon_common/utils.py
@@ -16,7 +16,7 @@ def get_ayon_appdirs(*args):
     """
 
     return os.path.join(
-        appdirs.user_data_dir("ayon", "ynput"),
+        appdirs.user_data_dir("AYON", "Ynput"),
         *args
     )
 

--- a/openpype/lib/local_settings.py
+++ b/openpype/lib/local_settings.py
@@ -529,7 +529,7 @@ def get_ayon_appdirs(*args):
     """
 
     return os.path.join(
-        appdirs.user_data_dir("ayon", "ynput"),
+        appdirs.user_data_dir("AYON", "Ynput"),
         *args
     )
 

--- a/openpype/modules/base.py
+++ b/openpype/modules/base.py
@@ -374,7 +374,7 @@ def _load_ayon_addons(openpype_modules, modules_key, log):
     if not addons_info:
         return v3_addons_to_skip
     addons_dir = os.path.join(
-        appdirs.user_data_dir("ayon", "ynput"),
+        appdirs.user_data_dir("AYON", "Ynput"),
         "addons"
     )
     if not os.path.exists(addons_dir):

--- a/openpype/vendor/python/common/ayon_api/thumbnails.py
+++ b/openpype/vendor/python/common/ayon_api/thumbnails.py
@@ -50,7 +50,7 @@ class ThumbnailCache:
         """
 
         if self._thumbnails_dir is None:
-            directory = appdirs.user_data_dir("ayon", "ynput")
+            directory = appdirs.user_data_dir("AYON", "Ynput")
             self._thumbnails_dir = os.path.join(directory, "thumbnails")
         return self._thumbnails_dir
 


### PR DESCRIPTION
## Changelog Description
Appdirs for AYON are case sensitive for linux and mac so we needed to change them to match ayon launcher. Changed 'ayon' to 'AYON' and 'ynput' to 'Ynput'.

## Additional information
Since windows is not case sensitive I didn't think about as an issue but it is an issue...