### PR TITLE
Maya: Multiverse USD Override inherit from correct new style creator

### DIFF
--- a/openpype/hosts/maya/plugins/create/create_multiverse_usd_over.py
+++ b/openpype/hosts/maya/plugins/create/create_multiverse_usd_over.py
@@ -6,7 +6,7 @@ from openpype.lib import (
 )
 
 
-class CreateMultiverseUsdOver(plugin.Creator):
+class CreateMultiverseUsdOver(plugin.MayaCreator):
     """Create Multiverse USD Override"""
 
     identifier = "io.openpype.creators.maya.mvusdoverride"


### PR DESCRIPTION
## Changelog Description

Fix Creator for Multiverse USD Override by inheriting from correct new style creator class type

## Testing notes:

1. Open Create tab in Publisher
2. Multivere USD Override should now be listed and be creatable.
