### PR TITLE
Chore: Schemas inside OpenPype

### DIFF
--- a/openpype/pipeline/schema/__init__.py
+++ b/openpype/pipeline/schema/__init__.py
@@ -122,16 +122,14 @@ def _precache():
     """Store available schemas in-memory for reduced disk access"""
     global _CACHED
 
-    schema_dir = os.path.join(CURRENT_DIR, "schema")
-
-    for schema in os.listdir(schema_dir):
+    for schema in os.listdir(CURRENT_DIR):
         if schema.startswith(("_", ".")):
             continue
         if not schema.endswith(".json"):
             continue
-        if not os.path.isfile(os.path.join(schema_dir, schema)):
+        if not os.path.isfile(os.path.join(CURRENT_DIR, schema)):
             continue
-        with open(os.path.join(schema_dir, schema)) as f:
+        with open(os.path.join(CURRENT_DIR, schema)) as f:
             log_.debug("Installing schema '%s'.." % schema)
             _cache[schema] = json.load(f)
     _CACHED = True

--- a/openpype/pipeline/schema/__init__.py
+++ b/openpype/pipeline/schema/__init__.py
@@ -24,6 +24,7 @@ log_ = logging.getLogger(__name__)
 
 ValidationError = jsonschema.ValidationError
 SchemaError = jsonschema.SchemaError
+CURRENT_DIR = os.path.dirname(os.path.abspath(__file__))
 
 _CACHED = False
 
@@ -121,8 +122,7 @@ def _precache():
     """Store available schemas in-memory for reduced disk access"""
     global _CACHED
 
-    repos_root = os.environ["OPENPYPE_REPOS_ROOT"]
-    schema_dir = os.path.join(repos_root, "schema")
+    schema_dir = os.path.join(CURRENT_DIR, "schema")
 
     for schema in os.listdir(schema_dir):
         if schema.startswith(("_", ".")):

--- a/openpype/pipeline/schema/application-1.0.json
+++ b/openpype/pipeline/schema/application-1.0.json
@@ -1,0 +1,68 @@
+{
+    "$schema": "http://json-schema.org/draft-04/schema#",
+
+    "title": "openpype:application-1.0",
+    "description": "An application definition.",
+
+    "type": "object",
+
+    "additionalProperties": true,
+
+    "required": [
+        "schema",
+        "label",
+        "application_dir",
+        "executable"
+    ],
+
+    "properties": {
+        "schema": {
+            "description": "Schema identifier for payload",
+            "type": "string"
+        },
+        "label": {
+            "description": "Nice name of application.",
+            "type": "string"
+        },
+        "application_dir": {
+            "description": "Name of directory used for application resources.",
+            "type": "string"
+        },
+        "executable": {
+            "description": "Name of callable executable, this is called to launch the application",
+            "type": "string"
+        },
+        "description": {
+            "description": "Description of application.",
+            "type": "string"
+        },
+        "environment": {
+            "description": "Key/value pairs for environment variables related to this application. Supports lists for paths, such as PYTHONPATH.",
+            "type": "object",
+            "items": {
+                "oneOf": [
+                    {"type": "string"},
+                    {"type": "array", "items": {"type": "string"}}
+                ]
+            }
+        },
+        "default_dirs": {
+            "type": "array",
+            "items": {
+                "type": "string"
+            }
+        },
+        "copy": {
+            "type": "object",
+            "patternProperties": {
+                "^.*$": {
+                    "anyOf": [
+                        {"type": "string"},
+                        {"type": "null"}
+                    ]
+                }
+            },
+            "additionalProperties": false
+        }
+    }
+}

--- a/openpype/pipeline/schema/asset-1.0.json
+++ b/openpype/pipeline/schema/asset-1.0.json
@@ -1,0 +1,35 @@
+{
+    "$schema": "http://json-schema.org/draft-04/schema#",
+
+    "title": "openpype:asset-1.0",
+    "description": "A unit of data",
+
+    "type": "object",
+
+    "additionalProperties": true,
+
+    "required": [
+        "schema",
+        "name",
+        "subsets"
+    ],
+
+    "properties": {
+        "schema": {
+            "description": "Schema identifier for payload",
+            "type": "string"
+        },
+        "name": {
+            "description": "Name of directory",
+            "type": "string"
+        },
+        "subsets": {
+            "type": "array",
+            "items": {
+                "$ref": "subset.json"
+            }
+        }
+    },
+
+    "definitions": {}
+}

--- a/openpype/pipeline/schema/asset-2.0.json
+++ b/openpype/pipeline/schema/asset-2.0.json
@@ -1,0 +1,55 @@
+{
+    "$schema": "http://json-schema.org/draft-04/schema#",
+
+    "title": "openpype:asset-2.0",
+    "description": "A unit of data",
+
+    "type": "object",
+
+    "additionalProperties": true,
+
+    "required": [
+        "schema",
+        "type",
+        "name",
+        "silo",
+        "data"
+    ],
+
+    "properties": {
+        "schema": {
+            "description": "Schema identifier for payload",
+            "type": "string",
+            "enum": ["openpype:asset-2.0"],
+            "example": "openpype:asset-2.0"
+        },
+        "type": {
+            "description": "The type of document",
+            "type": "string",
+            "enum": ["asset"],
+            "example": "asset"
+        },
+        "parent": {
+            "description": "Unique identifier to parent document",
+            "example": "592c33475f8c1b064c4d1696"
+        },
+        "name": {
+            "description": "Name of asset",
+            "type": "string",
+            "pattern": "^[a-zA-Z0-9_.]*$",
+            "example": "Bruce"
+        },
+        "silo": {
+            "description": "Group or container of asset",
+            "type": "string",
+            "example": "assets"
+        },
+        "data": {
+            "description": "Document metadata",
+            "type": "object",
+            "example": {"key": "value"}
+        }
+    },
+
+    "definitions": {}
+}

--- a/openpype/pipeline/schema/asset-3.0.json
+++ b/openpype/pipeline/schema/asset-3.0.json
@@ -1,0 +1,55 @@
+{
+    "$schema": "http://json-schema.org/draft-04/schema#",
+
+    "title": "openpype:asset-3.0",
+    "description": "A unit of data",
+
+    "type": "object",
+
+    "additionalProperties": true,
+
+    "required": [
+        "schema",
+        "type",
+        "name",
+        "data"
+    ],
+
+    "properties": {
+        "schema": {
+            "description": "Schema identifier for payload",
+            "type": "string",
+            "enum": ["openpype:asset-3.0"],
+            "example": "openpype:asset-3.0"
+        },
+        "type": {
+            "description": "The type of document",
+            "type": "string",
+            "enum": ["asset"],
+            "example": "asset"
+        },
+        "parent": {
+            "description": "Unique identifier to parent document",
+            "example": "592c33475f8c1b064c4d1696"
+        },
+        "name": {
+            "description": "Name of asset",
+            "type": "string",
+            "pattern": "^[a-zA-Z0-9_.]*$",
+            "example": "Bruce"
+        },
+        "silo": {
+            "description": "Group or container of asset",
+            "type": "string",
+            "pattern": "^[a-zA-Z0-9_.]*$",
+            "example": "assets"
+        },
+        "data": {
+            "description": "Document metadata",
+            "type": "object",
+            "example": {"key": "value"}
+        }
+    },
+
+    "definitions": {}
+}

