### PR TITLE
Houdini: Add farm toggle on creation menu

### DIFF
--- a/openpype/hosts/houdini/plugins/create/create_arnold_rop.py
+++ b/openpype/hosts/houdini/plugins/create/create_arnold_rop.py
@@ -1,5 +1,5 @@
 from openpype.hosts.houdini.api import plugin
-from openpype.lib import EnumDef
+from openpype.lib import EnumDef, BoolDef
 
 
 class CreateArnoldRop(plugin.HoudiniCreator):
@@ -24,7 +24,7 @@ class CreateArnoldRop(plugin.HoudiniCreator):
         # Add chunk size attribute
         instance_data["chunkSize"] = 1
         # Submit for job publishing
-        instance_data["farm"] = True
+        instance_data["farm"] = pre_create_data.get("farm")
 
         instance = super(CreateArnoldRop, self).create(
             subset_name,
@@ -64,6 +64,9 @@ class CreateArnoldRop(plugin.HoudiniCreator):
         ]
 
         return attrs + [
+            BoolDef("farm",
+                    label="Submitting to Farm",
+                    default=True),
             EnumDef("image_format",
                     image_format_enum,
                     default=self.ext,

--- a/openpype/hosts/houdini/plugins/create/create_karma_rop.py
+++ b/openpype/hosts/houdini/plugins/create/create_karma_rop.py
@@ -21,7 +21,7 @@ class CreateKarmaROP(plugin.HoudiniCreator):
         # Add chunk size attribute
         instance_data["chunkSize"] = 10
         # Submit for job publishing
-        instance_data["farm"] = True
+        instance_data["farm"] = pre_create_data.get("farm")
 
         instance = super(CreateKarmaROP, self).create(
             subset_name,
@@ -96,6 +96,9 @@ class CreateKarmaROP(plugin.HoudiniCreator):
         ]
 
         return attrs + [
+            BoolDef("farm",
+                    label="Submitting to Farm",
+                    default=True),
             EnumDef("image_format",
                     image_format_enum,
                     default="exr",

--- a/openpype/hosts/houdini/plugins/create/create_mantra_rop.py
+++ b/openpype/hosts/houdini/plugins/create/create_mantra_rop.py
@@ -21,7 +21,7 @@ class CreateMantraROP(plugin.HoudiniCreator):
         # Add chunk size attribute
         instance_data["chunkSize"] = 10
         # Submit for job publishing
-        instance_data["farm"] = True
+        instance_data["farm"] = pre_create_data.get("farm")
 
         instance = super(CreateMantraROP, self).create(
             subset_name,
@@ -76,6 +76,9 @@ class CreateMantraROP(plugin.HoudiniCreator):
         ]
 
         return attrs + [
+            BoolDef("farm",
+                    label="Submitting to Farm",
+                    default=True),
             EnumDef("image_format",
                     image_format_enum,
                     default="exr",

--- a/openpype/hosts/houdini/plugins/create/create_redshift_rop.py
+++ b/openpype/hosts/houdini/plugins/create/create_redshift_rop.py
@@ -3,7 +3,7 @@
 import hou  # noqa
 
 from openpype.hosts.houdini.api import plugin
-from openpype.lib import EnumDef
+from openpype.lib import EnumDef, BoolDef
 
 
 class CreateRedshiftROP(plugin.HoudiniCreator):
@@ -23,7 +23,7 @@ class CreateRedshiftROP(plugin.HoudiniCreator):
         # Add chunk size attribute
         instance_data["chunkSize"] = 10
         # Submit for job publishing
-        instance_data["farm"] = True
+        instance_data["farm"] = pre_create_data.get("farm")
 
         instance = super(CreateRedshiftROP, self).create(
             subset_name,
@@ -100,6 +100,9 @@ class CreateRedshiftROP(plugin.HoudiniCreator):
         ]
 
         return attrs + [
+            BoolDef("farm",
+                    label="Submitting to Farm",
+                    default=True),
             EnumDef("image_format",
                     image_format_enum,
                     default=self.ext,

--- a/openpype/hosts/houdini/plugins/create/create_vray_rop.py
+++ b/openpype/hosts/houdini/plugins/create/create_vray_rop.py
@@ -25,7 +25,7 @@ class CreateVrayROP(plugin.HoudiniCreator):
         # Add chunk size attribute
         instance_data["chunkSize"] = 10
         # Submit for job publishing
-        instance_data["farm"] = True
+        instance_data["farm"] = pre_create_data.get("farm")
 
         instance = super(CreateVrayROP, self).create(
             subset_name,
@@ -139,6 +139,9 @@ class CreateVrayROP(plugin.HoudiniCreator):
         ]
 
         return attrs + [
+            BoolDef("farm",
+                    label="Submitting to Farm",
+                    default=True),
             EnumDef("image_format",
                     image_format_enum,
                     default=self.ext,


### PR DESCRIPTION
## Changelog Description
Deadline Farm publishing and Rendering for Houdini was possible with this PR #4825 
farm publishing is enabled by default some ROP nodes which may surprise new users (like me).

I think adding a toggle (on by default) on creation UI is better so that users will be aware that there's a farm option for this publish instance.

ROPs Modified : 
- [x] Mantra ROP
- [x] Karma ROP
- [x] Arnold ROP
- [x] Redshift ROP
- [x] Vray ROP

## Additional info
I'm using the same toggle here #4903