### PR TITLE
AYON: Apply unknown ayon settings first

### DIFF
--- a/openpype/hosts/aftereffects/plugins/create/create_render.py
+++ b/openpype/hosts/aftereffects/plugins/create/create_render.py
@@ -28,7 +28,6 @@ class RenderCreator(Creator):
     create_allow_context_change = True
 
     # Settings
-    default_variants = []
     mark_for_review = True
 
     def create(self, subset_name_from_ui, data, pre_create_data):
@@ -171,6 +170,10 @@ class RenderCreator(Creator):
         )
 
         self.mark_for_review = plugin_settings["mark_for_review"]
+        self.default_variants = plugin_settings.get(
+            "default_variants",
+            plugin_settings.get("defaults") or []
+        )
 
     def get_detail_description(self):
         return """Creator for Render instances

--- a/openpype/settings/ayon_settings.py
+++ b/openpype/settings/ayon_settings.py
@@ -301,6 +301,10 @@ def convert_system_settings(ayon_settings, default_settings, addon_versions):
     if "core" in ayon_settings:
         _convert_general(ayon_settings, output, default_settings)
 
+    for key, value in ayon_settings.items():
+        if key not in output:
+            output[key] = value
+
     for key, value in default_settings.items():
         if key not in output:
             output[key] = value
@@ -1264,6 +1268,10 @@ def convert_project_settings(ayon_settings, default_settings):
     _convert_slack_project_settings(ayon_settings, output)
 
     _convert_global_project_settings(ayon_settings, output, default_settings)
+
+    for key, value in ayon_settings.items():
+        if key not in output:
+            output[key] = value
 
     for key, value in default_settings.items():
         if key not in output:

--- a/openpype/settings/defaults/project_settings/aftereffects.json
+++ b/openpype/settings/defaults/project_settings/aftereffects.json
@@ -12,7 +12,7 @@
     },
     "create": {
         "RenderCreator": {
-            "defaults": [
+            "default_variants": [
                 "Main"
             ],
             "mark_for_review": true

--- a/openpype/settings/defaults/project_settings/maya.json
+++ b/openpype/settings/defaults/project_settings/maya.json
@@ -547,7 +547,9 @@
         },
         "CreateUnrealSkeletalMesh": {
             "enabled": true,
-            "default_variants": [],
+            "default_variants": [
+                "Main"
+            ],
             "joint_hints": "jnt_org"
         },
         "CreateMultiverseLook": {

--- a/openpype/settings/entities/schemas/projects_schema/schema_project_aftereffects.json
+++ b/openpype/settings/entities/schemas/projects_schema/schema_project_aftereffects.json
@@ -32,7 +32,7 @@
                     "children": [
                         {
                             "type": "list",
-                            "key": "defaults",
+                            "key": "default_variants",
                             "label": "Default Variants",
                             "object_type": "text",
                             "docstring": "Fill default variant(s) (like 'Main' or 'Default') used in subset name creation."


### PR DESCRIPTION
## Changelog Description
Settings of custom addons are available in converted settings.

## Additional info
Settings of addons that are not in prepared conversion utils were not available in output ('ftrack', 'slack' 'shotgrid' addons).
