### PR TITLE
Houdini: Reset $JOB

### DIFF
--- a/openpype/hosts/houdini/api/lib.py
+++ b/openpype/hosts/houdini/api/lib.py
@@ -181,6 +181,22 @@ def validate_fps():
     return True
 
 
+# Valid JOB Path
+def validate_job_path():
+    """Validate $JOB value.
+
+    Currently, $JOB has the same value as $HIP.
+    """
+
+    job = os.environ["HIP"]
+    current_job = hou.hscript("echo -n `$JOB`")[0]
+
+    if current_job != job:
+        hou.hscript("set JOB=" + job)
+        os.environ["JOB"] = job
+        print("  - set $JOB to " + job)
+
+
 def create_remote_publish_node(force=True):
     """Function to create a remote publish node in /out
 

--- a/openpype/hosts/houdini/api/pipeline.py
+++ b/openpype/hosts/houdini/api/pipeline.py
@@ -299,6 +299,9 @@ def on_save():
 
     log.info("Running callback on save..")
 
+    # Validate $JOB value
+    lib.validate_job_path()
+
     nodes = lib.get_id_required_nodes()
     for node, new_id in lib.generate_ids(nodes):
         lib.set_id(node, new_id, overwrite=False)
@@ -311,6 +314,9 @@ def on_open():
         return
 
     log.info("Running callback on open..")
+
+    # Validate $JOB value
+    lib.validate_job_path()
 
     # Validate FPS after update_task_from_path to
     # ensure it is using correct FPS for the asset


### PR DESCRIPTION
## Changelog Description
Add `validate_job_path` to solve this issue https://github.com/ynput/OpenPype/issues/5517 when switching between assets

## Additional Info
Currently, `$JOB` has the same value as `$HIP` (_Default Houdini behavior_)

## Testing notes:
1. open any task in openpype
2. save it in another asset 
