### PR TITLE
use os.path.normpath to convert the path separator

### DIFF
--- a/openpype/hosts/substancepainter/plugins/load/load_mesh.py
+++ b/openpype/hosts/substancepainter/plugins/load/load_mesh.py
@@ -1,3 +1,4 @@
+import os
 from openpype.pipeline import (
     load,
     get_representation_path,
@@ -47,7 +48,8 @@ class SubstanceLoadProjectMesh(load.LoaderPlugin):
 
         if not substance_painter.project.is_open():
             # Allow to 'initialize' a new project
-            path = self.filepath_from_context(context)
+            path = os.path.normpath(self.filepath_from_context(context))
+            self.log.debug(f"path:{path}")
             result = prompt_new_file_with_mesh(mesh_filepath=path)
             if not result:
                 self.log.info("User cancelled new project prompt.")


### PR DESCRIPTION
## Changelog Description
Resolve #5333 due to the difference of how the path separators behaved in linux and windows.

## Additional info
n/a

## Testing notes:
1. Launch Substance Painter via OP
2. Load model