--- a/openpype/pipeline/schema/config-1.0.json
+++ b/openpype/pipeline/schema/config-1.0.json
@@ -1,0 +1,85 @@
+{
+    "$schema": "http://json-schema.org/draft-04/schema#",
+
+    "title": "openpype:config-1.0",
+    "description": "A project configuration.",
+
+    "type": "object",
+
+    "additionalProperties": false,
+    "required": [
+        "tasks",
+        "apps"
+    ],
+
+    "properties": {
+        "schema": {
+            "description": "Schema identifier for payload",
+            "type": "string"
+        },
+        "template": {
+            "type": "object",
+            "additionalProperties": false,
+            "patternProperties": {
+                "^.*$": {
+                    "type": "string"
+                }
+            }
+        },
+        "tasks": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "name": {"type": "string"},
+                    "icon": {"type": "string"},
+                    "group": {"type": "string"},
+                    "label": {"type": "string"}
+                },
+                "required": ["name"]
+            }
+        },
+        "apps": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "name": {"type": "string"},
+                    "icon": {"type": "string"},
+                    "group": {"type": "string"},
+                    "label": {"type": "string"}
+                },
+                "required": ["name"]
+            }
+        },
+        "families": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "name": {"type": "string"},
+                    "icon": {"type": "string"},
+                    "label": {"type": "string"},
+                    "hideFilter": {"type": "boolean"}
+                },
+                "required": ["name"]
+            }
+        },
+        "groups": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "name": {"type": "string"},
+                    "icon": {"type": "string"},
+                    "color": {"type": "string"},
+                    "order": {"type": ["integer", "number"]}
+                },
+                "required": ["name"]
+            }
+        },
+        "copy": {
+            "type": "object"
+        }
+    }
+}

--- a/openpype/pipeline/schema/config-1.1.json
+++ b/openpype/pipeline/schema/config-1.1.json
@@ -1,0 +1,87 @@
+{
+    "$schema": "http://json-schema.org/draft-04/schema#",
+
+    "title": "openpype:config-1.1",
+    "description": "A project configuration.",
+
+    "type": "object",
+
+    "additionalProperties": false,
+    "required": [
+        "tasks",
+        "apps"
+    ],
+
+    "properties": {
+        "schema": {
+            "description": "Schema identifier for payload",
+            "type": "string"
+        },
+        "template": {
+            "type": "object",
+            "additionalProperties": false,
+            "patternProperties": {
+                "^.*$": {
+                    "type": "string"
+                }
+            }
+        },
+        "tasks": {
+            "type": "object",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "name": {"type": "string"},
+                    "icon": {"type": "string"},
+                    "group": {"type": "string"},
+                    "label": {"type": "string"}
+                },
+                "required": [
+                    "short_name"
+                ]
+            }
+        },
+        "apps": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "name": {"type": "string"},
+                    "icon": {"type": "string"},
+                    "group": {"type": "string"},
+                    "label": {"type": "string"}
+                },
+                "required": ["name"]
+            }
+        },
+        "families": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "name": {"type": "string"},
+                    "icon": {"type": "string"},
+                    "label": {"type": "string"},
+                    "hideFilter": {"type": "boolean"}
+                },
+                "required": ["name"]
+            }
+        },
+        "groups": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "name": {"type": "string"},
+                    "icon": {"type": "string"},
+                    "color": {"type": "string"},
+                    "order": {"type": ["integer", "number"]}
+                },
+                "required": ["name"]
+            }
+        },
+        "copy": {
+            "type": "object"
+        }
+    }
+}

--- a/openpype/pipeline/schema/config-2.0.json
+++ b/openpype/pipeline/schema/config-2.0.json
@@ -1,0 +1,87 @@
+{
+    "$schema": "http://json-schema.org/draft-04/schema#",
+
+    "title": "openpype:config-2.0",
+    "description": "A project configuration.",
+
+    "type": "object",
+
+    "additionalProperties": false,
+    "required": [
+        "tasks",
+        "apps"
+    ],
+
+    "properties": {
+        "schema": {
+            "description": "Schema identifier for payload",
+            "type": "string"
+        },
+        "templates": {
+            "type": "object"
+        },
+        "roots": {
+            "type": "object"
+        },
+        "imageio": {
+            "type": "object"
+        },
+        "tasks": {
+            "type": "object",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "name": {"type": "string"},
+                    "icon": {"type": "string"},
+                    "group": {"type": "string"},
+                    "label": {"type": "string"}
+                },
+                "required": [
+                    "short_name"
+                ]
+            }
+        },
+        "apps": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "name": {"type": "string"},
+                    "icon": {"type": "string"},
+                    "group": {"type": "string"},
+                    "label": {"type": "string"}
+                },
+                "required": ["name"]
+            }
+        },
+        "families": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "name": {"type": "string"},
+                    "icon": {"type": "string"},
+                    "label": {"type": "string"},
+                    "hideFilter": {"type": "boolean"}
+                },
+                "required": ["name"]
+            }
+        },
+        "groups": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "name": {"type": "string"},
+                    "icon": {"type": "string"},
+                    "color": {"type": "string"},
+                    "order": {"type": ["integer", "number"]}
+                },
+                "required": ["name"]
+            }
+        },
+        "copy": {
+            "type": "object"
+        }
+    }
+}

