### PR TITLE
Maya: allow not creation of group for Import loaders

### DIFF
--- a/openpype/hosts/maya/api/plugin.py
+++ b/openpype/hosts/maya/api/plugin.py
@@ -535,17 +535,20 @@ class Loader(LoaderPlugin):
             loader_key (str): key to get separate configuration from Settings
                 ('reference_loader'|'import_loader')
         """
+        options["attach_to_root"] = True
+
         asset = context['asset']
         subset = context['subset']
         settings = get_project_settings(context['project']['name'])
         custom_naming = settings['maya']['load'][loader_key]
-        options["attach_to_root"] = True
+
         if not custom_naming['namespace']:
             raise LoadError("No namespace specified in "
                             "Maya ReferenceLoader settings")
         elif not custom_naming['group_name']:
             self.log.debug("No custom group_name, no group will be created.")
             options["attach_to_root"] = False
+
         formatting_data = {
             "asset_name": asset['name'],
             "asset_type": asset['type'],
@@ -554,16 +557,19 @@ class Loader(LoaderPlugin):
             },
             "subset": subset['name'],
             "family": (
-                    subset['data'].get('family') or
-                    subset['data']['families'][0]
+                subset['data'].get('family') or
+                subset['data']['families'][0]
             )
         }
+
         custom_namespace = custom_naming['namespace'].format(
             **formatting_data
         )
+
         custom_group_name = custom_naming['group_name'].format(
             **formatting_data
         )
+
         return custom_group_name, custom_namespace, options
 
 

--- a/openpype/hosts/maya/api/plugin.py
+++ b/openpype/hosts/maya/api/plugin.py
@@ -528,7 +528,6 @@ class Loader(LoaderPlugin):
         subset = context['subset']
         settings = get_project_settings(context['project']['name'])
         custom_naming = settings['maya']['load'][loader_key]
-
         options["attach_to_root"] = True
         if not custom_naming['namespace']:
             raise LoadError("No namespace specified in "

--- a/openpype/hosts/maya/api/plugin.py
+++ b/openpype/hosts/maya/api/plugin.py
@@ -524,6 +524,17 @@ class Loader(LoaderPlugin):
     hosts = ["maya"]
 
     def get_custom_namespace_and_group(self, context, options, loader_key):
+        """Queries Settings to get custom template for namespace and group.
+
+        Group template might be empty >> this forces to not wrap imported items
+        into separate group.
+
+        Args:
+            context (dict)
+            options (dict): artist modifiable options from dialog
+            loader_key (str): key to get separate configuration from Settings
+                ('reference_loader'|'import_loader')
+        """
         asset = context['asset']
         subset = context['subset']
         settings = get_project_settings(context['project']['name'])

--- a/openpype/hosts/maya/plugins/load/_load_animation.py
+++ b/openpype/hosts/maya/plugins/load/_load_animation.py
@@ -33,6 +33,13 @@ class AbcLoader(openpype.hosts.maya.api.plugin.ReferenceLoader):
             suffix="_abc"
         )
 
+        attach_to_root = options.get("attach_to_root", True)
+        group_name = options["group_name"]
+
+        # no group shall be created
+        if not attach_to_root:
+            group_name = namespace
+
         # hero_001 (abc)
         # asset_counter{optional}
         path = self.filepath_from_context(context)
@@ -41,8 +48,8 @@ class AbcLoader(openpype.hosts.maya.api.plugin.ReferenceLoader):
         nodes = cmds.file(file_url,
                           namespace=namespace,
                           sharedReferenceFile=False,
-                          groupReference=True,
-                          groupName=options['group_name'],
+                          groupReference=attach_to_root,
+                          groupName=group_name,
                           reference=True,
                           returnNewNodes=True)
 

--- a/openpype/hosts/maya/plugins/load/actions.py
+++ b/openpype/hosts/maya/plugins/load/actions.py
@@ -84,7 +84,7 @@ class SetFrameRangeWithHandlesLoader(load.LoaderPlugin):
                              animationEndTime=end)
 
 
-class ImportMayaLoader(openpype.hosts.maya.api.plugin.LoaderPlugin):
+class ImportMayaLoader(openpype.hosts.maya.api.plugin.Loader):
     """Import action for Maya (unmanaged)
 
     Warning:
@@ -132,12 +132,12 @@ class ImportMayaLoader(openpype.hosts.maya.api.plugin.LoaderPlugin):
             return
 
         custom_group_name, custom_namespace, options = \
-            self.get_custom_namespace_and_group(context, self.options,
+            self.get_custom_namespace_and_group(context, data,
                                                 "import_loader")
 
         namespace = get_custom_namespace(custom_namespace)
 
-        if not self.options.get("attach_to_root", True):
+        if not options.get("attach_to_root", True):
             custom_group_name = namespace
 
         path = self.filepath_from_context(context)
@@ -147,7 +147,8 @@ class ImportMayaLoader(openpype.hosts.maya.api.plugin.LoaderPlugin):
                               preserveReferences=True,
                               namespace=namespace,
                               returnNewNodes=True,
-                              groupReference=options["attach_to_root"],
+                              groupReference=options.get("attach_to_root",
+                                                         True),
                               groupName=custom_group_name)
 
             if data.get("clean_import", False):

