### PR TITLE
Maya: Yeti fix callback check per renderer used + validate once

### DIFF
--- a/openpype/hosts/maya/plugins/publish/validate_yeti_renderscript_callbacks.py
+++ b/openpype/hosts/maya/plugins/publish/validate_yeti_renderscript_callbacks.py
@@ -1,10 +1,16 @@
 from maya import cmds
 
 import pyblish.api
-from openpype.pipeline.publish import ValidateContentsOrder
+from openpype.pipeline.publish import (
+    context_plugin_should_run,
+    filter_instances_for_context_plugin,
+    ValidateContentsOrder,
+    RepairContextAction,
+    PublishValidationError
+)
 
 
-class ValidateYetiRenderScriptCallbacks(pyblish.api.InstancePlugin):
+class ValidateYetiRenderScriptCallbacks(pyblish.api.ContextPlugin):
     """Check if the render script callbacks will be used during the rendering
 
     In order to ensure the render tasks are executed properly we need to check
@@ -24,6 +30,7 @@ class ValidateYetiRenderScriptCallbacks(pyblish.api.InstancePlugin):
     label = "Yeti Render Script Callbacks"
     hosts = ["maya"]
     families = ["renderlayer"]
+    actions = [RepairContextAction]
 
     # Settings per renderer
     callbacks = {
@@ -36,82 +43,102 @@ class ValidateYetiRenderScriptCallbacks(pyblish.api.InstancePlugin):
         }
     }
 
-    def process(self, instance):
+    def process(self, context):
+        # Workaround bug pyblish-base#250
+        if not context_plugin_should_run(self, context):
+            return
 
-        invalid = self.get_invalid(instance)
+        invalid = self.get_invalid(context)
         if invalid:
-            raise ValueError("Invalid render callbacks found for '%s'!"
-                             % instance.name)
+            raise PublishValidationError(
+                "Invalid Yeti render callbacks found."
+            )
 
     @classmethod
-    def get_invalid(cls, instance):
+    def get_invalid(cls, context):
 
         yeti_loaded = cmds.pluginInfo("pgYetiMaya", query=True, loaded=True)
-
-        if not yeti_loaded and not cmds.ls(type="pgYetiMaya"):
+        if yeti_loaded and not cmds.ls(type="pgYetiMaya"):
             # The yeti plug-in is available and loaded so at
             # this point we don't really care whether the scene
             # has any yeti callback set or not since if the callback
             # is there it wouldn't error and if it weren't then
             # nothing happens because there are no yeti nodes.
-            cls.log.info(
+            cls.log.debug(
                 "Yeti is loaded but no yeti nodes were found. "
                 "Callback validation skipped.."
             )
-            return False
+            return {}
 
-        renderer = instance.data["renderer"]
+        # For all renderlayer instances find the renderer used, so we ensure
+        # to validate the callback for any unique supported renderer
+        instances = filter_instances_for_context_plugin(plugin=cls,
+                                                        context=context)
+        renderers = set(instance.data["renderer"] for instance in instances)
+        all_invalid = []
+        for renderer in renderers:
+            invalid = cls.validate_for_renderer(renderer, yeti_loaded)
+            if invalid:
+                all_invalid.extend(invalid)
+
+        return invalid
+
+    @classmethod
+    def validate_for_renderer(cls, renderer, yeti_loaded):
+
         if renderer == "redshift":
-            cls.log.info("Redshift ignores any pre and post render callbacks")
+            cls.log.debug("Redshift ignores any pre and post render callbacks")
             return False
 
         callback_lookup = cls.callbacks.get(renderer, {})
         if not callback_lookup:
             cls.log.warning("Renderer '%s' is not supported in this plugin"
                             % renderer)
-            return False
+            return []
 
-        pre_mel = cmds.getAttr("defaultRenderGlobals.preMel") or ""
-        post_mel = cmds.getAttr("defaultRenderGlobals.postMel") or ""
+        invalid = []
+        for when, yeti_callback in callback_lookup.items():
+            attr = "defaultRenderGlobals.{}Mel".format(when)  # pre or post
+            current = (cmds.getAttr(attr) or "").strip()      # current value
+            if current:
+                cls.log.debug("Found {} mel: `{}`".format(when, current))
 
-        if pre_mel.strip():
-            cls.log.debug("Found pre mel: `%s`" % pre_mel)
+            # Strip callbacks and turn into a set for quick lookup
+            current_callbacks = {cmd.strip() for cmd in current.split(";")}
 
-        if post_mel.strip():
-            cls.log.debug("Found post mel: `%s`" % post_mel)
-
-        # Strip callbacks and turn into a set for quick lookup
-        pre_callbacks = {cmd.strip() for cmd in pre_mel.split(";")}
-        post_callbacks = {cmd.strip() for cmd in post_mel.split(";")}
-
-        pre_script = callback_lookup.get("pre", "")
-        post_script = callback_lookup.get("post", "")
-
-        # If Yeti is not loaded
-        invalid = False
-        if not yeti_loaded:
-            if pre_script and pre_script in pre_callbacks:
-                cls.log.error("Found pre render callback '%s' which is not "
-                              "uses!" % pre_script)
-                invalid = True
-
-            if post_script and post_script in post_callbacks:
-                cls.log.error("Found post render callback '%s which is "
-                              "not used!" % post_script)
-                invalid = True
-
-        # If Yeti is loaded
-        else:
-            if pre_script and pre_script not in pre_callbacks:
+            if yeti_loaded and yeti_callback not in current_callbacks:
                 cls.log.error(
-                    "Could not find required pre render callback "
-                    "`%s`" % pre_script)
-                invalid = True
-
-            if post_script and post_script not in post_callbacks:
+                    "Could not find required {} render callback '{}' for Yeti."
+                    .format(when, yeti_callback)
+                )
+                invalid.append((attr, True, yeti_callback))
+            elif not yeti_loaded and yeti_callback in current_callbacks:
                 cls.log.error(
-                    "Could not find required post render callback"
-                    " `%s`" % post_script)
-                invalid = True
+                    "Found {} render callback '{}' while Yeti is not used!"
+                    .format(when, yeti_callback)
+                )
+                invalid.append((attr, False, yeti_callback))
 
         return invalid
+
+    @classmethod
+    def repair(cls, context):
+        invalid = cls.get_invalid(context)
+        if not invalid:
+            cls.log.info("Nothing to repair.")
+
+        for attr, add, callback in invalid:
+            current = (cmds.getAttr(attr) or "").strip()
+            if add:
+                # Add callback
+                if not current.endswith(";"):
+                    current += ";"
+                new = "{}{};".format(current, callback)
+                cmds.setAttr(attr, new, type="string")
+            else:
+                # Remove callback
+                new = ";".join(
+                    cmd for cmd in current.split(";")
+                    if cmd.strip() != callback
+                )
+                cmds.setAttr(attr, new, type="string")


### PR DESCRIPTION
## Changelog Description

Validate Yeti Callback per renderer + check only once globally (ContextPlugin)

## Additional info

This PR is dependent on https://github.com/ynput/OpenPype/pull/5559/files#diff-7b9879ee6c4f2db686b8338994be3031e3ccaf28f0d1d13bbd6fa46d48da1333 since that includes the `ContextRepairAction` implementation

## Testing notes:
1. Render with yeti callbacks in pre/post render scripts
2. Ensure they are validated as expected
