### PR TITLE
Fix/pyside6 multiselection combobox check state

### DIFF
--- a/openpype/tools/settings/settings/multiselection_combobox.py
+++ b/openpype/tools/settings/settings/multiselection_combobox.py
@@ -132,12 +132,10 @@ class MultiSelectionComboBox(QtWidgets.QComboBox):
 
         elif event.type() == QtCore.QEvent.KeyPress:
             # TODO: handle QtCore.Qt.Key_Enter, Key_Return?
-            if event.key() == QtCore.Qt.Key_Space:
+            if event.key() == QtCore.Qt.Key_Space and index_flags:
                 # toggle the current items check state
-                if index_flags & QtCore.Qt.ItemIsUserCheckable:
-                    if QtCore.Qt.ItemIsUserTristate:
-                        new_state = QtCore.Qt.CheckState((state.value + 1) % 3)
-                    elif state != QtCore.Qt.Checked:
+                if QtCore.Qt.ItemIsUserTristate:
+                    if state != QtCore.Qt.Checked:
                         new_state = QtCore.Qt.Checked
                     else:
                         new_state = QtCore.Qt.Unchecked

--- a/openpype/tools/settings/settings/multiselection_combobox.py
+++ b/openpype/tools/settings/settings/multiselection_combobox.py
@@ -302,7 +302,7 @@ class MultiSelectionComboBox(QtWidgets.QComboBox):
                 check_state = QtCore.Qt.Checked
             else:
                 check_state = QtCore.Qt.Unchecked
-            self.setItemData(idx, check_state, QtCore.Qt.CheckStateRole)
+            self.setItemData(idx, check_state.value, QtCore.Qt.CheckStateRole)
         self.update_size_hint()
 
     def value(self):

--- a/openpype/tools/settings/settings/multiselection_combobox.py
+++ b/openpype/tools/settings/settings/multiselection_combobox.py
@@ -135,19 +135,16 @@ class MultiSelectionComboBox(QtWidgets.QComboBox):
             # TODO: handle QtCore.Qt.Key_Enter, Key_Return?
             if event.key() == QtCore.Qt.Key_Space:
                 # toggle the current items check state
-                if (
-                    index_flags & QtCore.Qt.ItemIsUserCheckable
-                    and index_flags & QtCore.Qt.ItemIsTristate
-                ):
-                    new_state = QtCore.Qt.CheckState((int(state) + 1) % 3)
-
-                elif index_flags & QtCore.Qt.ItemIsUserCheckable:
-                    if state != QtCore.Qt.Checked:
+                if index_flags & QtCore.Qt.ItemIsUserCheckable:
+                    if QtCore.Qt.ItemIsUserTristate:
+                        new_state = QtCore.Qt.CheckState((state.value + 1) % 3)
+                    elif state != QtCore.Qt.Checked:
                         new_state = QtCore.Qt.Checked
                     else:
                         new_state = QtCore.Qt.Unchecked
 
         if new_state is not None:
+            new_state = new_state.value  # fix for PySide6
             model.setData(current_index, new_state, QtCore.Qt.CheckStateRole)
             self.view().update(current_index)
             self.update_size_hint()

--- a/openpype/tools/settings/settings/multiselection_combobox.py
+++ b/openpype/tools/settings/settings/multiselection_combobox.py
@@ -119,7 +119,6 @@ class MultiSelectionComboBox(QtWidgets.QComboBox):
                 self._block_mouse_release_timer.isActive()
                 or not current_index.isValid()
                 or not self.view().isVisible()
-                or not self.view().rect().contains(event.pos())
                 or not index_flags & QtCore.Qt.ItemIsSelectable
                 or not index_flags & QtCore.Qt.ItemIsEnabled
                 or not index_flags & QtCore.Qt.ItemIsUserCheckable

--- a/openpype/tools/settings/settings/multiselection_combobox.py
+++ b/openpype/tools/settings/settings/multiselection_combobox.py
@@ -90,6 +90,13 @@ class MultiSelectionComboBox(QtWidgets.QComboBox):
         super(MultiSelectionComboBox, self).hidePopup()
         self.view().clearFocus()
 
+    def _get_state_value(self, state):
+        try:
+            state = state.value  # fix for PySide6
+        except AttributeError:
+            pass
+        return state
+
     def _event_popup_shown(self, obj, event):
         if not self._popup_is_shown:
             return
@@ -139,9 +146,9 @@ class MultiSelectionComboBox(QtWidgets.QComboBox):
                         new_state = QtCore.Qt.Checked
                     else:
                         new_state = QtCore.Qt.Unchecked
-
+            
         if new_state is not None:
-            new_state = new_state.value  # fix for PySide6
+            new_state = self._get_state_value(new_state)
             model.setData(current_index, new_state, QtCore.Qt.CheckStateRole)
             self.view().update(current_index)
             self.update_size_hint()
@@ -302,7 +309,8 @@ class MultiSelectionComboBox(QtWidgets.QComboBox):
                 check_state = QtCore.Qt.Checked
             else:
                 check_state = QtCore.Qt.Unchecked
-            self.setItemData(idx, check_state.value, QtCore.Qt.CheckStateRole)
+            check_state = self._get_state_value(check_state)
+            self.setItemData(idx, check_state, QtCore.Qt.CheckStateRole)
         self.update_size_hint()
 
     def value(self):


### PR DESCRIPTION
## Changelog Description
* The check states are replaced with the values for PySide6
* `ItemIsUserTristate` is used instead of `ItemIsTristate` to avoid crashes on PySide6

## Additional info
`Qt.Checked`/ and `Qt.Unchecked` are converted to values for PySide6, as suggested here:
https://forum.qt.io/topic/138298/qt-checkstaterole-not-work-in-pyside-6-3-1/6?utm_source=pocket_saves

## Related issue:
https://github.com/ynput/OpenPype/issues/5313

## Testing notes:

1. Open OP Admin settings on macos
2. Open anatomy-attributes-applications list. All active elements will be checked
3. Click on empty box, check mark will appear
4. Select the box with a keyboard and press space, check mark will appear.

![photo_2023-07-17_23-10-412](https://github.com/ynput/OpenPype/assets/11698866/d5f89aa1-0693-46af-aa2b-f7514e98631f)



