### PR TITLE
Loader: Add colorspace entry to Version Info

### DIFF
--- a/openpype/tools/loader/widgets.py
+++ b/openpype/tools/loader/widgets.py
@@ -741,6 +741,16 @@ class VersionTextEdit(QtWidgets.QTextEdit):
             "source": source_label
         }
 
+        # Add colorspace info to Version Info tab
+        version_colorspace = version_doc["data"].get("colorspace")
+        colorspace_html = ""
+        if version_colorspace:
+            colorspace_html = "<b>Colorspace</b><br>{colorspace}<br><br>".format(
+                colorspace=version_colorspace
+            )
+
+        data["colorspace_html"] = colorspace_html
+
         self.setHtml((
             "<h2>{subset}</h2>"
             "<h3>{version}</h3>"
@@ -749,7 +759,7 @@ class VersionTextEdit(QtWidgets.QTextEdit):
 
             "<b>Created</b><br>"
             "{created}<br><br>"
-
+            "{colorspace_html}"
             "<b>Source</b><br>"
             "{source}"
         ).format(**data))

--- a/openpype/tools/loader/widgets.py
+++ b/openpype/tools/loader/widgets.py
@@ -745,8 +745,8 @@ class VersionTextEdit(QtWidgets.QTextEdit):
         version_colorspace = version_doc["data"].get("colorspace")
         colorspace_html = ""
         if version_colorspace:
-            colorspace_html = "<b>Colorspace</b><br>{colorspace}<br><br>".format(
-                colorspace=version_colorspace
+            colorspace_html = "<b>Colorspace</b><br>{}<br><br>".format(
+                version_colorspace
             )
 
         data["colorspace_html"] = colorspace_html


### PR DESCRIPTION
## Changelog Description
Small addition to add "Colorspace" entry in Version Info tab in loader if version has colorspace data

![image](https://github.com/ynput/OpenPype/assets/4348536/31f9394f-2d07-401a-a1a8-950fc93b0fa3)

## Testing notes:
1. Open the loader and click on a Version entry that has colorspace data
