### PR TITLE
Deadline: files on representation cannot be single item list

### DIFF
--- a/openpype/modules/deadline/plugins/publish/validate_expected_and_rendered_files.py
+++ b/openpype/modules/deadline/plugins/publish/validate_expected_and_rendered_files.py
@@ -70,7 +70,10 @@ class ValidateExpectedFiles(pyblish.api.InstancePlugin):
                     # Update the representation expected files
                     self.log.info("Update range from actual job range "
                                   "to frame list: {}".format(frame_list))
-                    repre["files"] = sorted(job_expected_files)
+                    # single item files must be string not list
+                    repre["files"] = (sorted(job_expected_files)
+                                      if len(job_expected_files) > 1 else
+                                      list(job_expected_files)[0])
 
                     # Update the expected files
                     expected_files = job_expected_files


### PR DESCRIPTION
## Changelog Description
Further logic expects that single item files will be only 'string' not 'list' (eg. repre["files"] = "abc.exr" not repre["files"] = ["abc.exr"].

This would cause an issue in ExtractReview later.

This could happen if DL rendered single frame file with different frame value.
