### PR TITLE
TrayPublisher: set default frame values to sequential data

### DIFF
--- a/openpype/hosts/traypublisher/plugins/publish/collect_missing_frame_range_asset_entity.py
+++ b/openpype/hosts/traypublisher/plugins/publish/collect_missing_frame_range_asset_entity.py
@@ -2,16 +2,18 @@ import pyblish.api
 from openpype.pipeline import OptionalPyblishPluginMixin
 
 
-class CollectFrameDataFromAssetEntity(pyblish.api.InstancePlugin,
-                                      OptionalPyblishPluginMixin):
-    """Collect Frame Range data From Asset Entity
+class CollectMissingFrameDataFromAssetEntity(
+    pyblish.api.InstancePlugin,
+    OptionalPyblishPluginMixin
+):
+    """Collect Missing Frame Range data From Asset Entity
 
     Frame range data will only be collected if the keys
     are not yet collected for the instance.
     """
 
     order = pyblish.api.CollectorOrder + 0.491
-    label = "Collect Frame Data From Asset Entity"
+    label = "Collect Missing Frame Data From Asset Entity"
     families = ["plate", "pointcache",
                 "vdbcache", "online",
                 "render"]

--- a/openpype/hosts/traypublisher/plugins/publish/validate_frame_ranges.py
+++ b/openpype/hosts/traypublisher/plugins/publish/validate_frame_ranges.py
@@ -15,7 +15,7 @@ class ValidateFrameRange(OptionalPyblishPluginMixin,
 
     label = "Validate Frame Range"
     hosts = ["traypublisher"]
-    families = ["render"]
+    families = ["render", "plate"]
     order = ValidateContentsOrder
 
     optional = True

--- a/openpype/plugins/publish/collect_sequence_frame_data.py
+++ b/openpype/plugins/publish/collect_sequence_frame_data.py
@@ -50,4 +50,7 @@ class CollectSequenceFrameData(pyblish.api.InstancePlugin):
             return {
                 "frameStart": repres_frames[0],
                 "frameEnd": repres_frames[-1],
+                "handleStart": 0,
+                "handleEnd": 0,
+                "fps": instance.context.data["projectEntity"]["data"]["fps"]
             }

--- a/openpype/plugins/publish/collect_sequence_frame_data.py
+++ b/openpype/plugins/publish/collect_sequence_frame_data.py
@@ -52,5 +52,5 @@ class CollectSequenceFrameData(pyblish.api.InstancePlugin):
                 "frameEnd": repres_frames[-1],
                 "handleStart": 0,
                 "handleEnd": 0,
-                "fps": instance.context.data["projectEntity"]["data"]["fps"]
+                "fps": instance.context.data["assetEntity"]["data"]["fps"]
             }


### PR DESCRIPTION
## Changelog Description
We are inheriting  default frame handles and fps data either from project or setting them to 0. This is just for case a production will decide not to injest the sequential representations with asset based metadata.

## Testing notes:
1. Open TrayPublisher on a context
2. drop some imagesequence data to Plate family.
3. Disable instance attribute for `Collect Sequence Frame Data`
4. Publish and see that all had been published as expected.
5. look into Loader and find the published product and see that the frame-range defined on the version is the same as the original frame-range and is not the same as it is defined on asset parent.
