### PR TITLE
Bugfix/maya validate frame rang fix

### DIFF
--- a/openpype/hosts/maya/plugins/publish/collect_review.py
+++ b/openpype/hosts/maya/plugins/publish/collect_review.py
@@ -107,10 +107,8 @@ class CollectReview(pyblish.api.InstancePlugin):
             data["displayLights"] = display_lights
             data["burninDataMembers"] = burninDataMembers
 
-            publish_attributes = data.setdefault("publish_attributes", {})
             for key, value in instance.data["publish_attributes"].items():
-                if key not in publish_attributes:
-                    publish_attributes[key] = value
+                data["publish_attributes"][key] = value
 
             # The review instance must be active
             cmds.setAttr(str(instance) + '.active', 1)

--- a/openpype/settings/entities/schemas/projects_schema/schemas/schema_maya_publish.json
+++ b/openpype/settings/entities/schemas/projects_schema/schemas/schema_maya_publish.json
@@ -103,7 +103,7 @@
                 },
                 {
                     "key": "exclude_families",
-                    "label": "Families",
+                    "label": "Exclude Families",
                     "type": "list",
                     "object_type": "text"
                 }


### PR DESCRIPTION
Suggestion for improvements to #5296

- All review publish attributes should be copied to the model instance.
- Better labelling of `project_settings/maya/publish/ValidateFrameRange/exclude_families`