### PR TITLE
fix typo

### DIFF
--- a/openpype/hosts/houdini/plugins/create/create_redshift_proxy.py
+++ b/openpype/hosts/houdini/plugins/create/create_redshift_proxy.py
@@ -33,7 +33,7 @@ class CreateRedshiftProxy(plugin.HoudiniCreator):
         instance_node = hou.node(instance.get("instance_node"))
 
         parms = {
-            "RS_archive_file": '$HIP/pyblish/`{}.$F4.rs'.format(subset_name),
+            "RS_archive_file": '$HIP/pyblish/{}.$F4.rs'.format(subset_name),
         }
 
         if self.selected_nodes:


### PR DESCRIPTION
## Changelog Description
I believe there's a typo in `create_redshift_proxy.py`   ( extra ` )  in filename, and I made this PR to fix

![image](https://github.com/ynput/OpenPype/assets/20871534/5c4ba770-bba4-4751-a356-184d90ea54fc)
