### PR TITLE
Nuke: node name influence product (subset) name

### DIFF
--- a/openpype/hosts/nuke/api/pipeline.py
+++ b/openpype/hosts/nuke/api/pipeline.py
@@ -564,6 +564,9 @@ def list_instances(creator_id=None):
         if creator_id and instance_data["creator_identifier"] != creator_id:
             continue
 
+        # node name could change, so update subset name data
+        _update_subset_name_data(instance_data, node)
+
         if "render_order" not in node.knobs():
             subset_instances.append((node, instance_data))
             continue
@@ -587,6 +590,25 @@ def list_instances(creator_id=None):
         ordered_instances.append(instances_by_subset[key])
 
     return ordered_instances
+
+
+def _update_subset_name_data(instance_data, node):
+    """Update subset name data in instance data.
+
+    Args:
+        instance_data (dict): instance creator data
+        node (nuke.Node): nuke node
+    """
+    # make sure node name is subset name
+    old_subset_name = instance_data["subset"]
+    old_variant = instance_data["variant"]
+    subset_name_root = old_subset_name.replace(old_variant, "")
+
+    new_subset_name = node.name()
+    new_variant = new_subset_name.replace(subset_name_root, "")
+
+    instance_data["subset"] = new_subset_name
+    instance_data["variant"] = new_variant
 
 
 def remove_instance(instance):

--- a/openpype/hosts/nuke/api/plugin.py
+++ b/openpype/hosts/nuke/api/plugin.py
@@ -212,8 +212,19 @@ class NukeCreator(NewCreator):
                 created_instance["creator_attributes"].pop(key)
 
     def update_instances(self, update_list):
-        for created_inst, _changes in update_list:
+        for created_inst, changes in update_list:
             instance_node = created_inst.transient_data["node"]
+
+            changed_keys = {
+                key: changes[key].new_value
+                for key in changes.changed_keys
+            }
+
+            # update instance node name if subset name changed
+            if "subset" in changed_keys:
+                instance_node["name"].setValue(
+                    changed_keys["subset"]
+                )
 
             # in case node is not existing anymore (user erased it manually)
             try:

--- a/openpype/hosts/nuke/api/plugin.py
+++ b/openpype/hosts/nuke/api/plugin.py
@@ -215,15 +215,10 @@ class NukeCreator(NewCreator):
         for created_inst, changes in update_list:
             instance_node = created_inst.transient_data["node"]
 
-            changed_keys = {
-                key: changes[key].new_value
-                for key in changes.changed_keys
-            }
-
             # update instance node name if subset name changed
-            if "subset" in changed_keys:
+            if "subset" in changes:
                 instance_node["name"].setValue(
-                    changed_keys["subset"]
+                    changes["subset"].new_value
                 )
 
             # in case node is not existing anymore (user erased it manually)

--- a/openpype/hosts/nuke/api/plugin.py
+++ b/openpype/hosts/nuke/api/plugin.py
@@ -216,7 +216,7 @@ class NukeCreator(NewCreator):
             instance_node = created_inst.transient_data["node"]
 
             # update instance node name if subset name changed
-            if "subset" in changes:
+            if "subset" in changes.changed_keys:
                 instance_node["name"].setValue(
                     changes["subset"].new_value
                 )


### PR DESCRIPTION
## Changelog Description
Nuke now allows users to duplicate publishing instances, making the workflow easier. By duplicating a node and changing its name, users can set the product (subset) name in the publishing context.

Users now have the ability to change the variant name in Publisher, which will automatically rename the associated instance node.

## Additional info
We are temporarily implementing order sorting, but once [this issue #5391]( https://github.com/ynput/OpenPype/issues/5391) is addressed, we will remove it.

## Testing notes:

1. Open the testing nuke script.
2. Create a write render product node.
3. Duplicate the node multiple times.
4. Refresh the Publisher and observe that those nodes are included in the instances stack.
5. Rename the Variant attribute in any instance and confirm the changes. Also, save the publisher context.
6. Notice that the related node name has been changed to whatever you have set.
