### PR TITLE
Maya: Fix setting of version to workfile instance

### DIFF
--- a/openpype/hosts/maya/plugins/publish/collect_render.py
+++ b/openpype/hosts/maya/plugins/publish/collect_render.py
@@ -304,9 +304,9 @@ class CollectMayaRender(pyblish.api.InstancePlugin):
 
         if self.sync_workfile_version:
             data["version"] = context.data["version"]
-            for instance in context:
-                if instance.data['family'] == "workfile":
-                    instance.data["version"] = context.data["version"]
+            for _instance in context:
+                if _instance.data['family'] == "workfile":
+                    _instance.data["version"] = context.data["version"]
 
         # Define nice label
         label = "{0} ({1})".format(layer_name, instance.data["asset"])


### PR DESCRIPTION
## Changelog Description
If there are multiple instances of renderlayer published, previous logic resulted in unpredictable rewrite of instance family to 'workfile' if `Sync render version with workfile` was on.


## Testing notes:
1. create multiple `render` instances
2. enable `Sync render version with workfile`  `project_settings/maya/publish/CollectMayaRender`
3. publish them with `workfile` instance
4. shouldn't fail on "Render Settings"
