### PR TITLE
Maya: Validate Shape Zero fix repair action + provide informational artist-facing report

### DIFF
--- a/openpype/hosts/maya/plugins/publish/validate_shape_zero.py
+++ b/openpype/hosts/maya/plugins/publish/validate_shape_zero.py
@@ -7,6 +7,7 @@ from openpype.hosts.maya.api import lib
 from openpype.pipeline.publish import (
     ValidateContentsOrder,
     RepairAction,
+    PublishValidationError
 )
 
 
@@ -67,5 +68,30 @@ class ValidateShapeZero(pyblish.api.Validator):
 
         invalid = self.get_invalid(instance)
         if invalid:
-            raise ValueError("Shapes found with non-zero component tweaks: "
-                             "{0}".format(invalid))
+            raise PublishValidationError(
+                title="Shape Component Tweaks",
+                message="Shapes found with non-zero component tweaks: '{}'"
+                        "".format(", ".join(invalid)),
+                description=(
+                    "## Shapes found with component tweaks\n"
+                    "Shapes were detected that have component tweaks on their "
+                    "components. Please remove the component tweaks to "
+                    "continue.\n\n"
+                    "### Repair\n"
+                    "The repair action will try to *freeze* the component "
+                    "tweaks into the shapes, which is usually the correct fix "
+                    "if the mesh has no construction history (= has its "
+                    "history deleted)."),
+                detail=(
+                    "Maya allows to store component tweaks within shape nodes "
+                    "which are applied between its `inMesh` and `outMesh` "
+                    "connections resulting in the output of a shape node "
+                    "differing from the input. We usually want to avoid this "
+                    "for published meshes (in particular for Maya scenes) as "
+                    "it can have unintended results when using these meshes "
+                    "as intermediate meshes since it applies positional "
+                    "differences without being visible edits in the node "
+                    "graph.\n\n"
+                    "These tweaks are traditionally stored in the `.pnts` "
+                    "attribute of shapes.")
+            )


### PR DESCRIPTION
## Changelog Description

Refactor to PublishValidationError to allow the RepairAction to work + provide informational report message

## Additional info

Fixes #5456

Example report:

![image](https://github.com/ynput/OpenPype/assets/2439881/6ba35937-3aaa-4eb1-9934-e8050c659785)


## Testing notes:

1. Make sure to enable the plug-in in settings: `project_settings/maya/publish/ValidateShapeZero/enabled`
2. Publish a model family with geometry with component tweaks, e.g.
   - Create a cube
   - Delete history
   - Move one vertex in edit mode (this is now a component tweak)