### PR TITLE
Bug: Error on multiple instance rig with maya

### DIFF
--- a/openpype/hosts/maya/plugins/create/create_rig.py
+++ b/openpype/hosts/maya/plugins/create/create_rig.py
@@ -20,6 +20,6 @@ class CreateRig(plugin.MayaCreator):
         instance_node = instance.get("instance_node")
 
         self.log.info("Creating Rig instance set up ...")
-        controls = cmds.sets(name="controls_SET", empty=True)
-        pointcache = cmds.sets(name="out_SET", empty=True)
+        controls = cmds.sets(name=subset_name + "_controls_SET", empty=True)
+        pointcache = cmds.sets(name=subset_name + "_out_SET", empty=True)
         cmds.sets([controls, pointcache], forceElement=instance_node)

--- a/openpype/hosts/maya/plugins/publish/validate_rig_output_ids.py
+++ b/openpype/hosts/maya/plugins/publish/validate_rig_output_ids.py
@@ -47,7 +47,7 @@ class ValidateRigOutputIds(pyblish.api.InstancePlugin):
         invalid = {}
 
         if compute:
-            out_set = next(x for x in instance if x.startswith("out_SET"))
+            out_set = next(x for x in instance if "out_SET" in x)
 
             instance_nodes = cmds.sets(out_set, query=True, nodesOnly=True)
             instance_nodes = cmds.ls(instance_nodes, long=True)

--- a/openpype/hosts/maya/plugins/publish/validate_rig_output_ids.py
+++ b/openpype/hosts/maya/plugins/publish/validate_rig_output_ids.py
@@ -47,7 +47,7 @@ class ValidateRigOutputIds(pyblish.api.InstancePlugin):
         invalid = {}
 
         if compute:
-            out_set = next(x for x in instance if x.endswith("out_SET"))
+            out_set = next(x for x in instance if x.startswith("out_SET"))
 
             instance_nodes = cmds.sets(out_set, query=True, nodesOnly=True)
             instance_nodes = cmds.ls(instance_nodes, long=True)


### PR DESCRIPTION
In case of multiple subset rig in the maya scene, there is an error on the plugin `rig output ids`

## Changelog Description

I change endswith method by startswith method because the set are automacaly name out_SET, out_SET1, out_SET2 ...
![image](https://github.com/ynput/OpenPype/assets/7068597/6bcf3727-042b-471e-a591-2956b875724f)


## Testing notes:
1. Open maya
2. Add multiple rig instance with different subset
3. Publish and see the error
