### PR TITLE
Blender: Support for ExtractBurnin

### DIFF
--- a/openpype/hosts/blender/plugins/publish/collect_review.py
+++ b/openpype/hosts/blender/plugins/publish/collect_review.py
@@ -43,8 +43,8 @@ class CollectReview(pyblish.api.InstancePlugin):
             task = instance.context.data["task"]
 
             # Store focal length in `burninDataMembers`
-            burninDataMembers = instance.data.get("burninDataMembers", {})
-            burninDataMembers["focalLength"] = focal_length
+            burninData = instance.data.setdefault("burninDataMembers", {})
+            burninData["focalLength"] = focal_length
 
             instance.data.update({
                 "subset": f"{task}Review",
@@ -53,7 +53,6 @@ class CollectReview(pyblish.api.InstancePlugin):
                 "frameEnd": instance.context.data["frameEnd"],
                 "fps": instance.context.data["fps"],
                 "isolate": isolate_objects,
-                "burninDataMembers": burninDataMembers,
             })
 
             self.log.debug(f"instance data: {instance.data}")

--- a/openpype/hosts/blender/plugins/publish/collect_review.py
+++ b/openpype/hosts/blender/plugins/publish/collect_review.py
@@ -29,6 +29,8 @@ class CollectReview(pyblish.api.InstancePlugin):
         camera = cameras[0].name
         self.log.debug(f"camera: {camera}")
 
+        focal_length = cameras[0].data.lens
+
         # get isolate objects list from meshes instance members .
         isolate_objects = [
             obj
@@ -40,6 +42,10 @@ class CollectReview(pyblish.api.InstancePlugin):
 
             task = instance.context.data["task"]
 
+            # Store focal length in `burninDataMembers`
+            burninDataMembers = instance.data.get("burninDataMembers", {})
+            burninDataMembers["focalLength"] = focal_length
+
             instance.data.update({
                 "subset": f"{task}Review",
                 "review_camera": camera,
@@ -47,6 +53,7 @@ class CollectReview(pyblish.api.InstancePlugin):
                 "frameEnd": instance.context.data["frameEnd"],
                 "fps": instance.context.data["fps"],
                 "isolate": isolate_objects,
+                "burninDataMembers": burninDataMembers,
             })
 
             self.log.debug(f"instance data: {instance.data}")

--- a/openpype/plugins/publish/extract_burnin.py
+++ b/openpype/plugins/publish/extract_burnin.py
@@ -52,7 +52,8 @@ class ExtractBurnin(publish.Extractor):
         "photoshop",
         "flame",
         "houdini",
-        "max"
+        "max",
+        "blender"
         # "resolve"
     ]
 


### PR DESCRIPTION
## Changelog Description
This PR adds support for ExtractBurnin for Blender, when publishing a Review.

## Testing notes:
1. In Project Settings, `project_settings/global/publish/ExtractBurnin/profiles`, be sure to have a profile for the `review` family and add Blender to the host names.
2. In Blender, create a Review. (You need to select a camera when creating it).
3. Publish the Review.
4. Check if the published review has the burnins.