### PR TITLE
Abstraction for publishing with prepared representation

### DIFF
--- a/openpype/hosts/nuke/plugins/publish/collect_nuke_instance_data.py
+++ b/openpype/hosts/nuke/plugins/publish/collect_nuke_instance_data.py
@@ -2,7 +2,7 @@ import nuke
 import pyblish.api
 
 
-class CollectNukeInstanceData(pyblish.api.InstancePlugin):
+class CollectInstanceData(pyblish.api.InstancePlugin):
     """Collect Nuke instance data
 
     """

--- a/openpype/hosts/nuke/plugins/publish/collect_nuke_instance_data.py
+++ b/openpype/hosts/nuke/plugins/publish/collect_nuke_instance_data.py
@@ -45,10 +45,9 @@ class CollectNukeInstanceData(pyblish.api.InstancePlugin):
 
         # add creator attributes to instance
         creator_attributes = instance.data["creator_attributes"]
-        instance.data.update(creator_attributes)
 
         # add review family if review activated on instance
-        if instance.data.get("review"):
+        if creator_attributes.get("review"):
             instance.data["families"].append("review")
 
         self.log.debug("Collected instance: {}".format(

--- a/openpype/hosts/nuke/plugins/publish/collect_writes.py
+++ b/openpype/hosts/nuke/plugins/publish/collect_writes.py
@@ -6,6 +6,7 @@ from openpype.pipeline import publish
 
 
 class CollectNukeWrites(pyblish.api.InstancePlugin,
+                        publish.PrepRepresentationPluginMixin,
                         publish.ColormanagedPyblishPluginMixin):
     """Collect all write nodes."""
 
@@ -14,17 +15,11 @@ class CollectNukeWrites(pyblish.api.InstancePlugin,
     hosts = ["nuke", "nukeassist"]
     families = ["render", "prerender", "image"]
 
-    # cache
-    _write_nodes = {}
-    _frame_ranges = {}
-
     def process(self, instance):
 
         group_node = instance.data["transientData"]["node"]
-        render_target = instance.data["render_target"]
 
         write_node = self._write_node_helper(instance)
-
         if write_node is None:
             self.log.warning(
                 "Created node '{}' is missing write node!".format(
@@ -33,112 +28,94 @@ class CollectNukeWrites(pyblish.api.InstancePlugin,
             )
             return
 
+        # get write file path
+        write_file_path = nuke.filename(write_node)
+        frame_start, frame_end = self._get_frame_range(write_node)
+
         # get colorspace and add to version data
         colorspace = napi.get_colorspace_from_node(write_node)
 
-        if render_target == "frames":
-            self._set_existing_files_data(instance, colorspace)
+        # split operations by render target
+        render_target = instance.data["render_target"]
+
+        if render_target == "farm":
+            self.add_farm_instance_data(instance)
+
+        elif render_target == "frames":
+            file_paths = self.prepare_collection_of_file_paths(
+                write_file_path, frame_start, frame_end, only_existing=True
+            )
+
+            representation = self.prepare_representation(
+                instance, file_paths, frame_start, frame_end,
+                reviewable=("review" in instance.data)
+            )
+
+            # QUESTION: should we set colorspace at this moment or downstream?
+            self.set_representation_colorspace(
+                representation, instance.context,
+                colorspace=colorspace
+            )
+            instance.data["representations"].append(representation)
 
         elif render_target == "frames_farm":
-            collected_frames = self._set_existing_files_data(
-                instance, colorspace)
+            file_paths = self.prepare_collection_of_file_paths(
+                write_file_path, frame_start, frame_end, only_existing=True
+            )
 
-            self._set_expected_files(instance, collected_frames)
+            representation = self.prepare_representation(
+                instance, file_paths, frame_start, frame_end,
+                reviewable=("review" in instance.data)
+            )
+            self.make_farm_publishing_representation(representation)
 
-            self._add_farm_instance_data(instance)
+            # QUESTION: should we set colorspace at this moment or downstream?
+            self.set_representation_colorspace(
+                representation, instance.context,
+                colorspace=colorspace
+            )
+            instance.data["representations"].append(representation)
 
-        elif render_target == "farm":
-            self._add_farm_instance_data(instance)
+            self.add_farm_instance_data(instance)
 
         # set additional instance data
-        self._set_additional_instance_data(instance, render_target, colorspace)
+        self._set_additional_instance_data(
+            instance, write_node, frame_start, frame_end, colorspace)
 
-    def _set_existing_files_data(self, instance, colorspace):
-        """Set existing files data to instance data.
-
-        Args:
-            instance (pyblish.api.Instance): pyblish instance
-            colorspace (str): colorspace
-
-        Returns:
-            list: collected frames
-        """
-        collected_frames = self._get_collected_frames(instance)
-
-        representation = self._get_existing_frames_representation(
-            instance, collected_frames
-        )
-
-        # inject colorspace data
-        self.set_representation_colorspace(
-            representation, instance.context,
-            colorspace=colorspace
-        )
-
-        instance.data["representations"].append(representation)
-
-        return collected_frames
-
-    def _set_expected_files(self, instance, collected_frames):
-        """Set expected files to instance data.
-
-        Args:
-            instance (pyblish.api.Instance): pyblish instance
-            collected_frames (list): collected frames
-        """
-        write_node = self._write_node_helper(instance)
-
-        write_file_path = nuke.filename(write_node)
-        output_dir = os.path.dirname(write_file_path)
-
-        instance.data["expectedFiles"] = [
-            os.path.join(output_dir, source_file)
-            for source_file in collected_frames
-        ]
-
-    def _get_frame_range_data(self, instance):
+    def _get_frame_range(self, write_node):
         """Get frame range data from instance.
 
         Args:
-            instance (pyblish.api.Instance): pyblish instance
+            write_node (nuke.Node): write node
 
         Returns:
-            tuple: first_frame, last_frame
+            tuple: frame_start, frame_end
         """
-
-        instance_name = instance.data["name"]
-
-        if self._frame_ranges.get(instance_name):
-            # return cashed write node
-            return self._frame_ranges[instance_name]
-
-        write_node = self._write_node_helper(instance)
-
         # Get frame range from workfile
-        first_frame = int(nuke.root()["first_frame"].getValue())
-        last_frame = int(nuke.root()["last_frame"].getValue())
+        frame_start = int(nuke.root()["first_frame"].getValue())
+        frame_end = int(nuke.root()["last_frame"].getValue())
 
         # Get frame range from write node if activated
         if write_node["use_limit"].getValue():
-            first_frame = int(write_node["first"].getValue())
-            last_frame = int(write_node["last"].getValue())
+            frame_start = int(write_node["first"].getValue())
+            frame_end = int(write_node["last"].getValue())
 
-        # add to cache
-        self._frame_ranges[instance_name] = (first_frame, last_frame)
-
-        return first_frame, last_frame
+        return frame_start, frame_end
 
     def _set_additional_instance_data(
-        self, instance, render_target, colorspace
+        self, instance, write_node, frame_start, frame_end, colorspace
     ):
         """Set additional instance data.
 
         Args:
             instance (pyblish.api.Instance): pyblish instance
-            render_target (str): render target
+            write_node (nuke.Node): write node
+            frame_start (int): first frame
+            frame_end (int): last frame
             colorspace (str): colorspace
         """
         family = instance.data["family"]
+        render_target = instance.data["render_target"]
 
         # add targeted family to families
         instance.data["families"].append(
@@ -148,15 +125,12 @@ class CollectNukeWrites(pyblish.api.InstancePlugin,
             family, render_target)
         )
 
-        write_node = self._write_node_helper(instance)
-
         # Determine defined file type
         ext = write_node["file_type"].value()
 
         # get frame range data
         handle_start = instance.context.data["handleStart"]
         handle_end = instance.context.data["handleEnd"]
-        first_frame, last_frame = self._get_frame_range_data(instance)
 
         # get output paths
         write_file_path = nuke.filename(write_node)
@@ -179,21 +153,20 @@ class CollectNukeWrites(pyblish.api.InstancePlugin,
             instance.data.update({
                 "handleStart": handle_start,
                 "handleEnd": handle_end,
-                "frameStart": first_frame + handle_start,
-                "frameEnd": last_frame - handle_end,
-                "frameStartHandle": first_frame,
-                "frameEndHandle": last_frame,
+                "frameStart": frame_start + handle_start,
+                "frameEnd": frame_end - handle_end,
+                "frameStartHandle": frame_start,
+                "frameEndHandle": frame_end,
             })
         else:
             instance.data.update({
                 "handleStart": 0,
                 "handleEnd": 0,
-                "frameStart": first_frame,
-                "frameEnd": last_frame,
-                "frameStartHandle": first_frame,
-                "frameEndHandle": last_frame,
+                "frameStart": frame_start,
+                "frameEnd": frame_end,
+                "frameStartHandle": frame_start,
+                "frameEndHandle": frame_end,
             })
-
 
         # TODO temporarily set stagingDir as persistent for backward
         # compatibility. This is mainly focused on `renders`folders which
@@ -212,12 +185,6 @@ class CollectNukeWrites(pyblish.api.InstancePlugin,
         Returns:
             nuke.Node: write node
         """
-        instance_name = instance.data["name"]
-
-        if self._write_nodes.get(instance_name):
-            # return cashed write node
-            return self._write_nodes[instance_name]
-
         # get all child nodes from group node
         child_nodes = napi.get_instance_group_node_childs(instance)
 
@@ -229,173 +196,10 @@ class CollectNukeWrites(pyblish.api.InstancePlugin,
             if node_.Class() == "Write":
                 write_node = node_
 
-        if write_node:
-            # for slate frame extraction
-            instance.data["transientData"]["writeNode"] = write_node
-            # add to cache
-            self._write_nodes[instance_name] = write_node
+        if not write_node:
+            return None
 
-            return self._write_nodes[instance_name]
+        # for slate frame extraction
+        instance.data["transientData"]["writeNode"] = write_node
 
-    def _get_existing_frames_representation(
-        self,
-        instance,
-        collected_frames
-    ):
-        """Get existing frames representation.
-
-        Args:
-            instance (pyblish.api.Instance): pyblish instance
-            collected_frames (list): collected frames
-
-        Returns:
-            dict: representation
-        """
-
-        first_frame, last_frame = self._get_frame_range_data(instance)
-
-        write_node = self._write_node_helper(instance)
-
-        write_file_path = nuke.filename(write_node)
-        output_dir = os.path.dirname(write_file_path)
-
-        # Determine defined file type
-        ext = write_node["file_type"].value()
-
-        representation = {
-            "name": ext,
-            "ext": ext,
-            "stagingDir": output_dir,
-            "tags": []
-        }
-
-        frame_start_str = self._get_frame_start_str(first_frame, last_frame)
-
-        representation['frameStart'] = frame_start_str
-
-        # set slate frame
-        collected_frames = self._add_slate_frame_to_collected_frames(
-            instance,
-            collected_frames,
-            first_frame,
-            last_frame
-        )
-
-        if len(collected_frames) == 1:
-            representation['files'] = collected_frames.pop()
-        else:
-            representation['files'] = collected_frames
-
-        return representation
-
-    def _get_frame_start_str(self, first_frame, last_frame):
-        """Get frame start string.
-
-        Args:
-            first_frame (int): first frame
-            last_frame (int): last frame
-
-        Returns:
-            str: frame start string
-        """
-        # convert first frame to string with padding
-        return (
-            "{{:0{}d}}".format(len(str(last_frame)))
-        ).format(first_frame)
-
-    def _add_slate_frame_to_collected_frames(
-        self,
-        instance,
-        collected_frames,
-        first_frame,
-        last_frame
-    ):
-        """Add slate frame to collected frames.
-
-        Args:
-            instance (pyblish.api.Instance): pyblish instance
-            collected_frames (list): collected frames
-            first_frame (int): first frame
-            last_frame (int): last frame
-
-        Returns:
-            list: collected frames
-        """
-        frame_start_str = self._get_frame_start_str(first_frame, last_frame)
-        frame_length = int(last_frame - first_frame + 1)
-
-        # this will only run if slate frame is not already
-        # rendered from previews publishes
-        if (
-            "slate" in instance.data["families"]
-            and frame_length == len(collected_frames)
-        ):
-            frame_slate_str = self._get_frame_start_str(
-                first_frame - 1,
-                last_frame
-            )
-
-            slate_frame = collected_frames[0].replace(
-                frame_start_str, frame_slate_str)
-            collected_frames.insert(0, slate_frame)
-
-        return collected_frames
-
-    def _add_farm_instance_data(self, instance):
-        """Add farm publishing related instance data.
-
-        Args:
-            instance (pyblish.api.Instance): pyblish instance
-        """
-
-        # make sure rendered sequence on farm will
-        # be used for extract review
-        if not instance.data.get("review"):
-            instance.data["useSequenceForReview"] = False
-
-        # Farm rendering
-        instance.data.update({
-            "transfer": False,
-            "farm": True  # to skip integrate
-        })
-        self.log.info("Farm rendering ON ...")
-
-    def _get_collected_frames(self, instance):
-        """Get collected frames.
-
-        Args:
-            instance (pyblish.api.Instance): pyblish instance
-
-        Returns:
-            list: collected frames
-        """
-
-        first_frame, last_frame = self._get_frame_range_data(instance)
-
-        write_node = self._write_node_helper(instance)
-
-        write_file_path = nuke.filename(write_node)
-        output_dir = os.path.dirname(write_file_path)
-
-        # get file path knob
-        node_file_knob = write_node["file"]
-        # list file paths based on input frames
-        expected_paths = list(sorted({
-            node_file_knob.evaluate(frame)
-            for frame in range(first_frame, last_frame + 1)
-        }))
-
-        # convert only to base names
-        expected_filenames = {
-            os.path.basename(filepath)
-            for filepath in expected_paths
-        }
-
-        # make sure files are existing at folder
-        collected_frames = [
-            filename
-            for filename in os.listdir(output_dir)
-            if filename in expected_filenames
-        ]
-
-        return collected_frames
+        return write_node

--- a/openpype/hosts/nuke/plugins/publish/collect_writes.py
+++ b/openpype/hosts/nuke/plugins/publish/collect_writes.py
@@ -47,8 +47,7 @@ class CollectNukeWrites(pyblish.api.InstancePlugin,
             )
 
             representation = self.prepare_representation(
-                instance, file_paths, frame_start, frame_end,
-                reviewable=("review" in creator_attributes)
+                instance, file_paths, frame_start, frame_end
             )
 
             # QUESTION: should we set colorspace at this moment or downstream?
@@ -64,8 +63,7 @@ class CollectNukeWrites(pyblish.api.InstancePlugin,
             )
 
             representation = self.prepare_representation(
-                instance, file_paths, frame_start, frame_end,
-                reviewable=("review" in creator_attributes)
+                instance, file_paths, frame_start, frame_end
             )
             self.make_farm_publishing_representation(representation)
 

--- a/openpype/hosts/nuke/plugins/publish/collect_writes.py
+++ b/openpype/hosts/nuke/plugins/publish/collect_writes.py
@@ -16,7 +16,7 @@ class CollectNukeWrites(pyblish.api.InstancePlugin,
     families = ["render", "prerender", "image"]
 
     def process(self, instance):
-
+        creator_attributes = instance.data["creator_attributes"]
         group_node = instance.data["transientData"]["node"]
 
         write_node = self._write_node_helper(instance)
@@ -36,7 +36,7 @@ class CollectNukeWrites(pyblish.api.InstancePlugin,
         colorspace = napi.get_colorspace_from_node(write_node)
 
         # split operations by render target
-        render_target = instance.data["render_target"]
+        render_target = creator_attributes["render_target"]
 
         if render_target == "farm":
             self.add_farm_instance_data(instance)
@@ -48,7 +48,7 @@ class CollectNukeWrites(pyblish.api.InstancePlugin,
 
             representation = self.prepare_representation(
                 instance, file_paths, frame_start, frame_end,
-                reviewable=("review" in instance.data)
+                reviewable=("review" in creator_attributes)
             )
 
             # QUESTION: should we set colorspace at this moment or downstream?
@@ -65,7 +65,7 @@ class CollectNukeWrites(pyblish.api.InstancePlugin,
 
             representation = self.prepare_representation(
                 instance, file_paths, frame_start, frame_end,
-                reviewable=("review" in instance.data)
+                reviewable=("review" in creator_attributes)
             )
             self.make_farm_publishing_representation(representation)
 
@@ -114,8 +114,9 @@ class CollectNukeWrites(pyblish.api.InstancePlugin,
             frame_end (int): last frame
             colorspace (str): colorspace
         """
+        creator_attributes = instance.data["creator_attributes"]
         family = instance.data["family"]
-        render_target = instance.data["render_target"]
+        render_target = creator_attributes["render_target"]
 
         # add targeted family to families
         instance.data["families"].append(

--- a/openpype/hosts/nuke/plugins/publish/extract_review_data_mov.py
+++ b/openpype/hosts/nuke/plugins/publish/extract_review_data_mov.py
@@ -133,7 +133,6 @@ class ExtractReviewDataMov(publish.Extractor):
         if generated_repres:
             # assign to representations
             instance.data["representations"] += generated_repres
-            instance.data["useSequenceForReview"] = False
         else:
             instance.data["families"].remove("review")
             self.log.info((

--- a/openpype/hosts/nuke/plugins/publish/extract_slate_frame.py
+++ b/openpype/hosts/nuke/plugins/publish/extract_slate_frame.py
@@ -276,7 +276,7 @@ class ExtractSlateFrame(publish.Extractor):
 
         if not matching_repre:
             self.log.info((
-                "Matching reresentaion was not found."
+                "Matching representation was not found."
                 " Representation files were not filled with slate."
             ))
             return
@@ -286,11 +286,7 @@ class ExtractSlateFrame(publish.Extractor):
             matching_repre["files"] = [first_filename, slate_filename]
         elif slate_filename not in matching_repre["files"]:
             matching_repre["files"].insert(0, slate_filename)
-            matching_repre["frameStart"] = (
-                "{{:0>{}}}"
-                .format(len(str(last_frame)))
-                .format(slate_first_frame)
-            )
+            matching_repre["frameStart"] = slate_first_frame
             self.log.debug(
                 "__ matching_repre: {}".format(pformat(matching_repre)))
 

--- a/openpype/hosts/traypublisher/plugins/publish/collect_simple_instances.py
+++ b/openpype/hosts/traypublisher/plugins/publish/collect_simple_instances.py
@@ -2,11 +2,13 @@ import os
 import tempfile
 from pathlib import Path
 
-import clique
 import pyblish.api
+from openpype.pipeline import publish
 
 
-class CollectSettingsSimpleInstances(pyblish.api.InstancePlugin):
+class CollectSettingsSimpleInstances(pyblish.api.InstancePlugin,
+                                     publish.PrepRepresentationPluginMixin,
+                                     publish.ColormanagedPyblishPluginMixin):
     """Collect data for instances created by settings creators.
 
     Plugin create representations for simple instances based
@@ -37,7 +39,9 @@ class CollectSettingsSimpleInstances(pyblish.api.InstancePlugin):
         if not instance.data.get("settings_creator"):
             return
 
+        context = instance.context
         instance_label = instance.data["name"]
+
         # Create instance's staging dir in temp
         tmp_folder = tempfile.mkdtemp(prefix="traypublisher_")
         instance.data["stagingDir"] = tmp_folder
@@ -47,35 +51,107 @@ class CollectSettingsSimpleInstances(pyblish.api.InstancePlugin):
             "Created temp staging directory for instance {}. {}"
         ).format(instance_label, tmp_folder))
 
+        creator_attributes = instance.data["creator_attributes"]
+        review_file_item = creator_attributes["reviewable"]
+        review_filenames = review_file_item.get("filenames")
+
+        # make instance reviewable if reviewable attribute is set
+        if review_filenames:
+            instance.data["families"].append("review")
+
         self._fill_version(instance, instance_label)
 
-        # Store filepaths for validation of their existence
+        # prep all representation files for processing
+        filepath_items = creator_attributes["representation_files"]
+        if not isinstance(filepath_items, list):
+            filepath_items = [filepath_items]
+
+        # also add reviewable item to list of items to process
+        if review_filenames:
+            filepath_items.append(review_file_item)
+
+        representation_files = self.get_processing_file_data(
+            instance, filepath_items)
+
+        for file_path, file_data in representation_files.items():
+            frame_start, frame_end = file_data["framerange"]
+
+            file_paths = self.prepare_collection_of_file_paths(
+                file_path, frame_start, frame_end
+            )
+
+            representation = self.prepare_representation(
+                instance, file_paths, frame_start, frame_end,
+                reviewable=("reviewable" in file_data)
+            )
+
+            # QUESTION: perhaps we should do this in other plugin
+            self.set_representation_colorspace(
+                representation, context
+            )
+            instance.data["representations"].append(representation)
+
+
+        self.log.debug(
+            (
+                "Created Simple Settings instance \"{}\""
+                " with {} representations"
+            ).format(
+                instance_label,
+                len(instance.data["representations"])
+            )
+        )
+
+    def get_processing_file_data(self, instance, filepath_items):
+        """Get data for processing files.
+
+        Args:
+            instance (pyblish.api.Instance): Instance to fill data for.
+            filepath_items (List[Dict[str, Any]]): List of items with
+                information about files.
+        Returns:
+            List[Dict[str, Any]]: List of items with data for processing files.
+        """
+        representation_files = {}
         source_filepaths = []
-        # Make sure there are no representations with same name
-        repre_names_counter = {}
-        # Store created names for logging
-        repre_names = []
-        # Store set of filepaths per each representation
-        representation_files_mapping = []
-        source = self._create_main_representations(
-            instance,
-            source_filepaths,
-            repre_names_counter,
-            repre_names,
-            representation_files_mapping
-        )
+        for filepath_item in filepath_items:
+            # Skip if filepath item does not have filenames
+            if not filepath_item["filenames"]:
+                continue
 
-        self._create_review_representation(
-            instance,
-            source_filepaths,
-            repre_names_counter,
-            repre_names,
-            representation_files_mapping
-        )
-        source_filepaths = list(set(source_filepaths))
-        instance.data["source"] = source
-        instance.data["sourceFilepaths"] = source_filepaths
+            filepaths = {
+                os.path.join(filepath_item["directory"], filename)
+                for filename in filepath_item["filenames"]
+            }
 
+            # add it to source filepaths
+            # for later validation of existence
+            source_filepaths.extend(filepaths)
+
+            file_path = self.get_single_filepath_from_list_of_files(
+                filepaths)
+            frame_start, frame_end = self.get_frame_range_from_list_of_files(
+                filepaths)
+            processing_file_data = {
+                file_path: {
+                    "framerange": (frame_start, frame_end)
+                }
+            }
+
+            # make sure there is no duplicity for case reviewable is duplicated
+            if file_path in representation_files:
+                # update the data to be reviewable
+                representation_files[file_path]["reviewable"] = True
+            else:
+                representation_files.update(processing_file_data)
+
+        # store source filepaths on instance
+        source_filepaths = sorted(list(set(source_filepaths)))
+
+        # NOTE: we need to make sure there are no duplicities
+        instance.data.setdefault(
+            "sourceFilepaths", source_filepaths
+        )
         # NOTE: Missing filepaths should not cause crashes (at least not here)
         # - if filepaths are required they should crash on validation
         if source_filepaths:
@@ -84,16 +160,10 @@ class CollectSettingsSimpleInstances(pyblish.api.InstancePlugin):
             origin_basename = Path(source_filepaths[0]).stem
             instance.data["originalBasename"] = origin_basename
 
-        self.log.debug(
-            (
-                "Created Simple Settings instance \"{}\""
-                " with {} representations: {}"
-            ).format(
-                instance_label,
-                len(instance.data["representations"]),
-                ", ".join(repre_names)
-            )
-        )
+        if not instance.data.get("thumbnailSource"):
+            instance.data["thumbnailSource"] = source_filepaths[0]
+
+        return representation_files
 
     def _fill_version(self, instance, instance_label):
         """Fill instance version under which will be instance integrated.
@@ -110,158 +180,11 @@ class CollectSettingsSimpleInstances(pyblish.api.InstancePlugin):
         use_next_version = creator_attributes.get("use_next_version", True)
         # If 'version_to_use' is '0' it means that next version should be used
         version_to_use = creator_attributes.get("version_to_use", 0)
+        instance.context.data["version"] = version_to_use
+
         if use_next_version or not version_to_use:
             return
         instance.data["version"] = version_to_use
         self.log.debug(
             "Version for instance \"{}\" was set to \"{}\"".format(
                 instance_label, version_to_use))
-
-    def _create_main_representations(
-        self,
-        instance,
-        source_filepaths,
-        repre_names_counter,
-        repre_names,
-        representation_files_mapping
-    ):
-        creator_attributes = instance.data["creator_attributes"]
-        filepath_items = creator_attributes["representation_files"]
-        if not isinstance(filepath_items, list):
-            filepath_items = [filepath_items]
-
-        source = None
-        for filepath_item in filepath_items:
-            # Skip if filepath item does not have filenames
-            if not filepath_item["filenames"]:
-                continue
-
-            filepaths = {
-                os.path.join(filepath_item["directory"], filename)
-                for filename in filepath_item["filenames"]
-            }
-            source_filepaths.extend(filepaths)
-
-            source = self._calculate_source(filepaths)
-            representation = self._create_representation_data(
-                filepath_item, repre_names_counter, repre_names
-            )
-            instance.data["representations"].append(representation)
-            representation_files_mapping.append(
-                (filepaths, representation, source)
-            )
-        return source
-
-    def _create_review_representation(
-        self,
-        instance,
-        source_filepaths,
-        repre_names_counter,
-        repre_names,
-        representation_files_mapping
-    ):
-        # Skip review representation creation if there are no representations
-        #   created for "main" part
-        #   - review representation must not be created in that case so
-        #       validation can care about it
-        if not representation_files_mapping:
-            self.log.warning((
-                "There are missing source representations."
-                " Creation of review representation was skipped."
-            ))
-            return
-
-        creator_attributes = instance.data["creator_attributes"]
-        review_file_item = creator_attributes["reviewable"]
-        filenames = review_file_item.get("filenames")
-        if not filenames:
-            self.log.debug((
-                "Filepath for review is not defined."
-                " Skipping review representation creation."
-            ))
-            return
-
-        item_dir = review_file_item["directory"]
-        first_filepath = os.path.join(item_dir, filenames[0])
-
-        filepaths = {
-            os.path.join(item_dir, filename)
-            for filename in filenames
-        }
-        source_filepaths.extend(filepaths)
-        # First try to find out representation with same filepaths
-        #   so it's not needed to create new representation just for review
-        review_representation = None
-        # Review path (only for logging)
-        review_path = None
-        for item in representation_files_mapping:
-            _filepaths, representation, repre_path = item
-            if _filepaths == filepaths:
-                review_representation = representation
-                review_path = repre_path
-                break
-
-        if review_representation is None:
-            self.log.debug("Creating new review representation")
-            review_path = self._calculate_source(filepaths)
-            review_representation = self._create_representation_data(
-                review_file_item, repre_names_counter, repre_names
-            )
-            instance.data["representations"].append(review_representation)
-
-        if "review" not in instance.data["families"]:
-            instance.data["families"].append("review")
-
-        if not instance.data.get("thumbnailSource"):
-            instance.data["thumbnailSource"] = first_filepath
-
-        review_representation["tags"].append("review")
-        self.log.debug("Representation {} was marked for review. {}".format(
-            review_representation["name"], review_path
-        ))
-
-    def _create_representation_data(
-        self, filepath_item, repre_names_counter, repre_names
-    ):
-        """Create new representation data based on file item.
-
-        Args:
-            filepath_item (Dict[str, Any]): Item with information about
-                representation paths.
-            repre_names_counter (Dict[str, int]): Store count of representation
-                names.
-            repre_names (List[str]): All used representation names. For
-                logging purposes.
-
-        Returns:
-            Dict: Prepared base representation data.
-        """
-
-        filenames = filepath_item["filenames"]
-        _, ext = os.path.splitext(filenames[0])
-        if len(filenames) == 1:
-            filenames = filenames[0]
-
-        repre_name = repre_ext = ext[1:]
-        if repre_name not in repre_names_counter:
-            repre_names_counter[repre_name] = 2
-        else:
-            counter = repre_names_counter[repre_name]
-            repre_names_counter[repre_name] += 1
-            repre_name = "{}_{}".format(repre_name, counter)
-        repre_names.append(repre_name)
-        return {
-            "ext": repre_ext,
-            "name": repre_name,
-            "stagingDir": filepath_item["directory"],
-            "files": filenames,
-            "tags": []
-        }
-
-    def _calculate_source(self, filepaths):
-        cols, rems = clique.assemble(filepaths)
-        if cols:
-            source = cols[0].format("{head}{padding}{tail}")
-        elif rems:
-            source = rems[0]
-        return source

--- a/openpype/modules/deadline/plugins/publish/submit_publish_job.py
+++ b/openpype/modules/deadline/plugins/publish/submit_publish_job.py
@@ -191,8 +191,7 @@ class ProcessSubmittedJobOnFarm(pyblish.api.InstancePlugin,
 
         # Transfer the environment from the original job to this dependent
         # job so they use the same environment
-        _, rootless_metadata_path = \
-            create_metadata_path(instance, anatomy)
+        _, rootless_metadata_path = create_metadata_path(instance, anatomy)
 
         environment = {
             "AVALON_PROJECT": instance.context.data["projectName"],
@@ -506,8 +505,7 @@ class ProcessSubmittedJobOnFarm(pyblish.api.InstancePlugin,
             }
             publish_job["ftrack"] = ftrack
 
-        metadata_path, _ = \
-            create_metadata_path(instance, anatomy)
+        metadata_path, _ = create_metadata_path(instance, anatomy)
 
         with open(metadata_path, "w") as f_:
             json.dump(publish_job, f_, indent=4, sort_keys=True)

--- a/openpype/modules/deadline/plugins/publish/submit_publish_job.py
+++ b/openpype/modules/deadline/plugins/publish/submit_publish_job.py
@@ -191,7 +191,7 @@ class ProcessSubmittedJobOnFarm(pyblish.api.InstancePlugin,
 
         # Transfer the environment from the original job to this dependent
         # job so they use the same environment
-        metadata_path, rootless_metadata_path = \
+        _, rootless_metadata_path = \
             create_metadata_path(instance, anatomy)
 
         environment = {
@@ -506,8 +506,8 @@ class ProcessSubmittedJobOnFarm(pyblish.api.InstancePlugin,
             }
             publish_job["ftrack"] = ftrack
 
-        metadata_path, rootless_metadata_path = \
-                create_metadata_path(instance, anatomy)
+        metadata_path, _ = \
+            create_metadata_path(instance, anatomy)
 
         with open(metadata_path, "w") as f_:
             json.dump(publish_job, f_, indent=4, sort_keys=True)

--- a/openpype/pipeline/file_collection.py
+++ b/openpype/pipeline/file_collection.py
@@ -275,7 +275,7 @@ def _add_slate_frame_to_collected_frames(
     if frame_length == len(collected_file_frames):
         frame_slate_str = frame_utils.get_frame_start_str(
             frame_start - 1,
-            frame_start
+            frame_end
         )
 
         slate_frame = collected_file_frames[0].replace(

--- a/openpype/pipeline/frame_utils.py
+++ b/openpype/pipeline/frame_utils.py
@@ -10,20 +10,6 @@ from openpype.client import get_asset_by_name
 log = Logger.get_logger(__name__)
 
 
-def get_frame_start_str(frame_start, frame_end):
-    """Get frame start string.
-
-    Args:
-        frame_start (int): first frame
-        frame_end (int): last frame
-
-    Returns:
-        str: frame start string
-    """
-    padding = len(str(frame_end))
-    return str(frame_start).zfill(padding)
-
-
 def get_asset_frame_range(project_name, asset_name, asset_doc=None):
     """Get the current assets frame range and handles.
 

--- a/openpype/pipeline/publish/__init__.py
+++ b/openpype/pipeline/publish/__init__.py
@@ -19,7 +19,8 @@ from .publish_plugins import (
     RepairContextAction,
 
     Extractor,
-    ColormanagedPyblishPluginMixin
+    ColormanagedPyblishPluginMixin,
+    PrepRepresentationPluginMixin,
 )
 
 from .lib import (
@@ -69,6 +70,7 @@ __all__ = (
 
     "Extractor",
     "ColormanagedPyblishPluginMixin",
+    "PrepRepresentationPluginMixin",
 
     "get_publish_template_name",
 

--- a/openpype/pipeline/publish/publish_plugins.py
+++ b/openpype/pipeline/publish/publish_plugins.py
@@ -483,14 +483,15 @@ class PrepRepresentationPluginMixin:
             instance (pyblish.api.Instance): pyblish instance
         """
 
-        # make sure rendered sequence on farm will
-        # be used for extract review
-        instance.data["useSequenceForReview"] = bool(
-            instance.data.get("review"))
+        # TODO: this should be removed
+        # - it is only needed if expectedFiles keys is used
+        # - not needed if representation tagged for farm
+        #   is used (make_farm_publishing_representation)
+        instance.data["useSequenceForReview"] = (
+            "review" in instance.data["families"])
 
         # Farm rendering
         instance.data.update({
-            "transfer": False,
             "farm": True  # to skip integrate
         })
         self.log.info("Farm rendering ON ...")

--- a/openpype/pipeline/publish/publish_plugins.py
+++ b/openpype/pipeline/publish/publish_plugins.py
@@ -444,7 +444,6 @@ class ColormanagedPyblishPluginMixin(object):
                 pformat(colorspace_data)))
 
 
-
 class PrepRepresentationPluginMixin:
     """Mixin for preparation of representation plugins.
 


### PR DESCRIPTION
## Changelog Description
Unified way of preparing representation data for local and farm publishing.

## Additional info
- added into traypublisher simple collector
- added into nuke collect write

## Testing notes:
1. try publishing and nuke should work as it was before

## Dependencies
Changes from this PR were initially implemented in [this pull request](https://github.com/ynput/OpenPype/pull/5451). However, due to its significant size, we made the decision to divide it into smaller portions. 

**!!! This PR should be merged after #5496. But before the merge the target branch should be changed to develop !!!**
