### PR TITLE
Farm publishing: asymmetric handles fixed

### DIFF
--- a/openpype/pipeline/farm/pyblish_functions.py
+++ b/openpype/pipeline/farm/pyblish_functions.py
@@ -116,8 +116,8 @@ def get_time_data_from_instance_or_context(instance):
              instance.context.data.get("fps")),
         handle_start=(instance.data.get("handleStart") or
                       instance.context.data.get("handleStart")),  # noqa: E501
-        handle_end=(instance.data.get("handleStart") or
-                    instance.context.data.get("handleStart"))
+        handle_end=(instance.data.get("handleEnd") or
+                    instance.context.data.get("handleEnd"))
     )
 
 


### PR DESCRIPTION
## Changelog Description
Handles are now set correctly on farm published product version if asymmetric were set to shot attributes.

## Testing notes:
1. set asymmetric handles to any of your testing shot
2. open any host app and set framerange to it from shot
3. publish on farm
4. notice in loader that product is having correct handles
