### PR TITLE
Webpublisher: Self contain test publish logic

### DIFF
--- a/openpype/hosts/webpublisher/addon.py
+++ b/openpype/hosts/webpublisher/addon.py
@@ -20,11 +20,10 @@ class WebpublisherAddon(OpenPypeModule, IHostAddon):
         Close Python process at the end.
         """
 
-        from openpype.pipeline.publish.lib import remote_publish
-        from .lib import get_webpublish_conn, publish_and_log
+        from .lib import get_webpublish_conn, publish_and_log, publish_in_test
 
         if is_test:
-            remote_publish(log, close_plugin_name)
+            publish_in_test(log, close_plugin_name)
             return
 
         dbcon = get_webpublish_conn()

--- a/openpype/hosts/webpublisher/lib.py
+++ b/openpype/hosts/webpublisher/lib.py
@@ -12,7 +12,6 @@ from openpype.client.mongo import OpenPypeMongoConnection
 from openpype.settings import get_project_settings
 from openpype.lib import Logger
 from openpype.lib.profiles_filtering import filter_profiles
-from openpype.pipeline.publish.lib import find_close_plugin
 
 ERROR_STATUS = "error"
 IN_PROGRESS_STATUS = "in_progress"
@@ -66,6 +65,53 @@ def get_batch_asset_task_info(ctx):
         asset = ctx["name"]
 
     return asset, task_name, task_type
+
+
+def find_close_plugin(close_plugin_name, log):
+    if close_plugin_name:
+        plugins = pyblish.api.discover()
+        for plugin in plugins:
+            if plugin.__name__ == close_plugin_name:
+                return plugin
+
+    log.debug("Close plugin not found, app might not close.")
+
+
+def publish_in_test(log, close_plugin_name=None, raise_error=False):
+    """Loops through all plugins, logs to console. Used for tests.
+
+    Args:
+        log (Logger)
+        close_plugin_name (Optional[str]): Name of plugin with responsibility
+            to close application.
+        raise_error (Optional[bool]): Raise RuntimeError on first error
+            if True.
+    """
+
+    # Error exit as soon as any error occurs.
+    error_format = "Failed {plugin.__name__}: {error} -- {error.traceback}"
+
+    close_plugin = find_close_plugin(close_plugin_name, log)
+
+    for result in pyblish.util.publish_iter():
+        for record in result["records"]:
+            # Why do we log again? pyblish logger is logging to stdout...
+            log.info("{}: {}".format(result["plugin"].label, record.msg))
+
+        if not result["error"]:
+            continue
+
+        error_message = error_format.format(**result)
+        log.error(error_message)
+        if close_plugin:  # close host app explicitly after error
+            context = pyblish.api.Context()
+            close_plugin().process(context)
+
+        # Raise error if needed
+        #   - fatal Error is because of Deadline
+        # QUESTION We don't break on error?
+        if raise_error:
+            raise RuntimeError("Fatal Error: {}".format(error_message))
 
 
 def get_webpublish_conn():

--- a/openpype/pipeline/publish/lib.py
+++ b/openpype/pipeline/publish/lib.py
@@ -537,44 +537,24 @@ def filter_pyblish_plugins(plugins):
             plugins.remove(plugin)
 
 
-def find_close_plugin(close_plugin_name, log):
-    if close_plugin_name:
-        plugins = pyblish.api.discover()
-        for plugin in plugins:
-            if plugin.__name__ == close_plugin_name:
-                return plugin
-
-    log.debug("Close plugin not found, app might not close.")
-
-
-def remote_publish(log, close_plugin_name=None, raise_error=False):
+def remote_publish(log):
     """Loops through all plugins, logs to console. Used for tests.
 
     Args:
         log (Logger)
-        close_plugin_name (str): name of plugin with responsibility to
-            close host app
     """
-    # Error exit as soon as any error occurs.
-    error_format = "Failed {plugin.__name__}: {error} -- {error.traceback}"
 
-    close_plugin = find_close_plugin(close_plugin_name, log)
+    # Error exit as soon as any error occurs.
+    error_format = "Failed {plugin.__name__}: {error}\n{error.traceback}"
 
     for result in pyblish.util.publish_iter():
-        for record in result["records"]:
-            log.info("{}: {}".format(
-                result["plugin"].label, record.msg))
+        if not result["error"]:
+            continue
 
-        if result["error"]:
-            error_message = error_format.format(**result)
-            log.error(error_message)
-            if close_plugin:  # close host app explicitly after error
-                context = pyblish.api.Context()
-                close_plugin().process(context)
-            if raise_error:
-                # Fatal Error is because of Deadline
-                error_message = "Fatal Error: " + error_format.format(**result)
-                raise RuntimeError(error_message)
+        error_message = error_format.format(**result)
+        log.error(error_message)
+        # 'Fatal Error: ' is because of Deadline
+        raise RuntimeError("Fatal Error: {}".format(error_message))
 
 
 def get_errored_instances_from_context(context, plugin=None):

--- a/openpype/scripts/remote_publish.py
+++ b/openpype/scripts/remote_publish.py
@@ -9,4 +9,4 @@ except ImportError as exc:
 if __name__ == "__main__":
     # Perform remote publish with thorough error checking
     log = Logger.get_logger(__name__)
-    remote_publish(log, raise_error=True)
+    remote_publish(log)


### PR DESCRIPTION
## Changelog Description
Moved test logic of publishing to webpublisher. Simplified `remote_publish` to remove webpublisher specific logic.

## Additional info
Function `remote_publish` was kept because of unknown reason of it's existence. It's used only in script `./openpype/scripts/remote_publish.py` which is used only in deadline plugin for maya remote publish. But the logic completelly skips registering of host, registering of plugins and handling of DCC process so I do expect it can be removed -> future PRs.

## Testing notes:
1. Webpublisher should work as before
