### PR TITLE
Chore: Do not try to add schema to zip files

### DIFF
--- a/igniter/bootstrap_repos.py
+++ b/igniter/bootstrap_repos.py
@@ -589,7 +589,7 @@ class BootstrapRepos:
         self.registry = OpenPypeSettingsRegistry()
         self.zip_filter = [".pyc", "__pycache__"]
         self.openpype_filter = [
-            "openpype", "schema", "LICENSE"
+            "openpype", "LICENSE"
         ]
 
         # dummy progress reporter


### PR DESCRIPTION
## Changelog Description
Do not add `schema` folder to zip file. This fixes issue cause by https://github.com/ynput/OpenPype/pull/5355 .

## Additional info
Schema folder was moved inside openpype codebase.

### Traceback
```
Traceback (most recent call last):
  File "C:\Users\qam\code\OpenPype\igniter\install_thread.py", line 166, in run
    local_openpype = bs.create_version_from_live_code()
  File "C:\Users\qam\code\OpenPype\igniter\bootstrap_repos.py", line 697, in create_version_from_live_code
    self._create_openpype_zip(temp_zip, repo_dir)
  File "C:\Users\qam\code\OpenPype\igniter\bootstrap_repos.py", line 867, in _create_openpype_zip
    sha256sum(sanitize_long_path(file.as_posix())),
  File "C:\Users\qam\code\OpenPype\igniter\bootstrap_repos.py", line 74, in sha256sum
    with open(filename, 'rb', buffering=0) as f:
FileNotFoundError: [Errno 2] No such file or directory: '\\\\?\\C:\\Users\\qam\\code\\OpenPype\\schema'
```

## Testing notes:
1. Run create zip script
2. It should not fail
