### PR TITLE
Maya: Extract active view as thumbnail when no thumbnail set

### DIFF
--- a/openpype/hosts/maya/plugins/publish/extract_active_view_thumbnail.py
+++ b/openpype/hosts/maya/plugins/publish/extract_active_view_thumbnail.py
@@ -46,5 +46,6 @@ class ExtractActiveViewThumbnail(pyblish.api.InstancePlugin):
             image.writeToFile(path, "jpg")
             self.log.debug("Generated thumbnail: {}".format(path))
 
+            context.data["cleanupFullPaths"].append(path)
             context.data[cache_key] = path
         return context.data[cache_key]

--- a/openpype/hosts/maya/plugins/publish/extract_active_view_thumbnail.py
+++ b/openpype/hosts/maya/plugins/publish/extract_active_view_thumbnail.py
@@ -7,7 +7,6 @@ import tempfile
 from openpype.hosts.maya.lib import IS_HEADLESS
 
 
-
 class ExtractActiveViewThumbnail(pyblish.api.InstancePlugin):
     """Set instance thumbnail to a screengrab of current active viewport.
 

--- a/openpype/hosts/maya/plugins/publish/extract_active_view_thumbnail.py
+++ b/openpype/hosts/maya/plugins/publish/extract_active_view_thumbnail.py
@@ -48,4 +48,3 @@ class ExtractActiveViewThumbnail(pyblish.api.InstancePlugin):
 
             context.data[cache_key] = path
         return context.data[cache_key]
-

--- a/openpype/hosts/maya/plugins/publish/extract_active_view_thumbnail.py
+++ b/openpype/hosts/maya/plugins/publish/extract_active_view_thumbnail.py
@@ -1,0 +1,51 @@
+import maya.api.OpenMaya as om
+import maya.api.OpenMayaUI as omui
+
+import pyblish.api
+import tempfile
+
+
+class ExtractActiveViewThumbnail(pyblish.api.InstancePlugin):
+    """Set instance thumbnail to a screengrab of current active viewport.
+
+    This makes it so that if an instance does not have a thumbnail set yet that
+    it will get a thumbnail of the currently active view at the time of
+    publishing as a fallback.
+
+    """
+    order = pyblish.api.ExtractorOrder + 0.49
+    label = "Active View Thumbnail"
+    families = ["workfile"]
+    hosts = ["maya"]
+
+    def process(self, instance):
+        thumbnail = instance.data.get("thumbnailPath")
+        if not thumbnail:
+            view_thumbnail = self.get_view_thumbnail(instance)
+            if not view_thumbnail:
+                return
+
+            self.log.debug("Setting instance thumbnail path to: {}".format(
+                view_thumbnail
+            ))
+            instance.data["thumbnailPath"] = view_thumbnail
+
+    def get_view_thumbnail(self, instance):
+        cache_key = "__maya_view_thumbnail"
+        context = instance.context
+
+        if cache_key not in context.data:
+            # Generate only a single thumbnail, even for multiple instances
+            with tempfile.NamedTemporaryFile(suffix="_thumbnail.jpg",
+                                             delete=False) as f:
+                path = f.name
+
+            view = omui.M3dView.active3dView()
+            image = om.MImage()
+            view.readColorBuffer(image, True)
+            image.writeToFile(path, "jpg")
+            self.log.debug("Generated thumbnail: {}".format(path))
+
+            context.data[cache_key] = path
+        return context.data[cache_key]
+

--- a/openpype/hosts/maya/plugins/publish/extract_active_view_thumbnail.py
+++ b/openpype/hosts/maya/plugins/publish/extract_active_view_thumbnail.py
@@ -4,7 +4,7 @@ import maya.api.OpenMayaUI as omui
 import pyblish.api
 import tempfile
 
-from openpype.hosts.maya.lib import IS_HEADLESS
+from openpype.hosts.maya.api.lib import IS_HEADLESS
 
 
 class ExtractActiveViewThumbnail(pyblish.api.InstancePlugin):

--- a/openpype/hosts/maya/plugins/publish/extract_active_view_thumbnail.py
+++ b/openpype/hosts/maya/plugins/publish/extract_active_view_thumbnail.py
@@ -4,6 +4,9 @@ import maya.api.OpenMayaUI as omui
 import pyblish.api
 import tempfile
 
+from openpype.hosts.maya.lib import IS_HEADLESS
+
+
 
 class ExtractActiveViewThumbnail(pyblish.api.InstancePlugin):
     """Set instance thumbnail to a screengrab of current active viewport.
@@ -19,6 +22,13 @@ class ExtractActiveViewThumbnail(pyblish.api.InstancePlugin):
     hosts = ["maya"]
 
     def process(self, instance):
+        if IS_HEADLESS:
+            self.log.debug(
+                "Skip extraction of active view thumbnail, due to being in"
+                "headless mode."
+            )
+            return
+
         thumbnail = instance.data.get("thumbnailPath")
         if not thumbnail:
             view_thumbnail = self.get_view_thumbnail(instance)


### PR DESCRIPTION
## Changelog Description

This sets the Maya instance's thumbnail to the current active view if no thumbnail was set yet.

## Additional info

It's currently set to only the workfile family for which it makes most sense - but I think it could even be nice for other families as at least a visual hint?

## Preview

![image](https://github.com/ynput/OpenPype/assets/2439881/7a96fd46-57f8-4401-b4b2-5f024e72950b)


## Testing notes:
1. Make sure thumbnails are enabled for your studio
    - Ensure you have `AVALON_THUMBNAIL_ROOT` set in OpenPype settings
3. Open Maya
4. Publish a workfile
5. Published workfile subset should now have a thumbnail
