### PR TITLE
Unreal: Custom location for Unreal Ayon Plugin

### DIFF
--- a/openpype/hosts/unreal/hooks/pre_workfile_preparation.py
+++ b/openpype/hosts/unreal/hooks/pre_workfile_preparation.py
@@ -187,24 +187,36 @@ class UnrealPrelaunchHook(PreLaunchHook):
 
         project_path.mkdir(parents=True, exist_ok=True)
 
-        # Set "AYON_UNREAL_PLUGIN" to current process environment for
-        # execution of `create_unreal_project`
-
-        if self.launch_context.env.get("AYON_UNREAL_PLUGIN"):
-            self.log.info((
-                f"{self.signature} using Ayon plugin from "
-                f"{self.launch_context.env.get('AYON_UNREAL_PLUGIN')}"
-            ))
-        env_key = "AYON_UNREAL_PLUGIN"
-        if self.launch_context.env.get(env_key):
-            os.environ[env_key] = self.launch_context.env[env_key]
-
         # engine_path points to the specific Unreal Engine root
         # so, we are going up from the executable itself 3 levels.
         engine_path: Path = Path(executable).parents[3]
 
-        if not unreal_lib.check_plugin_existence(engine_path):
-            self.exec_plugin_install(engine_path)
+        # Check if new env variable exists, and if it does, if the path
+        # actually contains the plugin. If not, install it.
+
+        built_plugin_path = self.launch_context.env.get(
+            "AYON_BUILT_UNREAL_PLUGIN", None)
+
+        if unreal_lib.check_built_plugin_existance(built_plugin_path):
+            self.log.info((
+                f"{self.signature} using existing built Ayon plugin from "
+                f"{built_plugin_path}"
+            ))
+            unreal_lib.move_built_plugin(engine_path, Path(built_plugin_path))
+        else:
+            # Set "AYON_UNREAL_PLUGIN" to current process environment for
+            # execution of `create_unreal_project`
+            env_key = "AYON_UNREAL_PLUGIN"
+            if self.launch_context.env.get(env_key):
+                self.log.info((
+                    f"{self.signature} using Ayon plugin from "
+                    f"{self.launch_context.env.get(env_key)}"
+                ))
+            if self.launch_context.env.get(env_key):
+                os.environ[env_key] = self.launch_context.env[env_key]
+
+            if not unreal_lib.check_plugin_existence(engine_path):
+                self.exec_plugin_install(engine_path)
 
         project_file = project_path / unreal_project_filename
 

--- a/openpype/hosts/unreal/lib.py
+++ b/openpype/hosts/unreal/lib.py
@@ -429,6 +429,36 @@ def get_build_id(engine_path: Path, ue_version: str) -> str:
             return "{" + loaded_modules.get("BuildId") + "}"
 
 
+def check_built_plugin_existance(plugin_path) -> bool:
+    if not plugin_path:
+        return False
+
+    integration_plugin_path = Path(plugin_path)
+
+    if not os.path.isdir(integration_plugin_path):
+        raise RuntimeError("Path to the integration plugin is null!")
+
+    if not (integration_plugin_path / "Binaries").is_dir() \
+            or not (integration_plugin_path / "Intermediate").is_dir():
+        return False
+
+    return True
+
+
+def move_built_plugin(engine_path: Path, plugin_path: Path) -> None:
+    ayon_plugin_path: Path = engine_path / "Engine/Plugins/Marketplace/Ayon"
+
+    if not ayon_plugin_path.is_dir():
+        ayon_plugin_path.mkdir(parents=True, exist_ok=True)
+
+        engine_plugin_config_path: Path = ayon_plugin_path / "Config"
+        engine_plugin_config_path.mkdir(exist_ok=True)
+
+        dir_util._path_created = {}
+
+    dir_util.copy_tree(plugin_path.as_posix(), ayon_plugin_path.as_posix())
+
+
 def check_plugin_existence(engine_path: Path, env: dict = None) -> bool:
     env = env or os.environ
     integration_plugin_path: Path = Path(env.get("AYON_UNREAL_PLUGIN", ""))


### PR DESCRIPTION
## Changelog Description
Added a new environment variable `AYON_BUILT_UNREAL_PLUGIN` to set an already existing and built Ayon Plugin for Unreal.

## Additional info
This allows to distribute the plugin without having to build it or without the Marketplace.

## Testing notes:
1. In Studio Settings, `applications/unreal/environment`, set the env variable `AYON_BUILT_UNREAL_PLUGIN` to a path where you have a built plugin.
2. Launch Unreal from the launcher.
3. In the log you should have the following message: `>>> [  ( UnrealPrelaunchHook ) using existing built Ayon plugin from ***Your path***  ] `
4. The Ayon integration in Unreal should work as usual.