### PR TITLE
Publisher: Fix create/publish animation

### DIFF
--- a/openpype/tools/publisher/widgets/overview_widget.py
+++ b/openpype/tools/publisher/widgets/overview_widget.py
@@ -161,14 +161,13 @@ class OverviewWidget(QtWidgets.QFrame):
         self._change_anim = change_anim
 
         # Start in create mode
-        self._create_widget_policy = create_widget.sizePolicy()
-        self._subset_views_widget_policy = subset_views_widget.sizePolicy()
-        self._subset_attributes_wrap_policy = (
-            subset_attributes_wrap.sizePolicy()
-        )
-        self._max_widget_width = None
         self._current_state = "create"
         subset_attributes_wrap.setVisible(False)
+
+    def make_sure_animation_is_finished(self):
+        if self._change_anim.state() == QtCore.QAbstractAnimation.Running:
+            self._change_anim.stop()
+            self._on_change_anim_finished()
 
     def set_state(self, new_state, animate):
         if new_state == self._current_state:
@@ -176,17 +175,9 @@ class OverviewWidget(QtWidgets.QFrame):
 
         self._current_state = new_state
 
-        anim_is_running = (
-            self._change_anim.state() == QtCore.QAbstractAnimation.Running
-        )
         if not animate:
-            self._change_visibility_for_state()
-            if anim_is_running:
-                self._change_anim.stop()
+            self.make_sure_animation_is_finished()
             return
-
-        if self._max_widget_width is None:
-            self._max_widget_width = self._subset_views_widget.maximumWidth()
 
         if new_state == "create":
             direction = QtCore.QAbstractAnimation.Backward
@@ -194,11 +185,38 @@ class OverviewWidget(QtWidgets.QFrame):
             direction = QtCore.QAbstractAnimation.Forward
         self._change_anim.setDirection(direction)
 
-        if not anim_is_running:
-            view_width = self._subset_views_widget.width()
-            self._subset_views_widget.setMinimumWidth(view_width)
-            self._subset_views_widget.setMaximumWidth(view_width)
+        if (
+            self._change_anim.state() != QtCore.QAbstractAnimation.Running
+        ):
+            self._start_animation()
+
+    def _start_animation(self):
+        views_geo = self._subset_views_widget.geometry()
+        layout_spacing = self._subset_content_layout.spacing()
+        if self._create_widget.isVisible():
+            create_geo = self._create_widget.geometry()
+            subset_geo = QtCore.QRect(create_geo)
+            subset_geo.moveTop(views_geo.top())
+            subset_geo.moveLeft(views_geo.right() + layout_spacing)
+            self._subset_attributes_wrap.setVisible(True)
+
+        elif self._subset_attributes_wrap.isVisible():
+            subset_geo = self._subset_attributes_wrap.geometry()
+            create_geo = QtCore.QRect(subset_geo)
+            create_geo.moveTop(views_geo.top())
+            create_geo.moveRight(views_geo.left() - layout_spacing)
+            self._create_widget.setVisible(True)
+        else:
             self._change_anim.start()
+            return
+
+        while self._subset_content_layout.count():
+            self._subset_content_layout.takeAt(0)
+        self._subset_views_widget.setGeometry(views_geo)
+        self._create_widget.setGeometry(create_geo)
+        self._subset_attributes_wrap.setGeometry(subset_geo)
+
+        self._change_anim.start()
 
     def get_subset_views_geo(self):
         parent = self._subset_views_widget.parent()
@@ -281,41 +299,40 @@ class OverviewWidget(QtWidgets.QFrame):
     def _on_change_anim(self, value):
         self._create_widget.setVisible(True)
         self._subset_attributes_wrap.setVisible(True)
