### PR TITLE
Enhancement: Update houdini main menu

### DIFF
--- a/openpype/hosts/houdini/startup/MainMenuCommon.xml
+++ b/openpype/hosts/houdini/startup/MainMenuCommon.xml
@@ -14,6 +14,8 @@ return label
 ]]></labelExpression>
             </actionItem>
 
+            <separatorItem/>
+
             <scriptItem id="openpype_create">
                 <label>Create...</label>
                 <scriptCode><![CDATA[

--- a/openpype/hosts/houdini/startup/MainMenuCommon.xml
+++ b/openpype/hosts/houdini/startup/MainMenuCommon.xml
@@ -2,7 +2,17 @@
 <mainMenu>
     <menuBar>
         <subMenu id="openpype_menu">
-            <label>OpenPype</label>
+            <labelExpression><![CDATA[
+import os
+return os.environ.get("AVALON_LABEL") or "OpenPype"
+]]></labelExpression>
+            <actionItem id="asset_name">
+                    <labelExpression><![CDATA[
+from openpype.pipeline import get_current_asset_name, get_current_task_name
+label = "{}, {}".format(get_current_asset_name(), get_current_task_name())
+return label
+]]></labelExpression>
+            </actionItem>
 
             <scriptItem id="openpype_create">
                 <label>Create...</label>


### PR DESCRIPTION
## Changelog Description
This PR adds two updates:
1. dynamic main menu 
2. dynamic asset name and task


## Testing notes:
1. Check main menu name in AYON and OpenPype
2. Switch among assets, check asset name and task

## Tests 
<table>
<tr>
<td><img src="https://github.com/ynput/OpenPype/assets/20871534/60a2a711-47c1-4c95-a77b-b7cb2e0bdc60"></td>
<td><img src="https://github.com/ynput/OpenPype/assets/20871534/761fba8f-fb64-40af-8bf6-fcae3a7a809e"></td>
<td><img src="https://github.com/ynput/OpenPype/assets/20871534/96584dd1-1d85-4d00-8b51-52a82d82b661"></td>
</tr>
</table>