### PR TITLE
Scene Inventory: Fix issue with 'sync_server'

### DIFF
--- a/openpype/tools/sceneinventory/view.py
+++ b/openpype/tools/sceneinventory/view.py
@@ -55,7 +55,7 @@ class SceneInventoryView(QtWidgets.QTreeView):
 
         manager = ModulesManager()
         sync_server = manager.modules_by_name.get("sync_server")
-        sync_enabled = sync_server is not None and self.sync_server.enabled
+        sync_enabled = sync_server is not None and sync_server.enabled
 
         self.sync_server = sync_server
         self.sync_enabled = sync_enabled


### PR DESCRIPTION
## Changelog Description
Fix accesss to `sync_server` attribute in scene inventory.

## Additional info
Bug caused by https://github.com/ynput/OpenPype/pull/5413.

## Testing notes:
1. Open Scene inventory
2. Should work as usual
