### PR TITLE
Ftrack: Sync to avalon settings

### DIFF
--- a/openpype/modules/ftrack/event_handlers_server/action_sync_to_avalon.py
+++ b/openpype/modules/ftrack/event_handlers_server/action_sync_to_avalon.py
@@ -40,6 +40,7 @@ class SyncToAvalonServer(ServerAction):
     #: Action description.
     description = "Send data from Ftrack to Avalon"
     role_list = {"Pypeclub", "Administrator", "Project Manager"}
+    settings_key = "sync_to_avalon"
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
@@ -48,11 +49,16 @@ class SyncToAvalonServer(ServerAction):
     def discover(self, session, entities, event):
         """ Validation """
         # Check if selection is valid
+        is_valid = False
         for ent in event["data"]["selection"]:
             # Ignore entities that are not tasks or projects
             if ent["entityType"].lower() in ["show", "task"]:
-                return True
-        return False
+                is_valid = True
+                break
+
+        if is_valid:
+            is_valid = self.valid_roles(session, entities, event)
+        return is_valid
 
     def launch(self, session, in_entities, event):
         self.log.debug("{}: Creating job".format(self.label))

--- a/openpype/settings/defaults/project_settings/ftrack.json
+++ b/openpype/settings/defaults/project_settings/ftrack.json
@@ -1,9 +1,10 @@
 {
     "events": {
         "sync_to_avalon": {
-            "statuses_name_change": [
-                "ready",
-                "not ready"
+            "role_list": [
+                "Pypeclub",
+                "Administrator",
+                "Project manager"
             ]
         },
         "prepare_project": {

--- a/openpype/settings/entities/schemas/projects_schema/schema_project_ftrack.json
+++ b/openpype/settings/entities/schemas/projects_schema/schema_project_ftrack.json
@@ -21,12 +21,9 @@
                         },
                         {
                             "type": "list",
-                            "key": "statuses_name_change",
-                            "label": "Statuses",
-                            "object_type": {
-                                "type": "text",
-                                "multiline": false
-                            }
+                            "key": "role_list",
+                            "label": "Roles",
+                            "object_type": "text"
                         }
                     ]
                 },


### PR DESCRIPTION
## Changelog Description
Added roles settings for sync to avalon action.

## Additional info
The action didn't have settings for roles and nobody noticed for a long time. Also the settings were there but used. The only key it had was `statuses_name_change` which is not used anywhere.

## Testing notes:
1. Open openpype settings
2. change Sync to Avalon (in Server actions) roles to one of roles you don't have
3. Start ftrack event server
4. Open ftrack in browser
5. Discover actions on a ftrack project
6. You should not see sync to avalon action
7. Change the settings to contain role you have
8. Wait 10 seconds (settings cache time)
9. Again discover actions on ftrack project
10. Now you should see the action