### PR TITLE
Blender: Added setting to set resolution and start/end frames at startup

### DIFF
--- a/openpype/hosts/blender/api/ops.py
+++ b/openpype/hosts/blender/api/ops.py
@@ -20,6 +20,7 @@ from openpype.pipeline import get_current_asset_name, get_current_task_name
 from openpype.tools.utils import host_tools
 
 from .workio import OpenFileCacher
+from . import pipeline
 
 PREVIEW_COLLECTIONS: Dict = dict()
 
@@ -344,6 +345,26 @@ class LaunchWorkFiles(LaunchQtApp):
         self._window.refresh()
 
 
+class SetFrameRange(bpy.types.Operator):
+    bl_idname = "wm.ayon_set_frame_range"
+    bl_label = "Set Frame Range"
+
+    def execute(self, context):
+        data = pipeline.get_asset_data()
+        pipeline.set_frame_range(data)
+        return {"FINISHED"}
+
+
+class SetResolution(bpy.types.Operator):
+    bl_idname = "wm.ayon_set_resolution"
+    bl_label = "Set Resolution"
+
+    def execute(self, context):
+        data = pipeline.get_asset_data()
+        pipeline.set_resolution(data)
+        return {"FINISHED"}
+
+
 class TOPBAR_MT_avalon(bpy.types.Menu):
     """Avalon menu."""
 
@@ -381,9 +402,11 @@ class TOPBAR_MT_avalon(bpy.types.Menu):
         layout.operator(LaunchManager.bl_idname, text="Manage...")
         layout.operator(LaunchLibrary.bl_idname, text="Library...")
         layout.separator()
+        layout.operator(SetFrameRange.bl_idname, text="Set Frame Range")
+        layout.operator(SetResolution.bl_idname, text="Set Resolution")
+        layout.separator()
         layout.operator(LaunchWorkFiles.bl_idname, text="Work Files...")
-        # TODO (jasper): maybe add 'Reload Pipeline', 'Set Frame Range' and
-        #                'Set Resolution'?
+        # TODO (jasper): maybe add 'Reload Pipeline'
 
 
 def draw_avalon_menu(self, context):
@@ -399,6 +422,8 @@ classes = [
     LaunchManager,
     LaunchLibrary,
     LaunchWorkFiles,
+    SetFrameRange,
+    SetResolution,
     TOPBAR_MT_avalon,
 ]
 

--- a/openpype/hosts/blender/api/pipeline.py
+++ b/openpype/hosts/blender/api/pipeline.py
@@ -113,22 +113,21 @@ def message_window(title, message):
     _process_app_events()
 
 
-def set_start_end_frames():
+def _get_asset_data():
     project_name = get_current_project_name()
     asset_name = get_current_asset_name()
     asset_doc = get_asset_by_name(project_name, asset_name)
 
+    return asset_doc.get("data")
+
+
+def set_start_end_frames(data):
     scene = bpy.context.scene
 
     # Default scene settings
     frameStart = scene.frame_start
     frameEnd = scene.frame_end
     fps = scene.render.fps / scene.render.fps_base
-    resolution_x = scene.render.resolution_x
-    resolution_y = scene.render.resolution_y
-
-    # Check if settings are set
-    data = asset_doc.get("data")
 
     if not data:
         return
@@ -139,26 +138,47 @@ def set_start_end_frames():
         frameEnd = data.get("frameEnd")
     if data.get("fps"):
         fps = data.get("fps")
-    if data.get("resolutionWidth"):
-        resolution_x = data.get("resolutionWidth")
-    if data.get("resolutionHeight"):
-        resolution_y = data.get("resolutionHeight")
 
     scene.frame_start = frameStart
     scene.frame_end = frameEnd
     scene.render.fps = round(fps)
     scene.render.fps_base = round(fps) / fps
+
+
+def set_resolution(data):
+    scene = bpy.context.scene
+
+    # Default scene settings
+    resolution_x = scene.render.resolution_x
+    resolution_y = scene.render.resolution_y
+
+    if not data:
+        return
+
+    if data.get("resolutionWidth"):
+        resolution_x = data.get("resolutionWidth")
+    if data.get("resolutionHeight"):
+        resolution_y = data.get("resolutionHeight")
+
     scene.render.resolution_x = resolution_x
     scene.render.resolution_y = resolution_y
 
 
 def on_new():
-    set_start_end_frames()
-
     project = os.environ.get("AVALON_PROJECT")
-    settings = get_project_settings(project)
+    settings = get_project_settings(project).get("blender")
 
