### PR TITLE
AYON: Add folder to template data

### DIFF
--- a/openpype/client/server/conversion_utils.py
+++ b/openpype/client/server/conversion_utils.py
@@ -133,7 +133,6 @@ def _get_default_template_name(templates):
 def _template_replacements_to_v3(template):
     return (
         template
-        .replace("{folder[name]}", "{asset}")
         .replace("{product[name]}", "{subset}")
         .replace("{product[type]}", "{family}")
     )
@@ -715,7 +714,6 @@ def convert_v4_representation_to_v3(representation):
     if "template" in output_data:
         output_data["template"] = (
             output_data["template"]
-            .replace("{folder[name]}", "{asset}")
             .replace("{product[name]}", "{subset}")
             .replace("{product[type]}", "{family}")
         )
@@ -977,7 +975,6 @@ def convert_create_representation_to_v4(representation, con):
     representation_data = representation["data"]
     representation_data["template"] = (
         representation_data["template"]
-        .replace("{asset}", "{folder[name]}")
         .replace("{subset}", "{product[name]}")
         .replace("{family}", "{product[type]}")
     )
@@ -1266,7 +1263,6 @@ def convert_update_representation_to_v4(
     if "template" in attribs:
         attribs["template"] = (
             attribs["template"]
-            .replace("{asset}", "{folder[name]}")
             .replace("{family}", "{product[type]}")
             .replace("{subset}", "{product[name]}")
         )

--- a/openpype/hosts/maya/api/plugin.py
+++ b/openpype/hosts/maya/api/plugin.py
@@ -581,6 +581,9 @@ class ReferenceLoader(Loader):
         formatting_data = {
             "asset_name": asset['name'],
             "asset_type": asset['type'],
+            "folder": {
+                "name": asset["name"],
+            },
             "subset": subset['name'],
             "family": (
                 subset['data'].get('family') or

--- a/openpype/lib/usdlib.py
+++ b/openpype/lib/usdlib.py
@@ -334,6 +334,9 @@ def get_usd_master_path(asset, subset, representation):
                 "name": project_name,
                 "code": project_doc.get("data", {}).get("code")
             },
+            "folder": {
+                "name": asset_doc["name"],
+            },
             "asset": asset_doc["name"],
             "subset": subset,
             "representation": representation,

--- a/openpype/pipeline/template_data.py
+++ b/openpype/pipeline/template_data.py
@@ -94,6 +94,9 @@ def get_asset_template_data(asset_doc, project_name):
 
     return {
         "asset": asset_doc["name"],
+        "folder": {
+            "name": asset_doc["name"]
+        },
         "hierarchy": hierarchy,
         "parent": parent_name
     }

--- a/openpype/settings/ayon_settings.py
+++ b/openpype/settings/ayon_settings.py
@@ -599,7 +599,6 @@ def _convert_maya_project_settings(ayon_settings, output):
     reference_loader = ayon_maya_load["reference_loader"]
     reference_loader["namespace"] = (
         reference_loader["namespace"]
-        .replace("{folder[name]}", "{asset_name}")
         .replace("{product[name]}", "{subset}")
     )
 


### PR DESCRIPTION
## Changelog Description
Added `folder` to template data, so `{folder[name]}` can be used in templates.

## Additional info
The folder has only `name` at this moment for which is used asset name. Can be also used in OpenPype. As far as I'm aware there are no other places where data for templates are prepared at this moment.

## Testing notes:
### Beginning
1. Make openpype addon, upload to AYON, set in bundle
2. Make sure you're using `{folder[name]}` in anatomy templates
3. Run OpenPype

### Workfiles
- Last workfile should be found on startup
- Last workfile should be found in workfiles tool
- Save in workfiles tool should work correctly
- Save as in workfiles tool should work correctly

### Publishing
1. Publish from host of your choice
2. Publishing should went smoothly