### PR TITLE
Houdini: fix wrong creator identifier in pointCache workflow

### DIFF
--- a/openpype/hosts/houdini/plugins/publish/collect_pointcache_type.py
+++ b/openpype/hosts/houdini/plugins/publish/collect_pointcache_type.py
@@ -17,5 +17,5 @@ class CollectPointcacheType(pyblish.api.InstancePlugin):
     def process(self, instance):
         if instance.data["creator_identifier"] == "io.openpype.creators.houdini.bgeo":  # noqa: E501
             instance.data["families"] += ["bgeo"]
-        elif instance.data["creator_identifier"] == "io.openpype.creators.houdini.alembic":  # noqa: E501
+        elif instance.data["creator_identifier"] == "io.openpype.creators.houdini.pointcache":  # noqa: E501
             instance.data["families"] += ["abc"]


### PR DESCRIPTION
## Changelog Description
FIxing a bug in publishing alembics, were invalid creator identifier caused missing family association.

## Additional info
Publishing of BGEO and pointCache (alembics) should work as expected

## Testing notes:
1. Open Houdini
2. create some testing geo
3. create PointCache instance
4. publishing should work with all almebics related validations, etc.
5. create BGEO instance
6. publishing should still work as expected.