### PR TITLE
Publisher: Tweak log message to provide plugin name after "Plugin"

### DIFF
--- a/openpype/pipeline/publish/lib.py
+++ b/openpype/pipeline/publish/lib.py
@@ -464,9 +464,8 @@ def apply_plugin_settings_automatically(plugin, settings, logger=None):
 
     for option, value in settings.items():
         if logger:
-            logger.debug("Plugin {} - Attr: {} -> {}".format(
-                plugin.__name__, option, value
-            ))
+            logger.debug("Plugin %s - Attr: %s -> %s",
+                         plugin.__name__, option, value)
         setattr(plugin, option, value)
 
 

--- a/openpype/pipeline/publish/lib.py
+++ b/openpype/pipeline/publish/lib.py
@@ -465,7 +465,7 @@ def apply_plugin_settings_automatically(plugin, settings, logger=None):
     for option, value in settings.items():
         if logger:
             logger.debug("Plugin {} - Attr: {} -> {}".format(
-                option, value, plugin.__name__
+                plugin.__name__, option, value
             ))
         setattr(plugin, option, value)
 


### PR DESCRIPTION
## Changelog Description

Fix logged message for settings automatically applied to plugin attributes

## Additional info

Before:
```
#   - { filter_pyblish_plugins }: [ Plugin enabled - Attr: False -> ValidateMeshNgons ] 
#   - { filter_pyblish_plugins }: [ Plugin optional - Attr: True -> ValidateMeshNgons ] 
#   - { filter_pyblish_plugins }: [ Plugin active - Attr: True -> ValidateMeshNgons ] 
#   - { filter_pyblish_plugins }: [ Plugin enabled - Attr: True -> ValidateModelContent ] 
#   - { filter_pyblish_plugins }: [ Plugin optional - Attr: False -> ValidateModelContent ] 
#   - { filter_pyblish_plugins }: [ Plugin validate_top_group - Attr: True -> ValidateModelContent ] 
```
After:
```
#   - { filter_pyblish_plugins }: [ Plugin ValidateMeshNgons - Attr: enabled -> False ] 
#   - { filter_pyblish_plugins }: [ Plugin ValidateMeshNgons - Attr: optional -> True ] 
#   - { filter_pyblish_plugins }: [ Plugin ValidateMeshNgons - Attr: active -> True ] 
#   - { filter_pyblish_plugins }: [ Plugin ValidateModelContent - Attr: enabled -> True ] 
#   - { filter_pyblish_plugins }: [ Plugin ValidateModelContent - Attr: optional -> False ] 
#   - { filter_pyblish_plugins }: [ Plugin ValidateModelContent - Attr: validate_top_group -> True ] 
```


## Testing notes:

1. Open the publisher
2. Check the logs
