### PR TITLE
Maya: Yeti Cache Include viewport preview settings from source

### DIFF
--- a/openpype/hosts/maya/plugins/load/load_yeti_cache.py
+++ b/openpype/hosts/maya/plugins/load/load_yeti_cache.py
@@ -15,6 +15,16 @@ from openpype.hosts.maya.api import lib
 from openpype.hosts.maya.api.pipeline import containerise
 
 
+# Do not reset these values on update but only apply on first load
+# to preserve any potential local overrides
+SKIP_UPDATE_ATTRS = {
+    "displayOutput",
+    "viewportDensity",
+    "viewportWidth",
+    "viewportLength",
+}
+
+
 def set_attribute(node, attr, value):
     """Wrapper of set attribute which ignores None values"""
     if value is None:
@@ -205,6 +215,8 @@ class YetiCacheLoader(load.LoaderPlugin):
                     yeti_node = yeti_nodes[0]
 
                     for attr, value in node_settings["attrs"].items():
+                        if attr in SKIP_UPDATE_ATTRS:
+                            continue
                         set_attribute(attr, value, yeti_node)
 
         cmds.setAttr("{}.representation".format(container_node),
@@ -311,7 +323,6 @@ class YetiCacheLoader(load.LoaderPlugin):
         # Update attributes with defaults
         attributes = node_settings["attrs"]
         attributes.update({
-            "viewportDensity": 0.1,
             "verbosity": 2,
             "fileMode": 1,
 
@@ -320,6 +331,9 @@ class YetiCacheLoader(load.LoaderPlugin):
             "visibleInReflections": True,
             "visibleInRefractions": True
         })
+
+        if "viewportDensity" not in attributes:
+            attributes["viewportDensity"] = 0.1
 
         # Apply attributes to pgYetiMaya node
         for attr, value in attributes.items():

--- a/openpype/hosts/maya/plugins/publish/collect_yeti_cache.py
+++ b/openpype/hosts/maya/plugins/publish/collect_yeti_cache.py
@@ -4,12 +4,23 @@ import pyblish.api
 
 from openpype.hosts.maya.api import lib
 
-SETTINGS = {"renderDensity",
-            "renderWidth",
-            "renderLength",
-            "increaseRenderBounds",
-            "imageSearchPath",
-            "cbId"}
+
+SETTINGS = {
+    # Preview
+    "displayOutput",
+    "colorR", "colorG", "colorB",
+    "viewportDensity",
+    "viewportWidth",
+    "viewportLength",
+    # Render attributes
+    "renderDensity",
+    "renderWidth",
+    "renderLength",
+    "increaseRenderBounds",
+    "imageSearchPath",
+    # Pipeline specific
+    "cbId"
+}
 
 
 class CollectYetiCache(pyblish.api.InstancePlugin):
@@ -39,10 +50,6 @@ class CollectYetiCache(pyblish.api.InstancePlugin):
         # Get yeti nodes and their transforms
         yeti_shapes = cmds.ls(instance, type="pgYetiMaya")
         for shape in yeti_shapes:
-            shape_data = {"transform": None,
-                          "name": shape,
-                          "cbId": lib.get_id(shape),
-                          "attrs": None}
 
             # Get specific node attributes
             attr_data = {}
@@ -58,9 +65,12 @@ class CollectYetiCache(pyblish.api.InstancePlugin):
             parent = cmds.listRelatives(shape, parent=True)[0]
             transform_data = {"name": parent, "cbId": lib.get_id(parent)}
 
-            # Store collected data
-            shape_data["attrs"] = attr_data
-            shape_data["transform"] = transform_data
+            shape_data = {
+                "transform": transform_data,
+                "name": shape,
+                "cbId": lib.get_id(shape),
+                "attrs": attr_data,
+            }
 
             settings["nodes"].append(shape_data)
 


### PR DESCRIPTION
## Changelog Description

When publishing and loading yeti caches persist the display output and preview colors + settings to ensure consistency in the view

## Testing notes:

1. Publish yeti cache in Maya with some tweaked preview settings (e.g. viewport preview color, etc)
2. Load in yeti cache, settings should be preserved.
