### PR TITLE
Webpublisher: better encode list values for click

### DIFF
--- a/openpype/hosts/webpublisher/publish_functions.py
+++ b/openpype/hosts/webpublisher/publish_functions.py
@@ -65,8 +65,7 @@ def cli_publish(project_name, batch_path, user_email, targets):
         if isinstance(targets, str):
             targets = [targets]
         for target in targets:
-            for target_item in target.split(" "):
-                pyblish.api.register_target(target_item)
+            pyblish.api.register_target(target)
 
     install_host(webpublisher_host)
 

--- a/openpype/hosts/webpublisher/publish_functions.py
+++ b/openpype/hosts/webpublisher/publish_functions.py
@@ -65,7 +65,8 @@ def cli_publish(project_name, batch_path, user_email, targets):
         if isinstance(targets, str):
             targets = [targets]
         for target in targets:
-            pyblish.api.register_target(target)
+            for target_item in target.split(" "):
+                pyblish.api.register_target(target_item)
 
     install_host(webpublisher_host)
 

--- a/openpype/hosts/webpublisher/webserver_service/webpublish_routes.py
+++ b/openpype/hosts/webpublisher/webserver_service/webpublish_routes.py
@@ -284,7 +284,7 @@ class BatchPublishEndpoint(WebpublishApiEndpoint):
                 args.append("--{}".format(key))
                 # Extend list into arguments (targets can be a list)
                 if isinstance(value, (tuple, list)):
-                    args.extend(value)
+                    args.append(" ".join(value))
                 else:
                     args.append(value)
 

--- a/openpype/hosts/webpublisher/webserver_service/webpublish_routes.py
+++ b/openpype/hosts/webpublisher/webserver_service/webpublish_routes.py
@@ -280,13 +280,14 @@ class BatchPublishEndpoint(WebpublishApiEndpoint):
 
         for key, value in add_args.items():
             # Skip key values where value is None
-            if value is not None:
-                args.append("--{}".format(key))
-                # Extend list into arguments (targets can be a list)
-                if isinstance(value, (tuple, list)):
-                    args.append(" ".join(value))
-                else:
-                    args.append(value)
+            if value is None:
+                continue
+            arg_key = "--{}".format(key)
+            if not isinstance(value, (tuple, list)):
+                value = [value]
+
+            for item in value:
+                args += [arg_key, item]
 
         log.info("args:: {}".format(args))
         if add_to_queue:


### PR DESCRIPTION
## Changelog Description
Targets could be a list, original implementation pushed it as a separate items, it must be added as `--targets webpulish --targets filepublish`.


`wepublish_routes` handles triggering from UI, changes in `publish_functions` handle triggering from cmd (for tests, api access).