### PR TITLE
Chore: Allow custom Qt scale factor rounding policy

### DIFF
--- a/openpype/tools/utils/lib.py
+++ b/openpype/tools/utils/lib.py
@@ -170,8 +170,12 @@ def get_openpype_qt_app():
             if attr is not None:
                 QtWidgets.QApplication.setAttribute(attr)
 
-        if hasattr(
-            QtWidgets.QApplication, "setHighDpiScaleFactorRoundingPolicy"
+        policy = os.getenv("QT_SCALE_FACTOR_ROUNDING_POLICY")
+        if (
+            hasattr(
+                QtWidgets.QApplication, "setHighDpiScaleFactorRoundingPolicy"
+            )
+            and not policy
         ):
             QtWidgets.QApplication.setHighDpiScaleFactorRoundingPolicy(
                 QtCore.Qt.HighDpiScaleFactorRoundingPolicy.PassThrough


### PR DESCRIPTION
## Changelog Description
Do not force `PassThrough` rounding policy if different policy is defined via env variable.

## Additional info
On some virtual machines is `PassThrough` rounding policy causing issues with calculated widget rectangle and paint rectangle. Painted rectangle has expected rectangle, but handling of events happens in smaller and offset rectangle. Probably caused by some bug in Qt. Widgets on top left are closer to expected behavior, bottom right is worse.

## Testing notes:
You must have some scaling set (e.g. 125% on windows).
1. Set environment variable `QT_SCALE_FACTOR_ROUNDING_POLICY` to e.g. `"Floor"`
2. Launch OpenPype
3. UIs should be resized by the rounding policy

NOTE: This does not affect when Igniter starts first. Changes in igniter are in separated PR https://github.com/ynput/OpenPype/pull/5554