### PR TITLE
AYON: Environment variables and functions

### DIFF
--- a/openpype/lib/__init__.py
+++ b/openpype/lib/__init__.py
@@ -55,13 +55,13 @@ from .env_tools import (
 
 from .terminal import Terminal
 from .execute import (
-    get_ayon_execute_args,
+    get_ayon_launcher_args,
     get_openpype_execute_args,
     get_linux_launcher_args,
     execute,
     run_subprocess,
     run_detached_process,
-    run_ayon_process,
+    run_ayon_launcher_process,
     run_openpype_process,
     clean_envs_for_openpype_process,
     path_to_subprocess_arg,
@@ -177,13 +177,13 @@ __all__ = [
     "emit_event",
     "register_event_callback",
 
-    "get_ayon_execute_args",
+    "get_ayon_launcher_args",
     "get_openpype_execute_args",
     "get_linux_launcher_args",
     "execute",
     "run_subprocess",
     "run_detached_process",
-    "run_ayon_process",
+    "run_ayon_launcher_process",
     "run_openpype_process",
     "clean_envs_for_openpype_process",
     "path_to_subprocess_arg",

--- a/openpype/lib/__init__.py
+++ b/openpype/lib/__init__.py
@@ -5,11 +5,11 @@
 import sys
 import os
 import site
+from openpype import PACKAGE_DIR
 
 # Add Python version specific vendor folder
 python_version_dir = os.path.join(
-    os.getenv("OPENPYPE_REPOS_ROOT", ""),
-    "openpype", "vendor", "python", "python_{}".format(sys.version[0])
+    PACKAGE_DIR, "vendor", "python", "python_{}".format(sys.version[0])
 )
 # Prepend path in sys paths
 sys.path.insert(0, python_version_dir)

--- a/openpype/lib/__init__.py
+++ b/openpype/lib/__init__.py
@@ -55,11 +55,13 @@ from .env_tools import (
 
 from .terminal import Terminal
 from .execute import (
+    get_ayon_execute_args,
     get_openpype_execute_args,
     get_linux_launcher_args,
     execute,
     run_subprocess,
     run_detached_process,
+    run_ayon_process,
     run_openpype_process,
     clean_envs_for_openpype_process,
     path_to_subprocess_arg,
@@ -175,11 +177,13 @@ __all__ = [
     "emit_event",
     "register_event_callback",
 
+    "get_ayon_execute_args",
     "get_openpype_execute_args",
     "get_linux_launcher_args",
     "execute",
     "run_subprocess",
     "run_detached_process",
+    "run_ayon_process",
     "run_openpype_process",
     "clean_envs_for_openpype_process",
     "path_to_subprocess_arg",

--- a/openpype/lib/applications.py
+++ b/openpype/lib/applications.py
@@ -11,6 +11,7 @@ from abc import ABCMeta, abstractmethod
 
 import six
 
+from openpype import PACKAGE_DIR
 from openpype.client import (
     get_project,
     get_asset_by_name,
@@ -1435,10 +1436,8 @@ def _add_python_version_paths(app, env, logger, modules_manager):
         return
 
     # Add Python 2/3 modules
-    openpype_root = os.getenv("OPENPYPE_REPOS_ROOT")
     python_vendor_dir = os.path.join(
-        openpype_root,
-        "openpype",
+        PACKAGE_DIR,
         "vendor",
         "python"
     )

--- a/openpype/lib/applications.py
+++ b/openpype/lib/applications.py
@@ -11,7 +11,7 @@ from abc import ABCMeta, abstractmethod
 
 import six
 
-from openpype import PACKAGE_DIR
+from openpype import AYON_SERVER_ENABLED, PACKAGE_DIR
 from openpype.client import (
     get_project,
     get_asset_by_name,
@@ -1949,17 +1949,28 @@ def get_non_python_host_kwargs(kwargs, allow_console=True):
         allow_console (bool): use False for inner Popen opening app itself or
            it will open additional console (at least for Harmony)
     """
+
     if kwargs is None:
         kwargs = {}
 
     if platform.system().lower() != "windows":
         return kwargs
 
-    executable_path = os.environ.get("OPENPYPE_EXECUTABLE")
+    if AYON_SERVER_ENABLED:
+        executable_path = os.environ.get("AYON_EXECUTABLE")
+    else:
+        executable_path = os.environ.get("OPENPYPE_EXECUTABLE")
+
     executable_filename = ""
     if executable_path:
         executable_filename = os.path.basename(executable_path)
-    if "openpype_gui" in executable_filename:
+
+    if AYON_SERVER_ENABLED:
+        is_gui_executable = "ayon_console" not in executable_filename
+    else:
+        is_gui_executable = "openpype_gui" in executable_filename
+
+    if is_gui_executable:
         kwargs.update({
             "creationflags": subprocess.CREATE_NO_WINDOW,
             "stdout": subprocess.DEVNULL,

--- a/openpype/lib/execute.py
+++ b/openpype/lib/execute.py
@@ -311,17 +311,21 @@ def get_openpype_execute_args(*args):
     It is possible to pass any arguments that will be added after pype
     executables.
     """
-    executable = os.environ["OPENPYPE_EXECUTABLE"]
+
+    if AYON_SERVER_ENABLED:
+        executable = os.environ["AYON_EXECUTABLE"]
+    else:
+        executable = os.environ["OPENPYPE_EXECUTABLE"]
     launch_args = [executable]
 
     executable_filename = os.path.basename(executable)
     if "python" in executable_filename.lower():
-        filename = "start.py"
         if AYON_SERVER_ENABLED:
-            filename = "ayon_start.py"
-        launch_args.append(
-            os.path.join(os.environ["OPENPYPE_ROOT"], filename)
-        )
+            root = os.environ["AYON_ROOT"]
+        else:
+            root = os.environ["OPENPYPE_ROOT"]
+        filepath = os.path.join(root, "start.py")
+        launch_args.append(filepath)
 
     if args:
         launch_args.extend(args)

--- a/openpype/lib/execute.py
+++ b/openpype/lib/execute.py
@@ -209,7 +209,7 @@ def clean_envs_for_openpype_process(env=None):
     return env
 
 
-def run_ayon_process(*args, **kwargs):
+def run_ayon_launcher_process(*args, **kwargs):
     """Execute OpenPype process with passed arguments and wait.
 
     Wrapper for 'run_process' which prepends OpenPype executable arguments
@@ -231,7 +231,7 @@ def run_ayon_process(*args, **kwargs):
         str: Full output of subprocess concatenated stdout and stderr.
     """
 
-    args = get_ayon_execute_args(*args)
+    args = get_ayon_launcher_args(*args)
     env = kwargs.pop("env", None)
     # Keep env untouched if are passed and not empty
     if not env:
@@ -264,7 +264,7 @@ def run_openpype_process(*args, **kwargs):
     """
 
     if AYON_SERVER_ENABLED:
-        return run_ayon_process(*args, **kwargs)
+        return run_ayon_launcher_process(*args, **kwargs)
 
     args = get_openpype_execute_args(*args)
     env = kwargs.pop("env", None)
@@ -363,7 +363,7 @@ def path_to_subprocess_arg(path):
     return subprocess.list2cmdline([path])
 
 
-def get_ayon_execute_args(*args):
+def get_ayon_launcher_args(*args):
     """Arguments to run ayon-launcher process.
 
     Arguments for subprocess when need to spawn new pype process. Which may be
@@ -413,7 +413,7 @@ def get_openpype_execute_args(*args):
     """
 
     if AYON_SERVER_ENABLED:
-        return get_ayon_execute_args(*args)
+        return get_ayon_launcher_args(*args)
 
     executable = os.environ["OPENPYPE_EXECUTABLE"]
     launch_args = [executable]

--- a/openpype/lib/openpype_version.py
+++ b/openpype/lib/openpype_version.py
@@ -26,8 +26,25 @@ def get_openpype_version():
     return openpype.version.__version__
 
 
+def get_ayon_launcher_version():
+    version_filepath = os.path.join(
+        os.environ["AYON_ROOT"],
+        "version.py"
+    )
+    if not os.path.exists(version_filepath):
+        return None
+    content = {}
+    with open(version_filepath, "r") as stream:
+        exec(stream.read(), content)
+    return content["__version__"]
+
+
 def get_build_version():
     """OpenPype version of build."""
+
+    if AYON_SERVER_ENABLED:
+        return get_ayon_launcher_version()
+
     # Return OpenPype version if is running from code
     if not is_running_from_build():
         return get_openpype_version()
@@ -51,7 +68,11 @@ def is_running_from_build():
     Returns:
         bool: True if running from build.
     """
-    executable_path = os.environ["OPENPYPE_EXECUTABLE"]
+
+    if AYON_SERVER_ENABLED:
+        executable_path = os.environ["AYON_EXECUTABLE"]
+    else:
+        executable_path = os.environ["OPENPYPE_EXECUTABLE"]
     executable_filename = os.path.basename(executable_path)
     if "python" in executable_filename.lower():
         return False
@@ -59,6 +80,8 @@ def is_running_from_build():
 
 
 def is_staging_enabled():
+    if AYON_SERVER_ENABLED:
+        return os.getenv("AYON_USE_STAGING") == "1"
     return os.environ.get("OPENPYPE_USE_STAGING") == "1"
 
 

--- a/server_addon/create_ayon_addons.py
+++ b/server_addon/create_ayon_addons.py
@@ -203,7 +203,8 @@ def create_openpype_package(
     ignored_modules = [
         "ftrack",
         "shotgrid",
-        "sync_server",
+        # Sync server is expected as always available at multuple places
+        # "sync_server",
         "example_addons",
         "slack"
     ]

--- a/server_addon/create_ayon_addons.py
+++ b/server_addon/create_ayon_addons.py
@@ -203,7 +203,7 @@ def create_openpype_package(
     ignored_modules = [
         "ftrack",
         "shotgrid",
-        # Sync server is expected as always available at multuple places
+        # Sync server is still expected at multiple places
         # "sync_server",
         "example_addons",
         "slack"


### PR DESCRIPTION
## Changelog Description
Prepare code for ayon-launcher compatibility. Fix ayon launcher subprocess calls, added more checks for `AYON_SERVER_ENABLED`, use ayon launcher suitable environment variables in AYON mode and changed outputs of some functions. Replaced usages of `OPENPYPE_REPOS_ROOT` environment variable with `PACKAGE_DIR` variable -> correct paths are used.

## Additional info
AYON mode with ayon-launcher is not fully compatible now at some points. It tries to launch `ayon_start.py` when running from code instead of `start.py` which is there from time when OpenPype had ayon executables.

## Testing notes:
### OpenPype
**Publishing**
1. Make sure a script with subprocess is executed (for example burnins extraction)
2. Run publishing in host of your choice
3. Publishing should not crash

**Info in tray**
1. Open info window in tray.
2. Check the information if is valid.

### AYON
1. Create openpype addon
3. Upload addon to server
4. Use the addon in a bundle -> set the bundle as production (or staging)
5. Run ayon launcher
6. Do same validations as for OpenPype