### PR TITLE
Nuke: workfile template fixes

### DIFF
--- a/openpype/hosts/nuke/api/workfile_template_builder.py
+++ b/openpype/hosts/nuke/api/workfile_template_builder.py
@@ -281,14 +281,6 @@ class NukePlaceholderLoadPlugin(NukePlaceholderPlugin, PlaceholderLoadMixin):
         placeholder.data["nb_children"] += 1
         reset_selection()
 
-        # # remove placeholders marked as delete
-        # if (
-        #     placeholder.data.get("delete")
-        #     and not placeholder.data.get("keep_placeholder")
-        # ):
-        #     self.log.debug("Deleting node: {}".format(placeholder_node.name()))
-        #     nuke.delete(placeholder_node)
-
         # go back to root group
         nuke.root().begin()
 
@@ -694,14 +686,6 @@ class NukePlaceholderCreatePlugin(
 
         placeholder.data["nb_children"] += 1
         reset_selection()
-
-        # # remove placeholders marked as delete
-        # if (
-        #     placeholder.data.get("delete")
-        #     and not placeholder.data.get("keep_placeholder")
-        # ):
-        #     self.log.debug("Deleting node: {}".format(placeholder_node.name()))
-        #     nuke.delete(placeholder_node)
 
         # go back to root group
         nuke.root().begin()

--- a/openpype/hosts/nuke/api/workfile_template_builder.py
+++ b/openpype/hosts/nuke/api/workfile_template_builder.py
@@ -114,7 +114,7 @@ class NukePlaceholderPlugin(PlaceholderPlugin):
             placeholder_data[key] = value
         return placeholder_data
 
-    def delete_placeholder(self, placeholder, failed):
+    def delete_placeholder(self, placeholder):
         """Remove placeholder if building was successful"""
         placeholder_node = nuke.toNode(placeholder.scene_identifier)
         nuke.delete(placeholder_node)

--- a/openpype/hosts/nuke/api/workfile_template_builder.py
+++ b/openpype/hosts/nuke/api/workfile_template_builder.py
@@ -114,6 +114,11 @@ class NukePlaceholderPlugin(PlaceholderPlugin):
             placeholder_data[key] = value
         return placeholder_data
 
+    def delete_placeholder(self, placeholder, failed):
+        """Remove placeholder if building was successful"""
+        placeholder_node = nuke.toNode(placeholder.scene_identifier)
+        nuke.delete(placeholder_node)
+
 
 class NukePlaceholderLoadPlugin(NukePlaceholderPlugin, PlaceholderLoadMixin):
     identifier = "nuke.load"
@@ -276,13 +281,13 @@ class NukePlaceholderLoadPlugin(NukePlaceholderPlugin, PlaceholderLoadMixin):
         placeholder.data["nb_children"] += 1
         reset_selection()
 
-        # remove placeholders marked as delete
-        if (
-            placeholder.data.get("delete")
-            and not placeholder.data.get("keep_placeholder")
-        ):
-            self.log.debug("Deleting node: {}".format(placeholder_node.name()))
-            nuke.delete(placeholder_node)
+        # # remove placeholders marked as delete
+        # if (
+        #     placeholder.data.get("delete")
+        #     and not placeholder.data.get("keep_placeholder")
+        # ):
+        #     self.log.debug("Deleting node: {}".format(placeholder_node.name()))
+        #     nuke.delete(placeholder_node)
 
         # go back to root group
         nuke.root().begin()
@@ -690,13 +695,13 @@ class NukePlaceholderCreatePlugin(
         placeholder.data["nb_children"] += 1
         reset_selection()
 
-        # remove placeholders marked as delete
-        if (
-            placeholder.data.get("delete")
-            and not placeholder.data.get("keep_placeholder")
-        ):
-            self.log.debug("Deleting node: {}".format(placeholder_node.name()))
-            nuke.delete(placeholder_node)
+        # # remove placeholders marked as delete
+        # if (
+        #     placeholder.data.get("delete")
+        #     and not placeholder.data.get("keep_placeholder")
+        # ):
+        #     self.log.debug("Deleting node: {}".format(placeholder_node.name()))
+        #     nuke.delete(placeholder_node)
 
         # go back to root group
         nuke.root().begin()

--- a/openpype/pipeline/workfile/workfile_template_builder.py
+++ b/openpype/pipeline/workfile/workfile_template_builder.py
@@ -1588,7 +1588,7 @@ class PlaceholderLoadMixin(object):
             )
             return
         if not placeholder.data.get("keep_placeholder", True):
-            self.delete_placeholder(placeholder)
+            self.delete_placeholder(placeholder, failed)
 
     def load_failed(self, placeholder, representation):
         if hasattr(placeholder, "load_failed"):
@@ -1781,6 +1781,17 @@ class PlaceholderCreateMixin(object):
 
         self.post_placeholder_process(placeholder, failed)
 
+        if failed:
+            self.log.debug(
+                "Placeholder cleanup skipped due to failed placeholder "
+                "population."
+            )
+            return
+
+        if not placeholder.data.get("keep_placeholder", True):
+            self.delete_placeholder(placeholder, failed)
+
+
     def create_failed(self, placeholder, creator_data):
         if hasattr(placeholder, "create_failed"):
             placeholder.create_failed(creator_data)
@@ -1800,8 +1811,11 @@ class PlaceholderCreateMixin(object):
                 representation.
             failed (bool): Loading of representation failed.
         """
-
         pass
+
+    def delete_placeholder(self, placeholder, failed):
+        """Called when all item population is done."""
+        self.log.debug("Clean up of placeholder is not implemented.")
 
     def _before_instance_create(self, placeholder):
         """Can be overriden. Is called before instance is created."""

--- a/openpype/pipeline/workfile/workfile_template_builder.py
+++ b/openpype/pipeline/workfile/workfile_template_builder.py
@@ -1588,7 +1588,7 @@ class PlaceholderLoadMixin(object):
             )
             return
         if not placeholder.data.get("keep_placeholder", True):
-            self.delete_placeholder(placeholder, failed)
+            self.delete_placeholder(placeholder)
 
     def load_failed(self, placeholder, representation):
         if hasattr(placeholder, "load_failed"):
@@ -1612,7 +1612,7 @@ class PlaceholderLoadMixin(object):
 
         pass
 
-    def delete_placeholder(self, placeholder, failed):
+    def delete_placeholder(self, placeholder):
         """Called when all item population is done."""
         self.log.debug("Clean up of placeholder is not implemented.")
 
@@ -1789,7 +1789,7 @@ class PlaceholderCreateMixin(object):
             return
 
         if not placeholder.data.get("keep_placeholder", True):
-            self.delete_placeholder(placeholder, failed)
+            self.delete_placeholder(placeholder)
 
 
     def create_failed(self, placeholder, creator_data):
@@ -1813,7 +1813,7 @@ class PlaceholderCreateMixin(object):
         """
         pass
 
-    def delete_placeholder(self, placeholder, failed):
+    def delete_placeholder(self, placeholder):
         """Called when all item population is done."""
         self.log.debug("Clean up of placeholder is not implemented.")
 


### PR DESCRIPTION
## Changelog Description
Some bunch of small bugs needed to be fixed 

## Additional info
- implemented **delete_placeholder** abstraction

## Testing notes:
1. create some testing template and set the template in a nuke template builder profelse
2. create the template inside Nuke and all should be working as expecting. Placeholders should be removed after the template is applied if the preset is having desabled `Keep placeholders`