--- a/openpype/pipeline/schema/container-1.0.json
+++ b/openpype/pipeline/schema/container-1.0.json
@@ -1,0 +1,100 @@
+{
+    "$schema": "http://json-schema.org/draft-04/schema#",
+
+    "title": "openpype:container-1.0",
+    "description": "A loaded asset",
+
+    "type": "object",
+
+    "additionalProperties": true,
+
+    "required": [
+        "id",
+        "objectName",
+        "name",
+        "author",
+        "loader",
+        "families",
+        "time",
+        "subset",
+        "asset",
+        "representation",
+        "version",
+        "silo",
+        "path",
+        "source"
+    ],
+    "properties": {
+        "id": {
+            "description": "Identifier for finding object in host",
+            "type": "string",
+            "enum": ["pyblish.mindbender.container"],
+            "example": "pyblish.mindbender.container"
+        },
+        "objectName": {
+            "description": "Name of internal object, such as the objectSet in Maya.",
+            "type": "string",
+            "example": "Bruce_:rigDefault_CON"
+        },
+        "name": {
+            "description": "Full name of application object",
+            "type": "string",
+            "example": "modelDefault"
+        },
+        "author": {
+            "description": "Name of the author of the published version",
+            "type": "string",
+            "example": "Marcus Ottosson"
+        },
+        "loader": {
+            "description": "Name of loader plug-in used to produce this container",
+            "type": "string",
+            "example": "ModelLoader"
+        },
+        "families": {
+            "description": "Families associated with the this subset",
+            "type": "string",
+            "example": "mindbender.model"
+        },
+        "time": {
+            "description": "File-system safe, formatted time",
+            "type": "string",
+            "example": "20170329T131545Z"
+        },
+        "subset": {
+            "description": "Name of source subset",
+            "type": "string",
+            "example": "modelDefault"
+        },
+        "asset": {
+            "description": "Name of source asset",
+            "type": "string"  ,
+            "example": "Bruce"
+        },
+        "representation": {
+            "description": "Name of source representation",
+            "type": "string"  ,
+            "example": ".ma"
+        },
+        "version": {
+            "description": "Version number",
+            "type": "number",
+            "example": 12
+        },
+        "silo": {
+            "description": "Silo of parent asset",
+            "type": "string",
+            "example": "assets"
+        },
+        "path": {
+            "description": "Absolute path on disk",
+            "type": "string",
+            "example": "{root}/assets/Bruce/publish/rigDefault/v002"
+        },
+        "source": {
+            "description": "Absolute path to file from which this version was published",
+            "type": "string",
+            "example": "{root}/assets/Bruce/work/rigging/maya/scenes/rig_v001.ma"
+        }
+    }
+}

--- a/openpype/pipeline/schema/container-2.0.json
+++ b/openpype/pipeline/schema/container-2.0.json
@@ -1,0 +1,59 @@
+{
+    "$schema": "http://json-schema.org/draft-04/schema#",
+
+    "title": "openpype:container-2.0",
+    "description": "A loaded asset",
+
+    "type": "object",
+
+    "additionalProperties": true,
+
+    "required": [
+        "schema",
+        "id",
+        "objectName",
+        "name",
+        "namespace",
+        "loader",
+        "representation"
+    ],
+    "properties": {
+        "schema": {
+            "description": "Schema identifier for payload",
+            "type": "string",
+            "enum": ["openpype:container-2.0"],
+            "example": "openpype:container-2.0"
+        },
+          "id": {
+            "description": "Identifier for finding object in host",
+            "type": "string",
+            "enum": ["pyblish.avalon.container"],
+            "example": "pyblish.avalon.container"
+        },
+        "objectName": {
+            "description": "Name of internal object, such as the objectSet in Maya.",
+            "type": "string",
+            "example": "Bruce_:rigDefault_CON"
+        },
+        "loader": {
+            "description": "Name of loader plug-in used to produce this container",
+            "type": "string",
+            "example": "ModelLoader"
+        },
+        "name": {
+            "description": "Internal object name of container in application",
+            "type": "string",
+            "example": "modelDefault_01"
+        },
+        "namespace": {
+            "description": "Internal namespace of container in application",
+            "type": "string",
+            "example": "Bruce_"
+        },
+        "representation": {
+            "description": "Unique id of representation in database",
+            "type": "string",
+            "example": "59523f355f8c1b5f6c5e8348"
+        }
+    }
+}

--- a/openpype/pipeline/schema/hero_version-1.0.json
+++ b/openpype/pipeline/schema/hero_version-1.0.json
@@ -1,0 +1,44 @@
+{
+    "$schema": "http://json-schema.org/draft-04/schema#",
+
+    "title": "openpype:hero_version-1.0",
+    "description": "Hero version of asset",
+
+    "type": "object",
+
+    "additionalProperties": true,
+
+    "required": [
+        "version_id",
+        "schema",
+        "type",
+        "parent"
+    ],
+
+    "properties": {
+        "_id": {
+            "description": "Document's id (database will create it's if not entered)",
+            "example": "ObjectId(592c33475f8c1b064c4d1696)"
+        },
+        "version_id": {
+            "description": "The version ID from which it was created",
+            "example": "ObjectId(592c33475f8c1b064c4d1695)"
+        },
+        "schema": {
+            "description": "The schema associated with this document",
+            "type": "string",
+            "enum": ["openpype:hero_version-1.0"],
+            "example": "openpype:hero_version-1.0"
+        },
+        "type": {
+            "description": "The type of document",
+            "type": "string",
+            "enum": ["hero_version"],
+            "example": "hero_version"
+        },
+        "parent": {
+            "description": "Unique identifier to parent document",
+            "example": "ObjectId(592c33475f8c1b064c4d1697)"
+        }
+    }
+}

--- a/openpype/pipeline/schema/inventory-1.0.json
+++ b/openpype/pipeline/schema/inventory-1.0.json
@@ -1,0 +1,10 @@
+{
+    "$schema": "http://json-schema.org/draft-04/schema#",
+
+    "title": "openpype:config-1.0",
+    "description": "A project configuration.",
+
+    "type": "object",
+
+    "additionalProperties": true
+}

--- a/openpype/pipeline/schema/inventory-1.1.json
+++ b/openpype/pipeline/schema/inventory-1.1.json
@@ -1,0 +1,10 @@
+{
+    "$schema": "http://json-schema.org/draft-04/schema#",
+
+    "title": "openpype:config-1.1",
+    "description": "A project configuration.",
+
+    "type": "object",
+
+    "additionalProperties": true
+}

