### PR TITLE
Nuke: returned not cleaning of renders folder on the farm

### DIFF
--- a/openpype/hosts/nuke/plugins/publish/collect_writes.py
+++ b/openpype/hosts/nuke/plugins/publish/collect_writes.py
@@ -193,4 +193,10 @@ class CollectNukeWrites(pyblish.api.InstancePlugin,
         if not instance.data.get("review"):
             instance.data["useSequenceForReview"] = False
 
+        # TODO temporarily set stagingDir as persistent for backward
+        # compatibility. This is mainly focused on `renders`folders which
+        # were previously not cleaned up (and could be used in read notes)
+        # this logic should be removed and replaced with custom staging dir
+        instance.data["stagingDir_persistent"] = True
+
         self.log.debug("instance.data: {}".format(pformat(instance.data)))

--- a/openpype/pipeline/farm/pyblish_functions.py
+++ b/openpype/pipeline/farm/pyblish_functions.py
@@ -268,8 +268,8 @@ def create_skeleton_instance(
     instance_skeleton_data["representations"] = []
     instance_skeleton_data["representations"] += representations
 
-    if instance.data.get("stagingDir_persistent"):
-        instance_skeleton_data["stagingDir_persistent"] = True
+    persistent = instance.data.get("stagingDir_persistent") is True
+    instance_skeleton_data["stagingDir_persistent"] = persistent
 
     return instance_skeleton_data
 

--- a/openpype/pipeline/farm/pyblish_functions.py
+++ b/openpype/pipeline/farm/pyblish_functions.py
@@ -268,6 +268,9 @@ def create_skeleton_instance(
     instance_skeleton_data["representations"] = []
     instance_skeleton_data["representations"] += representations
 
+    if instance.data.get("stagingDir_persistent"):
+        instance_skeleton_data["stagingDir_persistent"] = True
+
     return instance_skeleton_data
 
 

--- a/openpype/pipeline/publish/lib.py
+++ b/openpype/pipeline/publish/lib.py
@@ -981,7 +981,7 @@ def add_repre_files_for_cleanup(instance, repre):
     """
     files = repre["files"]
     staging_dir = repre.get("stagingDir")
-    if not staging_dir:
+    if not staging_dir or instance.data.get("stagingDir_persistent"):
         return
 
     if isinstance(files, str):


### PR DESCRIPTION
## Changelog Description
Previous PR enabled explicit cleanup of `renders` folder after farm publishing. This is not matching customer's workflows. Customer wants to have access to files in `renders` folder and potentially redo some frames for long frame sequences.

This PR extends logic of marking rendered files for deletion only if instance doesn't have `stagingDir_persistent`.
For backwards compatibility all Nuke instances have `stagingDir_persistent` set to True, eg. `renders` folder won't be cleaned after farm publish.

## Additional info
Whenever Custom staging directories are fully implemented in Nuke, this hardcoded value could be removed and behavior should be more controllable by profiles in `project_settings/global/tools/publish/custom_staging_dir_profiles`. No additional Settings were added/modified as Custom Staging implementation should take care of it in more transparent way. (There should be new default added to mark all stagingDir as persistent for all tasks in Nuke, potentially new template for `renders` folder created.) 
It could be then decided that some staging dirs should be persistent for some tasks, or cleaned up for all tasks etc.

## Testing notes:
1. Publish from Nuke via DL
2. Check `renders` in workarea for rendered files
