### PR TITLE
Applications: Use prelaunch hooks to extract environments

### DIFF
--- a/openpype/hooks/pre_add_last_workfile_arg.py
+++ b/openpype/hooks/pre_add_last_workfile_arg.py
@@ -1,6 +1,6 @@
 import os
 
-from openpype.lib import PreLaunchHook
+from openpype.lib.applications import PreLaunchHook, LaunchTypes
 
 
 class AddLastWorkfileToLaunchArgs(PreLaunchHook):
@@ -28,6 +28,7 @@ class AddLastWorkfileToLaunchArgs(PreLaunchHook):
         "substancepainter",
         "aftereffects"
     ]
+    launch_types = {LaunchTypes.local}
 
     def execute(self):
         if not self.data.get("start_last_workfile"):

--- a/openpype/hooks/pre_copy_template_workfile.py
+++ b/openpype/hooks/pre_copy_template_workfile.py
@@ -1,7 +1,7 @@
 import os
 import shutil
-from openpype.lib import PreLaunchHook
 from openpype.settings import get_project_settings
+from openpype.lib.applications import PreLaunchHook, LaunchTypes
 from openpype.pipeline.workfile import (
     get_custom_workfile_template,
     get_custom_workfile_template_by_string_context
@@ -20,6 +20,7 @@ class CopyTemplateWorkfile(PreLaunchHook):
     # Before `AddLastWorkfileToLaunchArgs`
     order = 0
     app_groups = ["blender", "photoshop", "tvpaint", "aftereffects"]
+    launch_types = {LaunchTypes.local}
 
     def execute(self):
         """Check if can copy template for context and do it if possible.

--- a/openpype/hooks/pre_create_extra_workdir_folders.py
+++ b/openpype/hooks/pre_create_extra_workdir_folders.py
@@ -1,5 +1,5 @@
 import os
-from openpype.lib import PreLaunchHook
+from openpype.lib.applications import PreLaunchHook, LaunchTypes
 from openpype.pipeline.workfile import create_workdir_extra_folders
 
 
@@ -14,6 +14,7 @@ class CreateWorkdirExtraFolders(PreLaunchHook):
 
     # Execute after workfile template copy
     order = 15
+    launch_types = {LaunchTypes.local}
 
     def execute(self):
         if not self.application.is_host:

--- a/openpype/hooks/pre_foundry_apps.py
+++ b/openpype/hooks/pre_foundry_apps.py
@@ -1,5 +1,5 @@
 import subprocess
-from openpype.lib import PreLaunchHook
+from openpype.lib.applications import PreLaunchHook, LaunchTypes
 
 
 class LaunchFoundryAppsWindows(PreLaunchHook):
@@ -15,6 +15,7 @@ class LaunchFoundryAppsWindows(PreLaunchHook):
     order = 1000
     app_groups = ["nuke", "nukeassist", "nukex", "hiero", "nukestudio"]
     platforms = ["windows"]
+    launch_types = {LaunchTypes.local}
 
     def execute(self):
         # Change `creationflags` to CREATE_NEW_CONSOLE

--- a/openpype/hooks/pre_global_host_data.py
+++ b/openpype/hooks/pre_global_host_data.py
@@ -1,5 +1,5 @@
 from openpype.client import get_project, get_asset_by_name
-from openpype.lib import (
+from openpype.lib.applications import (
     PreLaunchHook,
     EnvironmentPrepData,
     prepare_app_environments,
@@ -10,6 +10,7 @@ from openpype.pipeline import Anatomy
 
 class GlobalHostDataHook(PreLaunchHook):
     order = -100
+    launch_types = set()
 
     def execute(self):
         """Prepare global objects to `data` that will be used for sure."""

--- a/openpype/hooks/pre_mac_launch.py
+++ b/openpype/hooks/pre_mac_launch.py
@@ -1,5 +1,5 @@
 import os
-from openpype.lib import PreLaunchHook
+from openpype.lib.applications import PreLaunchHook, LaunchTypes
 
 
 class LaunchWithTerminal(PreLaunchHook):
@@ -13,6 +13,7 @@ class LaunchWithTerminal(PreLaunchHook):
     order = 1000
 
     platforms = ["darwin"]
+    launch_types = {LaunchTypes.local}
 
     def execute(self):
         executable = str(self.launch_context.executable)

--- a/openpype/hooks/pre_non_python_host_launch.py
+++ b/openpype/hooks/pre_non_python_host_launch.py
@@ -1,9 +1,7 @@
 import os
 
-from openpype.lib import (
-    PreLaunchHook,
-    get_openpype_execute_args
-)
+from openpype.lib import get_openpype_execute_args
+from openpype.lib import PreLaunchHook, LaunchTypes
 from openpype.lib.applications import get_non_python_host_kwargs
 
 from openpype import PACKAGE_DIR as OPENPYPE_DIR
@@ -19,6 +17,7 @@ class NonPythonHostHook(PreLaunchHook):
     app_groups = ["harmony", "photoshop", "aftereffects"]
 
     order = 20
+    launch_types = {LaunchTypes.local}
 
     def execute(self):
         # Pop executable
@@ -54,4 +53,3 @@ class NonPythonHostHook(PreLaunchHook):
 
         self.launch_context.kwargs = \
             get_non_python_host_kwargs(self.launch_context.kwargs)
-

--- a/openpype/hooks/pre_non_python_host_launch.py
+++ b/openpype/hooks/pre_non_python_host_launch.py
@@ -1,8 +1,11 @@
 import os
 
 from openpype.lib import get_openpype_execute_args
-from openpype.lib import PreLaunchHook, LaunchTypes
-from openpype.lib.applications import get_non_python_host_kwargs
+from openpype.lib.applications import (
+    get_non_python_host_kwargs,
+    PreLaunchHook,
+    LaunchTypes,
+)
 
 from openpype import PACKAGE_DIR as OPENPYPE_DIR
 

--- a/openpype/hooks/pre_ocio_hook.py
+++ b/openpype/hooks/pre_ocio_hook.py
@@ -22,6 +22,7 @@ class OCIOEnvHook(PreLaunchHook):
         "hiero",
         "resolve"
     ]
+    launch_types = set()
 
     def execute(self):
         """Hook entry method."""

--- a/openpype/hosts/blender/hooks/pre_add_run_python_script_arg.py
+++ b/openpype/hosts/blender/hooks/pre_add_run_python_script_arg.py
@@ -1,6 +1,6 @@
 from pathlib import Path
 
-from openpype.lib import PreLaunchHook
+from openpype.lib.applications import PreLaunchHook, LaunchTypes
 
 
 class AddPythonScriptToLaunchArgs(PreLaunchHook):
@@ -8,9 +8,8 @@ class AddPythonScriptToLaunchArgs(PreLaunchHook):
 
     # Append after file argument
     order = 15
-    app_groups = [
-        "blender",
-    ]
+    app_groups = {"blender"}
+    launch_types = {LaunchTypes.local}
 
     def execute(self):
         if not self.launch_context.data.get("python_scripts"):

--- a/openpype/hosts/blender/hooks/pre_pyside_install.py
+++ b/openpype/hosts/blender/hooks/pre_pyside_install.py
@@ -2,7 +2,7 @@ import os
 import re
 import subprocess
 from platform import system
-from openpype.lib import PreLaunchHook
+from openpype.lib.applications import PreLaunchHook, LaunchTypes
 
 
 class InstallPySideToBlender(PreLaunchHook):
@@ -16,7 +16,8 @@ class InstallPySideToBlender(PreLaunchHook):
     blender's python packages.
     """
 
-    app_groups = ["blender"]
+    app_groups = {"blender"}
+    launch_types = {LaunchTypes.local}
 
     def execute(self):
         # Prelaunch hook is not crucial

--- a/openpype/hosts/blender/hooks/pre_windows_console.py
+++ b/openpype/hosts/blender/hooks/pre_windows_console.py
@@ -1,5 +1,5 @@
 import subprocess
-from openpype.lib import PreLaunchHook
+from openpype.lib.applications import PreLaunchHook, LaunchTypes
 
 
 class BlenderConsoleWindows(PreLaunchHook):
@@ -15,6 +15,7 @@ class BlenderConsoleWindows(PreLaunchHook):
     order = 1000
     app_groups = ["blender"]
     platforms = ["windows"]
+    launch_types = {LaunchTypes.local}
 
     def execute(self):
         # Change `creationflags` to CREATE_NEW_CONSOLE

--- a/openpype/hosts/celaction/hooks/pre_celaction_setup.py
+++ b/openpype/hosts/celaction/hooks/pre_celaction_setup.py
@@ -2,7 +2,8 @@ import os
 import shutil
 import winreg
 import subprocess
-from openpype.lib import PreLaunchHook, get_openpype_execute_args
+from openpype.lib import get_openpype_execute_args
+from openpype.lib.applications import PreLaunchHook, LaunchTypes
 from openpype.hosts.celaction import scripts
 
 CELACTION_SCRIPTS_DIR = os.path.dirname(
@@ -16,6 +17,7 @@ class CelactionPrelaunchHook(PreLaunchHook):
     """
     app_groups = ["celaction"]
     platforms = ["windows"]
+    launch_types = {LaunchTypes.local}
 
     def execute(self):
         asset_doc = self.data["asset_doc"]

--- a/openpype/hosts/flame/hooks/pre_flame_setup.py
+++ b/openpype/hosts/flame/hooks/pre_flame_setup.py
@@ -6,13 +6,10 @@ import socket
 from pprint import pformat
 
 from openpype.lib import (
-    PreLaunchHook,
     get_openpype_username,
     run_subprocess,
 )
-from openpype.lib.applications import (
-    ApplicationLaunchFailed
-)
+from openpype.lib.applications import PreLaunchHook, LaunchTypes
 from openpype.hosts import flame as opflame
 
 
@@ -27,6 +24,7 @@ class FlamePrelaunch(PreLaunchHook):
 
     wtc_script_path = os.path.join(
         opflame.HOST_DIR, "api", "scripts", "wiretap_com.py")
+    launch_types = {LaunchTypes.local}
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)

--- a/openpype/hosts/fusion/hooks/pre_fusion_profile_hook.py
+++ b/openpype/hosts/fusion/hooks/pre_fusion_profile_hook.py
@@ -2,11 +2,15 @@ import os
 import shutil
 import platform
 from pathlib import Path
-from openpype.lib import PreLaunchHook, ApplicationLaunchFailed
 from openpype.hosts.fusion import (
     FUSION_HOST_DIR,
     FUSION_VERSIONS_DICT,
     get_fusion_version,
+)
+from openpype.lib.applications import (
+    PreLaunchHook,
+    LaunchTypes,
+    ApplicationLaunchFailed,
 )
 
 
@@ -23,6 +27,7 @@ class FusionCopyPrefsPrelaunch(PreLaunchHook):
 
     app_groups = ["fusion"]
     order = 2
+    launch_types = {LaunchTypes.local}
 
     def get_fusion_profile_name(self, profile_version) -> str:
         # Returns 'Default', unless FUSION16_PROFILE is set

--- a/openpype/hosts/fusion/hooks/pre_fusion_setup.py
+++ b/openpype/hosts/fusion/hooks/pre_fusion_setup.py
@@ -1,5 +1,9 @@
 import os
-from openpype.lib import PreLaunchHook, ApplicationLaunchFailed
+from openpype.lib.applications import (
+    PreLaunchHook,
+    LaunchTypes,
+    ApplicationLaunchFailed,
+)
 from openpype.hosts.fusion import (
     FUSION_HOST_DIR,
     FUSION_VERSIONS_DICT,
@@ -19,6 +23,7 @@ class FusionPrelaunch(PreLaunchHook):
 
     app_groups = ["fusion"]
     order = 1
+    launch_types = {LaunchTypes.local}
 
     def execute(self):
         # making sure python 3 is installed at provided path

--- a/openpype/hosts/houdini/hooks/set_paths.py
+++ b/openpype/hosts/houdini/hooks/set_paths.py
@@ -1,4 +1,4 @@
-from openpype.lib import PreLaunchHook
+from openpype.lib.applications import PreLaunchHook, LaunchTypes
 
 
 class SetPath(PreLaunchHook):
@@ -7,6 +7,7 @@ class SetPath(PreLaunchHook):
     Hook `GlobalHostDataHook` must be executed before this hook.
     """
     app_groups = ["houdini"]
+    launch_types = {LaunchTypes.local}
 
     def execute(self):
         workdir = self.launch_context.env.get("AVALON_WORKDIR", "")

--- a/openpype/hosts/max/hooks/force_startup_script.py
+++ b/openpype/hosts/max/hooks/force_startup_script.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 """Pre-launch to force 3ds max startup script."""
-from openpype.lib import PreLaunchHook
 import os
+from openpype.lib.applications import PreLaunchHook, LaunchTypes
 
 
 class ForceStartupScript(PreLaunchHook):
@@ -15,6 +15,7 @@ class ForceStartupScript(PreLaunchHook):
     """
     app_groups = ["3dsmax"]
     order = 11
+    launch_types = {LaunchTypes.local}
 
     def execute(self):
         startup_args = [

--- a/openpype/hosts/max/hooks/inject_python.py
+++ b/openpype/hosts/max/hooks/inject_python.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 """Pre-launch hook to inject python environment."""
-from openpype.lib import PreLaunchHook
 import os
+from openpype.lib.applications import PreLaunchHook, LaunchTypes
 
 
 class InjectPythonPath(PreLaunchHook):
@@ -14,6 +14,7 @@ class InjectPythonPath(PreLaunchHook):
     Hook `GlobalHostDataHook` must be executed before this hook.
     """
     app_groups = ["3dsmax"]
+    launch_types = {LaunchTypes.local}
 
     def execute(self):
         self.launch_context.env["MAX_PYTHONPATH"] = os.environ["PYTHONPATH"]

--- a/openpype/hosts/max/hooks/set_paths.py
+++ b/openpype/hosts/max/hooks/set_paths.py
@@ -1,4 +1,4 @@
-from openpype.lib import PreLaunchHook
+from openpype.lib.applications import PreLaunchHook, LaunchTypes
 
 
 class SetPath(PreLaunchHook):
@@ -7,6 +7,7 @@ class SetPath(PreLaunchHook):
     Hook `GlobalHostDataHook` must be executed before this hook.
     """
     app_groups = ["max"]
+    launch_types = {LaunchTypes.local}
 
     def execute(self):
         workdir = self.launch_context.env.get("AVALON_WORKDIR", "")

--- a/openpype/hosts/maya/hooks/pre_auto_load_plugins.py
+++ b/openpype/hosts/maya/hooks/pre_auto_load_plugins.py
@@ -1,4 +1,4 @@
-from openpype.lib import PreLaunchHook
+from openpype.lib.applications import PreLaunchHook, LaunchTypes
 
 
 class MayaPreAutoLoadPlugins(PreLaunchHook):
@@ -7,6 +7,7 @@ class MayaPreAutoLoadPlugins(PreLaunchHook):
     # Before AddLastWorkfileToLaunchArgs
     order = 9
     app_groups = ["maya"]
+    launch_types = {LaunchTypes.local}
 
     def execute(self):
 

--- a/openpype/hosts/maya/hooks/pre_copy_mel.py
+++ b/openpype/hosts/maya/hooks/pre_copy_mel.py
@@ -1,4 +1,4 @@
-from openpype.lib import PreLaunchHook
+from openpype.lib.applications import PreLaunchHook, LaunchTypes
 from openpype.hosts.maya.lib import create_workspace_mel
 
 
@@ -8,6 +8,7 @@ class PreCopyMel(PreLaunchHook):
     Hook `GlobalHostDataHook` must be executed before this hook.
     """
     app_groups = ["maya"]
+    launch_types = {LaunchTypes.local}
 
     def execute(self):
         project_doc = self.data["project_doc"]

--- a/openpype/hosts/maya/hooks/pre_open_workfile_post_initialization.py
+++ b/openpype/hosts/maya/hooks/pre_open_workfile_post_initialization.py
@@ -1,4 +1,4 @@
-from openpype.lib import PreLaunchHook
+from openpype.lib.applications import PreLaunchHook, LaunchTypes
 
 
 class MayaPreOpenWorkfilePostInitialization(PreLaunchHook):
@@ -7,6 +7,7 @@ class MayaPreOpenWorkfilePostInitialization(PreLaunchHook):
     # Before AddLastWorkfileToLaunchArgs.
     order = 9
     app_groups = ["maya"]
+    launch_types = {LaunchTypes.local}
 
     def execute(self):
 

--- a/openpype/hosts/nuke/hooks/pre_nukeassist_setup.py
+++ b/openpype/hosts/nuke/hooks/pre_nukeassist_setup.py
@@ -6,6 +6,7 @@ class PrelaunchNukeAssistHook(PreLaunchHook):
     Adding flag when nukeassist
     """
     app_groups = ["nukeassist"]
+    launch_types = set()
 
     def execute(self):
         self.launch_context.env["NUKEASSIST"] = "1"

--- a/openpype/hosts/nuke/hooks/pre_nukeassist_setup.py
+++ b/openpype/hosts/nuke/hooks/pre_nukeassist_setup.py
@@ -1,4 +1,4 @@
-from openpype.lib import PreLaunchHook
+from openpype.lib.applications import PreLaunchHook
 
 
 class PrelaunchNukeAssistHook(PreLaunchHook):

--- a/openpype/hosts/resolve/hooks/pre_resolve_last_workfile.py
+++ b/openpype/hosts/resolve/hooks/pre_resolve_last_workfile.py
@@ -1,5 +1,5 @@
 import os
-from openpype.lib import PreLaunchHook
+from openpype.lib.applications import PreLaunchHook, LaunchTypes
 
 
 class PreLaunchResolveLastWorkfile(PreLaunchHook):
@@ -10,6 +10,7 @@ class PreLaunchResolveLastWorkfile(PreLaunchHook):
     """
     order = 10
     app_groups = ["resolve"]
+    launch_types = {LaunchTypes.local}
 
     def execute(self):
         if not self.data.get("start_last_workfile"):

--- a/openpype/hosts/resolve/hooks/pre_resolve_setup.py
+++ b/openpype/hosts/resolve/hooks/pre_resolve_setup.py
@@ -1,7 +1,7 @@
 import os
 from pathlib import Path
 import platform
-from openpype.lib import PreLaunchHook
+from openpype.lib.applications import PreLaunchHook, LaunchTypes
 from openpype.hosts.resolve.utils import setup
 
 
@@ -31,6 +31,7 @@ class PreLaunchResolveSetup(PreLaunchHook):
     """
 
     app_groups = ["resolve"]
+    launch_types = {LaunchTypes.local}
 
     def execute(self):
         current_platform = platform.system().lower()

--- a/openpype/hosts/resolve/hooks/pre_resolve_startup.py
+++ b/openpype/hosts/resolve/hooks/pre_resolve_startup.py
@@ -1,6 +1,6 @@
 import os
 
-from openpype.lib import PreLaunchHook
+from openpype.lib.applications import PreLaunchHook, LaunchTypes
 import openpype.hosts.resolve
 
 
@@ -10,6 +10,7 @@ class PreLaunchResolveStartup(PreLaunchHook):
     """
     order = 11
     app_groups = ["resolve"]
+    launch_types = {LaunchTypes.local}
 
     def execute(self):
         # Set the openpype prelaunch startup script path for easy access

--- a/openpype/hosts/tvpaint/hooks/pre_launch_args.py
+++ b/openpype/hosts/tvpaint/hooks/pre_launch_args.py
@@ -1,7 +1,5 @@
-from openpype.lib import (
-    PreLaunchHook,
-    get_openpype_execute_args
-)
+from openpype.lib import get_openpype_execute_args
+from openpype.lib.applications import PreLaunchHook, LaunchTypes
 
 
 class TvpaintPrelaunchHook(PreLaunchHook):
@@ -14,6 +12,7 @@ class TvpaintPrelaunchHook(PreLaunchHook):
     to copy templated workfile from predefined path.
     """
     app_groups = ["tvpaint"]
+    launch_types = {LaunchTypes.local}
 
     def execute(self):
         # Pop tvpaint executable

--- a/openpype/hosts/unreal/hooks/pre_workfile_preparation.py
+++ b/openpype/hosts/unreal/hooks/pre_workfile_preparation.py
@@ -7,9 +7,10 @@ from pathlib import Path
 from qtpy import QtCore
 
 from openpype import resources
-from openpype.lib import (
+from openpype.lib.applications import (
     PreLaunchHook,
     ApplicationLaunchFailed,
+    LaunchTypes,
 )
 from openpype.pipeline.workfile import get_workfile_template_key
 import openpype.hosts.unreal.lib as unreal_lib
@@ -29,6 +30,8 @@ class UnrealPrelaunchHook(PreLaunchHook):
     shell script.
 
     """
+    hosts = {"unreal"}
+    launch_types = {LaunchTypes.local}
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)

--- a/openpype/hosts/unreal/hooks/pre_workfile_preparation.py
+++ b/openpype/hosts/unreal/hooks/pre_workfile_preparation.py
@@ -30,7 +30,7 @@ class UnrealPrelaunchHook(PreLaunchHook):
     shell script.
 
     """
-    hosts = {"unreal"}
+    app_groups = {"unreal"}
     launch_types = {LaunchTypes.local}
 
     def __init__(self, *args, **kwargs):

--- a/openpype/lib/applications.py
+++ b/openpype/lib/applications.py
@@ -931,8 +931,11 @@ class ApplicationLaunchContext:
 
         self.data = dict(data)
 
+        launch_args = []
+        if executable is not None:
+            launch_args = executable.as_args()
         # subprocess.Popen launch arguments (first argument in constructor)
-        self.launch_args = executable.as_args()
+        self.launch_args = launch_args
         self.launch_args.extend(application.arguments)
         if self.data.get("app_args"):
             self.launch_args.extend(self.data.pop("app_args"))

--- a/openpype/lib/applications.py
+++ b/openpype/lib/applications.py
@@ -1470,11 +1470,11 @@ def get_app_environments_for_context(
     app_manager = ApplicationManager()
     context = app_manager.create_launch_context(
         app_name,
-        env_group=env_group,
-        launch_type=launch_type,
         project_name=project_name,
         asset_name=asset_name,
         task_name=task_name,
+        env_group=env_group,
+        launch_type=launch_type,
         env=env,
         modules_manager=modules_manager,
     )

--- a/openpype/lib/applications.py
+++ b/openpype/lib/applications.py
@@ -787,7 +787,9 @@ class LaunchHook:
     # Set of platform availability
     platforms = set()
     # Set of launch types for which is available
-    launch_types = set()
+    # - if empty then is available for all launch types
+    # - by default has 'local' which is most common reason for launc hooks
+    launch_types = {LaunchTypes.local}
 
     def __init__(self, launch_context):
         """Constructor of launch hook.

--- a/openpype/lib/applications.py
+++ b/openpype/lib/applications.py
@@ -483,6 +483,42 @@ class ApplicationManager:
                 break
         return output
 
+    def create_launch_context(self, app_name, **data):
+        """Prepare launch context for application.
+
+        Args:
+            app_name (str): Name of application that should be launched.
+            **data (Any): Any additional data. Data may be used during
+
+        Returns:
+            ApplicationLaunchContext: Launch context for application.
+
+        Raises:
+            ApplicationNotFound: Application was not found by entered name.
+        """
+
+        app = self.applications.get(app_name)
+        if not app:
+            raise ApplicationNotFound(app_name)
+
+        executable = app.find_executable()
+
+        return ApplicationLaunchContext(
+            app, executable, **data
+        )
+
+    def launch_with_context(self, launch_context):
+        """Launch application using existing launch context.
+
+        Args:
+            launch_context (ApplicationLaunchContext): Prepared launch
+                context.
+        """
+
+        if not launch_context.executable:
+            raise ApplictionExecutableNotFound(launch_context.application)
+        return launch_context.launch()
+
     def launch(self, app_name, **data):
         """Launch procedure.
 
@@ -503,18 +539,10 @@ class ApplicationManager:
                 failed. Exception should contain explanation message,
                 traceback should not be needed.
         """
-        app = self.applications.get(app_name)
-        if not app:
-            raise ApplicationNotFound(app_name)
 
-        executable = app.find_executable()
-        if not executable:
-            raise ApplictionExecutableNotFound(app)
+        context = self.create_launch_context(app_name, **data)
+        return self.launch_with_context(context)
 
-        context = ApplicationLaunchContext(
-            app, executable, **data
-        )
-        return context.launch()
 
 
 class EnvironmentToolGroup:

--- a/openpype/modules/ftrack/launch_hooks/post_ftrack_changes.py
+++ b/openpype/modules/ftrack/launch_hooks/post_ftrack_changes.py
@@ -2,11 +2,12 @@ import os
 
 import ftrack_api
 from openpype.settings import get_project_settings
-from openpype.lib import PostLaunchHook
+from openpype.lib.applications import PostLaunchHook, LaunchTypes
 
 
 class PostFtrackHook(PostLaunchHook):
     order = None
+    launch_types = {LaunchTypes.local}
 
     def execute(self):
         project_name = self.data.get("project_name")

--- a/openpype/modules/slack/launch_hooks/pre_python2_vendor.py
+++ b/openpype/modules/slack/launch_hooks/pre_python2_vendor.py
@@ -1,5 +1,5 @@
 import os
-from openpype.lib import PreLaunchHook
+from openpype.lib.applications import PreLaunchHook
 from openpype_modules.slack import SLACK_MODULE_DIR
 
 
@@ -8,6 +8,7 @@ class PrePython2Support(PreLaunchHook):
 
     Path to vendor modules is added to the beginning of PYTHONPATH.
     """
+    launch_types = set()
 
     def execute(self):
         if not self.application.use_python_2:

--- a/openpype/modules/sync_server/launch_hooks/pre_copy_last_published_workfile.py
+++ b/openpype/modules/sync_server/launch_hooks/pre_copy_last_published_workfile.py
@@ -1,12 +1,8 @@
 import os
 import shutil
 
-from openpype.client.entities import (
-    get_representations,
-    get_project
-)
-
-from openpype.lib import PreLaunchHook
+from openpype.client.entities import get_representations
+from openpype.lib.applications import PreLaunchHook, LaunchTypes
 from openpype.lib.profiles_filtering import filter_profiles
 from openpype.modules.sync_server.sync_server import (
     download_last_published_workfile,
@@ -32,6 +28,7 @@ class CopyLastPublishedWorkfile(PreLaunchHook):
                   "nuke", "nukeassist", "nukex", "hiero", "nukestudio",
                   "maya", "harmony", "celaction", "flame", "fusion",
                   "houdini", "tvpaint"]
+    launch_types = {LaunchTypes.local}
 
     def execute(self):
         """Check if local workfile doesn't exist, else copy it.

--- a/openpype/modules/timers_manager/launch_hooks/post_start_timer.py
+++ b/openpype/modules/timers_manager/launch_hooks/post_start_timer.py
@@ -1,4 +1,4 @@
-from openpype.lib import PostLaunchHook
+from openpype.lib.applications import PostLaunchHook, LaunchTypes
 
 
 class PostStartTimerHook(PostLaunchHook):
@@ -7,6 +7,7 @@ class PostStartTimerHook(PostLaunchHook):
     This module requires enabled TimerManager module.
     """
     order = None
+    launch_types = {LaunchTypes.local}
 
     def execute(self):
         project_name = self.data.get("project_name")

--- a/openpype/pype_commands.py
+++ b/openpype/pype_commands.py
@@ -88,7 +88,10 @@ class PypeCommands:
         """
 
         from openpype.lib import Logger
-        from openpype.lib.applications import get_app_environments_for_context
+        from openpype.lib.applications import (
+            get_app_environments_for_context,
+            LaunchTypes,
+        )
         from openpype.modules import ModulesManager
         from openpype.pipeline import (
             install_openpype_plugins,
@@ -122,7 +125,8 @@ class PypeCommands:
                 context["project_name"],
                 context["asset_name"],
                 context["task_name"],
-                app_full_name
+                app_full_name,
+                launch_type=LaunchTypes.farm_publish,
             )
             os.environ.update(env)
 
@@ -237,11 +241,19 @@ class PypeCommands:
         Called by Deadline plugin to propagate environment into render jobs.
         """
 
-        from openpype.lib.applications import get_app_environments_for_context
+        from openpype.lib.applications import (
+            get_app_environments_for_context,
+            LaunchTypes,
+        )
 
         if all((project, asset, task, app)):
             env = get_app_environments_for_context(
-                project, asset, task, app, env_group
+                project,
+                asset,
+                task,
+                app,
+                env_group=env_group,
+                launch_type=LaunchTypes.farm_render,
             )
         else:
             env = os.environ.copy()


### PR DESCRIPTION
## Changelog Description
Environment variable preparation is based on prelaunch hooks. This should allow to pass OCIO environment variables to farm jobs.

## Additional info
To be able allow this option it was required to make `ApplicationLaunchContext` less strict about variables passed in. It was introduced new filtering option "launch type" which can be used for filtering of launch hooks. All launch hooks that should run only when application is launched locally have already set filter to be executed only locally. It is possible to create launch context and execute prelaunch hooks without launching the subprocess.

## Testing notes:
1. Applications launch should set all environments as expected (from launcher or ftrack actions)
    - last workfile
    - open workfiles tool on start
    - ocio envs
2. It should be possible to receive needed environment variables on farm for publish and render jobs with OCIO environment variables etc.
3. Remote publishing should work as expected.