### PR TITLE
Enhancement: Deadline plugins optimize, cleanup and fix optional support for validate deadline pools

### DIFF
--- a/openpype/modules/deadline/plugins/publish/collect_deadline_server_from_instance.py
+++ b/openpype/modules/deadline/plugins/publish/collect_deadline_server_from_instance.py
@@ -8,6 +8,7 @@ attribute or using default server if that attribute doesn't exists.
 from maya import cmds
 
 import pyblish.api
+from openpype.pipeline.publish import KnownPublishError
 
 
 class CollectDeadlineServerFromInstance(pyblish.api.InstancePlugin):
@@ -81,13 +82,14 @@ class CollectDeadlineServerFromInstance(pyblish.api.InstancePlugin):
             if k in default_servers
         }
 
-        msg = (
-            "\"{}\" server on instance is not enabled in project settings."
-            " Enabled project servers:\n{}".format(
-                instance_server, project_enabled_servers
+        if instance_server not in project_enabled_servers:
+            msg = (
+                "\"{}\" server on instance is not enabled in project settings."
+                " Enabled project servers:\n{}".format(
+                    instance_server, project_enabled_servers
+                )
             )
-        )
-        assert instance_server in project_enabled_servers, msg
+            raise KnownPublishError(msg)
 
         self.log.debug("Using project approved server.")
         return project_enabled_servers[instance_server]

--- a/openpype/modules/deadline/plugins/publish/help/validate_deadline_pools.xml
+++ b/openpype/modules/deadline/plugins/publish/help/validate_deadline_pools.xml
@@ -3,29 +3,29 @@
     <error id="main">
         <title>Scene setting</title>
         <description>
-            ## Invalid Deadline pools found
+## Invalid Deadline pools found
 
-            Configured pools don't match what is set in Deadline.
+Configured pools don't match what is set in Deadline.
 
-            {invalid_value_str}
+{invalid_value_str}
 
-            ### How to repair?
+### How to repair?
 
-            If your instance had deadline pools set on creation, remove or
-            change them.
+If your instance had deadline pools set on creation, remove or
+change them.
 
-        In other cases inform admin to change them in Settings.
+In other cases inform admin to change them in Settings.
 
-        Available deadline pools {pools_str}.
+Available deadline pools {pools_str}.
         </description>
         <detail>
-            ### __Detailed Info__
+### __Detailed Info__
 
-            This error is shown when deadline pool is not on Deadline anymore. It
-            could happen in case of republish old workfile which was created with
-            previous deadline pools,
-            or someone changed pools on Deadline side, but didn't modify Openpype
-            Settings.
+This error is shown when deadline pool is not on Deadline anymore. It
+could happen in case of republish old workfile which was created with
+previous deadline pools,
+or someone changed pools on Deadline side, but didn't modify Openpype
+Settings.
         </detail>
     </error>
 </root>

--- a/openpype/modules/deadline/plugins/publish/help/validate_deadline_pools.xml
+++ b/openpype/modules/deadline/plugins/publish/help/validate_deadline_pools.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <root>
     <error id="main">
-        <title>Scene setting</title>
+        <title>Deadline Pools</title>
         <description>
 ## Invalid Deadline pools found
 

--- a/openpype/modules/deadline/plugins/publish/help/validate_deadline_pools.xml
+++ b/openpype/modules/deadline/plugins/publish/help/validate_deadline_pools.xml
@@ -7,8 +7,6 @@
 
 Configured pools don't match available pools in Deadline.
 
-{invalid_value_str}
-
 ### How to repair?
 
 If your instance had deadline pools set on creation, remove or

--- a/openpype/modules/deadline/plugins/publish/help/validate_deadline_pools.xml
+++ b/openpype/modules/deadline/plugins/publish/help/validate_deadline_pools.xml
@@ -5,7 +5,7 @@
         <description>
 ## Invalid Deadline pools found
 
-Configured pools don't match what is set in Deadline.
+Configured pools don't match available pools in Deadline.
 
 {invalid_value_str}
 
@@ -16,16 +16,18 @@ change them.
 
 In other cases inform admin to change them in Settings.
 
-Available deadline pools {pools_str}.
+Available deadline pools:
+
+{pools_str}
+
         </description>
         <detail>
 ### __Detailed Info__
 
-This error is shown when deadline pool is not on Deadline anymore. It
-could happen in case of republish old workfile which was created with
-previous deadline pools,
-or someone changed pools on Deadline side, but didn't modify Openpype
-Settings.
+This error is shown when a configured pool is not available on Deadline. It
+can happen when publishing old workfiles which were created with previous
+deadline pools, or someone changed the available pools in Deadline,
+but didn't modify Openpype Settings to match the changes.
         </detail>
     </error>
 </root>

--- a/openpype/modules/deadline/plugins/publish/validate_deadline_connection.py
+++ b/openpype/modules/deadline/plugins/publish/validate_deadline_connection.py
@@ -1,7 +1,6 @@
-import os
-import requests
-
 import pyblish.api
+
+from openpype_modules.deadline.abstract_submit_deadline import requests_get
 
 
 class ValidateDeadlineConnection(pyblish.api.InstancePlugin):
@@ -24,22 +23,8 @@ class ValidateDeadlineConnection(pyblish.api.InstancePlugin):
         assert deadline_url, "Requires Deadline Webservice URL"
 
         # Check response
-        response = self._requests_get(deadline_url)
+        response = requests_get(deadline_url)
         assert response.ok, "Response must be ok"
         assert response.text.startswith("Deadline Web Service "), (
             "Web service did not respond with 'Deadline Web Service'"
         )
-
-    def _requests_get(self, *args, **kwargs):
-        """ Wrapper for requests, disabling SSL certificate validation if
-            DONT_VERIFY_SSL environment variable is found. This is useful when
-            Deadline or Muster server are running with self-signed certificates
-            and their certificate is not added to trusted certificates on
-            client machines.
-
-            WARNING: disabling SSL certificate validation is defeating one line
-            of defense SSL is providing and it is not recommended.
-        """
-        if 'verify' not in kwargs:
-            kwargs['verify'] = False if os.getenv("OPENPYPE_DONT_VERIFY_SSL", True) else True  # noqa
-        return requests.get(*args, **kwargs)

--- a/openpype/modules/deadline/plugins/publish/validate_deadline_connection.py
+++ b/openpype/modules/deadline/plugins/publish/validate_deadline_connection.py
@@ -17,9 +17,9 @@ class ValidateDeadlineConnection(pyblish.api.InstancePlugin):
         # if custom one is set in instance, use that
         if instance.data.get("deadlineUrl"):
             deadline_url = instance.data.get("deadlineUrl")
-            self.log.info(
-                "We have deadline URL on instance {}".format(
-                    deadline_url))
+            self.log.debug(
+                "We have deadline URL on instance {}".format(deadline_url)
+            )
         assert deadline_url, "Requires Deadline Webservice URL"
 
         # Check response

--- a/openpype/modules/deadline/plugins/publish/validate_deadline_connection.py
+++ b/openpype/modules/deadline/plugins/publish/validate_deadline_connection.py
@@ -11,6 +11,9 @@ class ValidateDeadlineConnection(pyblish.api.InstancePlugin):
     hosts = ["maya", "nuke"]
     families = ["renderlayer", "render"]
 
+    # cache
+    responses = {}
+
     def process(self, instance):
         # get default deadline webservice url from deadline module
         deadline_url = instance.context.data["defaultDeadline"]
@@ -22,8 +25,10 @@ class ValidateDeadlineConnection(pyblish.api.InstancePlugin):
             )
         assert deadline_url, "Requires Deadline Webservice URL"
 
