### PR TITLE
Fusion - Set selected tool to active

### DIFF
--- a/openpype/hosts/fusion/api/action.py
+++ b/openpype/hosts/fusion/api/action.py
@@ -51,6 +51,7 @@ class SelectInvalidAction(pyblish.api.Action):
         names = set()
         for tool in invalid:
             flow.Select(tool, True)
+            comp.SetActiveTool(tool)
             names.add(tool.Name)
         self.log.info(
             "Selecting invalid tools: %s" % ", ".join(sorted(names))

--- a/openpype/hosts/fusion/api/action.py
+++ b/openpype/hosts/fusion/api/action.py
@@ -18,8 +18,10 @@ class SelectInvalidAction(pyblish.api.Action):
     icon = "search"  # Icon from Awesome Icon
 
     def process(self, context, plugin):
-        errored_instances = get_errored_instances_from_context(context,
-                                                               plugin=plugin)
+        errored_instances = get_errored_instances_from_context(
+            context,
+            plugin=plugin,
+        )
 
         # Get the invalid nodes for the plug-ins
         self.log.info("Finding invalid nodes..")


### PR DESCRIPTION
## Changelog Description
When you run the action to select a node, this PR makes the node-flow show the selected node + you'll see the nodes controls in the inspector.

## Additional info
Paragraphs of text giving context of additional technical information or code examples.

## Testing notes:
1. With a Fusion project open, open OP and open Manage
2. Move the node flow away from any nodes
3. Right click a loader in the Manage window
4. Go to Actions -> Select Containers
5. The node flow should shift to show the selected node and you should see the controls in the inspector.
 