### PR TITLE
Bugfix: Maya update default_variants variable

### DIFF
--- a/openpype/hosts/maya/plugins/create/create_model.py
+++ b/openpype/hosts/maya/plugins/create/create_model.py
@@ -12,7 +12,7 @@ class CreateModel(plugin.MayaCreator):
     label = "Model"
     family = "model"
     icon = "cube"
-    defaults = ["Main", "Proxy", "_MD", "_HD", "_LD"]
+    default_variants = ["Main", "Proxy", "_MD", "_HD", "_LD"]
 
     write_color_sets = False
     write_face_sets = False

--- a/openpype/hosts/maya/plugins/create/create_setdress.py
+++ b/openpype/hosts/maya/plugins/create/create_setdress.py
@@ -9,7 +9,7 @@ class CreateSetDress(plugin.MayaCreator):
     label = "Set Dress"
     family = "setdress"
     icon = "cubes"
-    defaults = ["Main", "Anim"]
+    default_variants = ["Main", "Anim"]
 
     def get_instance_attr_defs(self):
         return [


### PR DESCRIPTION
## Changelog Description
So, something was forgotten while moving out from `LegacyCreator` to `NewCreator`  
`LegacyCreator` used `defaults` to list suggested subset names 
which was changed into `default_variants` in the the `NewCreator`
and setting `defaults` to any values has no effect! 

This update affects: 
- [x] Model
- [x] Set Dress

## Additional info
This bug is the same as #5367

## Testing notes:
1. open creator and check `Variants` menu
