### PR TITLE
Nuke: adding inherited colorspace from instance

### DIFF
--- a/openpype/hosts/nuke/plugins/publish/extract_thumbnail.py
+++ b/openpype/hosts/nuke/plugins/publish/extract_thumbnail.py
@@ -54,6 +54,7 @@ class ExtractThumbnail(publish.Extractor):
     def render_thumbnail(self, instance, output_name=None, **kwargs):
         first_frame = instance.data["frameStartHandle"]
         last_frame = instance.data["frameEndHandle"]
+        colorspace = instance.data["colorspace"]
 
         # find frame range and define middle thumb frame
         mid_frame = int((last_frame - first_frame) / 2)
@@ -112,8 +113,8 @@ class ExtractThumbnail(publish.Extractor):
         if self.use_rendered and os.path.isfile(path_render):
             # check if file exist otherwise connect to write node
             rnode = nuke.createNode("Read")
-
             rnode["file"].setValue(path_render)
+            rnode["colorspace"].setValue(colorspace)
 
             # turn it raw if none of baking is ON
             if all([


### PR DESCRIPTION
## Changelog Description
Thumbnails are extracted with inherited colorspace collected from rendering write node.

## Testing notes:
1. should work as it was