-    unit_scale_settings = settings.get("blender").get("unit_scale_settings")
+    set_resolution_startup = settings.get("set_resolution_startup")
+    set_frames_startup = settings.get("set_frames_startup")
+
+    data = _get_asset_data()
+
+    if set_resolution_startup:
+        set_resolution(data)
+    if set_frames_startup:
+        set_start_end_frames(data)
+
+    unit_scale_settings = settings.get("unit_scale_settings")
     unit_scale_enabled = unit_scale_settings.get("enabled")
     if unit_scale_enabled:
         unit_scale = unit_scale_settings.get("base_file_unit_scale")
@@ -166,12 +186,20 @@ def on_new():
 
 
 def on_open():
-    set_start_end_frames()
-
     project = os.environ.get("AVALON_PROJECT")
-    settings = get_project_settings(project)
+    settings = get_project_settings(project).get("blender")
 
-    unit_scale_settings = settings.get("blender").get("unit_scale_settings")
+    set_resolution_startup = settings.get("set_resolution_startup")
+    set_frames_startup = settings.get("set_frames_startup")
+
+    data = _get_asset_data()
+
+    if set_resolution_startup:
+        set_resolution(data)
+    if set_frames_startup:
+        set_start_end_frames(data)
+
+    unit_scale_settings = settings.get("unit_scale_settings")
     unit_scale_enabled = unit_scale_settings.get("enabled")
     apply_on_opening = unit_scale_settings.get("apply_on_opening")
     if unit_scale_enabled and apply_on_opening:

--- a/openpype/hosts/blender/api/pipeline.py
+++ b/openpype/hosts/blender/api/pipeline.py
@@ -113,7 +113,7 @@ def message_window(title, message):
     _process_app_events()
 
 
-def _get_asset_data():
+def get_asset_data():
     project_name = get_current_project_name()
     asset_name = get_current_asset_name()
     asset_doc = get_asset_by_name(project_name, asset_name)
@@ -121,7 +121,7 @@ def _get_asset_data():
     return asset_doc.get("data")
 
 
-def set_start_end_frames(data):
+def set_frame_range(data):
     scene = bpy.context.scene
 
     # Default scene settings
@@ -171,12 +171,12 @@ def on_new():
     set_resolution_startup = settings.get("set_resolution_startup")
     set_frames_startup = settings.get("set_frames_startup")
 
-    data = _get_asset_data()
+    data = get_asset_data()
 
     if set_resolution_startup:
         set_resolution(data)
     if set_frames_startup:
-        set_start_end_frames(data)
+        set_frame_range(data)
 
     unit_scale_settings = settings.get("unit_scale_settings")
     unit_scale_enabled = unit_scale_settings.get("enabled")
@@ -192,12 +192,12 @@ def on_open():
     set_resolution_startup = settings.get("set_resolution_startup")
     set_frames_startup = settings.get("set_frames_startup")
 
-    data = _get_asset_data()
+    data = get_asset_data()
 
     if set_resolution_startup:
         set_resolution(data)
     if set_frames_startup:
-        set_start_end_frames(data)
+        set_frame_range(data)
 
     unit_scale_settings = settings.get("unit_scale_settings")
     unit_scale_enabled = unit_scale_settings.get("enabled")

--- a/openpype/settings/defaults/project_settings/blender.json
+++ b/openpype/settings/defaults/project_settings/blender.json
@@ -4,6 +4,8 @@
         "apply_on_opening": false,
         "base_file_unit_scale": 0.01
     },
+    "set_resolution_startup": true,
+    "set_frames_startup": true,
     "imageio": {
         "activate_host_color_management": true,
         "ocio_config": {

--- a/openpype/settings/entities/schemas/projects_schema/schema_project_blender.json
+++ b/openpype/settings/entities/schemas/projects_schema/schema_project_blender.json
@@ -32,6 +32,16 @@
             ]
         },
         {
+            "key": "set_resolution_startup",
+            "type": "boolean",
+            "label": "Set Resolution on Startup"
+        },
+        {
+            "key": "set_frames_startup",
+            "type": "boolean",
+            "label": "Set Start/End Frames and FPS on Startup"
+        },
+        {
             "key": "imageio",
             "type": "dict",
             "label": "Color Management (OCIO managed)",


### PR DESCRIPTION
## Changelog Description
This PR adds `set_resolution_startup `and `set_frames_startup` settings. They automatically set respectively the resolution and start/end frames and FPS in Blender when opening a file or creating a new one.

## Testing notes:
1. Change default settings in the Project Manager for resolution, start/end frames and FPS.
2. Disable the new settings and check when opening Blender if those settings have changed. You can check from the *Property panel*, in the *Output properties* tab.
3. Now enable the settings and try opening Blender again, and check if those settings have changed.