-        # Check response
-        response = requests_get(deadline_url)
+        if deadline_url not in self.responses:
+            self.responses[deadline_url] = requests_get(deadline_url)
+
+        response = self.responses[deadline_url]
         assert response.ok, "Response must be ok"
         assert response.text.startswith("Deadline Web Service "), (
             "Web service did not respond with 'Deadline Web Service'"

--- a/openpype/modules/deadline/plugins/publish/validate_deadline_pools.py
+++ b/openpype/modules/deadline/plugins/publish/validate_deadline_pools.py
@@ -36,7 +36,7 @@ class ValidateDeadlinePools(OptionalPyblishPluginMixin,
             self.log.debug("Skipping local instance.")
             return
 
-        deadline_url = instance.context.data["defaultDeadline"]
+        deadline_url = self.get_deadline_url(instance)
         pools = self.get_pools(deadline_url)
 
         invalid_pools = {}
@@ -61,6 +61,14 @@ class ValidateDeadlinePools(OptionalPyblishPluginMixin,
                     "invalid_value_str": message,
                     "pools_str": ", ".join(pools)
                 })
+
+    def get_deadline_url(self, instance):
+        # get default deadline webservice url from deadline module
+        deadline_url = instance.context.data["defaultDeadline"]
+        if instance.data.get("deadlineUrl"):
+            # if custom one is set in instance, use that
+            deadline_url = instance.data.get("deadlineUrl")
+        return deadline_url
 
     def get_pools(self, deadline_url):
         if deadline_url not in self.pools_per_url:

--- a/openpype/modules/deadline/plugins/publish/validate_deadline_pools.py
+++ b/openpype/modules/deadline/plugins/publish/validate_deadline_pools.py
@@ -57,10 +57,8 @@ class ValidateDeadlinePools(OptionalPyblishPluginMixin,
             raise PublishXmlValidationError(
                 plugin=self,
                 message=message,
-                formatting_data={
-                    "invalid_value_str": message,
-                    "pools_str": ", ".join(pools)
-                })
+                formatting_data={"pools_str": ", ".join(pools)}
+            )
 
     def get_deadline_url(self, instance):
         # get default deadline webservice url from deadline module

--- a/openpype/modules/deadline/plugins/publish/validate_deadline_pools.py
+++ b/openpype/modules/deadline/plugins/publish/validate_deadline_pools.py
@@ -26,6 +26,9 @@ class ValidateDeadlinePools(OptionalPyblishPluginMixin,
     optional = True
 
     def process(self, instance):
+        if not self.is_active(instance.data):
+            return
+
         if not instance.data.get("farm"):
             self.log.debug("Skipping local instance.")
             return


### PR DESCRIPTION
## Changelog Description

- Fix optional support of validate deadline pools
- Query deadline webservice only once per URL for verification, and once for available deadline pools instead of for every instance
- Use `deadlineUrl` in `instance.data` when validating pools if it is set.
- Code cleanup: Re-use existing `requests_get` implementation

## Additional info

Example report of Validate Deadline Pools:
![image](https://github.com/ynput/OpenPype/assets/2439881/513da960-d3c7-45da-8233-d01dd06907f6)


## Testing notes:

1. Publish to Deadline from supported hosts, e.g. maya, fusion, nuke, etc.
