### PR TITLE
Nuke: Name of the Read Node should be updated correctly when switching versions or assets.

### DIFF
--- a/openpype/hosts/nuke/plugins/load/load_image.py
+++ b/openpype/hosts/nuke/plugins/load/load_image.py
@@ -96,7 +96,8 @@ class LoadImage(load.LoaderPlugin):
 
         file = file.replace("\\", "/")
 
-        repr_cont = context["representation"]["context"]
+        representation = context["representation"]
+        repr_cont = representation["context"]
         frame = repr_cont.get("frame")
         if frame:
             padding = len(frame)
@@ -104,16 +105,7 @@ class LoadImage(load.LoaderPlugin):
                 frame,
                 format(frame_number, "0{}".format(padding)))
 
-        name_data = {
-            "asset": repr_cont["asset"],
-            "subset": repr_cont["subset"],
-            "representation": context["representation"]["name"],
-            "ext": repr_cont["representation"],
-            "id": context["representation"]["_id"],
-            "class_name": self.__class__.__name__
-        }
-
-        read_name = self.node_name_template.format(**name_data)
+        read_name = self._get_node_name(representation)
 
         # Create the Loader with the filename path set
         with viewer_update_and_undo_stop():

--- a/openpype/hosts/nuke/plugins/load/load_image.py
+++ b/openpype/hosts/nuke/plugins/load/load_image.py
@@ -212,6 +212,8 @@ class LoadImage(load.LoaderPlugin):
         last = first = int(frame_number)
 
         # Set the global in to the start frame of the sequence
+        read_name = self._get_node_name(representation)
+        node["name"].setValue(read_name)
         node["file"].setValue(file)
         node["origfirst"].setValue(first)
         node["first"].setValue(first)
@@ -250,3 +252,17 @@ class LoadImage(load.LoaderPlugin):
 
         with viewer_update_and_undo_stop():
             nuke.delete(node)
+
+    def _get_node_name(self, representation):
+
+        repre_cont = representation["context"]
+        name_data = {
+            "asset": repre_cont["asset"],
+            "subset": repre_cont["subset"],
+            "representation": representation["name"],
+            "ext": repre_cont["representation"],
+            "id": representation["_id"],
+            "class_name": self.__class__.__name__
+        }
+
+        return self.node_name_template.format(**name_data)


### PR DESCRIPTION
## Changelog Description
Bug fixing of the read node's name not being updated correctly when setting version or switching asset.

## Additional info
n/a

## Testing notes:
1. Go to OP Setting `project_settings/nuke/load/LoadImage/node_name_template`
2. Set node_name template with the varying data by version/asset, such as `{class_name}_{id}_{ext}`
![image](https://github.com/ynput/OpenPype/assets/64118225/70442230-0c8f-4242-80f1-34aa581ed508)

3. Launch Nuke with Launcher/OP
4. Access "Load.." via AYON/OP Menu
5. Load image with the families such as plateMain, reviewMain etc...
6. Access "Manage.." via AYON/OP Menu
7. Right click to set version or switch asset
8. The name should be changed as expected
