### PR TITLE
Publisher: Fix multiselection value

### DIFF
--- a/openpype/tools/attribute_defs/widgets.py
+++ b/openpype/tools/attribute_defs/widgets.py
@@ -343,6 +343,7 @@ class TextAttrWidget(_BaseAttrDefWidget):
         return self._input_widget.text()
 
     def set_value(self, value, multivalue=False):
+        block_signals = False
         if multivalue:
             set_value = set(value)
             if None in set_value:
@@ -352,13 +353,18 @@ class TextAttrWidget(_BaseAttrDefWidget):
             if len(set_value) == 1:
                 value = tuple(set_value)[0]
             else:
+                block_signals = True
                 value = "< Multiselection >"
 
         if value != self.current_value():
+            if block_signals:
+                self._input_widget.blockSignals(True)
             if self.multiline:
                 self._input_widget.setPlainText(value)
             else:
                 self._input_widget.setText(value)
+            if block_signals:
+                self._input_widget.blockSignals(False)
 
 
 class BoolAttrWidget(_BaseAttrDefWidget):
@@ -391,7 +397,9 @@ class BoolAttrWidget(_BaseAttrDefWidget):
                 set_value.add(self.attr_def.default)
 
             if len(set_value) > 1:
+                self._input_widget.blockSignals(True)
                 self._input_widget.setCheckState(QtCore.Qt.PartiallyChecked)
+                self._input_widget.blockSignals(False)
                 return
             value = tuple(set_value)[0]
 


### PR DESCRIPTION
## Changelog Description
Selection of multiple instances in Publisher does not cause that all instances change all publish attributes to the same value.

## Additional info
It seems that text and boolean attributes are only one which are actually changing value of widget, which cause callback that change the value back to the instances. Changed the logic to not trigger any signals of a multiselection value is set.

## Testing notes:
1. Choose a creator which creates instances that have in Publish Attributes Boolean and Text fields
2. Create 2 instances
3. Select first instance and change both values
4. Select second instance and change values to be different from the first
5. Select both
6. Select only first, the values should not change from state before
7. Select only second, the values should not change from state before
