### PR TITLE
Maya: Fix attribute definitions for `CreateYetiCache`

### DIFF
--- a/openpype/hosts/maya/plugins/create/create_yeti_cache.py
+++ b/openpype/hosts/maya/plugins/create/create_yeti_cache.py
@@ -13,8 +13,7 @@ class CreateYetiCache(plugin.MayaCreator):
     family = "yeticache"
     icon = "pagelines"
 
-    def __init__(self, *args, **kwargs):
-        super(CreateYetiCache, self).__init__(*args, **kwargs)
+    def get_instance_attr_defs(self):
 
         defs = [
             NumberDef("preroll",
@@ -36,3 +35,5 @@ class CreateYetiCache(plugin.MayaCreator):
                       default=3,
                       decimals=0)
         )
+
+        return defs


### PR DESCRIPTION
## Changelog Description

Fix attribute definitions for `CreateYetiCache`

## Additional info

`__init__` was overridden instead of using `get_instance_attr_defs`. Previously the attribute definitions should not have worked.

Note that even with this PR [the issue here](https://github.com/ynput/OpenPype/issues/5468#issuecomment-1706070618) might still be present.

## Testing notes:

1. Create yeti cache instance
2. Publish it
