### PR TITLE
Unreal: Better handling of Exceptions in UE Worker threads

### DIFF
--- a/openpype/hosts/unreal/ue_workers.py
+++ b/openpype/hosts/unreal/ue_workers.py
@@ -314,6 +314,7 @@ class UEProjectGenerationWorker(UEWorker):
         self.progress.emit(100)
         self.finished.emit("Project successfully built!")
 
+
 class UEPluginInstallWorker(UEWorker):
     installing = QtCore.Signal(str)
 

--- a/openpype/hosts/unreal/ue_workers.py
+++ b/openpype/hosts/unreal/ue_workers.py
@@ -40,17 +40,34 @@ def retrieve_exit_code(line: str):
     return None
 
 
-class UEProjectGenerationWorker(QtCore.QObject):
+class UEWorker(QtCore.QObject):
     finished = QtCore.Signal(str)
-    failed = QtCore.Signal(str)
+    failed = QtCore.Signal(str, int)
     progress = QtCore.Signal(int)
     log = QtCore.Signal(str)
+
+    engine_path: Path = None
+    env = None
+
+    def execute(self):
+        raise NotImplementedError("Please implement this method!")
+
+    def run(self):
+        try:
+            self.execute()
+        except Exception as e:
+            import traceback
+            self.log.emit(str(e))
+            self.log.emit(traceback.format_exc())
+            self.failed.emit(str(e), 1)
+            raise e
+
+
+class UEProjectGenerationWorker(UEWorker):
     stage_begin = QtCore.Signal(str)
 
     ue_version: str = None
     project_name: str = None
-    env = None
-    engine_path: Path = None
     project_dir: Path = None
     dev_mode = False
 
@@ -87,7 +104,7 @@ class UEProjectGenerationWorker(QtCore.QObject):
         self.project_name = unreal_project_name
         self.engine_path = engine_path
 
-    def run(self):
+    def execute(self):
         # engine_path should be the location of UE_X.X folder
 
         ue_editor_exe = ue_lib.get_editor_exe_path(self.engine_path,
@@ -297,16 +314,8 @@ class UEProjectGenerationWorker(QtCore.QObject):
         self.progress.emit(100)
         self.finished.emit("Project successfully built!")
 
-
-class UEPluginInstallWorker(QtCore.QObject):
-    finished = QtCore.Signal(str)
+class UEPluginInstallWorker(UEWorker):
     installing = QtCore.Signal(str)
-    failed = QtCore.Signal(str, int)
-    progress = QtCore.Signal(int)
-    log = QtCore.Signal(str)
-
-    engine_path: Path = None
-    env = None
 
     def setup(self, engine_path: Path, env: dict = None, ):
         self.engine_path = engine_path
@@ -374,7 +383,7 @@ class UEPluginInstallWorker(QtCore.QObject):
 
         dir_util.remove_tree(temp_dir.as_posix())
 
-    def run(self):
+    def execute(self):
         src_plugin_dir = Path(self.env.get("AYON_UNREAL_PLUGIN", ""))
 
         if not os.path.isdir(src_plugin_dir):


### PR DESCRIPTION
## Changelog Description
Implemented a new `UEWorker` base class to handle exception during the execution of UE Workers.

## Additional info
The existing workers `UEProjectGenerationWorker` and `UEPluginInstallWorker` now inherit from `UEWorker` and have been modified to override the `execute` method instead of the `run` method. The `run` method calls `execute`, and it should catch any exception during the Worker execution.

## Testing notes:
1. Change the UE plugin code to fail the build.
2. Try running Unreal from the launcher. It should fail and the traceback should be printed in the log window.
