### PR TITLE
Ftrack: Fix version 0 when integrating to Ftrack - OP-6595

### DIFF
--- a/openpype/modules/ftrack/plugins/publish/integrate_ftrack_api.py
+++ b/openpype/modules/ftrack/plugins/publish/integrate_ftrack_api.py
@@ -353,7 +353,7 @@ class IntegrateFtrackApi(pyblish.api.InstancePlugin):
         status_name = asset_version_data.pop("status_name", None)
 
         # Try query asset version by criteria (asset id and version)
-        version = asset_version_data.get("version") or 0
+        version = asset_version_data.get("version") or "0"
         asset_version_entity = self._query_asset_version(
             session, version, asset_id
         )


### PR DESCRIPTION
## Changelog Description
Fix publishing version 0 to Ftrack.

## Additional info
Error:

```
Traceback (most recent call last):
  File "C:\Users\tokejepsen\OpenPype\.venv\lib\site-packages\pyblish\plugin.py", line 527, in __explicit_process
    runner(*args)
  File "C:\Users\tokejepsen\OpenPype\openpype\modules\ftrack\plugins\publish\integrate_ftrack_api.py", line 57, in process
  File "C:\Users\tokejepsen\OpenPype\openpype\modules\ftrack\plugins\publish\integrate_ftrack_api.py", line 149, in integrate_to_ftrack
TypeError: 'NoneType' object has no attribute '__getitem__'
```

## Testing notes:
1. Setup version 0 for any or all hosts.
2. Publish version 0 to Ftrack from the configured host.
