### PR TITLE
TVPaint: Fix 'repeat' behavior

### DIFF
--- a/openpype/hosts/tvpaint/api/lib.py
+++ b/openpype/hosts/tvpaint/api/lib.py
@@ -233,7 +233,7 @@ def get_layers_pre_post_behavior(layer_ids, communicator=None):
 
     Pre and Post behaviors is enumerator of possible values:
     - "none"
-    - "repeat" / "loop"
+    - "repeat"
     - "pingpong"
     - "hold"
 
@@ -242,7 +242,7 @@ def get_layers_pre_post_behavior(layer_ids, communicator=None):
     {
         0: {
             "pre": "none",
-            "post": "loop"
+            "post": "repeat"
         }
     }
     ```

--- a/openpype/hosts/tvpaint/lib.py
+++ b/openpype/hosts/tvpaint/lib.py
@@ -77,7 +77,7 @@ def _calculate_pre_behavior_copy(
         for frame_idx in range(range_start, layer_frame_start):
             output_idx_by_frame_idx[frame_idx] = first_exposure_frame
 
-    elif pre_beh in ("loop", "repeat"):
+    elif pre_beh == "repeat":
         # Loop backwards from last frame of layer
         for frame_idx in reversed(range(range_start, layer_frame_start)):
             eq_frame_idx_offset = (
@@ -141,7 +141,7 @@ def _calculate_post_behavior_copy(
         for frame_idx in range(layer_frame_end + 1, range_end + 1):
             output_idx_by_frame_idx[frame_idx] = last_exposure_frame
 
-    elif post_beh in ("loop", "repeat"):
+    elif post_beh == "repeat":
         # Loop backwards from last frame of layer
         for frame_idx in range(layer_frame_end + 1, range_end + 1):
             eq_frame_idx = layer_frame_start + (frame_idx % frame_count)

--- a/openpype/hosts/tvpaint/lib.py
+++ b/openpype/hosts/tvpaint/lib.py
@@ -83,7 +83,9 @@ def _calculate_pre_behavior_copy(
             eq_frame_idx_offset = (
                 (layer_frame_end - frame_idx) % frame_count
             )
-            eq_frame_idx = layer_frame_end - eq_frame_idx_offset
+            eq_frame_idx = layer_frame_start + (
+                layer_frame_end - eq_frame_idx_offset
+            )
             output_idx_by_frame_idx[frame_idx] = eq_frame_idx
 
     elif pre_beh == "pingpong":
@@ -142,7 +144,7 @@ def _calculate_post_behavior_copy(
     elif post_beh in ("loop", "repeat"):
         # Loop backwards from last frame of layer
         for frame_idx in range(layer_frame_end + 1, range_end + 1):
-            eq_frame_idx = frame_idx % frame_count
+            eq_frame_idx = layer_frame_start + (frame_idx % frame_count)
             output_idx_by_frame_idx[frame_idx] = eq_frame_idx
 
     elif post_beh == "pingpong":


### PR DESCRIPTION
## Changelog Description
Calculation of frames for repeat behavior is working correctly.

## Additional info
It did work only if layer started from frame `0`, now it should be able to handle any range.

## Testing notes:
1. Create asset with frame range 12 frames (1001 - 10013) - and task
2. Open workfile on task under the asset
3. Set mark in to 0 and mark out to 12
4. Make a layer that does start on frame 5
5. Make 4 frames in layer (with visibly different content)
6. Set pre and post behavior of the layer to repeat (loop)
7. Create -> Publish the layer
8. Check integrated frames and validate if the image content does match the content from workfile (the order of frames is correct)
