### PR TITLE
AYON: 3dsMax settings

### DIFF
--- a/openpype/hooks/pre_add_last_workfile_arg.py
+++ b/openpype/hooks/pre_add_last_workfile_arg.py
@@ -14,7 +14,7 @@ class AddLastWorkfileToLaunchArgs(PreLaunchHook):
     # Execute after workfile template copy
     order = 10
     app_groups = {
-        "3dsmax",
+        "3dsmax", "adsk_3dsmax",
         "maya",
         "nuke",
         "nukex",

--- a/openpype/hosts/max/hooks/force_startup_script.py
+++ b/openpype/hosts/max/hooks/force_startup_script.py
@@ -14,7 +14,7 @@ class ForceStartupScript(PreLaunchHook):
 
     Hook `GlobalHostDataHook` must be executed before this hook.
     """
-    app_groups = {"3dsmax"}
+    app_groups = {"3dsmax", "adsk_3dsmax"}
     order = 11
     launch_types = {LaunchTypes.local}
 

--- a/openpype/hosts/max/hooks/inject_python.py
+++ b/openpype/hosts/max/hooks/inject_python.py
@@ -13,7 +13,7 @@ class InjectPythonPath(PreLaunchHook):
 
     Hook `GlobalHostDataHook` must be executed before this hook.
     """
-    app_groups = {"3dsmax"}
+    app_groups = {"3dsmax", "adsk_3dsmax"}
     launch_types = {LaunchTypes.local}
 
     def execute(self):

--- a/openpype/settings/ayon_settings.py
+++ b/openpype/settings/ayon_settings.py
@@ -124,8 +124,6 @@ def _convert_applications_system_settings(
 
     # Applications settings
     ayon_apps = addon_settings["applications"]
-    if "adsk_3dsmax" in ayon_apps:
-        ayon_apps["3dsmax"] = copy.deepcopy(ayon_apps["adsk_3dsmax"])
 
     additional_apps = ayon_apps.pop("additional_apps")
     applications = _convert_applications_groups(

--- a/openpype/settings/ayon_settings.py
+++ b/openpype/settings/ayon_settings.py
@@ -125,7 +125,7 @@ def _convert_applications_system_settings(
     # Applications settings
     ayon_apps = addon_settings["applications"]
     if "adsk_3dsmax" in ayon_apps:
-        ayon_apps["3dsmax"] = ayon_apps.pop("adsk_3dsmax")
+        ayon_apps["3dsmax"] = copy.deepcopy(ayon_apps["adsk_3dsmax"])
 
     additional_apps = ayon_apps.pop("additional_apps")
     applications = _convert_applications_groups(


### PR DESCRIPTION
## Changelog Description
Keep `adsk_3dsmax` group in applications settings.

## Additional info
Because 3dsmax group in AYON is `adsk_3dsmax` but we're converting it to `3dsmax` it does not match and find available application in `ApplicationManage`. Because the group changed it was required to add `adsk_3dsmax` to launch hooks which had `3dsmax`.

## Testing notes:
1. 3dsMax can be launched in AYON
2. The prelaunch hooks are executed in both AYON and OpenPype modes
