### PR TITLE
have the addons loading respect a custom AYON_ADDONS_DIR

### DIFF
--- a/openpype/modules/base.py
+++ b/openpype/modules/base.py
@@ -373,7 +373,7 @@ def _load_ayon_addons(openpype_modules, modules_key, log):
     addons_info = _get_ayon_addons_information()
     if not addons_info:
         return v3_addons_to_skip
-    addons_dir = os.environ.get('AYON_ADDONS_DIR')
+    addons_dir = os.environ.get("AYON_ADDONS_DIR")
     if not addons_dir:
         addons_dir = os.path.join(
             appdirs.user_data_dir("AYON", "Ynput"),

--- a/openpype/modules/base.py
+++ b/openpype/modules/base.py
@@ -373,10 +373,12 @@ def _load_ayon_addons(openpype_modules, modules_key, log):
     addons_info = _get_ayon_addons_information()
     if not addons_info:
         return v3_addons_to_skip
-    addons_dir = os.path.join(
-        appdirs.user_data_dir("AYON", "Ynput"),
-        "addons"
-    )
+    addons_dir = os.environ.get('AYON_ADDONS_DIR')
+    if not addons_dir:
+        addons_dir = os.path.join(
+            appdirs.user_data_dir("AYON", "Ynput"),
+            "addons"
+        )
     if not os.path.exists(addons_dir):
         log.warning("Addons directory does not exists. Path \"{}\"".format(
             addons_dir


### PR DESCRIPTION
## Changelog Description
When using a custom AYON_ADDONS_DIR environment variable that variable is used in the launcher correctly and downloads and extracts addons to there, however when running Ayon does not respect this environment variable

## Testing notes:
1. set custom `$AYON_ADDONS_DIR`
2. start ayon-launcher
3. It should fetch the addons to the specified `$AYON_ADDONS_DIR`
4. When it then runs it uses the addons from there (instead of the dir under the users home folder)
