### PR TITLE
Igniter: Allow custom Qt scale factor rounding policy

### DIFF
--- a/igniter/__init__.py
+++ b/igniter/__init__.py
@@ -34,7 +34,11 @@ def _get_qt_app():
         if attr is not None:
             QtWidgets.QApplication.setAttribute(attr)
 
-    if hasattr(QtWidgets.QApplication, "setHighDpiScaleFactorRoundingPolicy"):
+    policy = os.getenv("QT_SCALE_FACTOR_ROUNDING_POLICY")
+    if (
+        hasattr(QtWidgets.QApplication, "setHighDpiScaleFactorRoundingPolicy")
+        and not policy
+    ):
         QtWidgets.QApplication.setHighDpiScaleFactorRoundingPolicy(
             QtCore.Qt.HighDpiScaleFactorRoundingPolicy.PassThrough
         )


### PR DESCRIPTION
## Changelog Description
Do not force `PassThrough` rounding policy if different policy is defined via env variable.

## Additional info
On some virtual machines is `PassThrough` rounding policy causing issues with calculated widget rectangle and paint rectangle. Painted rectangle has expected rectangle, but handling of events happens in smaller and offset rectangle. Probably caused by some bug in Qt. Widgets on top left are closer to expected behavior, bottom right is worse.

## Testing notes:
You must have some scaling set (e.g. 125% on windows).
1. Set environment variable `QT_SCALE_FACTOR_ROUNDING_POLICY` to e.g. `"Floor"`
2. Launch OpenPype so igniter is shown
3. The size of igniter should be rounded by the policy you set to env variable