--- a/openpype/pipeline/schema/project-2.0.json
+++ b/openpype/pipeline/schema/project-2.0.json
@@ -1,0 +1,86 @@
+{
+    "$schema": "http://json-schema.org/draft-04/schema#",
+
+    "title": "openpype:project-2.0",
+    "description": "A unit of data",
+
+    "type": "object",
+
+    "additionalProperties": true,
+
+    "required": [
+        "schema",
+        "type",
+        "name",
+        "data",
+        "config"
+    ],
+
+    "properties": {
+        "schema": {
+            "description": "Schema identifier for payload",
+            "type": "string",
+            "enum": ["openpype:project-2.0"],
+            "example": "openpype:project-2.0"
+        },
+        "type": {
+            "description": "The type of document",
+            "type": "string",
+            "enum": ["project"],
+            "example": "project"
+        },
+        "parent": {
+            "description": "Unique identifier to parent document",
+            "example": "592c33475f8c1b064c4d1696"
+        },
+        "name": {
+            "description": "Name of directory",
+            "type": "string",
+            "pattern": "^[a-zA-Z0-9_.]*$",
+            "example": "hulk"
+        },
+        "data": {
+            "description": "Document metadata",
+            "type": "object",
+            "example": {
+                "fps": 24,
+                "width": 1920,
+                "height": 1080
+            }
+        },
+        "config": {
+            "type": "object",
+            "description": "Document metadata",
+            "example": {
+                "schema": "openpype:config-1.0",
+                "apps": [
+                    {
+                        "name": "maya2016",
+                        "label": "Autodesk Maya 2016"
+                    },
+                    {
+                        "name": "nuke10",
+                        "label": "The Foundry Nuke 10.0"
+                    }
+                ],
+                "tasks": [
+                    {"name": "model"},
+                    {"name": "render"},
+                    {"name": "animate"},
+                    {"name": "rig"},
+                    {"name": "lookdev"},
+                    {"name": "layout"}
+                ],
+                "template": {
+                    "work":
+                        "{root}/{project}/{silo}/{asset}/work/{task}/{app}",
+                    "publish":
+                        "{root}/{project}/{silo}/{asset}/publish/{subset}/v{version:0>3}/{subset}.{representation}"
+                }
+            },
+            "$ref": "config-1.0.json"
+        }
+    },
+
+    "definitions": {}
+}

--- a/openpype/pipeline/schema/project-2.1.json
+++ b/openpype/pipeline/schema/project-2.1.json
@@ -1,0 +1,86 @@
+{
+    "$schema": "http://json-schema.org/draft-04/schema#",
+
+    "title": "openpype:project-2.1",
+    "description": "A unit of data",
+
+    "type": "object",
+
+    "additionalProperties": true,
+
+    "required": [
+        "schema",
+        "type",
+        "name",
+        "data",
+        "config"
+    ],
+
+    "properties": {
+        "schema": {
+            "description": "Schema identifier for payload",
+            "type": "string",
+            "enum": ["openpype:project-2.1"],
+            "example": "openpype:project-2.1"
+        },
+        "type": {
+            "description": "The type of document",
+            "type": "string",
+            "enum": ["project"],
+            "example": "project"
+        },
+        "parent": {
+            "description": "Unique identifier to parent document",
+            "example": "592c33475f8c1b064c4d1696"
+        },
+        "name": {
+            "description": "Name of directory",
+            "type": "string",
+            "pattern": "^[a-zA-Z0-9_.]*$",
+            "example": "hulk"
+        },
+        "data": {
+            "description": "Document metadata",
+            "type": "object",
+            "example": {
+                "fps": 24,
+                "width": 1920,
+                "height": 1080
+            }
+        },
+        "config": {
+            "type": "object",
+            "description": "Document metadata",
+            "example": {
+                "schema": "openpype:config-1.1",
+                "apps": [
+                    {
+                        "name": "maya2016",
+                        "label": "Autodesk Maya 2016"
+                    },
+                    {
+                        "name": "nuke10",
+                        "label": "The Foundry Nuke 10.0"
+                    }
+                ],
+                "tasks": {
+                    "Model":   {"short_name": "mdl"},
+                    "Render":  {"short_name": "rnd"},
+                    "Animate": {"short_name": "anim"},
+                    "Rig":     {"short_name": "rig"},
+                    "Lookdev": {"short_name": "look"},
+                    "Layout":  {"short_name": "lay"}
+                },
+                "template": {
+                    "work":
+                        "{root}/{project}/{silo}/{asset}/work/{task}/{app}",
+                    "publish":
+                        "{root}/{project}/{silo}/{asset}/publish/{subset}/v{version:0>3}/{subset}.{representation}"
+                }
+            },
+            "$ref": "config-1.1.json"
+        }
+    },
+
+    "definitions": {}
+}

--- a/openpype/pipeline/schema/project-3.0.json
+++ b/openpype/pipeline/schema/project-3.0.json
@@ -1,0 +1,59 @@
+{
+    "$schema": "http://json-schema.org/draft-04/schema#",
+
+    "title": "openpype:project-3.0",
+    "description": "A unit of data",
+
+    "type": "object",
+
+    "additionalProperties": true,
+
+    "required": [
+        "schema",
+        "type",
+        "name",
+        "data",
+        "config"
+    ],
+
+    "properties": {
+        "schema": {
+            "description": "Schema identifier for payload",
+            "type": "string",
+            "enum": ["openpype:project-3.0"],
+            "example": "openpype:project-3.0"
+        },
+        "type": {
+            "description": "The type of document",
+            "type": "string",
+            "enum": ["project"],
+            "example": "project"
+        },
+        "parent": {
+            "description": "Unique identifier to parent document",
+            "example": "592c33475f8c1b064c4d1696"
+        },
+        "name": {
+            "description": "Name of directory",
+            "type": "string",
+            "pattern": "^[a-zA-Z0-9_.]*$",
+            "example": "hulk"
+        },
+        "data": {
+            "description": "Document metadata",
+            "type": "object",
+            "example": {
+                "fps": 24,
+                "width": 1920,
+                "height": 1080
+            }
+        },
+        "config": {
+            "type": "object",
+            "description": "Document metadata",
+            "$ref": "config-2.0.json"
+        }
+    },
+
+    "definitions": {}
+}

--- a/openpype/pipeline/schema/representation-1.0.json
+++ b/openpype/pipeline/schema/representation-1.0.json
@@ -1,0 +1,28 @@
+{
+    "$schema": "http://json-schema.org/draft-04/schema#",
+
+    "title": "openpype:representation-1.0",
+    "description": "The inverse of an instance",
+
+    "type": "object",
+
+    "additionalProperties": true,
+
+    "required": [
+        "schema",
+        "format",
+        "path"
+    ],
+
+    "properties": {
+        "schema": {"type": "string"},
+        "format": {
+            "description": "File extension, including '.'",
+            "type": "string"
+        },
+        "path": {
+            "description": "Unformatted path to version.",
+            "type": "string"
+        }
+    }
+}

