### PR TITLE
Colorspace: including environments from launcher process

### DIFF
--- a/openpype/hooks/pre_ocio_hook.py
+++ b/openpype/hooks/pre_ocio_hook.py
@@ -39,7 +39,7 @@ class OCIOEnvHook(PreLaunchHook):
             project_settings=self.data["project_settings"],
             anatomy_data=template_data,
             anatomy=self.data["anatomy"],
-            environment=self.launch_context.env,
+            env=self.launch_context.env,
         )
 
         if config_data:

--- a/openpype/hooks/pre_ocio_hook.py
+++ b/openpype/hooks/pre_ocio_hook.py
@@ -38,7 +38,8 @@ class OCIOEnvHook(PreLaunchHook):
             host_name=self.host_name,
             project_settings=self.data["project_settings"],
             anatomy_data=template_data,
-            anatomy=self.data["anatomy"]
+            anatomy=self.data["anatomy"],
+            environment=self.launch_context.env,
         )
 
         if config_data:

--- a/openpype/pipeline/colorspace.py
+++ b/openpype/pipeline/colorspace.py
@@ -329,7 +329,8 @@ def get_imageio_config(
     host_name,
     project_settings=None,
     anatomy_data=None,
-    anatomy=None
+    anatomy=None,
+    env=None
 ):
     """Returns config data from settings
 
@@ -342,6 +343,7 @@ def get_imageio_config(
         project_settings (Optional[dict]): Project settings.
         anatomy_data (Optional[dict]): anatomy formatting data.
         anatomy (Optional[Anatomy]): Anatomy object.
+        env (Optional[dict]): Environment variables.
 
     Returns:
         dict: config path data or empty dict
@@ -414,13 +416,13 @@ def get_imageio_config(
 
     if override_global_config:
         config_data = _get_config_data(
-            host_ocio_config["filepath"], formatting_data
+            host_ocio_config["filepath"], formatting_data, env
         )
     else:
         # get config path from global
         config_global = imageio_global["ocio_config"]
         config_data = _get_config_data(
-            config_global["filepath"], formatting_data
+            config_global["filepath"], formatting_data, env
         )
 
     if not config_data:
@@ -432,7 +434,7 @@ def get_imageio_config(
     return config_data
 
 
-def _get_config_data(path_list, anatomy_data):
+def _get_config_data(path_list, anatomy_data, env=None):
     """Return first existing path in path list.
 
     If template is used in path inputs,
@@ -442,14 +444,17 @@ def _get_config_data(path_list, anatomy_data):
     Args:
         path_list (list[str]): list of abs paths
         anatomy_data (dict): formatting data
+        env (Optional[dict]): Environment variables.
 
     Returns:
         dict: config data
     """
     formatting_data = deepcopy(anatomy_data)
 
+    environment_vars = env or dict(**os.environ)
+
     # format the path for potential env vars
-    formatting_data.update(dict(**os.environ))
+    formatting_data.update(environment_vars)
 
     # first try host config paths
     for path_ in path_list:


### PR DESCRIPTION
## Changelog Description
Fixed bug in GitHub PR where the OCIO config template was not properly formatting environment variables from System Settings `general/environment`.

## Testing notes:
1. make sure `general/environmnet` is configured for multiplatform path
![image](https://github.com/ynput/OpenPype/assets/40640033/504ed7d9-f0f5-4601-b3e1-74e28f4e2a08)

2. use the defined environenment key in config path input
![image](https://github.com/ynput/OpenPype/assets/40640033/59bff128-92db-4472-ba39-c4b5b1302776)

3. open nuke task and see it is correctly adding OCIO env var and setting config path to running process
