### PR TITLE
Bugfix: Houdini Creator use selection even if it was toggled off

### DIFF
--- a/openpype/hosts/houdini/api/plugin.py
+++ b/openpype/hosts/houdini/api/plugin.py
@@ -170,6 +170,8 @@ class HoudiniCreator(NewCreator, HoudiniCreatorBase):
 
     def create(self, subset_name, instance_data, pre_create_data):
         try:
+            self.selected_nodes = []
+
             if pre_create_data.get("use_selection"):
                 self.selected_nodes = hou.selectedNodes()
 


### PR DESCRIPTION
## Changelog Description
When creating many product types (families) one after another without refreshing the creator window manually 
if you toggled `Use selection` once, all the later product types will use selection even if it was toggled off

Here's Before 
it will keep use selection even if it was toggled off, unless you refresh window manually 

https://github.com/ynput/OpenPype/assets/20871534/8b890122-5b53-4c6b-897d-6a2f3aa3388a



Here's After 
it works as expected


https://github.com/ynput/OpenPype/assets/20871534/6b1db990-de1b-428e-8828-04ab59a44e28



## Testing notes:
create publishes one after another with different `Use selection` on and off 