--- a/openpype/pipeline/schema/representation-2.0.json
+++ b/openpype/pipeline/schema/representation-2.0.json
@@ -1,0 +1,78 @@
+{
+    "$schema": "http://json-schema.org/draft-04/schema#",
+
+    "title": "openpype:representation-2.0",
+    "description": "The inverse of an instance",
+
+    "type": "object",
+
+    "additionalProperties": true,
+
+    "required": [
+        "schema",
+        "type",
+        "parent",
+        "name",
+        "data"
+    ],
+
+    "properties": {
+        "schema": {
+            "description": "Schema identifier for payload",
+            "type": "string",
+            "enum": ["openpype:representation-2.0"],
+            "example": "openpype:representation-2.0"
+        },
+        "type": {
+            "description": "The type of document",
+            "type": "string",
+            "enum": ["representation"],
+            "example": "representation"
+        },
+        "parent": {
+            "description": "Unique identifier to parent document",
+            "example": "592c33475f8c1b064c4d1696"
+        },
+        "name": {
+            "description": "Name of representation",
+            "type": "string",
+            "pattern": "^[a-zA-Z0-9_.]*$",
+            "example": "abc"
+        },
+        "data": {
+            "description": "Document metadata",
+            "type": "object",
+            "example": {
+                "label": "Alembic"
+            }
+        },
+        "dependencies": {
+            "description": "Other representation that this representation depends on",
+            "type": "array",
+            "items": {"type": "string"},
+            "example": [
+                "592d547a5f8c1b388093c145"
+            ]
+        },
+        "context": {
+            "description": "Summary of the context to which this representation belong.",
+            "type": "object",
+            "properties": {
+                "project": {"type": "object"},
+                "asset": {"type": "string"},
+                "silo": {"type": ["string", "null"]},
+                "subset": {"type": "string"},
+                "version": {"type": "number"},
+                "representation": {"type": "string"}
+            },
+            "example": {
+                "project": "hulk",
+                "asset": "Bruce",
+                "silo": "assets",
+                "subset": "rigDefault",
+                "version": 12,
+                "representation": "ma"
+            }
+        }
+    }
+}

--- a/openpype/pipeline/schema/session-1.0.json
+++ b/openpype/pipeline/schema/session-1.0.json
@@ -1,0 +1,143 @@
+{
+    "$schema": "http://json-schema.org/draft-04/schema#",
+
+    "title": "openpype:session-1.0",
+    "description": "The Avalon environment",
+
+    "type": "object",
+
+    "additionalProperties": true,
+
+    "required": [
+        "AVALON_PROJECTS",
+        "AVALON_PROJECT",
+        "AVALON_ASSET",
+        "AVALON_SILO",
+        "AVALON_CONFIG"
+    ],
+
+    "properties": {
+        "AVALON_PROJECTS": {
+            "description": "Absolute path to root of project directories",
+            "type": "string",
+            "example": "/nas/projects"
+        },
+        "AVALON_PROJECT": {
+            "description": "Name of project",
+            "type": "string",
+            "pattern": "^\\w*$",
+            "example": "Hulk"
+        },
+        "AVALON_ASSET": {
+            "description": "Name of asset",
+            "type": "string",
+            "pattern": "^\\w*$",
+            "example": "Bruce"
+        },
+        "AVALON_SILO": {
+            "description": "Name of asset group or container",
+            "type": "string",
+            "pattern": "^\\w*$",
+            "example": "assets"
+        },
+        "AVALON_TASK": {
+            "description": "Name of task",
+            "type": "string",
+            "pattern": "^\\w*$",
+            "example": "modeling"
+        },
+        "AVALON_CONFIG": {
+            "description": "Name of Avalon configuration",
+            "type": "string",
+            "pattern": "^\\w*$",
+            "example": "polly"
+        },
+        "AVALON_APP": {
+            "description": "Name of application",
+            "type": "string",
+            "pattern": "^\\w*$",
+            "example": "maya2016"
+        },
+        "AVALON_MONGO": {
+            "description": "Address to the asset database",
+            "type": "string",
+            "pattern": "^mongodb://[\\w/@:.]*$",
+            "example": "mongodb://localhost:27017",
+            "default": "mongodb://localhost:27017"
+        },
+        "AVALON_DB": {
+            "description": "Name of database",
+            "type": "string",
+            "pattern": "^\\w*$",
+            "example": "avalon",
+            "default": "avalon"
+        },
+        "AVALON_LABEL": {
+            "description": "Nice name of Avalon, used in e.g. graphical user interfaces",
+            "type": "string",
+            "example": "Mindbender",
+            "default": "Avalon"
+        },
+        "AVALON_SENTRY": {
+            "description": "Address to Sentry",
+            "type": "string",
+            "pattern": "^http[\\w/@:.]*$",
+            "example": "https://5b872b280de742919b115bdc8da076a5:8d278266fe764361b8fa6024af004a9c@logs.mindbender.com/2",
+            "default": null
+        },
+        "AVALON_DEADLINE": {
+            "description": "Address to Deadline",
+            "type": "string",
+            "pattern": "^http[\\w/@:.]*$",
+            "example": "http://192.168.99.101",
+            "default": null
+        },
+        "AVALON_TIMEOUT": {
+            "description": "Wherever there is a need for a timeout, this is the default value.",
+            "type": "string",
+            "pattern": "^[0-9]*$",
+            "default": "1000",
+            "example": "1000"
+        },
+        "AVALON_UPLOAD": {
+            "description": "Boolean of whether to upload published material to central asset repository",
+            "type": "string",
+            "default": null,
+            "example": "True"
+        },
+        "AVALON_USERNAME": {
+            "description": "Generic username",
+            "type": "string",
+            "pattern": "^\\w*$",
+            "default": "avalon",
+            "example": "myself"
+        },
+        "AVALON_PASSWORD": {
+            "description": "Generic password",
+            "type": "string",
+            "pattern": "^\\w*$",
+            "default": "secret",
+            "example": "abc123"
+        },
+        "AVALON_INSTANCE_ID": {
+            "description": "Unique identifier for instances in a working file",
+            "type": "string",
+            "pattern": "^[\\w.]*$",
+            "default": "avalon.instance",
+            "example": "avalon.instance"
+        },
+        "AVALON_CONTAINER_ID": {
+            "description": "Unique identifier for a loaded representation in a working file",
+            "type": "string",
+            "pattern": "^[\\w.]*$",
+            "default": "avalon.container",
+            "example": "avalon.container"
+        },
+        "AVALON_DEBUG": {
+            "description": "Enable debugging mode. Some applications may use this for e.g. extended verbosity or mock plug-ins.",
+            "type": "string",
+            "default": null,
+            "example": "True"
+        }
+    }
+}

