### PR TITLE
AYON: Deadline expand userpaths in executables list

### DIFF
--- a/openpype/modules/deadline/repository/custom/plugins/Ayon/Ayon.py
+++ b/openpype/modules/deadline/repository/custom/plugins/Ayon/Ayon.py
@@ -91,7 +91,13 @@ class AyonDeadlinePlugin(DeadlinePlugin):
         # clean '\ ' for MacOS pasting
         if platform.system().lower() == "darwin":
             exe_list = exe_list.replace("\\ ", " ")
-        exe = FileUtils.SearchFileList(exe_list)
+
+        expanded_paths = []
+        for path in exe_list.split(";"):
+            if path.startswith("~"):
+                path = os.path.expanduser(path)
+                expanded_paths.append(path)
+        exe = FileUtils.SearchFileList(";".join(expanded_paths))
 
         if exe == "":
             self.FailRender(

--- a/openpype/modules/deadline/repository/custom/plugins/GlobalJobPreLoad.py
+++ b/openpype/modules/deadline/repository/custom/plugins/GlobalJobPreLoad.py
@@ -547,7 +547,14 @@ def get_ayon_executable():
     # clean '\ ' for MacOS pasting
     if platform.system().lower() == "darwin":
         exe_list = exe_list.replace("\\ ", " ")
-    return exe_list
+
+    # Expand user paths
+    expanded_paths = []
+    for path in exe_list.split(";"):
+        if path.startswith("~"):
+            path = os.path.expanduser(path)
+        expanded_paths.append(path)
+    return ";".join(expanded_paths)
 
 
 def inject_render_job_id(deadlinePlugin):


### PR DESCRIPTION
## Changelog Description
Expande `~` paths in executables list.

## Additional info
This gives option to set executable to `~/.local/share/AYON/app/{version}/ayon` (or `~/AppData/local/Ynput/AYON/app/{version}/ayon.exe` for windows) without defining all usernames.

## Testing notes:
1. Fill path to AYON in deadline plugin with `~`
2. Install AYON there
3. Submit job
4. All should work as expected
