### PR TITLE
Maya: All base create plugins

### DIFF
--- a/openpype/hosts/maya/api/plugin.py
+++ b/openpype/hosts/maya/api/plugin.py
@@ -8,13 +8,24 @@ from maya import cmds
 from maya.app.renderSetup.model import renderSetup
 
 from openpype.lib import BoolDef, Logger
-from openpype.pipeline import AVALON_CONTAINER_ID, Anatomy, CreatedInstance
-from openpype.pipeline import Creator as NewCreator
-from openpype.pipeline import (
-    CreatorError, LegacyCreator, LoaderPlugin, get_representation_path,
-    legacy_io)
-from openpype.pipeline.load import LoadError
 from openpype.settings import get_project_settings
+from openpype.pipeline import (
+    AVALON_CONTAINER_ID,
+    Anatomy,
+
+    CreatedInstance,
+    Creator as NewCreator,
+    AutoCreator,
+    HiddenCreator,
+
+    CreatorError,
+    LegacyCreator,
+    LoaderPlugin,
+    get_representation_path,
+
+    legacy_io,
+)
+from openpype.pipeline.load import LoadError
 
 from . import lib
 from .lib import imprint, read
@@ -246,6 +257,40 @@ class MayaCreator(NewCreator, MayaCreatorBase):
                     label="Use selection",
                     default=True)
         ]
+
+
+class MayaAutoCreator(AutoCreator, MayaCreatorBase):
+    """Automatically triggered creator for Maya.
+
+    The plugin is not visible in UI, and 'create' method does not expect
+        any arguments.
+    """
+
+    def collect_instances(self):
+        return self._default_collect_instances()
+
+    def update_instances(self, update_list):
+        return self._default_update_instances(update_list)
+
+    def remove_instances(self, instances):
+        return self._default_remove_instances(instances)
+
+
+class MayaHiddenCreator(HiddenCreator, MayaCreatorBase):
+    """Hidden creator for Maya.
+
+    The plugin is not visible in UI, and it does not have strictly defined
+        arguments for 'create' method.
+    """
+
+    def collect_instances(self):
+        return self._default_collect_instances()
+
+    def update_instances(self, update_list):
+        return self._default_update_instances(update_list)
+
+    def remove_instances(self, instances):
+        return self._default_remove_instances(instances)
 
 
 def ensure_namespace(namespace):

--- a/openpype/pipeline/__init__.py
+++ b/openpype/pipeline/__init__.py
@@ -13,6 +13,7 @@ from .create import (
     BaseCreator,
     Creator,
     AutoCreator,
+    HiddenCreator,
     CreatedInstance,
     CreatorError,
 
@@ -114,6 +115,7 @@ __all__ = (
     "BaseCreator",
     "Creator",
     "AutoCreator",
+    "HiddenCreator",
     "CreatedInstance",
     "CreatorError",
 

--- a/openpype/pipeline/create/context.py
+++ b/openpype/pipeline/create/context.py
@@ -1165,8 +1165,8 @@ class CreatedInstance:
         Args:
             instance_data (Dict[str, Any]): Data in a structure ready for
                 'CreatedInstance' object.
-            creator (BaseCreator): Creator plugin which is creating the instance
-                of for which the instance belong.
+            creator (BaseCreator): Creator plugin which is creating the
+                instance of for which the instance belong.
         """
 
         instance_data = copy.deepcopy(instance_data)

--- a/openpype/pipeline/create/context.py
+++ b/openpype/pipeline/create/context.py
@@ -1165,7 +1165,7 @@ class CreatedInstance:
         Args:
             instance_data (Dict[str, Any]): Data in a structure ready for
                 'CreatedInstance' object.
-            creator (Creator): Creator plugin which is creating the instance
+            creator (BaseCreator): Creator plugin which is creating the instance
                 of for which the instance belong.
         """
 


### PR DESCRIPTION
## Changelog Description
Prepared base classes for each creator type in Maya. Extended `MayaCreatorBase` to have default implementations of common logic with instances which is used in each type of plugin.

## Additional info
This way the default instance logic is at single place and does not need to be implemented multiple times.

Idea for this PR came from this PR https://github.com/ynput/OpenPype/pull/5297