### PR TITLE
Bugfix: Houdini abc validator error message

### DIFF
--- a/openpype/hosts/houdini/plugins/publish/validate_primitive_hierarchy_paths.py
+++ b/openpype/hosts/houdini/plugins/publish/validate_primitive_hierarchy_paths.py
@@ -32,8 +32,9 @@ class ValidatePrimitiveHierarchyPaths(pyblish.api.InstancePlugin):
     def process(self, instance):
         invalid = self.get_invalid(instance)
         if invalid:
+            nodes = [n.path() for n in invalid]
             raise PublishValidationError(
-                "See log for details. " "Invalid nodes: {0}".format(invalid),
+                "See log for details. " "Invalid nodes: {0}".format(nodes),
                 title=self.label
             )
 


### PR DESCRIPTION
## Changelog Description

When ABC path validator fails, it prints node objects not node paths or names

This bug happened because of updating `get_invalid` method to return nodes instead of node paths 

Before
![image](https://github.com/ynput/OpenPype/assets/20871534/1e0d99ab-f6ef-4787-ab25-448a490e0e8f)


After 
![image](https://github.com/ynput/OpenPype/assets/20871534/b9305e12-b3f7-4581-aea4-42f1c1b73b57)

## Additional Info
`get_invalid` method should return a list of nodes objects because this is what `get invalid action` expects. 

## Testing notes:
1. create a geo without path attr
1. create alembic pointcache instance
2. check error message