--- a/openpype/pipeline/schema/session-2.0.json
+++ b/openpype/pipeline/schema/session-2.0.json
@@ -1,0 +1,134 @@
+{
+    "$schema": "http://json-schema.org/draft-04/schema#",
+
+    "title": "openpype:session-2.0",
+    "description": "The Avalon environment",
+
+    "type": "object",
+
+    "additionalProperties": true,
+
+    "required": [
+        "AVALON_PROJECT",
+        "AVALON_ASSET",
+        "AVALON_CONFIG"
+    ],
+
+    "properties": {
+        "AVALON_PROJECTS": {
+            "description": "Absolute path to root of project directories",
+            "type": "string",
+            "example": "/nas/projects"
+        },
+        "AVALON_PROJECT": {
+            "description": "Name of project",
+            "type": "string",
+            "pattern": "^\\w*$",
+            "example": "Hulk"
+        },
+        "AVALON_ASSET": {
+            "description": "Name of asset",
+            "type": "string",
+            "pattern": "^\\w*$",
+            "example": "Bruce"
+        },
+        "AVALON_SILO": {
+            "description": "Name of asset group or container",
+            "type": "string",
+            "pattern": "^\\w*$",
+            "example": "assets"
+        },
+        "AVALON_TASK": {
+            "description": "Name of task",
+            "type": "string",
+            "pattern": "^\\w*$",
+            "example": "modeling"
+        },
+        "AVALON_CONFIG": {
+            "description": "Name of Avalon configuration",
+            "type": "string",
+            "pattern": "^\\w*$",
+            "example": "polly"
+        },
+        "AVALON_APP": {
+            "description": "Name of application",
+            "type": "string",
+            "pattern": "^\\w*$",
+            "example": "maya2016"
+        },
+        "AVALON_DB": {
+            "description": "Name of database",
+            "type": "string",
+            "pattern": "^\\w*$",
+            "example": "avalon",
+            "default": "avalon"
+        },
+        "AVALON_LABEL": {
+            "description": "Nice name of Avalon, used in e.g. graphical user interfaces",
+            "type": "string",
+            "example": "Mindbender",
+            "default": "Avalon"
+        },
+        "AVALON_SENTRY": {
+            "description": "Address to Sentry",
+            "type": "string",
+            "pattern": "^http[\\w/@:.]*$",
+            "example": "https://5b872b280de742919b115bdc8da076a5:8d278266fe764361b8fa6024af004a9c@logs.mindbender.com/2",
+            "default": null
+        },
+        "AVALON_DEADLINE": {
+            "description": "Address to Deadline",
+            "type": "string",
+            "pattern": "^http[\\w/@:.]*$",
+            "example": "http://192.168.99.101",
+            "default": null
+        },
+        "AVALON_TIMEOUT": {
+            "description": "Wherever there is a need for a timeout, this is the default value.",
+            "type": "string",
+            "pattern": "^[0-9]*$",
+            "default": "1000",
+            "example": "1000"
+        },
+        "AVALON_UPLOAD": {
+            "description": "Boolean of whether to upload published material to central asset repository",
+            "type": "string",
+            "default": null,
+            "example": "True"
+        },
+        "AVALON_USERNAME": {
+            "description": "Generic username",
+            "type": "string",
+            "pattern": "^\\w*$",
+            "default": "avalon",
+            "example": "myself"
+        },
+        "AVALON_PASSWORD": {
+            "description": "Generic password",
+            "type": "string",
+            "pattern": "^\\w*$",
+            "default": "secret",
+            "example": "abc123"
+        },
+        "AVALON_INSTANCE_ID": {
+            "description": "Unique identifier for instances in a working file",
+            "type": "string",
+            "pattern": "^[\\w.]*$",
+            "default": "avalon.instance",
+            "example": "avalon.instance"
+        },
+        "AVALON_CONTAINER_ID": {
+            "description": "Unique identifier for a loaded representation in a working file",
+            "type": "string",
+            "pattern": "^[\\w.]*$",
+            "default": "avalon.container",
+            "example": "avalon.container"
+        },
+        "AVALON_DEBUG": {
+            "description": "Enable debugging mode. Some applications may use this for e.g. extended verbosity or mock plug-ins.",
+            "type": "string",
+            "default": null,
+            "example": "True"
+        }
+    }
+}

--- a/openpype/pipeline/schema/session-3.0.json
+++ b/openpype/pipeline/schema/session-3.0.json
@@ -1,0 +1,81 @@
+{
+    "$schema": "http://json-schema.org/draft-04/schema#",
+
+    "title": "openpype:session-3.0",
+    "description": "The Avalon environment",
+
+    "type": "object",
+
+    "additionalProperties": true,
+
+    "required": [
+        "AVALON_PROJECT",
+        "AVALON_ASSET"
+    ],
+
+    "properties": {
+        "AVALON_PROJECTS": {
+            "description": "Absolute path to root of project directories",
+            "type": "string",
+            "example": "/nas/projects"
+        },
+        "AVALON_PROJECT": {
+            "description": "Name of project",
+            "type": "string",
+            "pattern": "^\\w*$",
+            "example": "Hulk"
+        },
+        "AVALON_ASSET": {
+            "description": "Name of asset",
+            "type": "string",
+            "pattern": "^\\w*$",
+            "example": "Bruce"
+        },
+        "AVALON_TASK": {
+            "description": "Name of task",
+            "type": "string",
+            "pattern": "^\\w*$",
+            "example": "modeling"
+        },
+        "AVALON_APP": {
+            "description": "Name of host",
+            "type": "string",
+            "pattern": "^\\w*$",
+            "example": "maya2016"
+        },
+        "AVALON_DB": {
+            "description": "Name of database",
+            "type": "string",
+            "pattern": "^\\w*$",
+            "example": "avalon",
+            "default": "avalon"
+        },
+        "AVALON_LABEL": {
+            "description": "Nice name of Avalon, used in e.g. graphical user interfaces",
+            "type": "string",
+            "example": "Mindbender",
+            "default": "Avalon"
+        },
+        "AVALON_TIMEOUT": {
+            "description": "Wherever there is a need for a timeout, this is the default value.",
+            "type": "string",
+            "pattern": "^[0-9]*$",
+            "default": "1000",
+            "example": "1000"
+        },
+        "AVALON_INSTANCE_ID": {
+            "description": "Unique identifier for instances in a working file",
+            "type": "string",
+            "pattern": "^[\\w.]*$",
+            "default": "avalon.instance",
+            "example": "avalon.instance"
+        },
+        "AVALON_CONTAINER_ID": {
+            "description": "Unique identifier for a loaded representation in a working file",
+            "type": "string",
+            "pattern": "^[\\w.]*$",
+            "default": "avalon.container",
+            "example": "avalon.container"
+        }
+    }
+}

--- a/openpype/pipeline/schema/shaders-1.0.json
+++ b/openpype/pipeline/schema/shaders-1.0.json
@@ -1,0 +1,32 @@
+{
+    "$schema": "http://json-schema.org/draft-04/schema#",
+
+    "title": "openpype:shaders-1.0",
+    "description": "Relationships between shaders and Avalon IDs",
+
+    "type": "object",
+
+    "additionalProperties": true,
+
+    "required": [
+        "schema",
+        "shader"
+    ],
+
+    "properties": {
+        "schema": {
+            "description": "Schema identifier for payload",
+            "type": "string"
+        },
+        "shader": {
+            "description": "Name of directory",
+            "type": "array",
+            "items": {
+                "type": "str",
+                "description": "Avalon ID and optional face indexes, e.g. 'f9520572-ac1d-11e6-b39e-3085a99791c9.f[5002:5185]'"
+            }
+        }
+    },
+
+    "definitions": {}
+}

