### PR TITLE
Bugfix: Houdini update defaults variable

### DIFF
--- a/openpype/hosts/houdini/plugins/create/create_arnold_ass.py
+++ b/openpype/hosts/houdini/plugins/create/create_arnold_ass.py
@@ -10,7 +10,6 @@ class CreateArnoldAss(plugin.HoudiniCreator):
     label = "Arnold ASS"
     family = "ass"
     icon = "magic"
-    defaults = ["Main"]
 
     # Default extension: `.ass` or `.ass.gz`
     ext = ".ass"

--- a/openpype/hosts/houdini/plugins/create/create_arnold_rop.py
+++ b/openpype/hosts/houdini/plugins/create/create_arnold_rop.py
@@ -9,7 +9,6 @@ class CreateArnoldRop(plugin.HoudiniCreator):
     label = "Arnold ROP"
     family = "arnold_rop"
     icon = "magic"
-    default_variants = ["Master"]
 
     # Default extension
     ext = "exr"

--- a/openpype/hosts/houdini/plugins/create/create_arnold_rop.py
+++ b/openpype/hosts/houdini/plugins/create/create_arnold_rop.py
@@ -9,7 +9,7 @@ class CreateArnoldRop(plugin.HoudiniCreator):
     label = "Arnold ROP"
     family = "arnold_rop"
     icon = "magic"
-    defaults = ["master"]
+    default_variants = ["master"]
 
     # Default extension
     ext = "exr"

--- a/openpype/hosts/houdini/plugins/create/create_arnold_rop.py
+++ b/openpype/hosts/houdini/plugins/create/create_arnold_rop.py
@@ -9,7 +9,7 @@ class CreateArnoldRop(plugin.HoudiniCreator):
     label = "Arnold ROP"
     family = "arnold_rop"
     icon = "magic"
-    default_variants = ["master"]
+    default_variants = ["Master"]
 
     # Default extension
     ext = "exr"

--- a/openpype/hosts/houdini/plugins/create/create_karma_rop.py
+++ b/openpype/hosts/houdini/plugins/create/create_karma_rop.py
@@ -11,7 +11,7 @@ class CreateKarmaROP(plugin.HoudiniCreator):
     label = "Karma ROP"
     family = "karma_rop"
     icon = "magic"
-    defaults = ["master"]
+    default_variants = ["master"]
 
     def create(self, subset_name, instance_data, pre_create_data):
         import hou  # noqa

--- a/openpype/hosts/houdini/plugins/create/create_karma_rop.py
+++ b/openpype/hosts/houdini/plugins/create/create_karma_rop.py
@@ -11,7 +11,7 @@ class CreateKarmaROP(plugin.HoudiniCreator):
     label = "Karma ROP"
     family = "karma_rop"
     icon = "magic"
-    default_variants = ["master"]
+    default_variants = ["Master"]
 
     def create(self, subset_name, instance_data, pre_create_data):
         import hou  # noqa

--- a/openpype/hosts/houdini/plugins/create/create_karma_rop.py
+++ b/openpype/hosts/houdini/plugins/create/create_karma_rop.py
@@ -11,7 +11,6 @@ class CreateKarmaROP(plugin.HoudiniCreator):
     label = "Karma ROP"
     family = "karma_rop"
     icon = "magic"
-    default_variants = ["Master"]
 
     def create(self, subset_name, instance_data, pre_create_data):
         import hou  # noqa

--- a/openpype/hosts/houdini/plugins/create/create_mantra_rop.py
+++ b/openpype/hosts/houdini/plugins/create/create_mantra_rop.py
@@ -11,7 +11,6 @@ class CreateMantraROP(plugin.HoudiniCreator):
     label = "Mantra ROP"
     family = "mantra_rop"
     icon = "magic"
-    default_variants = ["Master"]
 
     def create(self, subset_name, instance_data, pre_create_data):
         import hou  # noqa

--- a/openpype/hosts/houdini/plugins/create/create_mantra_rop.py
+++ b/openpype/hosts/houdini/plugins/create/create_mantra_rop.py
@@ -11,7 +11,7 @@ class CreateMantraROP(plugin.HoudiniCreator):
     label = "Mantra ROP"
     family = "mantra_rop"
     icon = "magic"
