### PR TITLE
Nuke: farm rendering of prerender ignore roots in nuke

### DIFF
--- a/openpype/pipeline/farm/pyblish_functions.py
+++ b/openpype/pipeline/farm/pyblish_functions.py
@@ -212,7 +212,7 @@ def create_skeleton_instance(
                      "This may cause issues.").format(source))
 
     family = ("render"
-              if "prerender" not in instance.data["families"]
+              if "prerender.farm" not in instance.data["families"]
               else "prerender")
     families = [family]
 

--- a/tests/integration/hosts/nuke/test_deadline_publish_in_nuke_prerender.py
+++ b/tests/integration/hosts/nuke/test_deadline_publish_in_nuke_prerender.py
@@ -1,0 +1,106 @@
+import logging
+
+from tests.lib.assert_classes import DBAssert
+from tests.integration.hosts.nuke.lib import NukeDeadlinePublishTestClass
+
+log = logging.getLogger("test_publish_in_nuke")
+
+
+class TestDeadlinePublishInNukePrerender(NukeDeadlinePublishTestClass):
+    """Basic test case for publishing in Nuke and Deadline for prerender
+
+        It is different from `test_deadline_publish_in_nuke` as that one is for
+        `render` family >> this test expects different subset names.
+
+        Uses generic TestCase to prepare fixtures for test data, testing DBs,
+        env vars.
+
+        !!!
+        It expects path in WriteNode starting with 'c:/projects', it replaces
+        it with correct value in temp folder.
+        Access file path by selecting WriteNode group, CTRL+Enter, update file
+        input
+        !!!
+
+        Opens Nuke, run publish on prepared workile.
+
+        Then checks content of DB (if subset, version, representations were
+        created.
+        Checks tmp folder if all expected files were published.
+
+        How to run:
+        (in cmd with activated {OPENPYPE_ROOT}/.venv)
+        {OPENPYPE_ROOT}/.venv/Scripts/python.exe {OPENPYPE_ROOT}/start.py
+        runtests ../tests/integration/hosts/nuke  # noqa: E501
+
+        To check log/errors from launched app's publish process keep PERSIST
+        to True and check `test_openpype.logs` collection.
+    """
+    TEST_FILES = [
+        ("1aQaKo3cF-fvbTfvODIRFMxgherjbJ4Ql",
+         "test_nuke_deadline_publish_in_nuke_prerender.zip", "")
+    ]
+
+    APP_GROUP = "nuke"
+
+    TIMEOUT = 180  # publish timeout
+
+    # could be overwritten by command line arguments
+    # keep empty to locate latest installed variant or explicit
+    APP_VARIANT = ""
+    PERSIST = False  # True - keep test_db, test_openpype, outputted test files
+    TEST_DATA_FOLDER = None
+
+    def test_db_asserts(self, dbcon, publish_finished):
+        """Host and input data dependent expected results in DB."""
+        print("test_db_asserts")
+        failures = []
+
+        failures.append(DBAssert.count_of_types(dbcon, "version", 2))
+
+        failures.append(
+            DBAssert.count_of_types(dbcon, "version", 0, name={"$ne": 1}))
+
+        # prerender has only default subset format `{family}{variant}`,
+        # Key01 is used variant
+        failures.append(
+            DBAssert.count_of_types(dbcon, "subset", 1,
+                                    name="prerenderKey01"))
+
+        failures.append(
+            DBAssert.count_of_types(dbcon, "subset", 1,
+                                    name="workfileTest_task"))
+
+        failures.append(
+            DBAssert.count_of_types(dbcon, "representation", 2))
+
+        additional_args = {"context.subset": "workfileTest_task",
+                           "context.ext": "nk"}
+        failures.append(
+            DBAssert.count_of_types(dbcon, "representation", 1,
+                                    additional_args=additional_args))
+
+        additional_args = {"context.subset": "prerenderKey01",
+                           "context.ext": "exr"}
+        failures.append(
+            DBAssert.count_of_types(dbcon, "representation", 1,
+                                    additional_args=additional_args))
+
+        # prerender doesn't have set creation of review by default
+        additional_args = {"context.subset": "prerenderKey01",
+                           "name": "thumbnail"}
+        failures.append(
+            DBAssert.count_of_types(dbcon, "representation", 0,
+                                    additional_args=additional_args))
+
+        additional_args = {"context.subset": "prerenderKey01",
+                           "name": "h264_mov"}
+        failures.append(
+            DBAssert.count_of_types(dbcon, "representation", 0,
+                                    additional_args=additional_args))
+
+        assert not any(failures)
+
+
+if __name__ == "__main__":
+    test_case = TestDeadlinePublishInNukePrerender()


### PR DESCRIPTION
## Changelog Description
`prerender` family was using wrong subset, same as `render` which should be different.

## Additional info
Added new test class added which covers default settings for `prererender`:
- default subset name template (without task)
- no reviews

## Testing notes:
1. create `prerender` instance in Nuke
2. publish via Deadline
3. it should create `prerender` folder in `publish` (without it it would create `render` folder, eg. subset/product)

