### PR TITLE
Unreal: Fix Unreal build script

### DIFF
--- a/openpype/hosts/unreal/addon.py
+++ b/openpype/hosts/unreal/addon.py
@@ -12,6 +12,11 @@ class UnrealAddon(OpenPypeModule, IHostAddon):
     def initialize(self, module_settings):
         self.enabled = True
 
+    def get_global_environments(self):
+        return {
+            "AYON_UNREAL_ROOT": UNREAL_ROOT_DIR,
+        }
+
     def add_implementation_envs(self, env, app):
         """Modify environments to contain all required for implementation."""
         # Set AYON_UNREAL_PLUGIN required for Unreal implementation


### PR DESCRIPTION
## Changelog Description
Define 'AYON_UNREAL_ROOT' environment variable in unreal addon.

## Additional info
The scripts are using `AYON_ROOT` environment variable which is not available in OpenPype and does not point to root of openpype addon in AYON.

Note: We have to first merge integration submodule before merging this PR.

## TODO
- [ ] Update unreal integration submodule when [this PR](https://github.com/ynput/ayon-unreal-plugin/pull/2) is merged.

## Testing notes:
1. Checkout unreal integration submodule to [this PR](https://github.com/ynput/ayon-unreal-plugin/pull/2)
2. Launch unreal
