### PR TITLE
Houdini: make validations use currentFrame if frameStart doesn't exist

### DIFF
--- a/openpype/hosts/houdini/plugins/publish/validate_abc_primitive_to_detail.py
+++ b/openpype/hosts/houdini/plugins/publish/validate_abc_primitive_to_detail.py
@@ -82,7 +82,7 @@ class ValidateAbcPrimitiveToDetail(pyblish.api.InstancePlugin):
             return
 
         # Check if the primitive attribute exists
-        frame = instance.data.get("frameStart", 0)
+        frame = instance.data.get("frameStart", hou.intFrame())
         geo = output_node.geometryAtFrame(frame)
 
         # If there are no primitives on the start frame then it might be

--- a/openpype/hosts/houdini/plugins/publish/validate_alembic_input_node.py
+++ b/openpype/hosts/houdini/plugins/publish/validate_alembic_input_node.py
@@ -50,7 +50,7 @@ class ValidateAlembicInputNode(pyblish.api.InstancePlugin):
             cls.log.warning("No geometry output node found, skipping check..")
             return
 
-        frame = instance.data.get("frameStart", 0)
+        frame = instance.data.get("frameStart", hou.intFrame())
         geo = output_node.geometryAtFrame(frame)
 
         invalid = False

--- a/openpype/hosts/houdini/plugins/publish/validate_primitive_hierarchy_paths.py
+++ b/openpype/hosts/houdini/plugins/publish/validate_primitive_hierarchy_paths.py
@@ -80,7 +80,7 @@ class ValidatePrimitiveHierarchyPaths(pyblish.api.InstancePlugin):
             return
 
         # Check if the primitive attribute exists
-        frame = instance.data.get("frameStart", 0)
+        frame = instance.data.get("frameStart", hou.intFrame())
         geo = output_node.geometryAtFrame(frame)
 
         # If there are no primitives on the current frame then we can't

--- a/openpype/hosts/houdini/plugins/publish/validate_vdb_output_node.py
+++ b/openpype/hosts/houdini/plugins/publish/validate_vdb_output_node.py
@@ -115,7 +115,7 @@ class ValidateVDBOutputNode(pyblish.api.InstancePlugin):
             )
             return [hou.node(instance_node), error]
 
-        frame = instance.data.get("frameStart", 0)
+        frame = instance.data.get("frameStart", hou.intFrame())
         geometry = get_geometry_at_frame(node, frame)
         if geometry is None:
             # No geometry data on this node, maybe the node hasn't cooked?


### PR DESCRIPTION
## Changelog Description
Hard coded "frameStart" value can cause a bug when `"frameStart"` is missing when user render current frame (`trange == 0`)

## Additional Info 1
Hard coded "frameStart" leaded to this  issue https://github.com/ynput/OpenPype/issues/5488
when validator was checking geo at frame 0 and imported file hadn't any geo at frame 0 but it workd fine in the current frame

## Additional Info 2
Some Product-types crash when rendering the current frame range like BGEO. 
which is another issue https://github.com/ynput/OpenPype/issues/5507
![image](https://github.com/ynput/OpenPype/assets/20871534/6432bb5e-47c0-4d8d-b9d2-9631fec635e3)


## Testing notes:
1. create and instance  (e.g abc)
2. publish
