### PR TITLE
Chore: Create plugin does not expect system settings

### DIFF
--- a/openpype/hosts/aftereffects/plugins/create/create_render.py
+++ b/openpype/hosts/aftereffects/plugins/create/create_render.py
@@ -164,7 +164,7 @@ class RenderCreator(Creator):
                 api.get_stub().rename_item(comp_id,
                                            new_comp_name)
 
-    def apply_settings(self, project_settings, system_settings):
+    def apply_settings(self, project_settings):
         plugin_settings = (
             project_settings["aftereffects"]["create"]["RenderCreator"]
         )

--- a/openpype/hosts/fusion/plugins/create/create_saver.py
+++ b/openpype/hosts/fusion/plugins/create/create_saver.py
@@ -30,10 +30,6 @@ class CreateSaver(NewCreator):
     instance_attributes = [
         "reviewable"
     ]
-    default_variants = [
-        "Main",
-        "Mask"
-    ]
 
     # TODO: This should be renamed together with Nuke so it is aligned
     temp_rendering_path_template = (

--- a/openpype/hosts/fusion/plugins/create/create_saver.py
+++ b/openpype/hosts/fusion/plugins/create/create_saver.py
@@ -250,11 +250,7 @@ class CreateSaver(NewCreator):
             label="Review",
         )
 
-    def apply_settings(
-        self,
-        project_settings,
-        system_settings
-    ):
+    def apply_settings(self, project_settings):
         """Method called on initialization of plugin to apply settings."""
 
         # plugin settings

--- a/openpype/hosts/houdini/api/plugin.py
+++ b/openpype/hosts/houdini/api/plugin.py
@@ -296,7 +296,7 @@ class HoudiniCreator(NewCreator, HoudiniCreatorBase):
         """
         return [hou.ropNodeTypeCategory()]
 
-    def apply_settings(self, project_settings, system_settings):
+    def apply_settings(self, project_settings):
         """Method called on initialization of plugin to apply settings."""
 
         settings_name = self.settings_name

--- a/openpype/hosts/maya/api/plugin.py
+++ b/openpype/hosts/maya/api/plugin.py
@@ -260,7 +260,7 @@ class MayaCreator(NewCreator, MayaCreatorBase):
                     default=True)
         ]
 
-    def apply_settings(self, project_settings, system_settings):
+    def apply_settings(self, project_settings):
         """Method called on initialization of plugin to apply settings."""
 
         settings_name = self.settings_name

--- a/openpype/hosts/maya/plugins/create/create_animation.py
+++ b/openpype/hosts/maya/plugins/create/create_animation.py
@@ -81,10 +81,8 @@ class CreateAnimation(plugin.MayaHiddenCreator):
 
         return defs
 
-    def apply_settings(self, project_settings, system_settings):
-        super(CreateAnimation, self).apply_settings(
-            project_settings, system_settings
-        )
+    def apply_settings(self, project_settings):
+        super(CreateAnimation, self).apply_settings(project_settings)
         # Hardcoding creator to be enabled due to existing settings would
         # disable the creator causing the creator plugin to not be
         # discoverable.

--- a/openpype/hosts/maya/plugins/create/create_render.py
+++ b/openpype/hosts/maya/plugins/create/create_render.py
@@ -34,7 +34,7 @@ class CreateRenderlayer(plugin.RenderlayerCreator):
     render_settings = {}
 
     @classmethod
-    def apply_settings(cls, project_settings, system_settings):
+    def apply_settings(cls, project_settings):
         cls.render_settings = project_settings["maya"]["RenderSettings"]
 
     def create(self, subset_name, instance_data, pre_create_data):

--- a/openpype/hosts/maya/plugins/create/create_unreal_skeletalmesh.py
+++ b/openpype/hosts/maya/plugins/create/create_unreal_skeletalmesh.py
@@ -21,7 +21,7 @@ class CreateUnrealSkeletalMesh(plugin.MayaCreator):
     # Defined in settings
     joint_hints = set()
 
-    def apply_settings(self, project_settings, system_settings):
+    def apply_settings(self, project_settings):
         """Apply project settings to creator"""
         settings = (
             project_settings["maya"]["create"]["CreateUnrealSkeletalMesh"]

--- a/openpype/hosts/maya/plugins/create/create_unreal_staticmesh.py
+++ b/openpype/hosts/maya/plugins/create/create_unreal_staticmesh.py
@@ -16,7 +16,7 @@ class CreateUnrealStaticMesh(plugin.MayaCreator):
     # Defined in settings
     collision_prefixes = []
 
-    def apply_settings(self, project_settings, system_settings):
+    def apply_settings(self, project_settings):
         """Apply project settings to creator"""
         settings = project_settings["maya"]["create"]["CreateUnrealStaticMesh"]
         self.collision_prefixes = settings["collision_prefixes"]

--- a/openpype/hosts/maya/plugins/create/create_vrayscene.py
+++ b/openpype/hosts/maya/plugins/create/create_vrayscene.py
@@ -22,7 +22,7 @@ class CreateVRayScene(plugin.RenderlayerCreator):
     singleton_node_name = "vraysceneMain"
 
     @classmethod
-    def apply_settings(cls, project_settings, system_settings):
+    def apply_settings(cls, project_settings):
         cls.render_settings = project_settings["maya"]["RenderSettings"]
 
     def create(self, subset_name, instance_data, pre_create_data):

--- a/openpype/hosts/nuke/api/plugin.py
+++ b/openpype/hosts/nuke/api/plugin.py
@@ -379,11 +379,7 @@ class NukeWriteCreator(NukeCreator):
                 sys.exc_info()[2]
             )
 
-    def apply_settings(
-        self,
-        project_settings,
-        system_settings
-    ):
+    def apply_settings(self, project_settings):
         """Method called on initialization of plugin to apply settings."""
 
         # plugin settings

--- a/openpype/hosts/photoshop/plugins/create/create_flatten_image.py
+++ b/openpype/hosts/photoshop/plugins/create/create_flatten_image.py
@@ -98,7 +98,7 @@ class AutoImageCreator(PSAutoCreator):
             )
         ]
 
-    def apply_settings(self, project_settings, system_settings):
+    def apply_settings(self, project_settings):
         plugin_settings = (
             project_settings["photoshop"]["create"]["AutoImageCreator"]
         )

--- a/openpype/hosts/photoshop/plugins/create/create_image.py
+++ b/openpype/hosts/photoshop/plugins/create/create_image.py
@@ -171,7 +171,7 @@ class ImageCreator(Creator):
             )
         ]
 
-    def apply_settings(self, project_settings, system_settings):
+    def apply_settings(self, project_settings):
         plugin_settings = (
             project_settings["photoshop"]["create"]["ImageCreator"]
         )

--- a/openpype/hosts/photoshop/plugins/create/create_review.py
+++ b/openpype/hosts/photoshop/plugins/create/create_review.py
@@ -18,7 +18,7 @@ class ReviewCreator(PSAutoCreator):
         it will get recreated in next publish either way).
         """
 
