### PR TITLE
Maya: Apply project settings to creators

### DIFF
--- a/openpype/hosts/maya/api/plugin.py
+++ b/openpype/hosts/maya/api/plugin.py
@@ -181,6 +181,8 @@ class MayaCreatorBase(object):
 @six.add_metaclass(ABCMeta)
 class MayaCreator(NewCreator, MayaCreatorBase):
 
+    settings_name = None
+
     def create(self, subset_name, instance_data, pre_create_data):
 
         members = list()
@@ -237,6 +239,24 @@ class MayaCreator(NewCreator, MayaCreatorBase):
                     label="Use selection",
                     default=True)
         ]
+
+    def apply_settings(self, project_settings, system_settings):
+        """Method called on initialization of plugin to apply settings."""
+
+        settings_name = self.settings_name
+        if settings_name is None:
+            settings_name = self.__class__.__name__
+
+        settings = project_settings["maya"]["create"]
+        settings = settings.get(settings_name)
+        if settings is None:
+            self.log.debug(
+                "No settings found for {}".format(self.__class__.__name__)
+            )
+            return
+
+        for key, value in settings.items():
+            setattr(self, key, value)
 
 
 def ensure_namespace(namespace):

--- a/openpype/hosts/maya/plugins/create/create_arnold_scene_source.py
+++ b/openpype/hosts/maya/plugins/create/create_arnold_scene_source.py
@@ -15,6 +15,7 @@ class CreateArnoldSceneSource(plugin.MayaCreator):
     label = "Arnold Scene Source"
     family = "ass"
     icon = "cube"
+    settings_name = "CreateAss"
 
     expandProcedurals = False
     motionBlur = True


### PR DESCRIPTION
## Changelog Description
Project settings were not applied to the creators.

## Testing notes:
1. Make a change from the default settings on any of the Maya creators; `project_settings/maya/create`
2. In Maya create the modified creator.
3. Verify the settings from the project settings are applied.