-        width = (
-            self._subset_content_widget.width()
-            - (
-                self._subset_views_widget.width()
-                + (self._subset_content_layout.spacing() * 2)
-            )
+        layout_spacing = self._subset_content_layout.spacing()
+
+        content_width = (
+            self._subset_content_widget.width() - (layout_spacing * 2)
         )
+        views_width = max(
+            content_width * 0.3,
+            self._subset_views_widget.minimumWidth()
+        )
+        width = content_width - views_width
         subset_attrs_width = int((float(width) / self.anim_end_value) * value)
         if subset_attrs_width > width:
             subset_attrs_width = width
 
         create_width = width - subset_attrs_width
 
-        self._create_widget.setMinimumWidth(create_width)
-        self._create_widget.setMaximumWidth(create_width)
-        self._subset_attributes_wrap.setMinimumWidth(subset_attrs_width)
-        self._subset_attributes_wrap.setMaximumWidth(subset_attrs_width)
+        views_geo = self._subset_views_widget.geometry()
+        views_geo.moveLeft(create_width + layout_spacing)
+        views_geo.setWidth(views_width)
+        self._subset_views_widget.setGeometry(views_geo)
+
+        create_geo = self._create_widget.geometry()
+        create_geo.moveRight(views_geo.left() - layout_spacing)
+        self._create_widget.setGeometry(create_geo)
+
+        subset_attrs_geo = self._subset_attributes_wrap.geometry()
+        subset_attrs_geo.moveLeft(views_geo.right() + layout_spacing)
+        self._subset_attributes_wrap.setGeometry(subset_attrs_geo)
 
     def _on_change_anim_finished(self):
         self._change_visibility_for_state()
-        self._create_widget.setMinimumWidth(0)
-        self._create_widget.setMaximumWidth(self._max_widget_width)
-        self._subset_attributes_wrap.setMinimumWidth(0)
-        self._subset_attributes_wrap.setMaximumWidth(self._max_widget_width)
-        self._subset_views_widget.setMinimumWidth(0)
-        self._subset_views_widget.setMaximumWidth(self._max_widget_width)
-        self._create_widget.setSizePolicy(
-            self._create_widget_policy
-        )
-        self._subset_attributes_wrap.setSizePolicy(
-            self._subset_attributes_wrap_policy
-        )
-        self._subset_views_widget.setSizePolicy(
-            self._subset_views_widget_policy
-        )
+        self._subset_content_layout.addWidget(self._create_widget, 7)
+        self._subset_content_layout.addWidget(self._subset_views_widget, 3)
+        self._subset_content_layout.addWidget(self._subset_attributes_wrap, 7)
 
     def _change_visibility_for_state(self):
         self._create_widget.setVisible(

--- a/openpype/tools/publisher/window.py
+++ b/openpype/tools/publisher/window.py
@@ -634,16 +634,7 @@ class PublisherWindow(QtWidgets.QDialog):
         if old_tab == "details":
             self._publish_details_widget.close_details_popup()
 
-        if new_tab in ("create", "publish"):
-            animate = True
-            if old_tab not in ("create", "publish"):
-                animate = False
-                self._content_stacked_layout.setCurrentWidget(
-                    self._overview_widget
-                )
-            self._overview_widget.set_state(new_tab, animate)
-
-        elif new_tab == "details":
+        if new_tab == "details":
             self._content_stacked_layout.setCurrentWidget(
                 self._publish_details_widget
             )
@@ -653,6 +644,21 @@ class PublisherWindow(QtWidgets.QDialog):
             self._content_stacked_layout.setCurrentWidget(
                 self._report_widget
             )
+
+        old_on_overview = old_tab in ("create", "publish")
+        if new_tab in ("create", "publish"):
+            self._content_stacked_layout.setCurrentWidget(
+                self._overview_widget
+            )
+            # Overview state is animated only when switching between
+            #   'create' and 'publish' tab
+            self._overview_widget.set_state(new_tab, old_on_overview)
+
+        elif old_on_overview:
+            # Make sure animation finished if previous tab was 'create'
+            #   or 'publish'. That is just for safety to avoid stuck animation
+            #   when user clicks too fast.
+            self._overview_widget.make_sure_animation_is_finished()
 
         is_create = new_tab == "create"
         if is_create:


### PR DESCRIPTION
## Changelog Description
Use geometry movement instead of changing min/max width.

## Additional info
When animation starts the widgets are removed from parent layout to be able position them freely. When animation is finished they're locked back to layout. The ratio of widgets widths should stay the same.

This may be safer approach how the animation should happen, but there might appear artefacts outside of window borders if Qt in a DCC does not have set window clipping properly (didn't happen to me).

## Testing notes:
1. Run host of your choice (maya, nuke, houdini, other DCCs with their Qt)
2. Open publisher
3. Swap between create, publish and other tabs

Resolves https://github.com/ynput/OpenPype/issues/5328