### PR TITLE
Maya: Fix wrong subset name of render family in deadline

### DIFF
--- a/openpype/hosts/maya/api/plugin.py
+++ b/openpype/hosts/maya/api/plugin.py
@@ -22,8 +22,6 @@ from openpype.pipeline import (
     LegacyCreator,
     LoaderPlugin,
     get_representation_path,
-
-    legacy_io,
 )
 from openpype.pipeline.load import LoadError
 from openpype.client import get_asset_by_name

--- a/openpype/hosts/maya/api/plugin.py
+++ b/openpype/hosts/maya/api/plugin.py
@@ -413,8 +413,7 @@ class RenderlayerCreator(NewCreator, MayaCreatorBase):
                 }
                 asset_doc = get_asset_by_name(project_name,
                                               instance_data["asset"])
-                subset_name = get_subset_name(
-                    self.layer_instance_prefix,
+                subset_name = self.get_subset_name(
                     layer.name(),
                     instance_data["task"],
                     asset_doc,
@@ -525,6 +524,22 @@ class RenderlayerCreator(NewCreator, MayaCreatorBase):
                 node = instance.data.get("instance_node")
                 if node and cmds.objExists(node):
                     cmds.delete(node)
+
+    def get_subset_name(
+        self,
+        variant,
+        task_name,
+        asset_doc,
+        project_name,
+        host_name=None,
+        instance=None
+    ):
+        # creator.family != 'render' as expected
+        return get_subset_name(self.layer_instance_prefix,
+                               variant,
+                               task_name,
+                               asset_doc,
+                               project_name)
 
 
 class Loader(LoaderPlugin):

--- a/openpype/hosts/maya/api/plugin.py
+++ b/openpype/hosts/maya/api/plugin.py
@@ -406,6 +406,7 @@ class RenderlayerCreator(NewCreator, MayaCreatorBase):
                 # this instance will not have the `instance_node` data yet
                 # until it's been saved/persisted at least once.
                 project_name = self.create_context.get_current_project_name()
+
                 instance_data = {
                     "asset": self.create_context.get_current_asset_name(),
                     "task": self.create_context.get_current_task_name(),

--- a/openpype/hosts/maya/api/plugin.py
+++ b/openpype/hosts/maya/api/plugin.py
@@ -407,8 +407,8 @@ class RenderlayerCreator(NewCreator, MayaCreatorBase):
                 # until it's been saved/persisted at least once.
                 project_name = self.create_context.get_current_project_name()
                 instance_data = {
-                    "asset": self.create_context.get_current_asset_name,
-                    "task": self.create_context.get_current_task_name,
+                    "asset": self.create_context.get_current_asset_name(),
+                    "task": self.create_context.get_current_task_name(),
                     "variant": layer.name(),
                 }
                 asset_doc = get_asset_by_name(project_name,

--- a/openpype/hosts/maya/plugins/create/convert_legacy.py
+++ b/openpype/hosts/maya/plugins/create/convert_legacy.py
@@ -2,6 +2,10 @@ from openpype.pipeline.create.creator_plugins import SubsetConvertorPlugin
 from openpype.hosts.maya.api import plugin
 from openpype.hosts.maya.api.lib import read
 
+from openpype.client import get_asset_by_name
+from openpype.pipeline.create import get_subset_name
+from openpype.pipeline import get_current_project_name
+
 from maya import cmds
 from maya.app.renderSetup.model import renderSetup
 
@@ -134,6 +138,19 @@ class MayaLegacyConvertor(SubsetConvertorPlugin,
             # The family gets converted to the new family (this is due to
             # "rendering" family being converted to "renderlayer" family)
             original_data["family"] = creator.family
+
+
+            # recreate subset name as without it would be
+            # `renderingMain` vs correct `renderMain`
+            project_name = get_current_project_name()
+            asset_doc = get_asset_by_name(project_name,
+                                          original_data["asset"])
+            subset_name = get_subset_name("render",
+                                          original_data["variant"],
+                                          data["task"],
+                                          asset_doc,
+                                          project_name)
+            original_data["subset"] = subset_name
 
             # Convert to creator attributes when relevant
             creator_attributes = {}

--- a/openpype/hosts/maya/plugins/create/convert_legacy.py
+++ b/openpype/hosts/maya/plugins/create/convert_legacy.py
@@ -4,7 +4,6 @@ from openpype.hosts.maya.api.lib import read
 
 from openpype.client import get_asset_by_name
 from openpype.pipeline.create import get_subset_name
-from openpype.pipeline import get_current_project_name
 
 from maya import cmds
 from maya.app.renderSetup.model import renderSetup
@@ -141,7 +140,7 @@ class MayaLegacyConvertor(SubsetConvertorPlugin,
 
             # recreate subset name as without it would be
             # `renderingMain` vs correct `renderMain`
-            project_name = get_current_project_name()
+            project_name = self.create_context.get_current_project_name()
             asset_doc = get_asset_by_name(project_name,
                                           original_data["asset"])
             subset_name = get_subset_name("render",

--- a/openpype/hosts/maya/plugins/create/convert_legacy.py
+++ b/openpype/hosts/maya/plugins/create/convert_legacy.py
@@ -143,11 +143,11 @@ class MayaLegacyConvertor(SubsetConvertorPlugin,
             project_name = self.create_context.get_current_project_name()
             asset_doc = get_asset_by_name(project_name,
                                           original_data["asset"])
-            subset_name = get_subset_name("render",
-                                          original_data["variant"],
-                                          data["task"],
-                                          asset_doc,
-                                          project_name)
+            subset_name = creator.get_subset_name(
+                original_data["variant"],
+                data["task"],
+                asset_doc,
+                project_name)
             original_data["subset"] = subset_name
 
             # Convert to creator attributes when relevant

--- a/openpype/hosts/maya/plugins/create/convert_legacy.py
+++ b/openpype/hosts/maya/plugins/create/convert_legacy.py
@@ -139,7 +139,6 @@ class MayaLegacyConvertor(SubsetConvertorPlugin,
             # "rendering" family being converted to "renderlayer" family)
             original_data["family"] = creator.family
 
-
             # recreate subset name as without it would be
             # `renderingMain` vs correct `renderMain`
             project_name = get_current_project_name()

--- a/openpype/hosts/maya/plugins/create/convert_legacy.py
+++ b/openpype/hosts/maya/plugins/create/convert_legacy.py
@@ -3,7 +3,6 @@ from openpype.hosts.maya.api import plugin
 from openpype.hosts.maya.api.lib import read
 
 from openpype.client import get_asset_by_name
-from openpype.pipeline.create import get_subset_name
 
 from maya import cmds
 from maya.app.renderSetup.model import renderSetup

--- a/openpype/pipeline/farm/pyblish_functions.py
+++ b/openpype/pipeline/farm/pyblish_functions.py
@@ -568,9 +568,15 @@ def _create_instances_for_aov(instance, skeleton, aov_filter, additional_data,
             col = list(cols[0])
 
         # create subset name `familyTaskSubset_AOV`
-        group_name = 'render{}{}{}{}'.format(
-            task[0].upper(), task[1:],
-            subset[0].upper(), subset[1:])
+        # TODO reactor/remove me
+        family = skeleton["family"]
+        if not subset.startswith(family):
+            group_name = '{}{}{}'.format(
+                family,
+                task.capitalize(),
+                task.capitalize())
+        else:
+            group_name = subset
 
         # if there are multiple cameras, we need to add camera name
         if isinstance(col, (list, tuple)):

--- a/openpype/pipeline/farm/pyblish_functions.py
+++ b/openpype/pipeline/farm/pyblish_functions.py
@@ -568,13 +568,13 @@ def _create_instances_for_aov(instance, skeleton, aov_filter, additional_data,
             col = list(cols[0])
 
         # create subset name `familyTaskSubset_AOV`
-        # TODO reactor/remove me
+        # TODO refactor/remove me
         family = skeleton["family"]
         if not subset.startswith(family):
             group_name = '{}{}{}'.format(
                 family,
                 task.capitalize(),
-                task.capitalize())
+                subset.capitalize())
         else:
             group_name = subset
 

--- a/openpype/pipeline/farm/pyblish_functions.py
+++ b/openpype/pipeline/farm/pyblish_functions.py
@@ -571,10 +571,10 @@ def _create_instances_for_aov(instance, skeleton, aov_filter, additional_data,
         # TODO refactor/remove me
         family = skeleton["family"]
         if not subset.startswith(family):
-            group_name = '{}{}{}'.format(
+            group_name = '{}{}{}{}{}'.format(
                 family,
-                task.capitalize(),
-                subset.capitalize())
+                task[0].upper(), task[1:],
+                subset[0].upper(), subset[1:])
         else:
             group_name = subset
 


### PR DESCRIPTION
## Changelog Description
New Publisher is creating different subset names than previously which resulted in duplication of `render` string in final subset name of `render` family published on Deadline.
This PR solves that, it also fixes issues with legacy instances from old publisher, it matches the subset name as was before.

This solves same issue in Max implementation.

## Additional info
`renderModelingMain_beauty` in old publisher >> `renderModelingRenderingMain_beauty`
![AnyDeskMSI_56csq5vzNi](https://github.com/ynput/OpenPype/assets/4457962/9cfd67c6-fff0-416f-8277-e8821e713b99)



## Testing notes:
1. create new render instance, publish to deadline, check subset name (folder name)
2. use old workfile with instances created in old publisher, use `Convert legacy` to re-create instance, check subset names
