### PR TITLE
Fix colorspace compatibility check

### DIFF
--- a/openpype/pipeline/colorspace.py
+++ b/openpype/pipeline/colorspace.py
@@ -237,10 +237,15 @@ def get_data_subprocess(config_path, data_type):
 
 
 def compatibility_check():
-    """Making sure PyOpenColorIO is importable"""
+    """checking if user has a compatible PyOpenColorIO >= 2.
+
+    It's achieved by checking if PyOpenColorIO is importable
+    and calling any version 2 specific function
+    """
     try:
         import PyOpenColorIO
-        # old PyOpenColorIO uses `PyOpenColorIO.version` instead
+
+        # ocio versions lower than 2 will raise AttributeError
         PyOpenColorIO.GetVersion()
     except (ImportError, AttributeError):
         return False

--- a/openpype/pipeline/colorspace.py
+++ b/openpype/pipeline/colorspace.py
@@ -239,8 +239,10 @@ def get_data_subprocess(config_path, data_type):
 def compatibility_check():
     """Making sure PyOpenColorIO is importable"""
     try:
-        import PyOpenColorIO  # noqa: F401
-    except ImportError:
+        import PyOpenColorIO
+        # old PyOpenColorIO uses `PyOpenColorIO.version` instead
+        PyOpenColorIO.GetVersion()
+    except (ImportError, AttributeError):
         return False
     return True
 


### PR DESCRIPTION
## Changelog Description
for some reason a user may have `PyOpenColorIO` installed to his machine,  _in my case it came with renderman._

it can trick the compatibility check as `import PyOpenColorIO` won't raise an error 
however it may be an old version _like my case_ 

Before
compatibility check was true and It used wrapper directly 
![houdini_before](https://github.com/ynput/OpenPype/assets/20871534/dc8c6042-aaf8-4079-9097-2a8e12ead93b)

After Fix 
It will use wrapper via subprocess instead
![houdini_after](https://github.com/ynput/OpenPype/assets/20871534/4505ecdf-6169-4a52-8428-4c2b1c621465)

