### PR TITLE
Max: Fixing the bug of falling back to use workfile for Arnold or any renderers except Redshift

### DIFF
--- a/openpype/modules/deadline/plugins/publish/submit_max_deadline.py
+++ b/openpype/modules/deadline/plugins/publish/submit_max_deadline.py
@@ -249,12 +249,8 @@ class MaxSubmitDeadline(abstract_submit_deadline.AbstractSubmitDeadline,
         if instance.data["renderer"] == "Redshift_Renderer":
             self.log.debug("Using Redshift...published scene wont be used..")
             replace_in_path = False
-            return replace_with_published_scene_path(
-                instance, replace_in_path)
-        else:
-            return replace_with_published_scene_path(
-                instance, replace_in_path)
-
+        return replace_with_published_scene_path(
+            instance, replace_in_path)
 
     @staticmethod
     def _iter_expected_files(exp):

--- a/openpype/modules/deadline/plugins/publish/submit_max_deadline.py
+++ b/openpype/modules/deadline/plugins/publish/submit_max_deadline.py
@@ -12,7 +12,9 @@ from openpype.pipeline import (
     legacy_io,
     OpenPypePyblishPluginMixin
 )
-from openpype.settings import get_project_settings
+from openpype.pipeline.publish.lib import (
+    replace_with_published_scene_path
+)
 from openpype.hosts.max.api.lib import (
     get_current_renderer,
     get_multipass_setting
@@ -247,7 +249,12 @@ class MaxSubmitDeadline(abstract_submit_deadline.AbstractSubmitDeadline,
         if instance.data["renderer"] == "Redshift_Renderer":
             self.log.debug("Using Redshift...published scene wont be used..")
             replace_in_path = False
-            return replace_in_path
+            return replace_with_published_scene_path(
+                instance, replace_in_path)
+        else:
+            return replace_with_published_scene_path(
+                instance, replace_in_path)
+
 
     @staticmethod
     def _iter_expected_files(exp):


### PR DESCRIPTION
## Changelog Description
Fix the bug of falling back to use workfile for Arnold 
## Additional info
n/a
## Testing notes:
1. Launch Max via launcher
2. Create Render Instance with Arnold or some renderers
3. Publish