--- a/openpype/pipeline/schema/subset-1.0.json
+++ b/openpype/pipeline/schema/subset-1.0.json
@@ -1,0 +1,35 @@
+{
+    "$schema": "http://json-schema.org/draft-04/schema#",
+
+    "title": "openpype:subset-1.0",
+    "description": "A container of instances",
+
+    "type": "object",
+
+    "additionalProperties": true,
+
+    "required": [
+        "schema",
+        "name",
+        "versions"
+    ],
+
+    "properties": {
+        "schema": {
+            "description": "Schema identifier for payload",
+            "type": "string"
+        },
+        "name": {
+            "description": "Name of directory",
+            "type": "string"
+        },
+        "versions": {
+            "type": "array",
+            "items": {
+                "$ref": "version.json"
+            }
+        }
+    },
+
+    "definitions": {}
+}

--- a/openpype/pipeline/schema/subset-2.0.json
+++ b/openpype/pipeline/schema/subset-2.0.json
@@ -1,0 +1,51 @@
+{
+    "$schema": "http://json-schema.org/draft-04/schema#",
+
+    "title": "openpype:subset-2.0",
+    "description": "A container of instances",
+
+    "type": "object",
+
+    "additionalProperties": true,
+
+    "required": [
+        "schema",
+        "type",
+        "parent",
+        "name",
+        "data"
+    ],
+
+    "properties": {
+        "schema": {
+            "description": "The schema associated with this document",
+            "type": "string",
+            "enum": ["openpype:subset-2.0"],
+            "example": "openpype:subset-2.0"
+        },
+        "type": {
+            "description": "The type of document",
+            "type": "string",
+            "enum": ["subset"],
+            "example": "subset"
+        },
+        "parent": {
+            "description": "Unique identifier to parent document",
+            "example": "592c33475f8c1b064c4d1696"
+        },
+        "name": {
+            "description": "Name of directory",
+            "type": "string",
+            "pattern": "^[a-zA-Z0-9_.]*$",
+            "example": "shot01"
+        },
+        "data": {
+            "type": "object",
+            "description": "Document metadata",
+            "example": {
+                "frameStart": 1000,
+                "frameEnd": 1201
+            }
+        }
+    }
+}

--- a/openpype/pipeline/schema/subset-3.0.json
+++ b/openpype/pipeline/schema/subset-3.0.json
@@ -1,0 +1,62 @@
+{
+    "$schema": "http://json-schema.org/draft-04/schema#",
+
+    "title": "openpype:subset-3.0",
+    "description": "A container of instances",
+
+    "type": "object",
+
+    "additionalProperties": true,
+
+    "required": [
+        "schema",
+        "type",
+        "parent",
+        "name",
+        "data"
+    ],
+
+    "properties": {
+        "schema": {
+            "description": "The schema associated with this document",
+            "type": "string",
+            "enum": ["openpype:subset-3.0"],
+            "example": "openpype:subset-3.0"
+        },
+        "type": {
+            "description": "The type of document",
+            "type": "string",
+            "enum": ["subset"],
+            "example": "subset"
+        },
+        "parent": {
+            "description": "Unique identifier to parent document",
+            "example": "592c33475f8c1b064c4d1696"
+        },
+        "name": {
+            "description": "Name of directory",
+            "type": "string",
+            "pattern": "^[a-zA-Z0-9_.]*$",
+            "example": "shot01"
+        },
+        "data": {
+            "description": "Document metadata",
+            "type": "object",
+            "required": ["families"],
+            "properties": {
+                "families": {
+                    "type": "array",
+                    "items": {"type": "string"},
+                    "description": "One or more families associated with this subset"
+                }
+            },
+            "example": {
+                "families" : [
+                    "avalon.camera"
+                ],
+                "frameStart": 1000,
+                "frameEnd": 1201
+            }
+        }
+    }
+}

--- a/openpype/pipeline/schema/thumbnail-1.0.json
+++ b/openpype/pipeline/schema/thumbnail-1.0.json
@@ -1,0 +1,42 @@
+{
+    "$schema": "http://json-schema.org/draft-04/schema#",
+
+    "title": "openpype:thumbnail-1.0",
+    "description": "Entity with thumbnail data",
+
+    "type": "object",
+
+    "additionalProperties": true,
+
+    "required": [
+        "schema",
+        "type",
+        "data"
+    ],
+
+    "properties": {
+        "schema": {
+            "description": "The schema associated with this document",
+            "type": "string",
+            "enum": ["openpype:thumbnail-1.0"],
+            "example": "openpype:thumbnail-1.0"
+        },
+        "type": {
+            "description": "The type of document",
+            "type": "string",
+            "enum": ["thumbnail"],
+            "example": "thumbnail"
+        },
+        "data": {
+            "description": "Thumbnail data",
+            "type": "object",
+            "example": {
+                "binary_data": "Binary({byte data of image})",
+                "template": "{thumbnail_root}/{project[name]}/{_id}{ext}}",
+                "template_data": {
+                    "ext": ".jpg"
+                }
+            }
+        }
+    }
+}

--- a/openpype/pipeline/schema/version-1.0.json
+++ b/openpype/pipeline/schema/version-1.0.json
@@ -1,0 +1,50 @@
+{
+    "$schema": "http://json-schema.org/draft-04/schema#",
+
+    "title": "openpype:version-1.0",
+    "description": "An individual version",
+
+    "type": "object",
+
+    "additionalProperties": true,
+
+    "required": [
+        "schema",
+        "version",
+        "path",
+        "time",
+        "author",
+        "source",
+        "representations"
+    ],
+
+    "properties": {
+        "schema": {"type": "string"},
+        "representations": {
+            "type": "array",
+            "items": {
+                "$ref": "representation.json"
+            }
+        },
+        "time": {
+            "description": "ISO formatted, file-system compatible time",
+            "type": "string"
+        },
+        "author": {
+            "description": "User logged on to the machine at time of publish",
+            "type": "string"
+        },
+        "version": {
+            "description": "Number of this version",
+            "type": "number"
+        },
+        "path": {
+            "description": "Unformatted path, e.g. '{root}/assets/Bruce/publish/lookdevDefault/v001",
+            "type": "string"
+        },
+        "source": {
+            "description": "Original file from which this version was made.",
+            "type": "string"
+        }
+    }
+}

