### PR TITLE
Global: avoiding cleanup of flagged representation

### DIFF
--- a/openpype/pipeline/publish/lib.py
+++ b/openpype/pipeline/publish/lib.py
@@ -953,6 +953,7 @@ def replace_with_published_scene_path(instance, replace_in_path=True):
 
     return file_path
 
+
 def add_repre_files_for_cleanup(instance, repre):
     """ Explicitly mark repre files to be deleted.
 
@@ -961,7 +962,16 @@ def add_repre_files_for_cleanup(instance, repre):
     """
     files = repre["files"]
     staging_dir = repre.get("stagingDir")
-    if not staging_dir or instance.data.get("stagingDir_persistent"):
+
+    # first make sure representation level is not persistent
+    if (
+        not staging_dir
+        or repre.get("stagingDir_persistent")
+    ):
+        return
+
+    # then look into instance level if it's not persistent
+    if instance.data.get("stagingDir_persistent"):
         return
 
     if isinstance(files, str):


### PR DESCRIPTION
## Changelog Description
Publishing folder can be flagged as persistent at representation level.

## Testing notes:
1.all should work as usually. This only is not removing files after publish if the representation is having persistancy flag in representation data.