-    def apply_settings(self, project_settings, system_settings):
+    def apply_settings(self, project_settings):
         plugin_settings = (
             project_settings["photoshop"]["create"]["ReviewCreator"]
         )

--- a/openpype/hosts/photoshop/plugins/create/create_workfile.py
+++ b/openpype/hosts/photoshop/plugins/create/create_workfile.py
@@ -19,7 +19,7 @@ class WorkfileCreator(PSAutoCreator):
         in next publish automatically).
         """
 
-    def apply_settings(self, project_settings, system_settings):
+    def apply_settings(self, project_settings):
         plugin_settings = (
             project_settings["photoshop"]["create"]["WorkfileCreator"]
         )

--- a/openpype/hosts/traypublisher/plugins/create/create_movie_batch.py
+++ b/openpype/hosts/traypublisher/plugins/create/create_movie_batch.py
@@ -36,7 +36,7 @@ class BatchMovieCreator(TrayPublishCreator):
     # Position batch creator after simple creators
     order = 110
 
-    def apply_settings(self, project_settings, system_settings):
+    def apply_settings(self, project_settings):
         creator_settings = (
             project_settings["traypublisher"]["create"]["BatchMovieCreator"]
         )

--- a/openpype/hosts/tvpaint/plugins/create/create_render.py
+++ b/openpype/hosts/tvpaint/plugins/create/create_render.py
@@ -387,7 +387,7 @@ class CreateRenderPass(TVPaintCreator):
     # Settings
     mark_for_review = True
 
-    def apply_settings(self, project_settings, system_settings):
+    def apply_settings(self, project_settings):
         plugin_settings = (
             project_settings["tvpaint"]["create"]["create_render_pass"]
         )
@@ -690,7 +690,7 @@ class TVPaintAutoDetectRenderCreator(TVPaintCreator):
     group_idx_offset = 10
     group_idx_padding = 3
 
-    def apply_settings(self, project_settings, system_settings):
+    def apply_settings(self, project_settings):
         plugin_settings = (
             project_settings
             ["tvpaint"]
@@ -1029,7 +1029,7 @@ class TVPaintSceneRenderCreator(TVPaintAutoCreator):
     mark_for_review = True
     active_on_create = False
 
-    def apply_settings(self, project_settings, system_settings):
+    def apply_settings(self, project_settings):
         plugin_settings = (
             project_settings["tvpaint"]["create"]["create_render_scene"]
         )

--- a/openpype/hosts/tvpaint/plugins/create/create_render.py
+++ b/openpype/hosts/tvpaint/plugins/create/create_render.py
@@ -139,7 +139,7 @@ class CreateRenderlayer(TVPaintCreator):
     # - Mark by default instance for review
     mark_for_review = True
 
-    def apply_settings(self, project_settings, system_settings):
+    def apply_settings(self, project_settings):
         plugin_settings = (
             project_settings["tvpaint"]["create"]["create_render_layer"]
         )

--- a/openpype/hosts/tvpaint/plugins/create/create_review.py
+++ b/openpype/hosts/tvpaint/plugins/create/create_review.py
@@ -12,7 +12,7 @@ class TVPaintReviewCreator(TVPaintAutoCreator):
     # Settings
     active_on_create = True
 
-    def apply_settings(self, project_settings, system_settings):
+    def apply_settings(self, project_settings):
         plugin_settings = (
             project_settings["tvpaint"]["create"]["create_review"]
         )

--- a/openpype/hosts/tvpaint/plugins/create/create_workfile.py
+++ b/openpype/hosts/tvpaint/plugins/create/create_workfile.py
@@ -9,7 +9,7 @@ class TVPaintWorkfileCreator(TVPaintAutoCreator):
     label = "Workfile"
     icon = "fa.file-o"
 
-    def apply_settings(self, project_settings, system_settings):
+    def apply_settings(self, project_settings):
         plugin_settings = (
             project_settings["tvpaint"]["create"]["create_workfile"]
         )

--- a/openpype/lib/python_module_tools.py
+++ b/openpype/lib/python_module_tools.py
@@ -270,8 +270,8 @@ def is_func_signature_supported(func, *args, **kwargs):
 
     Args:
         func (function): A function where the signature should be tested.
-        *args (tuple[Any]): Positional arguments for function signature.
-        **kwargs (dict[str, Any]): Keyword arguments for function signature.
+        *args (Any): Positional arguments for function signature.
+        **kwargs (Any): Keyword arguments for function signature.
 
     Returns:
         bool: Function can pass in arguments.

--- a/openpype/pipeline/create/context.py
+++ b/openpype/pipeline/create/context.py
@@ -16,7 +16,6 @@ from openpype.settings import (
     get_system_settings,
     get_project_settings
 )
-from openpype.lib import is_func_signature_supported
 from openpype.lib.attribute_definitions import (
     UnknownDef,
     serialize_attr_defs,
@@ -1799,15 +1798,12 @@ class CreateContext:
                 ).format(creator_class.host_name, self.host_name))
                 continue
 
-            if is_func_signature_supported(
-                creator_class, project_settings, self, self.headless
-            ):
-                creator = creator_class(project_settings, self, self.headless)
-            else:
-                # Backwards compatibility to pass system settings to creators
-                creator = creator_class(
-                    project_settings, system_settings, self, self.headless
-                )
+            creator = creator_class(
+                project_settings,
+                system_settings,
+                self,
+                self.headless
+            )
 
             if not creator.enabled:
                 disabled_creators[creator_identifier] = creator

--- a/openpype/pipeline/create/creator_plugins.py
+++ b/openpype/pipeline/create/creator_plugins.py
@@ -193,7 +193,9 @@ class BaseCreator:
     # QUESTION make this required?
     host_name = None
 
-    def __init__(self, project_settings, create_context, headless=False):
+    def __init__(
+        self, project_settings, system_settings, create_context, headless=False
+    ):
         # Reference to CreateContext
         self.create_context = create_context
         self.project_settings = project_settings
@@ -202,13 +204,26 @@ class BaseCreator:
         # - we may use UI inside processing this attribute should be checked
         self.headless = headless
 
+        expect_system_settings = False
         if is_func_signature_supported(
             self.apply_settings, project_settings
         ):
             self.apply_settings(project_settings)
         else:
+            expect_system_settings = True
             # Backwards compatibility for system settings
-            self.apply_settings(project_settings, {})
+            self.apply_settings(project_settings, system_settings)
+
+        init_overriden = self.__class__.__init__ is not BaseCreator.__init__
+        if init_overriden or expect_system_settings:
+            self.log.warning((
+                "WARNING: Source - Create plugin {}."
+                " System settings argument will not be passed to"
+                " '__init__' and 'apply_settings' methods in future versions"
+                " of OpenPype. Planned version to drop the support"
+                " is 3.15.6 or 3.16.0. Please contact Ynput core team if you"
+                " need to keep system settings."
+            ).format(self.__class__.__name__))
 
     def apply_settings(self, project_settings):
         """Method called on initialization of plugin to apply settings.

