### PR TITLE
Bugfix: Dependency without 'inputLinks' not downloaded

### DIFF
--- a/openpype/client/mongo/entity_links.py
+++ b/openpype/client/mongo/entity_links.py
@@ -212,14 +212,12 @@ def _process_referenced_pipeline_result(result, link_type):
             continue
 
         for output in sorted(outputs_recursive, key=lambda o: o["depth"]):
-            output_links = output.get("data", {}).get("inputLinks")
-
             # Leaf
             if output["_id"] not in correctly_linked_ids:
                 continue
 
             _filter_input_links(
-                output_links,
+                output.get("data", {}).get("inputLinks"),
                 link_type,
                 correctly_linked_ids
             )

--- a/openpype/client/mongo/entity_links.py
+++ b/openpype/client/mongo/entity_links.py
@@ -213,8 +213,6 @@ def _process_referenced_pipeline_result(result, link_type):
 
         for output in sorted(outputs_recursive, key=lambda o: o["depth"]):
             output_links = output.get("data", {}).get("inputLinks")
-            if not output_links and output["type"] != "hero_version":
-                continue
 
             # Leaf
             if output["_id"] not in correctly_linked_ids:


### PR DESCRIPTION
## Changelog Description
Remove condition that avoids downloading dependency without `inputLinks`. 

## Additional Context
This PR is to open discussion about this condition I don't know the original purpose of and about which I'd be glad to have @kalisp 's opinion.

As far as I understand the issue, audio published versions don't have `inputLinks`, which makes the fetch process avoid them from being downloaded when they are not hero versions. In fact I cannot figure why this is like that, and if my proposal is wrong, I'd be glad to learn a bit about it.

## Testing notes:
1. Open Blender
2. Load an audio into a workfile
3. Publish
4. Remove the local workfile (not the published one)
5. Using the Sync Queue, remove from local the audio
6. Launch the same task to process the `copy last published workfile` process
7. The audio isn't fetched
