### PR TITLE
Nuke: loading sequences is working

### DIFF
--- a/openpype/hosts/nuke/plugins/load/load_clip.py
+++ b/openpype/hosts/nuke/plugins/load/load_clip.py
@@ -91,14 +91,14 @@ class LoadClip(plugin.NukeLoader):
         # reset container id so it is always unique for each instance
         self.reset_container_id()
 
-        self.log.warning(self.extensions)
-
         is_sequence = len(representation["files"]) > 1
 
         if is_sequence:
-            representation = self._representation_with_hash_in_frame(
-                representation
+            context["representation"] = \
+                self._representation_with_hash_in_frame(
+                    representation
             )
+
         filepath = self.filepath_from_context(context)
         filepath = filepath.replace("\\", "/")
         self.log.debug("_ filepath: {}".format(filepath))
@@ -260,6 +260,7 @@ class LoadClip(plugin.NukeLoader):
             representation = self._representation_with_hash_in_frame(
                 representation
             )
+
         filepath = get_representation_path(representation).replace("\\", "/")
         self.log.debug("_ filepath: {}".format(filepath))
 


### PR DESCRIPTION
## Changelog Description
Loading image sequences was broken after the latest release, version 3.16. However, I am pleased to inform you that it is now functioning as expected.

## Testing notes:
1. open Nuke in your testing project
2. load any image sequence product version
3. read node should be working well with #### for sequence
