### PR TITLE
Chore: Queued event system

### DIFF
--- a/tests/unit/openpype/lib/test_event_system.py
+++ b/tests/unit/openpype/lib/test_event_system.py
@@ -1,0 +1,83 @@
+from openpype.lib.events import EventSystem, QueuedEventSystem
+
+
+def test_default_event_system():
+    output = []
+    expected_output = [3, 2, 1]
+    event_system = EventSystem()
+
+    def callback_1():
+        event_system.emit("topic.2", {}, None)
+        output.append(1)
+
+    def callback_2():
+        event_system.emit("topic.3", {}, None)
+        output.append(2)
+
+    def callback_3():
+        output.append(3)
+
+    event_system.add_callback("topic.1", callback_1)
+    event_system.add_callback("topic.2", callback_2)
+    event_system.add_callback("topic.3", callback_3)
+
+    event_system.emit("topic.1", {}, None)
+
+    assert output == expected_output, (
+        "Callbacks were not called in correct order")
+
+
+def test_base_event_system_queue():
+    output = []
+    expected_output = [1, 2, 3]
+    event_system = QueuedEventSystem()
+
+    def callback_1():
+        event_system.emit("topic.2", {}, None)
+        output.append(1)
+
+    def callback_2():
+        event_system.emit("topic.3", {}, None)
+        output.append(2)
+
+    def callback_3():
+        output.append(3)
+
+    event_system.add_callback("topic.1", callback_1)
+    event_system.add_callback("topic.2", callback_2)
+    event_system.add_callback("topic.3", callback_3)
+
+    event_system.emit("topic.1", {}, None)
+
+    assert output == expected_output, (
+        "Callbacks were not called in correct order")
+
+
+def test_manual_event_system_queue():
+    output = []
+    expected_output = [1, 2, 3]
+    event_system = QueuedEventSystem(auto_execute=False)
+
+    def callback_1():
+        event_system.emit("topic.2", {}, None)
+        output.append(1)
+
+    def callback_2():
+        event_system.emit("topic.3", {}, None)
+        output.append(2)
+
+    def callback_3():
+        output.append(3)
+
+    event_system.add_callback("topic.1", callback_1)
+    event_system.add_callback("topic.2", callback_2)
+    event_system.add_callback("topic.3", callback_3)
+
+    event_system.emit("topic.1", {}, None)
+
+    while True:
+        if event_system.process_next_event() is None:
+            break
+
+    assert output == expected_output, (
+        "Callbacks were not called in correct order")


### PR DESCRIPTION
## Changelog Description
Implemented event system with more expected behavior of event system. If an event is triggered during other event callback, it is not processed immediately but waits until all callbacks of previous events are done. The event system also allows to not trigger events directly once `emit_event` is called which gives option to process events in custom loops.

## Additional info
The event system is not used anywhere, I need it for refactor of workfiles tool, where order of events matter. The changes can be added as part of that PR, but I thought it would be easier to do a review in smaller PR.
