### PR TITLE
Add kitsu credentials to deadline publish job 

### DIFF
--- a/openpype/modules/deadline/plugins/publish/submit_publish_job.py
+++ b/openpype/modules/deadline/plugins/publish/submit_publish_job.py
@@ -121,7 +121,9 @@ class ProcessSubmittedJobOnFarm(pyblish.api.InstancePlugin,
         "FTRACK_SERVER",
         "AVALON_APP_NAME",
         "OPENPYPE_USERNAME",
-        "OPENPYPE_SG_USER"
+        "OPENPYPE_SG_USER",
+        "KITSU_LOGIN",
+        "KITSU_PWD"
     ]
 
     # custom deadline attributes


### PR DESCRIPTION
## Changelog Description
This PR hopefully fixes this issue #5440  

## Additional Info
This solution was a dumb test that worked! 
I don't know if it covers all the cases (e.g. Muster)

## Testing notes:
1. enable kitsu module
2. submit a deadline job
