### PR TITLE
Chore: add default isort config

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -29,3 +29,10 @@ directory = ./coverage
 
 [tool:pytest]
 norecursedirs = repos/* openpype/modules/ftrack/*
+
+[isort]
+line_length = 79
+multi_line_output = 3
+include_trailing_comma = True
+force_grid_wrap = 0
+combine_as_imports = True

--- a/setup.cfg
+++ b/setup.cfg
@@ -28,7 +28,7 @@ omit = /tests
 directory = ./coverage
 
 [tool:pytest]
-norecursedirs = repos/* openpype/modules/ftrack/*
+norecursedirs = openpype/modules/ftrack/*
 
 [isort]
 line_length = 79


### PR DESCRIPTION
## Changelog Description
Add default configuration for [isort tool](https://pycqa.github.io/isort/)

## Testing notes:
This shouldn't affect any functionality of OpenPype/AYON
