### PR TITLE
Maya: Context plugin shouldn't be tied to family

### DIFF
--- a/openpype/hosts/maya/plugins/publish/collect_current_file.py
+++ b/openpype/hosts/maya/plugins/publish/collect_current_file.py
@@ -10,7 +10,6 @@ class CollectCurrentFile(pyblish.api.ContextPlugin):
     order = pyblish.api.CollectorOrder - 0.4
     label = "Maya Current File"
     hosts = ['maya']
-    families = ["workfile"]
 
     def process(self, context):
         """Inject the current working file"""


### PR DESCRIPTION
## Changelog Description
`Maya Current File` collector was tied to `workfile` unnecessary. It should run even if `workile` instance is not being published.


## Testing notes:
1. Disable `workfile` instance and publish
2. `Collect Scene Version` shouldnt fail
