### PR TITLE
Unreal: Move unreal splash screen to unreal

### DIFF
--- a/openpype/hosts/unreal/hooks/pre_workfile_preparation.py
+++ b/openpype/hosts/unreal/hooks/pre_workfile_preparation.py
@@ -3,21 +3,21 @@
 import os
 import copy
 from pathlib import Path
-from openpype.widgets.splash_screen import SplashScreen
+
 from qtpy import QtCore
-from openpype.hosts.unreal.ue_workers import (
-    UEProjectGenerationWorker,
-    UEPluginInstallWorker
-)
 
 from openpype import resources
 from openpype.lib import (
     PreLaunchHook,
     ApplicationLaunchFailed,
-    ApplicationNotFound,
 )
 from openpype.pipeline.workfile import get_workfile_template_key
 import openpype.hosts.unreal.lib as unreal_lib
+from openpype.hosts.unreal.ue_workers import (
+    UEProjectGenerationWorker,
+    UEPluginInstallWorker
+)
+from openpype.hosts.unreal.ui import SplashScreen
 
 
 class UnrealPrelaunchHook(PreLaunchHook):

--- a/openpype/hosts/unreal/ui/__init__.py
+++ b/openpype/hosts/unreal/ui/__init__.py
@@ -1,0 +1,5 @@
+from .splash_screen import SplashScreen
+
+__all__ = (
+    "SplashScreen",
+)

--- a/openpype/hosts/unreal/ui/splash_screen.py
+++ b/openpype/hosts/unreal/ui/splash_screen.py
@@ -1,6 +1,5 @@
 from qtpy import QtWidgets, QtCore, QtGui
 from openpype import style, resources
-from igniter.nice_progress_bar import NiceProgressBar
 
 
 class SplashScreen(QtWidgets.QDialog):
@@ -143,7 +142,7 @@ class SplashScreen(QtWidgets.QDialog):
         button_layout.addWidget(self.close_btn)
 
         # Progress Bar
-        self.progress_bar = NiceProgressBar()
+        self.progress_bar = QtWidgets.QProgressBar()
         self.progress_bar.setValue(0)
         self.progress_bar.setAlignment(QtCore.Qt.AlignTop)
 


### PR DESCRIPTION
## Changelog Description
Moved splash screen code to unreal integration and removed import from Igniter.

## Additional info
The `NiceProgress` is not nice if igniters stylesheest are not used. The changes in progress bar don't add any visual value.
