### PR TITLE
Maya: Validate Model Content

### DIFF
--- a/openpype/hosts/maya/plugins/publish/validate_model_content.py
+++ b/openpype/hosts/maya/plugins/publish/validate_model_content.py
@@ -63,15 +63,10 @@ class ValidateModelContent(pyblish.api.InstancePlugin):
             return True
 
         # Top group
-        assemblies = cmds.ls(content_instance, assemblies=True, long=True)
-        if len(assemblies) != 1 and cls.validate_top_group:
+        top_parents = set([x.split("|")[1] for x in content_instance])
+        if cls.validate_top_group and len(top_parents) != 1:
             cls.log.error("Must have exactly one top group")
-            return assemblies
-        if len(assemblies) == 0:
-            cls.log.warning("No top group found. "
-                            "(Are there objects in the instance?"
-                            " Or is it parented in another group?)")
-            return assemblies or True
+            return top_parents
 
         def _is_visible(node):
             """Return whether node is visible"""
@@ -82,11 +77,11 @@ class ValidateModelContent(pyblish.api.InstancePlugin):
                                   visibility=True)
 
         # The roots must be visible (the assemblies)
-        for assembly in assemblies:
-            if not _is_visible(assembly):
-                cls.log.error("Invisible assembly (root node) is not "
-                              "allowed: {0}".format(assembly))
-                invalid.add(assembly)
+        for parent in top_parents:
+            if not _is_visible(parent):
+                cls.log.error("Invisible parent (root node) is not "
+                              "allowed: {0}".format(parent))
+                invalid.add(parent)
 
         # Ensure at least one shape is visible
         if not any(_is_visible(shape) for shape in shapes):


### PR DESCRIPTION
## Changelog Description
`assemblies` in `cmds.ls` does not seem to work;
```python
from maya import cmds


content_instance = ['|group2|pSphere1_GEO', '|group2|pSphere1_GEO|pSphere1_GEOShape', '|group1|pSphere1_GEO', '|group1|pSphere1_GEO|pSphere1_GEOShape']
assemblies = cmds.ls(content_instance, assemblies=True, long=True)
print(assemblies)
```

Fixing with string splitting instead.

## Testing notes:
1. Setup model instance with geometry from two different top level parents.
2. Publish and verify validation fails.
