### PR TITLE
Publisher: Avoid warnings on thumbnails if source image also has alpha channel

### DIFF
--- a/openpype/plugins/publish/extract_thumbnail_from_source.py
+++ b/openpype/plugins/publish/extract_thumbnail_from_source.py
@@ -128,7 +128,7 @@ class ExtractThumbnailFromSource(pyblish.api.InstancePlugin):
         if thumbnail_created:
             return full_output_path
 
-        self.log.warning("Thumbanil has not been created.")
+        self.log.warning("Thumbnail has not been created.")
 
     def _instance_has_thumbnail(self, instance):
         if "representations" not in instance.data:

--- a/openpype/plugins/publish/extract_thumbnail_from_source.py
+++ b/openpype/plugins/publish/extract_thumbnail_from_source.py
@@ -147,6 +147,7 @@ class ExtractThumbnailFromSource(pyblish.api.InstancePlugin):
         oiio_cmd = get_oiio_tool_args(
             "oiiotool",
             "-a", src_path,
+            "--ch", "R,G,B",
             "-o", dst_path
         )
         self.log.info("Running: {}".format(" ".join(oiio_cmd)))


### PR DESCRIPTION
## Changelog Description

Avoids the following warning from `ExtractThumbnailFromSource`:
```
// pyblish.ExtractThumbnailFromSource : oiiotool WARNING: -o : Can't save 4 channels to jpeg... saving only R,G,B
```

## Additional info

Added argument `--ch R,G,B`.
This is fine because the output thumbnail is currently always `.jpg` and doesn't support alpha.

[Mentioned on Ynput Discord here](https://discord.com/channels/517362899170230292/517382145552154634/1144627806844752002).

## Testing notes:
1. Use a screenshot in the new publisher, e.g. take one from screenshot tool or paste from clipboard (or browse)
2. Publish

It'd be good to also test if publishing thumbnail using 'browse' works fine if the source itself isn't a `.jpg` or `.png` but potentially a file format more complex than that.
