### PR TITLE
TrayPublisher: adding audio product type into default presets

### DIFF
--- a/openpype/settings/defaults/project_settings/traypublisher.json
+++ b/openpype/settings/defaults/project_settings/traypublisher.json
@@ -256,6 +256,23 @@
             "allow_multiple_items": true,
             "allow_version_control": false,
             "extensions": []
+        },
+        {
+            "family": "audio",
+            "identifier": "",
+            "label": "Audio ",
+            "icon": "fa5s.file-audio",
+            "default_variants": [
+                "Main"
+            ],
+            "description": "Audio product",
+            "detailed_description": "Audio files for review or final delivery",
+            "allow_sequences": false,
+            "allow_multiple_items": false,
+            "allow_version_control": false,
+            "extensions": [
+                ".wav"
+            ]
         }
     ],
     "editorial_creators": {


### PR DESCRIPTION
## Changelog Description
Adding Audio product type into default presets so anybody can publish audio to their shots.


## Testing notes:
1. Open publisher and se there is new product / family available on top Audio.
2. Set context and drop any wav into representation field and publish.
3. All should be publish as expected.

