### PR TITLE
OCIO: windows unc path support in Nuke and Hiero

### DIFF
--- a/openpype/hooks/pre_ocio_hook.py
+++ b/openpype/hooks/pre_ocio_hook.py
@@ -45,6 +45,9 @@ class OCIOEnvHook(PreLaunchHook):
         if config_data:
             ocio_path = config_data["path"]
 
+            if self.host_name in ["nuke", "hiero"]:
+                ocio_path = ocio_path.replace("\\", "/")
+
             self.log.info(
                 f"Setting OCIO environment to config path: {ocio_path}")
 

--- a/openpype/hosts/nuke/api/lib.py
+++ b/openpype/hosts/nuke/api/lib.py
@@ -2107,8 +2107,9 @@ class WorkfileSettings(object):
 
         # set ocio config path
         if config_data:
+            config_path = config_data["path"].replace("\\", "/")
             log.info("OCIO config path found: `{}`".format(
-                config_data["path"]))
+                config_path))
 
             # check if there's a mismatch between environment and settings
             correct_settings = self._is_settings_matching_environment(
@@ -2233,7 +2234,7 @@ Reopening Nuke should synchronize these paths and resolve any discrepancies.
         Returns:
             str: OCIO config path with environment variable TCL expression
         """
-        config_path = config_data["path"]
+        config_path = config_data["path"].replace("\\", "/")
         config_template = config_data["template"]
 
         included_vars = self._get_included_vars(config_template)

--- a/openpype/hosts/nuke/api/lib.py
+++ b/openpype/hosts/nuke/api/lib.py
@@ -2177,6 +2177,7 @@ Reopening Nuke should synchronize these paths and resolve any discrepancies.
         """
         # replace path with env var if possible
         ocio_path = self._replace_ocio_path_with_env_var(config_data)
+        ocio_path = ocio_path.replace("\\", "/")
 
         log.info("Setting OCIO config path to: `{}`".format(
             ocio_path))


### PR DESCRIPTION
## Changelog Description
Hiero and Nuke is not supporting windows unc path formatting in OCIO environment variable.

## Testing notes:
1. Add ocio config with unc path
2. open nuke and check that the unc path is added into custom config.