--- a/openpype/pipeline/schema/version-2.0.json
+++ b/openpype/pipeline/schema/version-2.0.json
@@ -1,0 +1,92 @@
+{
+    "$schema": "http://json-schema.org/draft-04/schema#",
+
+    "title": "openpype:version-2.0",
+    "description": "An individual version",
+
+    "type": "object",
+
+    "additionalProperties": true,
+
+    "required": [
+        "schema",
+        "type",
+        "parent",
+        "name",
+        "data"
+    ],
+
+    "properties": {
+        "schema": {
+            "description": "The schema associated with this document",
+            "type": "string",
+            "enum": ["openpype:version-2.0"],
+            "example": "openpype:version-2.0"
+        },
+        "type": {
+            "description": "The type of document",
+            "type": "string",
+            "enum": ["version"],
+            "example": "version"
+        },
+        "parent": {
+            "description": "Unique identifier to parent document",
+            "example": "592c33475f8c1b064c4d1696"
+        },
+        "name": {
+            "description": "Number of version",
+            "type": "number",
+            "example": 12
+        },
+        "locations": {
+            "description": "Where on the planet this version can be found.",
+            "type": "array",
+            "items": {"type": "string"},
+            "example": ["data.avalon.com"]
+        },
+        "data": {
+            "description": "Document metadata",
+            "type": "object",
+            "required": ["families", "author", "source", "time"],
+            "properties": {
+                "time": {
+                    "description": "ISO formatted, file-system compatible time",
+                    "type": "string"
+                },
+                "timeFormat": {
+                    "description": "ISO format of time",
+                    "type": "string"
+                },
+                "author": {
+                    "description": "User logged on to the machine at time of publish",
+                    "type": "string"
+                },
+                "version": {
+                    "description": "Number of this version",
+                    "type": "number"
+                },
+                "path": {
+                    "description": "Unformatted path, e.g. '{root}/assets/Bruce/publish/lookdevDefault/v001",
+                    "type": "string"
+                },
+                "source": {
+                    "description": "Original file from which this version was made.",
+                    "type": "string"
+                },
+                "families": {
+                    "type": "array",
+                    "items": {"type": "string"},
+                    "description": "One or more families associated with this version"
+                }
+            },
+            "example": {
+                "source" : "{root}/f02_prod/assets/BubbleWitch/work/modeling/marcus/maya/scenes/model_v001.ma",
+                "author" : "marcus",
+                "families" : [
+                    "avalon.model"
+                ],
+                "time" : "20170510T090203Z"
+            }
+        }
+    }
+}

--- a/openpype/pipeline/schema/version-3.0.json
+++ b/openpype/pipeline/schema/version-3.0.json
@@ -1,0 +1,84 @@
+{
+    "$schema": "http://json-schema.org/draft-04/schema#",
+
+    "title": "openpype:version-3.0",
+    "description": "An individual version",
+
+    "type": "object",
+
+    "additionalProperties": true,
+
+    "required": [
+        "schema",
+        "type",
+        "parent",
+        "name",
+        "data"
+    ],
+
+    "properties": {
+        "schema": {
+            "description": "The schema associated with this document",
+            "type": "string",
+            "enum": ["openpype:version-3.0"],
+            "example": "openpype:version-3.0"
+        },
+        "type": {
+            "description": "The type of document",
+            "type": "string",
+            "enum": ["version"],
+            "example": "version"
+        },
+        "parent": {
+            "description": "Unique identifier to parent document",
+            "example": "592c33475f8c1b064c4d1696"
+        },
+        "name": {
+            "description": "Number of version",
+            "type": "number",
+            "example": 12
+        },
+        "locations": {
+            "description": "Where on the planet this version can be found.",
+            "type": "array",
+            "items": {"type": "string"},
+            "example": ["data.avalon.com"]
+        },
+        "data": {
+            "description": "Document metadata",
+            "type": "object",
+            "required": ["author", "source", "time"],
+            "properties": {
+                "time": {
+                    "description": "ISO formatted, file-system compatible time",
+                    "type": "string"
+                },
+                "timeFormat": {
+                    "description": "ISO format of time",
+                    "type": "string"
+                },
+                "author": {
+                    "description": "User logged on to the machine at time of publish",
+                    "type": "string"
+                },
+                "version": {
+                    "description": "Number of this version",
+                    "type": "number"
+                },
+                "path": {
+                    "description": "Unformatted path, e.g. '{root}/assets/Bruce/publish/lookdevDefault/v001",
+                    "type": "string"
+                },
+                "source": {
+                    "description": "Original file from which this version was made.",
+                    "type": "string"
+                }
+            },
+            "example": {
+                "source" : "{root}/f02_prod/assets/BubbleWitch/work/modeling/marcus/maya/scenes/model_v001.ma",
+                "author" : "marcus",
+                "time" : "20170510T090203Z"
+            }
+        }
+    }
+}

--- a/openpype/pipeline/schema/workfile-1.0.json
+++ b/openpype/pipeline/schema/workfile-1.0.json
@@ -1,0 +1,52 @@
+{
+    "$schema": "http://json-schema.org/draft-04/schema#",
+
+    "title": "openpype:workfile-1.0",
+    "description": "Workfile additional information.",
+
+    "type": "object",
+
+    "additionalProperties": true,
+
+    "required": [
+        "schema",
+        "type",
+        "filename",
+        "task_name",
+        "parent"
+    ],
+
+    "properties": {
+        "schema": {
+            "description": "Schema identifier for payload",
+            "type": "string",
+            "enum": ["openpype:workfile-1.0"],
+            "example": "openpype:workfile-1.0"
+        },
+        "type": {
+            "description": "The type of document",
+            "type": "string",
+            "enum": ["workfile"],
+            "example": "workfile"
+        },
+        "parent": {
+            "description": "Unique identifier to parent document",
+            "example": "592c33475f8c1b064c4d1696"
+        },
+        "filename": {
+            "description": "Workfile's filename",
+            "type": "string",
+            "example": "kuba_each_case_Alpaca_01_animation_v001.ma"
+        },
+        "task_name": {
+            "description": "Task name",
+            "type": "string",
+            "example": "animation"
+        },
+        "data": {
+            "description": "Document metadata",
+            "type": "object",
+            "example": {"key": "value"}
+        }
+    }
+}


### PR DESCRIPTION
## Changelog Description
Moved/copied schemas from repository root inside openpype/pipeline.

## Additional info
The movement is necessary because of AYON addon conversion. Since ayon-launcher does not contain the schemas and openpype neither there is not way how it can be accessed. The easiest solution is to move schemas inside openpype codebase.

Most of the schemas are very outdated and should be probably removed, but that is not purpose of this PR.

I've kept the schema directory in the root of repository and will create different [PR in next-minor branch](https://github.com/ynput/OpenPype/pull/5355) that will remove them.

## Testing notes:
### OpenPype
There should not be any issues with schema validation.
When does schema validation happen? e.g. on host install (open of DCC) or integration.

### AYON
When used openpype as an addon via ayon-launcher should not cause any issues with schemas.