### PR TITLE
AYON: 3rd party addon usage

### DIFF
--- a/openpype/hosts/harmony/plugins/publish/extract_render.py
+++ b/openpype/hosts/harmony/plugins/publish/extract_render.py
@@ -94,9 +94,8 @@ class ExtractRender(pyblish.api.InstancePlugin):
 
         # Generate thumbnail.
         thumbnail_path = os.path.join(path, "thumbnail.png")
-        ffmpeg_path = openpype.lib.get_ffmpeg_tool_path("ffmpeg")
-        args = [
-            ffmpeg_path,
+        ffmpeg_args = openpype.lib.get_ffmpeg_tool_args("ffmpeg")
+        args = ffmpeg_args + [
             "-y",
             "-i", os.path.join(path, list(collections[0])[0]),
             "-vf", "scale=300:-1",

--- a/openpype/hosts/hiero/plugins/publish/extract_frames.py
+++ b/openpype/hosts/hiero/plugins/publish/extract_frames.py
@@ -2,7 +2,7 @@ import os
 import pyblish.api
 
 from openpype.lib import (
-    get_oiio_tools_path,
+    get_oiio_tools_args,
     run_subprocess,
 )
 from openpype.pipeline import publish
@@ -18,7 +18,7 @@ class ExtractFrames(publish.Extractor):
     movie_extensions = ["mov", "mp4"]
 
     def process(self, instance):
-        oiio_tool_path = get_oiio_tools_path()
+        oiio_tool_args = get_oiio_tools_args()
         staging_dir = self.staging_dir(instance)
         output_template = os.path.join(staging_dir, instance.data["name"])
         sequence = instance.context.data["activeTimeline"]
@@ -36,7 +36,7 @@ class ExtractFrames(publish.Extractor):
             output_path = output_template
             output_path += ".{:04d}.{}".format(int(frame), output_ext)
 
-            args = [oiio_tool_path]
+            args = list(oiio_tool_args)
 
             ext = os.path.splitext(input_path)[1][1:]
             if ext in self.movie_extensions:

--- a/openpype/hosts/maya/plugins/publish/extract_look.py
+++ b/openpype/hosts/maya/plugins/publish/extract_look.py
@@ -16,7 +16,7 @@ import pyblish.api
 from maya import cmds  # noqa
 
 from openpype.lib.vendor_bin_utils import find_executable
-from openpype.lib import source_hash, run_subprocess, get_oiio_tools_path
+from openpype.lib import source_hash, run_subprocess, get_oiio_tools_args
 from openpype.pipeline import legacy_io, publish, KnownPublishError
 from openpype.hosts.maya.api import lib
 
@@ -267,11 +267,10 @@ class MakeTX(TextureProcessor):
 
         """
 
-        maketx_path = get_oiio_tools_path("maketx")
-
-        if not maketx_path:
+        maketx_args = get_oiio_tools_args("maketx")
+        if not maketx_args:
             raise AssertionError(
-                "OIIO 'maketx' tool not found. Result: {}".format(maketx_path)
+                "OIIO 'maketx' tool not found."
             )
 
         # Define .tx filepath in staging if source file is not .tx
@@ -328,8 +327,7 @@ class MakeTX(TextureProcessor):
 
         self.log.info("Generating .tx file for %s .." % source)
 
-        subprocess_args = [
-            maketx_path,
+        subprocess_args = maketx_args + [
             "-v",  # verbose
             "-u",  # update mode
             # --checknan doesn't influence the output file but aborts the

--- a/openpype/hosts/photoshop/plugins/publish/extract_review.py
+++ b/openpype/hosts/photoshop/plugins/publish/extract_review.py
@@ -1,10 +1,9 @@
 import os
-import shutil
 from PIL import Image
 
 from openpype.lib import (
     run_subprocess,
-    get_ffmpeg_tool_path,
+    get_ffmpeg_tool_args,
 )
 from openpype.pipeline import publish
 from openpype.hosts.photoshop import api as photoshop
@@ -85,7 +84,7 @@ class ExtractReview(publish.Extractor):
             instance.data["representations"].append(repre_skeleton)
             processed_img_names = [img_list]
 
-        ffmpeg_path = get_ffmpeg_tool_path("ffmpeg")
+        ffmpeg_path = get_ffmpeg_tool_args("ffmpeg")
 
         instance.data["stagingDir"] = staging_dir
 
@@ -94,13 +93,21 @@ class ExtractReview(publish.Extractor):
         source_files_pattern = self._check_and_resize(processed_img_names,
                                                       source_files_pattern,
                                                       staging_dir)
-        self._generate_thumbnail(ffmpeg_path, instance, source_files_pattern,
-                                 staging_dir)
+        self._generate_thumbnail(
+            list(ffmpeg_path),
+            instance,
+            source_files_pattern,
+            staging_dir)
 
         no_of_frames = len(processed_img_names)
         if no_of_frames > 1:
-            self._generate_mov(ffmpeg_path, instance, fps, no_of_frames,
-                               source_files_pattern, staging_dir)
+            self._generate_mov(
+                list(ffmpeg_path),
+                instance,
+                fps,
+                no_of_frames,
+                source_files_pattern,
+                staging_dir)
 
         self.log.info(f"Extracted {instance} to {staging_dir}")
 
@@ -142,8 +149,9 @@ class ExtractReview(publish.Extractor):
             "tags": self.mov_options['tags']
         })
 
-    def _generate_thumbnail(self, ffmpeg_path, instance, source_files_pattern,
-                            staging_dir):
+    def _generate_thumbnail(
+        self, ffmpeg_args, instance, source_files_pattern, staging_dir
+    ):
         """Generates scaled down thumbnail and adds it as representation.
 
         Args:
@@ -157,8 +165,7 @@ class ExtractReview(publish.Extractor):
         # Generate thumbnail
         thumbnail_path = os.path.join(staging_dir, "thumbnail.jpg")
         self.log.info(f"Generate thumbnail {thumbnail_path}")
-        args = [
-            ffmpeg_path,
+        args = ffmpeg_args + [
             "-y",
             "-i", source_files_pattern,
             "-vf", "scale=300:-1",

--- a/openpype/hosts/standalonepublisher/plugins/publish/extract_thumbnail.py
+++ b/openpype/hosts/standalonepublisher/plugins/publish/extract_thumbnail.py
@@ -1,8 +1,9 @@
 import os
+import subprocess
 import tempfile
 import pyblish.api
 from openpype.lib import (
-    get_ffmpeg_tool_path,
+    get_ffmpeg_tool_args,
     get_ffprobe_streams,
     path_to_subprocess_arg,
     run_subprocess,
@@ -62,12 +63,12 @@ class ExtractThumbnailSP(pyblish.api.InstancePlugin):
 
         instance.context.data["cleanupFullPaths"].append(full_thumbnail_path)
 
-        ffmpeg_path = get_ffmpeg_tool_path("ffmpeg")
+        ffmpeg_executable_args = get_ffmpeg_tool_args("ffmpeg")
 
         ffmpeg_args = self.ffmpeg_args or {}
 
         jpeg_items = [
-            path_to_subprocess_arg(ffmpeg_path),
+            subprocess.list2cmdline(ffmpeg_executable_args),
             # override file if already exists
             "-y"
         ]

--- a/openpype/hosts/tvpaint/plugins/publish/extract_convert_to_exr.py
+++ b/openpype/hosts/tvpaint/plugins/publish/extract_convert_to_exr.py
@@ -9,7 +9,7 @@ import json
 
 import pyblish.api
 from openpype.lib import (
-    get_oiio_tools_path,
+    get_oiio_tools_args,
     run_subprocess,
 )
 from openpype.pipeline import KnownPublishError
@@ -34,10 +34,10 @@ class ExtractConvertToEXR(pyblish.api.InstancePlugin):
         if not repres:
             return
 
-        oiio_path = get_oiio_tools_path()
+        oiio_args = get_oiio_tools_args()
         # Raise an exception when oiiotool is not available
         # - this can currently happen on MacOS machines
-        if not os.path.exists(oiio_path):
+        if not oiio_args:
             KnownPublishError(
                 "OpenImageIO tool is not available on this machine."
             )
@@ -64,8 +64,8 @@ class ExtractConvertToEXR(pyblish.api.InstancePlugin):
 
                 src_filepaths.add(src_filepath)
 
-                args = [
-                    oiio_path, src_filepath,
+                args = oiio_args + [
+                    src_filepath,
                     "--compression", self.exr_compression,
                     # TODO how to define color conversion?
                     "--colorconvert", "sRGB", "linear",

--- a/openpype/lib/__init__.py
+++ b/openpype/lib/__init__.py
@@ -25,7 +25,9 @@ from .vendor_bin_utils import (
     find_executable,
     get_vendor_bin_path,
     get_oiio_tools_path,
+    get_oiio_tools_args,
     get_ffmpeg_tool_path,
+    get_ffmpeg_tool_args,
     is_oiio_supported
 )
 
@@ -222,7 +224,9 @@ __all__ = [
 
     "get_vendor_bin_path",
     "get_oiio_tools_path",
+    "get_oiio_tools_args",
     "get_ffmpeg_tool_path",
+    "get_ffmpeg_tool_args",
     "is_oiio_supported",
 
     "AbstractAttrDef",

--- a/openpype/lib/transcoding.py
+++ b/openpype/lib/transcoding.py
@@ -11,8 +11,8 @@ import xml.etree.ElementTree
 
 from .execute import run_subprocess
 from .vendor_bin_utils import (
-    get_ffmpeg_tool_path,
-    get_oiio_tools_path,
+    get_ffmpeg_tool_args,
+    get_oiio_tools_args,
     is_oiio_supported,
 )
 
@@ -83,8 +83,7 @@ def get_oiio_info_for_input(filepath, logger=None, subimages=False):
 
     Stdout should contain xml format string.
     """
-    args = [
-        get_oiio_tools_path(),
+    args = get_oiio_tools_args() + [
         "--info",
         "-v"
     ]
@@ -486,9 +485,7 @@ def convert_for_ffmpeg(
         compression = "none"
 
     # Prepare subprocess arguments
-    oiio_cmd = [
-        get_oiio_tools_path(),
-
+    oiio_cmd = get_oiio_tools_args() + [
         # Don't add any additional attributes
         "--nosoftwareattrib",
     ]
@@ -656,9 +653,7 @@ def convert_input_paths_for_ffmpeg(
 
     for input_path in input_paths:
         # Prepare subprocess arguments
-        oiio_cmd = [
-            get_oiio_tools_path(),
-
+        oiio_cmd = get_oiio_tools_args() + [
             # Don't add any additional attributes
             "--nosoftwareattrib",
         ]
@@ -729,8 +724,8 @@ def get_ffprobe_data(path_to_file, logger=None):
     logger.info(
         "Getting information about input \"{}\".".format(path_to_file)
     )
-    args = [
-        get_ffmpeg_tool_path("ffprobe"),
+    ffprobe_args = get_ffmpeg_tool_args("ffprobe")
+    args = ffprobe_args + [
         "-hide_banner",
         "-loglevel", "fatal",
         "-show_error",
@@ -1084,8 +1079,7 @@ def convert_colorspace(
     if logger is None:
         logger = logging.getLogger(__name__)
 
-    oiio_cmd = [
-        get_oiio_tools_path(),
+    oiio_cmd = get_oiio_tools_args() + [
         input_path,
         # Don't add any additional attributes
         "--nosoftwareattrib",

--- a/openpype/lib/vendor_bin_utils.py
+++ b/openpype/lib/vendor_bin_utils.py
@@ -306,12 +306,12 @@ def _get_ayon_oiio_tool_args(tool_name):
 
 
 def get_oiio_tools_path(tool="oiiotool"):
-    """Path to vendorized OpenImageIO tool executables.
+    """Path to OpenImageIO tool executables.
 
-    On Window it adds .exe extension if missing from tool argument.
+    On Windows it adds .exe extension if missing from tool argument.
 
     Args:
-        tool (string): Tool name (oiiotool, maketx, ...).
+        tool (string): Tool name 'oiiotool', 'maketx', etc.
             Default is "oiiotool".
     """
 
@@ -431,7 +431,7 @@ def get_ffmpeg_tool_path(tool="ffmpeg"):
     """Path to vendorized FFmpeg executable.
 
     Args:
-        tool (string): Tool name (ffmpeg, ffprobe, ...).
+        tool (str): Tool name 'ffmpeg', 'ffprobe', etc.
             Default is "ffmpeg".
 
     Returns:

--- a/openpype/lib/vendor_bin_utils.py
+++ b/openpype/lib/vendor_bin_utils.py
@@ -505,13 +505,9 @@ def is_oiio_supported():
     Returns:
         bool: OIIO tool executable is available.
     """
-    loaded_path = oiio_path = get_oiio_tools_path()
-    if oiio_path:
-        oiio_path = find_executable(oiio_path)
 
-    if not oiio_path:
-        log.debug("OIIOTool is not configured or not present at {}".format(
-            loaded_path
-        ))
+    args = get_oiio_tools_args()
+    if not args:
+        log.debug("OIIOTool is not configured or not present.")
         return False
-    return True
+    return _oiio_executable_validation(args)

--- a/openpype/lib/vendor_bin_utils.py
+++ b/openpype/lib/vendor_bin_utils.py
@@ -370,7 +370,6 @@ def get_oiio_tools_args(tool_name="oiiotool"):
         if args:
             return args
 
-    raise ValueError("This is test")
     path = get_oiio_tools_path(tool_name)
     if path:
         return [path]

--- a/openpype/lib/vendor_bin_utils.py
+++ b/openpype/lib/vendor_bin_utils.py
@@ -254,7 +254,7 @@ def _check_args_returncode(args):
     return proc.returncode == 0
 
 
-def _oiio_executable_validation(filepath):
+def _oiio_executable_validation(args):
     """Validate oiio tool executable if can be executed.
 
     Validation has 2 steps. First is using 'find_executable' to fill possible
@@ -272,17 +272,22 @@ def _oiio_executable_validation(filepath):
             should be used.
 
     Args:
-        filepath (str): Path to executable.
+        args (Union[str, list[str]]): Arguments to launch tool or
+            path to tool executable.
 
     Returns:
         bool: Filepath is valid executable.
     """
 
-    filepath = find_executable(filepath)
-    if not filepath:
+    if not args:
         return False
 
-    return _check_args_returncode([filepath, "--help"])
+    if not isinstance(args, list):
+        filepath = find_executable(args)
+        if not filepath:
+            return False
+        args = [filepath]
+    return _check_args_returncode(args + ["--help"])
 
 
 def _get_ayon_oiio_tool_args(tool_name):
@@ -361,7 +366,7 @@ def get_oiio_tools_args(tool_name="oiiotool"):
     return []
 
 
-def _ffmpeg_executable_validation(filepath):
+def _ffmpeg_executable_validation(args):
     """Validate ffmpeg tool executable if can be executed.
 
     Validation has 2 steps. First is using 'find_executable' to fill possible
@@ -378,17 +383,22 @@ def _ffmpeg_executable_validation(filepath):
         It does not validate if the executable is really a ffmpeg tool.
 
     Args:
-        filepath (str): Path to executable.
+        args (Union[str, list[str]]): Arguments to launch tool or
+            path to tool executable.
 
     Returns:
         bool: Filepath is valid executable.
     """
 
-    filepath = find_executable(filepath)
-    if not filepath:
+    if not args:
         return False
 
-    return _check_args_returncode([filepath, "-version"])
+    if not isinstance(args, list):
+        filepath = find_executable(args)
+        if not filepath:
+            return False
+        args = [filepath]
+    return _check_args_returncode(args + ["--help"])
 
 
 def _get_ayon_ffmpeg_tool_args(tool_name):

--- a/openpype/lib/vendor_bin_utils.py
+++ b/openpype/lib/vendor_bin_utils.py
@@ -318,6 +318,17 @@ def get_oiio_tools_path(tool="oiiotool"):
     if CachedToolPaths.is_tool_cached(tool):
         return CachedToolPaths.get_executable_path(tool)
 
+    if AYON_SERVER_ENABLED:
+        args = _get_ayon_oiio_tool_args(tool)
+        if args:
+            if len(args) > 1:
+                raise ValueError(
+                    "AYON oiio arguments consist of multiple arguments."
+                )
+            tool_executable_path = args[0]
+            CachedToolPaths.cache_executable_path(tool, tool_executable_path)
+            return tool_executable_path
+
     custom_paths_str = os.environ.get("OPENPYPE_OIIO_PATHS") or ""
     tool_executable_path = find_tool_in_custom_paths(
         custom_paths_str.split(os.pathsep),
@@ -430,6 +441,17 @@ def get_ffmpeg_tool_path(tool="ffmpeg"):
 
     if CachedToolPaths.is_tool_cached(tool):
         return CachedToolPaths.get_executable_path(tool)
+
+    if AYON_SERVER_ENABLED:
+        args = _get_ayon_ffmpeg_tool_args(tool)
+        if args is not None:
+            if len(args) > 1:
+                raise ValueError(
+                    "AYON ffmpeg arguments consist of multiple arguments."
+                )
+            tool_executable_path = args[0]
+            CachedToolPaths.cache_executable_path(tool, tool_executable_path)
+            return tool_executable_path
 
     custom_paths_str = os.environ.get("OPENPYPE_FFMPEG_PATHS") or ""
     tool_executable_path = find_tool_in_custom_paths(

--- a/openpype/plugins/publish/extract_otio_audio_tracks.py
+++ b/openpype/plugins/publish/extract_otio_audio_tracks.py
@@ -1,7 +1,7 @@
 import os
 import pyblish
 from openpype.lib import (
-    get_ffmpeg_tool_path,
+    get_ffmpeg_tool_args,
     run_subprocess
 )
 import tempfile
@@ -19,9 +19,6 @@ class ExtractOtioAudioTracks(pyblish.api.ContextPlugin):
     order = pyblish.api.ExtractorOrder - 0.44
     label = "Extract OTIO Audio Tracks"
     hosts = ["hiero", "resolve", "flame"]
-
-    # FFmpeg tools paths
-    ffmpeg_path = get_ffmpeg_tool_path("ffmpeg")
 
     def process(self, context):
         """Convert otio audio track's content to audio representations
@@ -91,8 +88,7 @@ class ExtractOtioAudioTracks(pyblish.api.ContextPlugin):
                 # temp audio file
                 audio_fpath = self.create_temp_file(name)
 
-                cmd = [
-                    self.ffmpeg_path,
+                cmd = get_ffmpeg_tool_args("ffmpeg") + [
                     "-ss", str(start_sec),
                     "-t", str(duration_sec),
                     "-i", audio_file,
@@ -211,7 +207,7 @@ class ExtractOtioAudioTracks(pyblish.api.ContextPlugin):
 
         # create empty cmd
         cmd = [
-            self.ffmpeg_path,
+            get_ffmpeg_tool_args("ffmpeg"),
             "-f", "lavfi",
             "-i", "anullsrc=channel_layout=stereo:sample_rate=48000",
             "-t", str(max_duration_sec),
@@ -295,7 +291,7 @@ class ExtractOtioAudioTracks(pyblish.api.ContextPlugin):
             filters_tmp_filepath = tmp_file.name
             tmp_file.write(",".join(filters))
 
-        args = [self.ffmpeg_path]
+        args = get_ffmpeg_tool_args("ffmpeg")
         args.extend(input_args)
         args.extend([
             "-filter_complex_script", filters_tmp_filepath,

--- a/openpype/plugins/publish/extract_otio_review.py
+++ b/openpype/plugins/publish/extract_otio_review.py
@@ -20,7 +20,7 @@ import opentimelineio as otio
 from pyblish import api
 
 from openpype.lib import (
-    get_ffmpeg_tool_path,
+    get_ffmpeg_tool_args,
     run_subprocess,
 )
 from openpype.pipeline import publish
@@ -338,8 +338,6 @@ class ExtractOTIOReview(publish.Extractor):
         Returns:
             otio.time.TimeRange: trimmed available range
         """
-        # get rendering app path
-        ffmpeg_path = get_ffmpeg_tool_path("ffmpeg")
 
         # create path  and frame start to destination
         output_path, out_frame_start = self._get_ffmpeg_output()
@@ -348,7 +346,7 @@ class ExtractOTIOReview(publish.Extractor):
             out_frame_start += end_offset
 
         # start command list
-        command = [ffmpeg_path]
+        command = get_ffmpeg_tool_args("ffmpeg")
 
         input_extension = None
         if sequence:

--- a/openpype/plugins/publish/extract_otio_trimming_video.py
+++ b/openpype/plugins/publish/extract_otio_trimming_video.py
@@ -11,7 +11,7 @@ from copy import deepcopy
 import pyblish.api
 
 from openpype.lib import (
-    get_ffmpeg_tool_path,
+    get_ffmpeg_tool_args,
     run_subprocess,
 )
 from openpype.pipeline import publish
@@ -75,14 +75,12 @@ class ExtractOTIOTrimmingVideo(publish.Extractor):
             otio_range (opentime.TimeRange): range to trim to
 
         """
-        # get rendering app path
-        ffmpeg_path = get_ffmpeg_tool_path("ffmpeg")
 
         # create path to destination
         output_path = self._get_ffmpeg_output(input_file_path)
 
         # start command list
-        command = [ffmpeg_path]
+        command = get_ffmpeg_tool_args("ffmpeg")
 
         video_path = input_file_path
         frame_start = otio_range.start_time.value

--- a/openpype/plugins/publish/extract_review.py
+++ b/openpype/plugins/publish/extract_review.py
@@ -3,6 +3,7 @@ import re
 import copy
 import json
 import shutil
+import subprocess
 from abc import ABCMeta, abstractmethod
 
 import six
@@ -11,7 +12,7 @@ import speedcopy
 import pyblish.api
 
 from openpype.lib import (
-    get_ffmpeg_tool_path,
+    get_ffmpeg_tool_args,
     filter_profiles,
     path_to_subprocess_arg,
     run_subprocess,
@@ -71,9 +72,6 @@ class ExtractReview(pyblish.api.InstancePlugin):
     supported_exts = image_exts + video_exts
 
     alpha_exts = ["exr", "png", "dpx"]
-
-    # FFmpeg tools paths
-    ffmpeg_path = get_ffmpeg_tool_path("ffmpeg")
 
     # Preset attributes
     profiles = None
@@ -788,7 +786,9 @@ class ExtractReview(pyblish.api.InstancePlugin):
                     audio_filters.append(arg)
 
         all_args = []
-        all_args.append(path_to_subprocess_arg(self.ffmpeg_path))
+        all_args.append(
+            subprocess.list2cmdline(get_ffmpeg_tool_args("ffmpeg"))
+        )
         all_args.extend(input_args)
         if video_filters:
             all_args.append("-filter:v")

--- a/openpype/plugins/publish/extract_scanline_exr.py
+++ b/openpype/plugins/publish/extract_scanline_exr.py
@@ -5,7 +5,7 @@ import shutil
 
 import pyblish.api
 
-from openpype.lib import run_subprocess, get_oiio_tools_path
+from openpype.lib import run_subprocess, get_oiio_tools_args
 
 
 class ExtractScanlineExr(pyblish.api.InstancePlugin):
@@ -45,10 +45,9 @@ class ExtractScanlineExr(pyblish.api.InstancePlugin):
 
             stagingdir = os.path.normpath(repre.get("stagingDir"))
 
-            oiio_tool_path = get_oiio_tools_path()
-            if not os.path.exists(oiio_tool_path):
-                self.log.error(
-                    "OIIO tool not found in {}".format(oiio_tool_path))
+            oiio_tool_args = get_oiio_tools_args()
+            if not oiio_tool_args:
+                self.log.error("OIIO tool not found.")
                 raise AssertionError("OIIO tool not found")
 
             for file in input_files:
@@ -57,8 +56,7 @@ class ExtractScanlineExr(pyblish.api.InstancePlugin):
                 temp_name = os.path.join(stagingdir, "__{}".format(file))
                 # move original render to temp location
                 shutil.move(original_name, temp_name)
-                oiio_cmd = [
-                    oiio_tool_path,
+                oiio_cmd = oiio_tool_args + [
                     os.path.join(stagingdir, temp_name), "--scanline", "-o",
                     os.path.join(stagingdir, original_name)
                 ]

--- a/openpype/plugins/publish/extract_thumbnail_from_source.py
+++ b/openpype/plugins/publish/extract_thumbnail_from_source.py
@@ -17,8 +17,8 @@ import tempfile
 
 import pyblish.api
 from openpype.lib import (
-    get_ffmpeg_tool_path,
-    get_oiio_tools_path,
+    get_ffmpeg_tool_args,
+    get_oiio_tools_args,
     is_oiio_supported,
 
     run_subprocess,
@@ -144,9 +144,7 @@ class ExtractThumbnailFromSource(pyblish.api.InstancePlugin):
 
     def create_thumbnail_oiio(self, src_path, dst_path):
         self.log.info("outputting {}".format(dst_path))
-        oiio_tool_path = get_oiio_tools_path()
-        oiio_cmd = [
-            oiio_tool_path,
+        oiio_cmd = get_oiio_tools_args() + [
             "-a", src_path,
             "-o", dst_path
         ]
@@ -162,11 +160,8 @@ class ExtractThumbnailFromSource(pyblish.api.InstancePlugin):
             return False
 
     def create_thumbnail_ffmpeg(self, src_path, dst_path):
-        ffmpeg_path = get_ffmpeg_tool_path("ffmpeg")
-
         max_int = str(2147483647)
-        ffmpeg_cmd = [
-            ffmpeg_path,
+        ffmpeg_cmd = get_ffmpeg_tool_args("ffmpeg") + [
             "-y",
             "-analyzeduration", max_int,
             "-probesize", max_int,

--- a/openpype/plugins/publish/extract_trim_video_audio.py
+++ b/openpype/plugins/publish/extract_trim_video_audio.py
@@ -4,7 +4,7 @@ from pprint import pformat
 import pyblish.api
 
 from openpype.lib import (
-    get_ffmpeg_tool_path,
+    get_ffmpeg_tool_args,
     run_subprocess,
 )
 from openpype.pipeline import publish
@@ -32,7 +32,7 @@ class ExtractTrimVideoAudio(publish.Extractor):
             instance.data["representations"] = list()
 
         # get ffmpet path
-        ffmpeg_path = get_ffmpeg_tool_path("ffmpeg")
+        ffmpeg_tool_args = get_ffmpeg_tool_args("ffmpeg")
 
         # get staging dir
         staging_dir = self.staging_dir(instance)
@@ -76,8 +76,7 @@ class ExtractTrimVideoAudio(publish.Extractor):
                     if "trimming" not in fml
                 ]
 
-            ffmpeg_args = [
-                ffmpeg_path,
+            ffmpeg_args = ffmpeg_tool_args + [
                 "-ss", str(clip_start_h / fps),
                 "-i", video_file_path,
                 "-t", str(clip_dur_h / fps)

--- a/openpype/scripts/otio_burnin.py
+++ b/openpype/scripts/otio_burnin.py
@@ -8,21 +8,15 @@ from string import Formatter
 
 import opentimelineio_contrib.adapters.ffmpeg_burnins as ffmpeg_burnins
 from openpype.lib import (
-    get_ffmpeg_tool_path,
+    get_ffmpeg_tool_args,
     get_ffmpeg_codec_args,
     get_ffmpeg_format_args,
     convert_ffprobe_fps_value,
-    convert_ffprobe_fps_to_float,
 )
 
-
-ffmpeg_path = get_ffmpeg_tool_path("ffmpeg")
-ffprobe_path = get_ffmpeg_tool_path("ffprobe")
-
-
 FFMPEG = (
-    '"{}"%(input_args)s -i "%(input)s" %(filters)s %(args)s%(output)s'
-).format(ffmpeg_path)
+    '{}%(input_args)s -i "%(input)s" %(filters)s %(args)s%(output)s'
+).format(subprocess.list2cmdline(get_ffmpeg_tool_args("ffmpeg")))
 
 DRAWTEXT = (
     "drawtext@'%(label)s'=fontfile='%(font)s':text=\\'%(text)s\\':"
@@ -46,8 +40,7 @@ def _get_ffprobe_data(source):
     :param str source: source media file
     :rtype: [{}, ...]
     """
-    command = [
-        ffprobe_path,
+    command = get_ffmpeg_tool_args("ffprobe") + [
         "-v", "quiet",
         "-print_format", "json",
         "-show_format",

--- a/openpype/tools/publisher/widgets/thumbnail_widget.py
+++ b/openpype/tools/publisher/widgets/thumbnail_widget.py
@@ -7,8 +7,8 @@ from openpype.style import get_objected_colors
 from openpype.lib import (
     run_subprocess,
     is_oiio_supported,
-    get_oiio_tools_path,
-    get_ffmpeg_tool_path,
+    get_oiio_tools_args,
+    get_ffmpeg_tool_args,
 )
 from openpype.lib.transcoding import (
     IMAGE_EXTENSIONS,
@@ -481,8 +481,7 @@ def _convert_thumbnail_oiio(src_path, dst_path):
     if not is_oiio_supported():
         return None
 
-    oiio_cmd = [
-        get_oiio_tools_path(),
+    oiio_cmd = get_oiio_tools_args() + [
         "-i", src_path,
         "--subimage", "0",
         "-o", dst_path
@@ -495,8 +494,10 @@ def _convert_thumbnail_oiio(src_path, dst_path):
 
 
 def _convert_thumbnail_ffmpeg(src_path, dst_path):
-    ffmpeg_cmd = [
-        get_ffmpeg_tool_path(),
+    ffmpeg_args = get_ffmpeg_tool_args()
+    if not ffmpeg_args:
+        return None
+    ffmpeg_cmd = ffmpeg_args + [
         "-y",
         "-i", src_path,
         dst_path

--- a/openpype/tools/standalonepublish/widgets/widget_drop_frame.py
+++ b/openpype/tools/standalonepublish/widgets/widget_drop_frame.py
@@ -5,6 +5,8 @@ import clique
 import subprocess
 import openpype.lib
 from qtpy import QtWidgets, QtCore
+
+from openpype.lib import get_ffprobe_data
 from . import DropEmpty, ComponentsList, ComponentItem
 
 
@@ -269,26 +271,8 @@ class DropDataFrame(QtWidgets.QFrame):
         self._process_data(data)
 
     def load_data_with_probe(self, filepath):
-        ffprobe_path = openpype.lib.get_ffmpeg_tool_path("ffprobe")
-        args = [
-            "\"{}\"".format(ffprobe_path),
-            '-v', 'quiet',
-            '-print_format json',
-            '-show_format',
-            '-show_streams',
-            '"{}"'.format(filepath)
-        ]
-        ffprobe_p = subprocess.Popen(
-            ' '.join(args),
-            stdout=subprocess.PIPE,
-            shell=True
-        )
-        ffprobe_output = ffprobe_p.communicate()[0]
-        if ffprobe_p.returncode != 0:
-            raise RuntimeError(
-                'Failed on ffprobe: check if ffprobe path is set in PATH env'
-            )
-        return json.loads(ffprobe_output)['streams'][0]
+        ffprobe_data = get_ffprobe_data(filepath)
+        return ffprobe_data["streams"][0]
 
     def get_file_data(self, data):
         filepath = data['files'][0]


### PR DESCRIPTION
## Changelog Description
Prepare OpenPype code to be able use `ayon-third-party` addon which supply ffmpeg and OpenImageIO executables. Because they both can support to define custom arguments (more than one) a new functions were needed to supply.

New functions are `get_ffmpeg_tool_args` and `get_oiio_tool_args`. They work similar to previous but instead of string are returning list of strings. All places using previous functions `get_ffmpeg_tool_path` and `get_oiio_tool_path` are now using new ones. They should be backwards compatible and even with addon if returns single argument.

## Testing notes:
This is tricky one. Since dependency packages are not yet available there are 2 ways how to be able start executable that would be able to use `ayon-third-party` addon:
1. Install/Copy needed dependencies to ayon-launcher so it is possible to launch it with openpype addon.
2. Copy `common` folder from `ayon-launcher` to `OpenPype` repository, so `ayon-third-party` addon has needed requirements.

Prerequirements:
1. Working executable
2. openpype addon on AYON server
3. `ayon-third-party` addon on AYON server

Testing:
1. Start tray
2. 3rd part addon should download ffmpeg and oiio to your machine
3. Launch any host of your preference that is working with ffmpeg or oiio
4. Run publishing which will use them (e.g. review)
5. Validate in output that ffmpeg/oiio from 3rd party addon was used (`...\addons\ayon_third_party_0.0.1\ayon_third_party\downloads\ffmpeg\bin\ffmpeg.exe`)