-    defaults = ["master"]
+    default_variants = ["master"]
 
     def create(self, subset_name, instance_data, pre_create_data):
         import hou  # noqa

--- a/openpype/hosts/houdini/plugins/create/create_mantra_rop.py
+++ b/openpype/hosts/houdini/plugins/create/create_mantra_rop.py
@@ -11,7 +11,7 @@ class CreateMantraROP(plugin.HoudiniCreator):
     label = "Mantra ROP"
     family = "mantra_rop"
     icon = "magic"
-    default_variants = ["master"]
+    default_variants = ["Master"]
 
     def create(self, subset_name, instance_data, pre_create_data):
         import hou  # noqa

--- a/openpype/hosts/houdini/plugins/create/create_redshift_rop.py
+++ b/openpype/hosts/houdini/plugins/create/create_redshift_rop.py
@@ -13,7 +13,7 @@ class CreateRedshiftROP(plugin.HoudiniCreator):
     label = "Redshift ROP"
     family = "redshift_rop"
     icon = "magic"
-    default_variants = ["master"]
+    default_variants = ["Master"]
     ext = "exr"
 
     def create(self, subset_name, instance_data, pre_create_data):

--- a/openpype/hosts/houdini/plugins/create/create_redshift_rop.py
+++ b/openpype/hosts/houdini/plugins/create/create_redshift_rop.py
@@ -13,7 +13,7 @@ class CreateRedshiftROP(plugin.HoudiniCreator):
     label = "Redshift ROP"
     family = "redshift_rop"
     icon = "magic"
-    defaults = ["master"]
+    default_variants = ["master"]
     ext = "exr"
 
     def create(self, subset_name, instance_data, pre_create_data):

--- a/openpype/hosts/houdini/plugins/create/create_redshift_rop.py
+++ b/openpype/hosts/houdini/plugins/create/create_redshift_rop.py
@@ -13,7 +13,6 @@ class CreateRedshiftROP(plugin.HoudiniCreator):
     label = "Redshift ROP"
     family = "redshift_rop"
     icon = "magic"
-    default_variants = ["Master"]
     ext = "exr"
 
     def create(self, subset_name, instance_data, pre_create_data):

--- a/openpype/hosts/houdini/plugins/create/create_vray_rop.py
+++ b/openpype/hosts/houdini/plugins/create/create_vray_rop.py
@@ -14,7 +14,7 @@ class CreateVrayROP(plugin.HoudiniCreator):
     label = "VRay ROP"
     family = "vray_rop"
     icon = "magic"
-    defaults = ["master"]
+    default_variants = ["master"]
 
     ext = "exr"
 

--- a/openpype/hosts/houdini/plugins/create/create_vray_rop.py
+++ b/openpype/hosts/houdini/plugins/create/create_vray_rop.py
@@ -14,8 +14,6 @@ class CreateVrayROP(plugin.HoudiniCreator):
     label = "VRay ROP"
     family = "vray_rop"
     icon = "magic"
-    default_variants = ["Master"]
-
     ext = "exr"
 
     def create(self, subset_name, instance_data, pre_create_data):

--- a/openpype/hosts/houdini/plugins/create/create_vray_rop.py
+++ b/openpype/hosts/houdini/plugins/create/create_vray_rop.py
@@ -14,7 +14,7 @@ class CreateVrayROP(plugin.HoudiniCreator):
     label = "VRay ROP"
     family = "vray_rop"
     icon = "magic"
-    default_variants = ["master"]
+    default_variants = ["Master"]
 
     ext = "exr"
 


### PR DESCRIPTION
## Changelog Description
So, something was forgotten while moving out from `LegacyCreator` to `NewCreator`  
`LegacyCreator` used `defaults` to list suggested subset names 
which was changed into `default_variants` in the the `NewCreator`
and setting `defaults` to any values has no effect! 

This update affects: 
- [x] Arnold ASS
- [x] Arnold ROP
- [x] Karma ROP
- [x] Mantra ROP
- [x] Redshift ROP
- [x] VRay ROP

## Additional info1
I have removed  `default_variants` which effectively set variants to `"Main"` as default, so no need to setting it explicitly.

## Additional info2
This bug is the same as #5368

## Testing notes:
1. open creator and check `Variants` menu