--- a/openpype/pipeline/create/creator_plugins.py
+++ b/openpype/pipeline/create/creator_plugins.py
@@ -221,7 +221,7 @@ class BaseCreator:
                 " System settings argument will not be passed to"
                 " '__init__' and 'apply_settings' methods in future versions"
                 " of OpenPype. Planned version to drop the support"
-                " is 3.15.6 or 3.16.0. Please contact Ynput core team if you"
+                " is 3.16.6 or 3.17.0. Please contact Ynput core team if you"
                 " need to keep system settings."
             ).format(self.__class__.__name__))
 

--- a/openpype/pipeline/create/creator_plugins.py
+++ b/openpype/pipeline/create/creator_plugins.py
@@ -1,11 +1,7 @@
 import copy
 import collections
 
-from abc import (
-    ABCMeta,
-    abstractmethod,
-    abstractproperty
-)
+from abc import ABCMeta, abstractmethod
 
 import six
 
@@ -84,7 +80,8 @@ class SubsetConvertorPlugin(object):
     def host(self):
         return self._create_context.host
 
-    @abstractproperty
+    @property
+    @abstractmethod
     def identifier(self):
         """Converted identifier.
 
@@ -231,7 +228,8 @@ class BaseCreator:
 
         return self.family
 
-    @abstractproperty
+    @property
+    @abstractmethod
     def family(self):
         """Family that plugin represents."""
 

--- a/openpype/pipeline/create/creator_plugins.py
+++ b/openpype/pipeline/create/creator_plugins.py
@@ -10,7 +10,7 @@ from abc import (
 import six
 
 from openpype.settings import get_system_settings, get_project_settings
-from openpype.lib import Logger
+from openpype.lib import Logger, is_func_signature_supported
 from openpype.pipeline.plugin_discover import (
     discover,
     register_plugin,
@@ -161,7 +161,6 @@ class BaseCreator:
 
     Args:
         project_settings (Dict[str, Any]): Project settings.
-        system_settings (Dict[str, Any]): System settings.
         create_context (CreateContext): Context which initialized creator.
         headless (bool): Running in headless mode.
     """
