### PR TITLE
Chore: Lower urllib3 to support older OpenSSL

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -3372,21 +3372,20 @@ files = [
 
 [[package]]
 name = "urllib3"
-version = "2.0.2"
+version = "1.26.16"
 description = "HTTP library with thread-safe connection pooling, file post, and more."
 category = "main"
 optional = false
-python-versions = ">=3.7"
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, !=3.5.*"
 files = [
-    {file = "urllib3-2.0.2-py3-none-any.whl", hash = "sha256:d055c2f9d38dc53c808f6fdc8eab7360b6fdbbde02340ed25cfbcd817c62469e"},
-    {file = "urllib3-2.0.2.tar.gz", hash = "sha256:61717a1095d7e155cdb737ac7bb2f4324a858a1e2e6466f6d03ff630ca68d3cc"},
+    {file = "urllib3-1.26.16-py2.py3-none-any.whl", hash = "sha256:8d36afa7616d8ab714608411b4a3b13e58f463aee519024578e062e141dce20f"},
+    {file = "urllib3-1.26.16.tar.gz", hash = "sha256:8f135f6502756bde6b2a9b28989df5fbe87c9970cecaa69041edcce7f0589b14"},
 ]
 
 [package.extras]
-brotli = ["brotli (>=1.0.9)", "brotlicffi (>=0.8.0)"]
-secure = ["certifi", "cryptography (>=1.9)", "idna (>=2.0.0)", "pyopenssl (>=17.1.0)", "urllib3-secure-extra"]
-socks = ["pysocks (>=1.5.6,!=1.5.7,<2.0)"]
-zstd = ["zstandard (>=0.18.0)"]
+brotli = ["brotli (>=1.0.9)", "brotlicffi (>=0.8.0)", "brotlipy (>=0.6.0)"]
+secure = ["certifi", "cryptography (>=1.3.4)", "idna (>=2.0.0)", "ipaddress", "pyOpenSSL (>=0.14)", "urllib3-secure-extra"]
+socks = ["PySocks (>=1.5.6,!=1.5.7,<2.0)"]
 
 [[package]]
 name = "virtualenv"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,6 +56,7 @@ QtPy = "^2.3.0"
 qtawesome = "0.7.3"
 speedcopy = "^2.1"
 six = "^1.15"
+urllib3 = "1.26.16"
 semver = "^2.13.0" # for version resolution
 wsrpc_aiohttp = "^3.1.1" # websocket server
 pywin32 = { version = "301", markers = "sys_platform == 'win32'" }


### PR DESCRIPTION
## Changelog Description
Lowered `urllib3` to `1.26.16` to support older OpenSSL.

## Additional info
Package `urllib3` since `2.0.0` requires OpenSSL version 1.1.1+ which is not available in builds of older DCCs like Maya 2022 or Nuke 13 (or at least on CentOS). To "fix" the issue an older version is used instead.

This PR should probably point to next-minor branch as it contains changes in requirements?

## Testing notes:
1. Prepare CentOS machine
2. Create build using this PR
3. Launch the build on CentOS and launch Maya 2022 from the build
4. It should be possible to launch the Maya and run publishing
