### PR TITLE
Scene Inventory: Provider icons fix

### DIFF
--- a/openpype/tools/sceneinventory/model.py
+++ b/openpype/tools/sceneinventory/model.py
@@ -85,7 +85,7 @@ class InventoryModel(TreeModel):
         self.remote_provider = remote_provider
         self._site_icons = {
             provider: QtGui.QIcon(icon_path)
-            for provider, icon_path in self.get_site_icons().items()
+            for provider, icon_path in sync_server.get_site_icons().items()
         }
         if "active_site" not in self.Columns:
             self.Columns.append("active_site")


### PR DESCRIPTION
## Changelog Description
Fix how provider icons are accessed in scene inventory.

## Additional info
Call `get_site_icons` on sync sever module instead of calling it on self.

## Testing notes:
1. Enabled sync server module
2. Open scene inventory in any host
3. It should not crash

Resolves https://github.com/ynput/OpenPype/issues/5449