### PR TITLE
Blender: Extract Camera as Alembic

### DIFF
--- a/openpype/hosts/blender/plugins/publish/extract_camera_fbx.py
+++ b/openpype/hosts/blender/plugins/publish/extract_camera_fbx.py
@@ -9,7 +9,7 @@ from openpype.hosts.blender.api import plugin
 class ExtractCamera(publish.Extractor):
     """Extract as the camera as FBX."""
 
-    label = "Extract Camera"
+    label = "Extract Camera (FBX)"
     hosts = ["blender"]
     families = ["camera"]
     optional = True

--- a/openpype/settings/defaults/project_settings/blender.json
+++ b/openpype/settings/defaults/project_settings/blender.json
@@ -85,6 +85,11 @@
             "optional": true,
             "active": true
         },
+        "ExtractCameraABC": {
+            "enabled": true,
+            "optional": true,
+            "active": true
+        },
         "ExtractLayout": {
             "enabled": true,
             "optional": true,

--- a/openpype/settings/entities/schemas/projects_schema/schemas/schema_blender_publish.json
+++ b/openpype/settings/entities/schemas/projects_schema/schemas/schema_blender_publish.json
@@ -108,6 +108,10 @@
                     "label": "Extract FBX Camera as FBX"
                 },
                 {
+                    "key": "ExtractCameraABC",
+                    "label": "Extract Camera as ABC"
+                },
+                {
                     "key": "ExtractLayout",
                     "label": "Extract Layout as JSON"
                 }

--- a/openpype/settings/entities/schemas/projects_schema/schemas/schema_blender_publish.json
+++ b/openpype/settings/entities/schemas/projects_schema/schemas/schema_blender_publish.json
@@ -105,7 +105,7 @@
                 },
                 {
                     "key": "ExtractCamera",
-                    "label": "Extract FBX Camera as FBX"
+                    "label": "Extract Camera as FBX"
                 },
                 {
                     "key": "ExtractCameraABC",


### PR DESCRIPTION
## Changelog Description
Added support to extract Alembic Cameras in Blender.

## Testing notes:
1. Check that `project_settings/blender/publish/ExtractCameraABC` is enabled.
2. Try publishing a camera from Blender (be sure that the *Extract Camera (ABC)* extractor is enabled).
3. Try loading the published camera.