@@ -197,9 +196,7 @@ class BaseCreator:
     # QUESTION make this required?
     host_name = None
 
-    def __init__(
-        self, project_settings, system_settings, create_context, headless=False
-    ):
+    def __init__(self, project_settings, create_context, headless=False):
         # Reference to CreateContext
         self.create_context = create_context
         self.project_settings = project_settings
@@ -208,10 +205,20 @@ class BaseCreator:
         # - we may use UI inside processing this attribute should be checked
         self.headless = headless
 
-        self.apply_settings(project_settings, system_settings)
+        if is_func_signature_supported(
+            self.apply_settings, project_settings
+        ):
+            self.apply_settings(project_settings)
+        else:
+            # Backwards compatibility for system settings
+            self.apply_settings(project_settings, {})
 
-    def apply_settings(self, project_settings, system_settings):
-        """Method called on initialization of plugin to apply settings."""
+    def apply_settings(self, project_settings):
+        """Method called on initialization of plugin to apply settings.
+
+        Args:
+            project_settings (dict[str, Any]): Project settings.
+        """
 
         pass
 


### PR DESCRIPTION
## Changelog Description
System settings are not passed to initialization of create plugin initialization (and `apply_settings`).

## Additional info
Reasons: The system settings are not used anywhere, and since AYON there won't be 2 types of settings.

We need validation of all Create plugins: They should not use `system_settings` in `apply_settings` method and they should not override `__init__` method.

To make this PR safer the system settings can still be passed to creator initialization, but eventually it will be removed in future PR anyway, so it would be just temporary backwards compatibility.

This PR must be updated with latest develop and revalidated changes before merge.

## Testing notes:
1. Technically run all available creators in Publisher

- [x] Traypublisher
- [x] Maya
- [x] Nuke
- [x] AfterEffects
- [x] Photoshop
- [x] 3dsMax
- [x] Houdini
- [ ] TVPaint