--- a/openpype/hosts/maya/plugins/load/load_reference.py
+++ b/openpype/hosts/maya/plugins/load/load_reference.py
@@ -9,8 +9,7 @@ from openpype.hosts.maya.api.lib import (
     maintained_selection,
     get_container_members,
     parent_nodes,
-    create_rig_animation_instance,
-    get_reference_node
+    create_rig_animation_instance
 )
 
 

--- a/openpype/hosts/maya/plugins/load/load_yeti_rig.py
+++ b/openpype/hosts/maya/plugins/load/load_yeti_rig.py
@@ -19,8 +19,15 @@ class YetiRigLoader(openpype.hosts.maya.api.plugin.ReferenceLoader):
     def process_reference(
         self, context, name=None, namespace=None, options=None
     ):
-        group_name = options['group_name']
         path = self.filepath_from_context(context)
+
+        attach_to_root = options.get("attach_to_root", True)
+        group_name = options["group_name"]
+
+        # no group shall be created
+        if not attach_to_root:
+            group_name = namespace
+
         with lib.maintained_selection():
             file_url = self.prepare_root_value(
                 path, context["project"]["name"]
@@ -30,7 +37,7 @@ class YetiRigLoader(openpype.hosts.maya.api.plugin.ReferenceLoader):
                 namespace=namespace,
                 reference=True,
                 returnNewNodes=True,
-                groupReference=True,
+                groupReference=attach_to_root,
                 groupName=group_name
             )
 

--- a/openpype/settings/ayon_settings.py
+++ b/openpype/settings/ayon_settings.py
@@ -602,6 +602,13 @@ def _convert_maya_project_settings(ayon_settings, output):
         .replace("{product[name]}", "{subset}")
     )
 
+    if ayon_maya_load.get("import_loader"):
+        import_loader = ayon_maya_load["import_loader"]
+        import_loader["namespace"] = (
+            import_loader["namespace"]
+            .replace("{product[name]}", "{subset}")
+        )
+
     output["maya"] = ayon_maya
 
 

--- a/openpype/settings/defaults/project_settings/maya.json
+++ b/openpype/settings/defaults/project_settings/maya.json
@@ -1463,6 +1463,10 @@
             "namespace": "{asset_name}_{subset}_##_",
             "group_name": "_GRP",
             "display_handle": true
+        },
+        "import_loader": {
+            "namespace": "{asset_name}_{subset}_##_",
+            "group_name": "_GRP"
         }
     },
     "workfile_build": {

--- a/openpype/settings/entities/schemas/projects_schema/schemas/schema_maya_load.json
+++ b/openpype/settings/entities/schemas/projects_schema/schemas/schema_maya_load.json
@@ -121,6 +121,28 @@
                     "label": "Display Handle On Load References"
                 }
             ]
+        },
+        {
+            "type": "dict",
+            "collapsible": true,
+            "key": "import_loader",
+            "label": "Import Loader",
+            "children": [
+                {
+                    "type": "text",
+                    "label": "Namespace",
+                    "key": "namespace"
+                },
+                {
+                    "type": "text",
+                    "label": "Group name",
+                    "key": "group_name"
+                },
+                {
+                    "type": "label",
+                    "label": "Here's a link to the doc where you can find explanations about customing the naming of referenced assets: https://openpype.io/docs/admin_hosts_maya#load-plugins"
+                }
+            ]
         }
     ]
 }

--- a/server_addon/maya/server/settings/loaders.py
+++ b/server_addon/maya/server/settings/loaders.py
@@ -45,6 +45,11 @@ class ReferenceLoaderModel(BaseSettingsModel):
     display_handle: bool = Field(title="Display Handle On Load References")
 
 
+class ImportLoaderModel(BaseSettingsModel):
+    namespace: str = Field(title="Namespace")
+    group_name: str = Field(title="Group name")
+
+
 class LoadersModel(BaseSettingsModel):
     colors: ColorsSetting = Field(
         default_factory=ColorsSetting,
@@ -55,6 +60,10 @@ class LoadersModel(BaseSettingsModel):
         title="Reference Loader"
     )
 
+    import_loader: ImportLoaderModel = Field(
+        default_factory=ImportLoaderModel,
+        title="Import Loader"
+    )
 
 DEFAULT_LOADERS_SETTING = {
     "colors": {

--- a/server_addon/maya/server/version.py
+++ b/server_addon/maya/server/version.py
@@ -1,3 +1,3 @@
 # -*- coding: utf-8 -*-
 """Package declaring addon version."""
-__version__ = "0.1.2"
+__version__ = "0.1.3"


### PR DESCRIPTION
## Changelog Description
This PR enhances previous one. All ReferenceLoaders could not wrap imported products into explicit group.
Also `Import` Loaders have same options. Control for this is separate in Settings, eg. Reference might wrap loaded items in group, `Import` might not.


## Testing notes:
1. Remove `_GRP` in `project_settings/maya/load/import_loader`
2. Try to `Import` anything into Maya
3. Try import `abc` representation of `animation`
