### PR TITLE
Houdini: Reset FPS when clicking Set Frame Range

### DIFF
--- a/openpype/hosts/houdini/api/lib.py
+++ b/openpype/hosts/houdini/api/lib.py
@@ -474,6 +474,11 @@ def maintained_selection():
 def reset_framerange():
     """Set frame range to current asset"""
 
+    # Set new scene fps
+    fps = get_asset_fps()
+    print("Setting scene FPS to {}".format(int(fps)))
+    set_scene_fps(fps)
+
     project_name = get_current_project_name()
     asset_name = get_current_asset_name()
     # Get the asset ID from the database for the asset of current context

--- a/openpype/hosts/houdini/api/lib.py
+++ b/openpype/hosts/houdini/api/lib.py
@@ -27,7 +27,7 @@ def get_asset_fps(asset_doc=None):
 
     if asset_doc is None:
         asset_doc = get_current_project_asset(fields=["data.fps"])
-    return asset_doc["data"].get("fps")
+    return asset_doc["data"]["fps"]
 
 
 def set_id(node, unique_id, overwrite=False):

--- a/openpype/hosts/houdini/api/lib.py
+++ b/openpype/hosts/houdini/api/lib.py
@@ -22,9 +22,12 @@ log = logging.getLogger(__name__)
 JSON_PREFIX = "JSON:::"
 
 
-def get_asset_fps():
+def get_asset_fps(asset_doc=None):
     """Return current asset fps."""
-    return get_current_project_asset()["data"].get("fps")
+
+    if asset_doc is None:
+        asset_doc = get_current_project_asset(fields=["data.fps"])
+    return asset_doc["data"].get("fps")
 
 
 def set_id(node, unique_id, overwrite=False):
@@ -472,19 +475,19 @@ def maintained_selection():
 
 
 def reset_framerange():
-    """Set frame range to current asset"""
+    """Set frame range and FPS to current asset"""
 
-    # Set new scene fps
-    fps = get_asset_fps()
-    print("Setting scene FPS to {}".format(int(fps)))
-    set_scene_fps(fps)
-
+    # Get asset data
     project_name = get_current_project_name()
     asset_name = get_current_asset_name()
     # Get the asset ID from the database for the asset of current context
     asset_doc = get_asset_by_name(project_name, asset_name)
     asset_data = asset_doc["data"]
 
+    # Get FPS
+    fps = get_asset_fps(asset_doc)
+
+    # Get Start and End Frames
     frame_start = asset_data.get("frameStart")
     frame_end = asset_data.get("frameEnd")
 
@@ -498,8 +501,12 @@ def reset_framerange():
     frame_start -= int(handle_start)
     frame_end += int(handle_end)
 
+    # Set frame range and FPS
+    print("Setting scene FPS to {}".format(int(fps)))
+    set_scene_fps(fps)
     hou.playbar.setFrameRange(frame_start, frame_end)
     hou.playbar.setPlaybackRange(frame_start, frame_end)
+    print("Setting current frame to {}".format(frame_start))
     hou.setFrame(frame_start)
 
 

--- a/openpype/hosts/houdini/api/lib.py
+++ b/openpype/hosts/houdini/api/lib.py
@@ -506,7 +506,6 @@ def reset_framerange():
     set_scene_fps(fps)
     hou.playbar.setFrameRange(frame_start, frame_end)
     hou.playbar.setPlaybackRange(frame_start, frame_end)
-    print("Setting current frame to {}".format(frame_start))
     hou.setFrame(frame_start)
 
 

--- a/openpype/hosts/houdini/api/pipeline.py
+++ b/openpype/hosts/houdini/api/pipeline.py
@@ -25,7 +25,6 @@ from openpype.lib import (
     emit_event,
 )
 
-from .lib import get_asset_fps
 
 log = logging.getLogger("openpype.hosts.houdini")
 
@@ -384,11 +383,6 @@ def _set_context_settings():
     Returns:
         None
     """
-
-    # Set new scene fps
-    fps = get_asset_fps()
-    print("Setting scene FPS to %i" % fps)
-    lib.set_scene_fps(fps)
 
     lib.reset_framerange()
 


### PR DESCRIPTION
## Changelog Description
*Similar to Maya,* Make `Set Frame Range` resets FPS, issue https://github.com/ynput/OpenPype/issues/5516

## Additional Info
There are couple of callbacks that validates FPS (e.g.  `before_save`)
> If you think This PR is not necessary, I can close it! 

![image](https://github.com/ynput/OpenPype/assets/20871534/1e61abcf-02cc-4851-8a92-656d973970a4)


## Testing notes:
1. open new houdini session 
2. try setting fps to different values
3. click `Set Frame Range`
