### PR TITLE
Maya: Add `OptionalPyblishPluginMixin` to all validators

### DIFF
--- a/openpype/hosts/maya/plugins/publish/validate_animation_content.py
+++ b/openpype/hosts/maya/plugins/publish/validate_animation_content.py
@@ -1,8 +1,9 @@
 import pyblish.api
+
 import openpype.hosts.maya.api.action
 from openpype.pipeline.publish import (
     PublishValidationError,
-    ValidateContentsOrder
+    ValidateContentsOrder,
 )
 
 

--- a/openpype/hosts/maya/plugins/publish/validate_animation_out_set_related_node_ids.py
+++ b/openpype/hosts/maya/plugins/publish/validate_animation_out_set_related_node_ids.py
@@ -1,16 +1,18 @@
 import maya.cmds as cmds
-
 import pyblish.api
+
 import openpype.hosts.maya.api.action
 from openpype.hosts.maya.api import lib
 from openpype.pipeline.publish import (
+    OptionalPyblishPluginMixin,
+    PublishValidationError,
     RepairAction,
     ValidateContentsOrder,
-    PublishValidationError
 )
 
 
-class ValidateOutRelatedNodeIds(pyblish.api.InstancePlugin):
+class ValidateOutRelatedNodeIds(pyblish.api.InstancePlugin,
+                                OptionalPyblishPluginMixin):
     """Validate if deformed shapes have related IDs to the original shapes
 
     When a deformer is applied in the scene on a referenced mesh that already

--- a/openpype/hosts/maya/plugins/publish/validate_arnold_scene_source.py
+++ b/openpype/hosts/maya/plugins/publish/validate_arnold_scene_source.py
@@ -1,10 +1,14 @@
 import pyblish.api
+
 from openpype.pipeline.publish import (
-    ValidateContentsOrder, PublishValidationError
+    OptionalPyblishPluginMixin,
+    PublishValidationError,
+    ValidateContentsOrder,
 )
 
 
-class ValidateArnoldSceneSource(pyblish.api.InstancePlugin):
+class ValidateArnoldSceneSource(pyblish.api.InstancePlugin,
+                                OptionalPyblishPluginMixin):
     """Validate Arnold Scene Source.
 
     We require at least 1 root node/parent for the meshes. This is to ensure we

--- a/openpype/hosts/maya/plugins/publish/validate_arnold_scene_source_cbid.py
+++ b/openpype/hosts/maya/plugins/publish/validate_arnold_scene_source_cbid.py
@@ -1,11 +1,16 @@
 import pyblish.api
+
 from openpype.hosts.maya.api import lib
 from openpype.pipeline.publish import (
-    ValidateContentsOrder, PublishValidationError, RepairAction
+    OptionalPyblishPluginMixin,
+    PublishValidationError,
+    RepairAction,
+    ValidateContentsOrder,
 )
 
 
-class ValidateArnoldSceneSourceCbid(pyblish.api.InstancePlugin):
+class ValidateArnoldSceneSourceCbid(pyblish.api.InstancePlugin,
+                                    OptionalPyblishPluginMixin):
     """Validate Arnold Scene Source Cbid.
 
     It is required for the proxy and content nodes to share the same cbid.

--- a/openpype/hosts/maya/plugins/publish/validate_ass_relative_paths.py
+++ b/openpype/hosts/maya/plugins/publish/validate_ass_relative_paths.py
@@ -2,17 +2,19 @@ import os
 import types
 
 import maya.cmds as cmds
+import pyblish.api
 from mtoa.core import createOptions
 
-import pyblish.api
 from openpype.pipeline.publish import (
+    OptionalPyblishPluginMixin,
+    PublishValidationError,
     RepairAction,
     ValidateContentsOrder,
-    PublishValidationError
 )
 
 
-class ValidateAssRelativePaths(pyblish.api.InstancePlugin):
+class ValidateAssRelativePaths(pyblish.api.InstancePlugin,
+                               OptionalPyblishPluginMixin):
     """Ensure exporting ass file has set relative texture paths"""
 
     order = ValidateContentsOrder

--- a/openpype/hosts/maya/plugins/publish/validate_assembly_name.py
+++ b/openpype/hosts/maya/plugins/publish/validate_assembly_name.py
@@ -1,12 +1,15 @@
-import pyblish.api
 import maya.cmds as cmds
+import pyblish.api
+
 import openpype.hosts.maya.api.action
 from openpype.pipeline.publish import (
-    PublishValidationError
+    OptionalPyblishPluginMixin,
+    PublishValidationError,
 )
 
 
-class ValidateAssemblyName(pyblish.api.InstancePlugin):
+class ValidateAssemblyName(pyblish.api.InstancePlugin,
+                           OptionalPyblishPluginMixin):
     """ Ensure Assembly name ends with `GRP`
 
     Check if assembly name ends with `_GRP` string.

--- a/openpype/hosts/maya/plugins/publish/validate_assembly_namespaces.py
+++ b/openpype/hosts/maya/plugins/publish/validate_assembly_namespaces.py
@@ -1,10 +1,14 @@
 import pyblish.api
+
 import openpype.hosts.maya.api.action
 from openpype.pipeline.publish import (
-    PublishValidationError
+    OptionalPyblishPluginMixin,
+    PublishValidationError,
 )
 
-class ValidateAssemblyNamespaces(pyblish.api.InstancePlugin):
+
+class ValidateAssemblyNamespaces(pyblish.api.InstancePlugin,
+                                 OptionalPyblishPluginMixin):
     """Ensure namespaces are not nested
 
     In the outliner an item in a normal namespace looks as following:

--- a/openpype/hosts/maya/plugins/publish/validate_assembly_transforms.py
+++ b/openpype/hosts/maya/plugins/publish/validate_assembly_transforms.py
@@ -2,10 +2,15 @@ import pyblish.api
 from maya import cmds
 
 import openpype.hosts.maya.api.action
-from openpype.pipeline.publish import PublishValidationError, RepairAction
+from openpype.pipeline.publish import (
+    OptionalPyblishPluginMixin,
+    PublishValidationError,
+    RepairAction,
+)
 
 
-class ValidateAssemblyModelTransforms(pyblish.api.InstancePlugin):
+class ValidateAssemblyModelTransforms(pyblish.api.InstancePlugin,
+                                      OptionalPyblishPluginMixin):
     """Verify only root nodes of the loaded asset have transformations.
 
     Note: This check is temporary and is subject to change.

--- a/openpype/hosts/maya/plugins/publish/validate_attributes.py
+++ b/openpype/hosts/maya/plugins/publish/validate_attributes.py
@@ -5,8 +5,11 @@ from maya import cmds
 
 from openpype.hosts.maya.api.lib import set_attribute
 from openpype.pipeline.publish import (
-    OptionalPyblishPluginMixin, PublishValidationError, RepairAction,
-    ValidateContentsOrder)
+    OptionalPyblishPluginMixin,
+    PublishValidationError,
+    RepairAction,
+    ValidateContentsOrder,
+)
 
 
 class ValidateAttributes(pyblish.api.InstancePlugin,

--- a/openpype/hosts/maya/plugins/publish/validate_camera_attributes.py
+++ b/openpype/hosts/maya/plugins/publish/validate_camera_attributes.py
@@ -3,10 +3,14 @@ from maya import cmds
 
 import openpype.hosts.maya.api.action
 from openpype.pipeline.publish import (
-    PublishValidationError, ValidateContentsOrder)
+    OptionalPyblishPluginMixin,
+    PublishValidationError,
+    ValidateContentsOrder,
+)
 
 
-class ValidateCameraAttributes(pyblish.api.InstancePlugin):
+class ValidateCameraAttributes(pyblish.api.InstancePlugin,
+                               OptionalPyblishPluginMixin):
     """Validates Camera has no invalid attribute keys or values.
 
     The Alembic file format does not a specific subset of attributes as such

--- a/openpype/hosts/maya/plugins/publish/validate_camera_contents.py
+++ b/openpype/hosts/maya/plugins/publish/validate_camera_contents.py
@@ -3,10 +3,14 @@ from maya import cmds
 
 import openpype.hosts.maya.api.action
 from openpype.pipeline.publish import (
-    PublishValidationError, ValidateContentsOrder)
+    OptionalPyblishPluginMixin,
+    PublishValidationError,
+    ValidateContentsOrder,
+)
 
 
-class ValidateCameraContents(pyblish.api.InstancePlugin):
+class ValidateCameraContents(pyblish.api.InstancePlugin,
+                             OptionalPyblishPluginMixin):
     """Validates Camera instance contents.
 
     A Camera instance may only hold a SINGLE camera's transform, nothing else.

--- a/openpype/hosts/maya/plugins/publish/validate_color_sets.py
+++ b/openpype/hosts/maya/plugins/publish/validate_color_sets.py
@@ -1,11 +1,11 @@
+import pyblish.api
 from maya import cmds
 
-import pyblish.api
 import openpype.hosts.maya.api.action
 from openpype.pipeline.publish import (
+    OptionalPyblishPluginMixin,
     RepairAction,
     ValidateMeshOrder,
-    OptionalPyblishPluginMixin
 )
 
 

--- a/openpype/hosts/maya/plugins/publish/validate_current_renderlayer_renderable.py
+++ b/openpype/hosts/maya/plugins/publish/validate_current_renderlayer_renderable.py
@@ -1,10 +1,14 @@
 import pyblish.api
-
 from maya import cmds
-from openpype.pipeline.publish import context_plugin_should_run
+
+from openpype.pipeline.publish import (
+    OptionalPyblishPluginMixin,
+    context_plugin_should_run,
+)
 
 
-class ValidateCurrentRenderLayerIsRenderable(pyblish.api.ContextPlugin):
+class ValidateCurrentRenderLayerIsRenderable(pyblish.api.ContextPlugin,
+                                             OptionalPyblishPluginMixin):
     """Validate if current render layer has a renderable camera
 
     There is a bug in Redshift which occurs when the current render layer

--- a/openpype/hosts/maya/plugins/publish/validate_cycle_error.py
+++ b/openpype/hosts/maya/plugins/publish/validate_cycle_error.py
@@ -4,7 +4,10 @@ from maya import cmds
 import openpype.hosts.maya.api.action
 from openpype.hosts.maya.api.lib import maintained_selection
 from openpype.pipeline.publish import (
-    OptionalPyblishPluginMixin, PublishValidationError, ValidateContentsOrder)
+    OptionalPyblishPluginMixin,
+    PublishValidationError,
+    ValidateContentsOrder,
+)
 
 
 class ValidateCycleError(pyblish.api.InstancePlugin,

--- a/openpype/hosts/maya/plugins/publish/validate_frame_range.py
+++ b/openpype/hosts/maya/plugins/publish/validate_frame_range.py
@@ -1,17 +1,17 @@
 import pyblish.api
-
 from maya import cmds
+from maya.app.renderSetup.model.override import AbsOverride
+
+from openpype.hosts.maya.api.lib_rendersetup import (
+    get_attr_in_layer,
+    get_attr_overrides,
+)
 from openpype.pipeline.publish import (
+    OptionalPyblishPluginMixin,
+    PublishValidationError,
     RepairAction,
     ValidateContentsOrder,
-    PublishValidationError,
-    OptionalPyblishPluginMixin
 )
-from openpype.hosts.maya.api.lib_rendersetup import (
-    get_attr_overrides,
-    get_attr_in_layer,
-)
-from maya.app.renderSetup.model.override import AbsOverride
 
 
 class ValidateFrameRange(pyblish.api.InstancePlugin,

--- a/openpype/hosts/maya/plugins/publish/validate_glsl_material.py
+++ b/openpype/hosts/maya/plugins/publish/validate_glsl_material.py
@@ -1,15 +1,18 @@
 import os
-from maya import cmds
 
 import pyblish.api
-from openpype.pipeline.publish import (
-    RepairAction,
-    ValidateContentsOrder
-)
+from maya import cmds
+
 from openpype.pipeline import PublishValidationError
+from openpype.pipeline.publish import (
+    OptionalPyblishPluginMixin,
+    RepairAction,
+    ValidateContentsOrder,
+)
 
 
-class ValidateGLSLMaterial(pyblish.api.InstancePlugin):
+class ValidateGLSLMaterial(pyblish.api.InstancePlugin,
+                           OptionalPyblishPluginMixin):
     """
     Validate if the asset uses GLSL Shader
     """

--- a/openpype/hosts/maya/plugins/publish/validate_glsl_plugin.py
+++ b/openpype/hosts/maya/plugins/publish/validate_glsl_plugin.py
@@ -1,15 +1,16 @@
 
+import pyblish.api
 from maya import cmds
 
-import pyblish.api
 from openpype.pipeline.publish import (
+    PublishValidationError,
     RepairAction,
     ValidateContentsOrder,
-    PublishValidationError
 )
 
 
-class ValidateGLSLPlugin(pyblish.api.InstancePlugin):
+class ValidateGLSLPlugin(pyblish.api.InstancePlugin,
+                         OptionalPyblishPluginMixin):
     """
     Validate if the asset uses GLSL Shader
     """

--- a/openpype/hosts/maya/plugins/publish/validate_glsl_plugin.py
+++ b/openpype/hosts/maya/plugins/publish/validate_glsl_plugin.py
@@ -3,6 +3,7 @@ import pyblish.api
 from maya import cmds
 
 from openpype.pipeline.publish import (
+    OptionalPyblishPluginMixin,
     PublishValidationError,
     RepairAction,
     ValidateContentsOrder,

--- a/openpype/hosts/maya/plugins/publish/validate_instance_has_members.py
+++ b/openpype/hosts/maya/plugins/publish/validate_instance_has_members.py
@@ -1,12 +1,15 @@
 import pyblish.api
+
 import openpype.hosts.maya.api.action
 from openpype.pipeline.publish import (
+    OptionalPyblishPluginMixin,
+    PublishValidationError,
     ValidateContentsOrder,
-    PublishValidationError
 )
 
 
-class ValidateInstanceHasMembers(pyblish.api.InstancePlugin):
+class ValidateInstanceHasMembers(pyblish.api.InstancePlugin,
+                                 OptionalPyblishPluginMixin):
     """Validates instance objectSet has *any* members."""
 
     order = ValidateContentsOrder

--- a/openpype/hosts/maya/plugins/publish/validate_instance_in_context.py
+++ b/openpype/hosts/maya/plugins/publish/validate_instance_in_context.py
@@ -3,15 +3,15 @@
 from __future__ import absolute_import
 
 import pyblish.api
+from maya import cmds
+
 import openpype.hosts.maya.api.action
 from openpype.pipeline.publish import (
+    OptionalPyblishPluginMixin,
+    PublishValidationError,
     RepairAction,
     ValidateContentsOrder,
-    PublishValidationError,
-    OptionalPyblishPluginMixin
 )
-
-from maya import cmds
 
 
 class ValidateInstanceInContext(pyblish.api.InstancePlugin,

--- a/openpype/hosts/maya/plugins/publish/validate_instance_subset.py
+++ b/openpype/hosts/maya/plugins/publish/validate_instance_subset.py
@@ -4,7 +4,8 @@ import string
 import six
 from openpype.pipeline.publish import (
     ValidateContentsOrder,
-    PublishValidationError
+    PublishValidationError,
+    OptionalPyblishPluginMixin,
 )
 
 # Allow only characters, numbers and underscore
@@ -18,7 +19,8 @@ def validate_name(subset):
     return all(x in allowed for x in subset)
 
 
-class ValidateSubsetName(pyblish.api.InstancePlugin):
+class ValidateSubsetName(pyblish.api.InstancePlugin,
+                         OptionalPyblishPluginMixin):
     """Validates subset name has only valid characters"""
 
     order = ValidateContentsOrder

--- a/openpype/hosts/maya/plugins/publish/validate_instancer_content.py
+++ b/openpype/hosts/maya/plugins/publish/validate_instancer_content.py
@@ -2,10 +2,14 @@ import maya.cmds as cmds
 import pyblish.api
 
 from openpype.hosts.maya.api import lib
-from openpype.pipeline.publish import PublishValidationError
+from openpype.pipeline.publish import (
+    OptionalPyblishPluginMixin,
+    PublishValidationError,
+)
 
 
-class ValidateInstancerContent(pyblish.api.InstancePlugin):
+class ValidateInstancerContent(pyblish.api.InstancePlugin,
+                               OptionalPyblishPluginMixin):
     """Validates that all meshes in the instance have object IDs.
 
     This skips a check on intermediate objects because we consider them

--- a/openpype/hosts/maya/plugins/publish/validate_instancer_frame_ranges.py
+++ b/openpype/hosts/maya/plugins/publish/validate_instancer_frame_ranges.py
@@ -3,7 +3,10 @@ import re
 
 import pyblish.api
 
-from openpype.pipeline.publish import PublishValidationError
+from openpype.pipeline.publish import (
+    OptionalPyblishPluginMixin,
+    PublishValidationError,
+)
 
 VERBOSE = False
 
@@ -36,7 +39,8 @@ def filter_ticks(files):
     return tick_files, ticks
 
 
-class ValidateInstancerFrameRanges(pyblish.api.InstancePlugin):
+class ValidateInstancerFrameRanges(pyblish.api.InstancePlugin,
+                                   OptionalPyblishPluginMixin):
     """Validates all instancer particle systems are cached correctly.
 
     This means they should have the files/frames as required by the start-end

--- a/openpype/hosts/maya/plugins/publish/validate_loaded_plugin.py
+++ b/openpype/hosts/maya/plugins/publish/validate_loaded_plugin.py
@@ -1,14 +1,17 @@
 import os
-import pyblish.api
+
 import maya.cmds as cmds
+import pyblish.api
 
 from openpype.pipeline.publish import (
+    OptionalPyblishPluginMixin,
+    PublishValidationError,
     RepairContextAction,
-    PublishValidationError
 )
 
 
-class ValidateLoadedPlugin(pyblish.api.ContextPlugin):
+class ValidateLoadedPlugin(pyblish.api.ContextPlugin,
+                           OptionalPyblishPluginMixin):
     """Ensure there are no unauthorized loaded plugins"""
 
     label = "Loaded Plugin"

--- a/openpype/hosts/maya/plugins/publish/validate_look_contents.py
+++ b/openpype/hosts/maya/plugins/publish/validate_look_contents.py
@@ -1,15 +1,16 @@
 import pyblish.api
+from maya import cmds  # noqa
+
 import openpype.hosts.maya.api.action
 from openpype.pipeline.publish import (
+    OptionalPyblishPluginMixin,
     PublishValidationError,
-    ValidateContentsOrder
+    ValidateContentsOrder,
 )
 
 
-from maya import cmds  # noqa
-
-
-class ValidateLookContents(pyblish.api.InstancePlugin):
+class ValidateLookContents(pyblish.api.InstancePlugin,
+                           OptionalPyblishPluginMixin):
     """Validate look instance contents
 
     Rules:

--- a/openpype/hosts/maya/plugins/publish/validate_look_default_shaders_connections.py
+++ b/openpype/hosts/maya/plugins/publish/validate_look_default_shaders_connections.py
@@ -1,13 +1,15 @@
+import pyblish.api
 from maya import cmds
 
-import pyblish.api
 from openpype.pipeline.publish import (
+    OptionalPyblishPluginMixin,
+    PublishValidationError,
     ValidateContentsOrder,
-    PublishValidationError
 )
 
 
-class ValidateLookDefaultShadersConnections(pyblish.api.InstancePlugin):
+class ValidateLookDefaultShadersConnections(pyblish.api.InstancePlugin,
+                                            OptionalPyblishPluginMixin):
     """Validate default shaders in the scene have their default connections.
 
     For example the lambert1 could potentially be disconnected from the

--- a/openpype/hosts/maya/plugins/publish/validate_look_id_reference_edits.py
+++ b/openpype/hosts/maya/plugins/publish/validate_look_id_reference_edits.py
@@ -1,16 +1,19 @@
 from collections import defaultdict
-from maya import cmds
 
 import pyblish.api
+from maya import cmds
+
 import openpype.hosts.maya.api.action
 from openpype.pipeline.publish import (
+    OptionalPyblishPluginMixin,
+    PublishValidationError,
     RepairAction,
     ValidateContentsOrder,
-    PublishValidationError
 )
 
 
-class ValidateLookIdReferenceEdits(pyblish.api.InstancePlugin):
+class ValidateLookIdReferenceEdits(pyblish.api.InstancePlugin,
+                                   OptionalPyblishPluginMixin):
     """Validate nodes in look have no reference edits to cbId.
 
     Note:

--- a/openpype/hosts/maya/plugins/publish/validate_look_members_unique.py
+++ b/openpype/hosts/maya/plugins/publish/validate_look_members_unique.py
@@ -4,10 +4,14 @@ import pyblish.api
 
 import openpype.hosts.maya.api.action
 from openpype.pipeline.publish import (
-    PublishValidationError, ValidatePipelineOrder)
+    OptionalPyblishPluginMixin,
+    PublishValidationError,
+    ValidatePipelineOrder,
+)
 
 
-class ValidateUniqueRelationshipMembers(pyblish.api.InstancePlugin):
+class ValidateUniqueRelationshipMembers(pyblish.api.InstancePlugin,
+                                        OptionalPyblishPluginMixin):
     """Validate the relational nodes of the look data to ensure every node is
     unique.
 

--- a/openpype/hosts/maya/plugins/publish/validate_look_no_default_shaders.py
+++ b/openpype/hosts/maya/plugins/publish/validate_look_no_default_shaders.py
@@ -4,11 +4,13 @@ import pyblish.api
 import openpype.hosts.maya.api.action
 from openpype.pipeline.publish import (
     ValidateContentsOrder,
-    PublishValidationError
+    PublishValidationError,
+    OptionalPyblishPluginMixin
 )
 
 
-class ValidateLookNoDefaultShaders(pyblish.api.InstancePlugin):
+class ValidateLookNoDefaultShaders(pyblish.api.InstancePlugin,
+                                   OptionalPyblishPluginMixin):
     """Validate if any node has a connection to a default shader.
 
     This checks whether the look has any members of:

--- a/openpype/hosts/maya/plugins/publish/validate_look_sets.py
+++ b/openpype/hosts/maya/plugins/publish/validate_look_sets.py
@@ -1,13 +1,16 @@
 import pyblish.api
+
 import openpype.hosts.maya.api.action
 from openpype.hosts.maya.api import lib
 from openpype.pipeline.publish import (
+    OptionalPyblishPluginMixin,
+    PublishValidationError,
     ValidateContentsOrder,
-    PublishValidationError
 )
 
 
-class ValidateLookSets(pyblish.api.InstancePlugin):
+class ValidateLookSets(pyblish.api.InstancePlugin,
+                       OptionalPyblishPluginMixin):
     """Validate if any sets relationships are not being collected.
 
     A shader can be assigned to a node that is missing a Colorbleed ID.

--- a/openpype/hosts/maya/plugins/publish/validate_look_shading_group.py
+++ b/openpype/hosts/maya/plugins/publish/validate_look_shading_group.py
@@ -1,15 +1,17 @@
+import pyblish.api
 from maya import cmds
 
-import pyblish.api
 import openpype.hosts.maya.api.action
 from openpype.pipeline.publish import (
+    OptionalPyblishPluginMixin,
+    PublishValidationError,
     RepairAction,
     ValidateContentsOrder,
-    PublishValidationError
 )
 
 
-class ValidateShadingEngine(pyblish.api.InstancePlugin):
+class ValidateShadingEngine(pyblish.api.InstancePlugin,
+                            OptionalPyblishPluginMixin):
     """Validate all shading engines are named after the surface material.
 
     Shading engines should be named "{surface_shader}SG"

--- a/openpype/hosts/maya/plugins/publish/validate_look_single_shader.py
+++ b/openpype/hosts/maya/plugins/publish/validate_look_single_shader.py
@@ -3,10 +3,14 @@ from maya import cmds
 
 import openpype.hosts.maya.api.action
 from openpype.pipeline.publish import (
-    PublishValidationError, ValidateContentsOrder)
+    OptionalPyblishPluginMixin,
+    PublishValidationError,
+    ValidateContentsOrder,
+)
 
 
-class ValidateSingleShader(pyblish.api.InstancePlugin):
+class ValidateSingleShader(pyblish.api.InstancePlugin,
+                           OptionalPyblishPluginMixin):
     """Validate all nurbsSurfaces and meshes have exactly one shader assigned.
 
     This will error if a shape has no shaders or more than one shader.

--- a/openpype/hosts/maya/plugins/publish/validate_maya_units.py
+++ b/openpype/hosts/maya/plugins/publish/validate_maya_units.py
@@ -1,17 +1,18 @@
 import maya.cmds as cmds
-
 import pyblish.api
 
 import openpype.hosts.maya.api.lib as mayalib
 from openpype.pipeline.context_tools import get_current_project_asset
 from openpype.pipeline.publish import (
+    OptionalPyblishPluginMixin,
+    PublishXmlValidationError,
     RepairContextAction,
     ValidateSceneOrder,
-    PublishXmlValidationError
 )
 
 
-class ValidateMayaUnits(pyblish.api.ContextPlugin):
+class ValidateMayaUnits(pyblish.api.ContextPlugin,
+                        OptionalPyblishPluginMixin):
     """Check if the Maya units are set correct"""
 
     order = ValidateSceneOrder

--- a/openpype/hosts/maya/plugins/publish/validate_mesh_arnold_attributes.py
+++ b/openpype/hosts/maya/plugins/publish/validate_mesh_arnold_attributes.py
@@ -1,19 +1,19 @@
-from maya import cmds
 import pyblish.api
+from maya import cmds
 
 import openpype.hosts.maya.api.action
 from openpype.hosts.maya.api.lib import (
-    maintained_selection,
     delete_after,
-    undo_chunk,
     get_attribute,
-    set_attribute
+    maintained_selection,
+    set_attribute,
+    undo_chunk,
 )
 from openpype.pipeline.publish import (
     OptionalPyblishPluginMixin,
+    PublishValidationError,
     RepairAction,
     ValidateMeshOrder,
-    PublishValidationError
 )
 
 

--- a/openpype/hosts/maya/plugins/publish/validate_mesh_empty.py
+++ b/openpype/hosts/maya/plugins/publish/validate_mesh_empty.py
@@ -1,15 +1,17 @@
+import pyblish.api
 from maya import cmds
 
-import pyblish.api
 import openpype.hosts.maya.api.action
 from openpype.pipeline.publish import (
+    OptionalPyblishPluginMixin,
+    PublishValidationError,
     RepairAction,
     ValidateMeshOrder,
-    PublishValidationError
 )
 
 
-class ValidateMeshEmpty(pyblish.api.InstancePlugin):
+class ValidateMeshEmpty(pyblish.api.InstancePlugin,
+                        OptionalPyblishPluginMixin):
     """Validate meshes have some vertices.
 
     Its possible to have meshes without any vertices. To replicate

--- a/openpype/hosts/maya/plugins/publish/validate_mesh_has_uv.py
+++ b/openpype/hosts/maya/plugins/publish/validate_mesh_has_uv.py
@@ -1,13 +1,13 @@
+import pyblish.api
 from maya import cmds
 
-import pyblish.api
 import openpype.hosts.maya.api.action
-from openpype.pipeline.publish import (
-    ValidateMeshOrder,
-    OptionalPyblishPluginMixin,
-    PublishValidationError
-)
 from openpype.hosts.maya.api.lib import len_flattened
+from openpype.pipeline.publish import (
+    OptionalPyblishPluginMixin,
+    PublishValidationError,
+    ValidateMeshOrder,
+)
 
 
 class ValidateMeshHasUVs(pyblish.api.InstancePlugin,

--- a/openpype/hosts/maya/plugins/publish/validate_mesh_lamina_faces.py
+++ b/openpype/hosts/maya/plugins/publish/validate_mesh_lamina_faces.py
@@ -1,11 +1,15 @@
+import pyblish.api
 from maya import cmds
 
-import pyblish.api
 import openpype.hosts.maya.api.action
-from openpype.pipeline.publish import ValidateMeshOrder
+from openpype.pipeline.publish import (
+    OptionalPyblishPluginMixin,
+    ValidateMeshOrder,
+)
 
 
-class ValidateMeshLaminaFaces(pyblish.api.InstancePlugin):
+class ValidateMeshLaminaFaces(pyblish.api.InstancePlugin,
+                              OptionalPyblishPluginMixin):
     """Validate meshes don't have lamina faces.
 
     Lamina faces share all of their edges.

--- a/openpype/hosts/maya/plugins/publish/validate_mesh_ngons.py
+++ b/openpype/hosts/maya/plugins/publish/validate_mesh_ngons.py
@@ -1,12 +1,16 @@
+import pyblish.api
 from maya import cmds
 
-import pyblish.api
 import openpype.hosts.maya.api.action
 from openpype.hosts.maya.api import lib
-from openpype.pipeline.publish import ValidateContentsOrder
+from openpype.pipeline.publish import (
+    OptionalPyblishPluginMixin,
+    ValidateContentsOrder,
+)
 
 
-class ValidateMeshNgons(pyblish.api.Validator):
+class ValidateMeshNgons(pyblish.api.Validator,
+                        OptionalPyblishPluginMixin):
     """Ensure that meshes don't have ngons
 
     Ngon are faces with more than 4 sides.

--- a/openpype/hosts/maya/plugins/publish/validate_mesh_no_negative_scale.py
+++ b/openpype/hosts/maya/plugins/publish/validate_mesh_no_negative_scale.py
@@ -1,10 +1,11 @@
+import pyblish.api
 from maya import cmds
 
-import pyblish.api
 import openpype.hosts.maya.api.action
 from openpype.pipeline.publish import (
+    OptionalPyblishPluginMixin,
+    PublishValidationError,
     ValidateMeshOrder,
-    PublishValidationError
 )
 
 
@@ -15,7 +16,8 @@ def _as_report_list(values, prefix="- ", suffix="\n"):
     return prefix + (suffix + prefix).join(values)
 
 
-class ValidateMeshNoNegativeScale(pyblish.api.Validator):
+class ValidateMeshNoNegativeScale(pyblish.api.Validator,
+                                  OptionalPyblishPluginMixin):
     """Ensure that meshes don't have a negative scale.
 
     Using negatively scaled proxies in a VRayMesh results in inverted

--- a/openpype/hosts/maya/plugins/publish/validate_mesh_non_manifold.py
+++ b/openpype/hosts/maya/plugins/publish/validate_mesh_non_manifold.py
@@ -1,10 +1,11 @@
+import pyblish.api
 from maya import cmds
 
-import pyblish.api
 import openpype.hosts.maya.api.action
 from openpype.pipeline.publish import (
+    OptionalPyblishPluginMixin,
+    PublishValidationError,
     ValidateMeshOrder,
-    PublishValidationError
 )
 
 
@@ -15,7 +16,8 @@ def _as_report_list(values, prefix="- ", suffix="\n"):
     return prefix + (suffix + prefix).join(values)
 
 
-class ValidateMeshNonManifold(pyblish.api.Validator):
+class ValidateMeshNonManifold(pyblish.api.Validator,
+                              OptionalPyblishPluginMixin):
     """Ensure that meshes don't have non-manifold edges or vertices
 
     To debug the problem on the meshes you can use Maya's modeling

--- a/openpype/hosts/maya/plugins/publish/validate_mesh_non_zero_edge.py
+++ b/openpype/hosts/maya/plugins/publish/validate_mesh_non_zero_edge.py
@@ -1,12 +1,12 @@
+import pyblish.api
 from maya import cmds
 
-import pyblish.api
 import openpype.hosts.maya.api.action
 from openpype.hosts.maya.api import lib
 from openpype.pipeline.publish import (
-    ValidateMeshOrder,
     OptionalPyblishPluginMixin,
-    PublishValidationError
+    PublishValidationError,
+    ValidateMeshOrder,
 )
 
 

--- a/openpype/hosts/maya/plugins/publish/validate_mesh_normals_unlocked.py
+++ b/openpype/hosts/maya/plugins/publish/validate_mesh_normals_unlocked.py
@@ -1,13 +1,13 @@
-from maya import cmds
 import maya.api.OpenMaya as om2
-
 import pyblish.api
+from maya import cmds
+
 import openpype.hosts.maya.api.action
 from openpype.pipeline.publish import (
+    OptionalPyblishPluginMixin,
+    PublishValidationError,
     RepairAction,
     ValidateMeshOrder,
-    OptionalPyblishPluginMixin,
-    PublishValidationError
 )
 
 

--- a/openpype/hosts/maya/plugins/publish/validate_mesh_overlapping_uvs.py
+++ b/openpype/hosts/maya/plugins/publish/validate_mesh_overlapping_uvs.py
@@ -1,15 +1,15 @@
 import math
-from six.moves import xrange
 
-from maya import cmds
 import maya.api.OpenMaya as om
 import pyblish.api
+from maya import cmds
+from six.moves import xrange
 
 import openpype.hosts.maya.api.action
 from openpype.pipeline.publish import (
-    ValidateMeshOrder,
     OptionalPyblishPluginMixin,
-    PublishValidationError
+    PublishValidationError,
+    ValidateMeshOrder,
 )
 
 

--- a/openpype/hosts/maya/plugins/publish/validate_mesh_shader_connections.py
+++ b/openpype/hosts/maya/plugins/publish/validate_mesh_shader_connections.py
@@ -1,11 +1,12 @@
+import pyblish.api
 from maya import cmds
 
-import pyblish.api
 import openpype.hosts.maya.api.action
 from openpype.pipeline.publish import (
+    OptionalPyblishPluginMixin,
+    PublishValidationError,
     RepairAction,
     ValidateMeshOrder,
-    PublishValidationError
 )
 
 
@@ -79,7 +80,8 @@ def disconnect(node_a, node_b):
             cmds.disconnectAttr(source, input)
 
 
-class ValidateMeshShaderConnections(pyblish.api.InstancePlugin):
+class ValidateMeshShaderConnections(pyblish.api.InstancePlugin,
+                                    OptionalPyblishPluginMixin):
     """Ensure mesh shading engine connections are valid.
 
     In some scenarios Maya keeps connections to multiple shaders even if just

--- a/openpype/hosts/maya/plugins/publish/validate_mesh_single_uv_set.py
+++ b/openpype/hosts/maya/plugins/publish/validate_mesh_single_uv_set.py
@@ -1,12 +1,12 @@
+import pyblish.api
 from maya import cmds
 
-import pyblish.api
 import openpype.hosts.maya.api.action
 from openpype.hosts.maya.api import lib
 from openpype.pipeline.publish import (
+    OptionalPyblishPluginMixin,
     RepairAction,
     ValidateMeshOrder,
-    OptionalPyblishPluginMixin
 )
 
 

--- a/openpype/hosts/maya/plugins/publish/validate_mesh_uv_set_map1.py
+++ b/openpype/hosts/maya/plugins/publish/validate_mesh_uv_set_map1.py
@@ -1,11 +1,11 @@
+import pyblish.api
 from maya import cmds
 
-import pyblish.api
 import openpype.hosts.maya.api.action
 from openpype.pipeline.publish import (
+    OptionalPyblishPluginMixin,
     RepairAction,
     ValidateMeshOrder,
-    OptionalPyblishPluginMixin
 )
 
 

--- a/openpype/hosts/maya/plugins/publish/validate_mesh_vertices_have_edges.py
+++ b/openpype/hosts/maya/plugins/publish/validate_mesh_vertices_have_edges.py
@@ -11,7 +11,8 @@ from openpype.pipeline.publish import (
 )
 
 
-class ValidateMeshVerticesHaveEdges(pyblish.api.InstancePlugin, OptionalPyblishPluginMixin):
+class ValidateMeshVerticesHaveEdges(pyblish.api.InstancePlugin,
+                                    OptionalPyblishPluginMixin):
     """Validate meshes have only vertices that are connected to edges.
 
     Maya can have invalid geometry with vertices that have no edges or

--- a/openpype/hosts/maya/plugins/publish/validate_mesh_vertices_have_edges.py
+++ b/openpype/hosts/maya/plugins/publish/validate_mesh_vertices_have_edges.py
@@ -4,10 +4,14 @@ from maya import cmds
 import openpype.hosts.maya.api.action
 from openpype.hosts.maya.api.lib import len_flattened
 from openpype.pipeline.publish import (
-    PublishValidationError, RepairAction, ValidateMeshOrder)
+    OptionalPyblishPluginMixin,
+    PublishValidationError,
+    RepairAction,
+    ValidateMeshOrder,
+)
 
 
-class ValidateMeshVerticesHaveEdges(pyblish.api.InstancePlugin):
+class ValidateMeshVerticesHaveEdges(pyblish.api.InstancePlugin, OptionalPyblishPluginMixin):
     """Validate meshes have only vertices that are connected to edges.
 
     Maya can have invalid geometry with vertices that have no edges or
@@ -20,7 +24,7 @@ class ValidateMeshVerticesHaveEdges(pyblish.api.InstancePlugin):
     and merge the components.
 
     To find these invalid vertices select all vertices of the mesh
-    that are visible in the viewport (drag to select), afterwards
+    that are visible in the viewport (drag to select), afterward
     invert your selection (Ctrl + Shift + I). The remaining selection
     contains the invalid vertices.
 

--- a/openpype/hosts/maya/plugins/publish/validate_model_content.py
+++ b/openpype/hosts/maya/plugins/publish/validate_model_content.py
@@ -1,15 +1,17 @@
+import pyblish.api
 from maya import cmds
 
-import pyblish.api
 import openpype.hosts.maya.api.action
 from openpype.hosts.maya.api import lib
 from openpype.pipeline.publish import (
+    OptionalPyblishPluginMixin,
+    PublishValidationError,
     ValidateContentsOrder,
-    PublishValidationError
 )
 
 
-class ValidateModelContent(pyblish.api.InstancePlugin):
+class ValidateModelContent(pyblish.api.InstancePlugin,
+                           OptionalPyblishPluginMixin):
     """Adheres to the content of 'model' family
 
     - Must have one top group. (configurable)

--- a/openpype/hosts/maya/plugins/publish/validate_model_name.py
+++ b/openpype/hosts/maya/plugins/publish/validate_model_name.py
@@ -11,10 +11,14 @@ from maya import cmds
 import openpype.hosts.maya.api.action
 from openpype.client.mongo import OpenPypeMongoConnection
 from openpype.hosts.maya.api.shader_definition_editor import (
-    DEFINITION_FILENAME)
+    DEFINITION_FILENAME,
+)
 from openpype.pipeline import legacy_io
 from openpype.pipeline.publish import (
-    OptionalPyblishPluginMixin, PublishValidationError, ValidateContentsOrder)
+    OptionalPyblishPluginMixin,
+    PublishValidationError,
+    ValidateContentsOrder,
+)
 
 
 class ValidateModelName(pyblish.api.InstancePlugin,

--- a/openpype/hosts/maya/plugins/publish/validate_mvlook_contents.py
+++ b/openpype/hosts/maya/plugins/publish/validate_mvlook_contents.py
@@ -1,12 +1,13 @@
 import os
+
 import pyblish.api
+
 import openpype.hosts.maya.api.action
 from openpype.pipeline.publish import (
-    ValidateContentsOrder,
     OptionalPyblishPluginMixin,
-    PublishValidationError
+    PublishValidationError,
+    ValidateContentsOrder,
 )
-
 
 COLOUR_SPACES = ['sRGB', 'linear', 'auto']
 MIPMAP_EXTENSIONS = ['tdl']

--- a/openpype/hosts/maya/plugins/publish/validate_no_animation.py
+++ b/openpype/hosts/maya/plugins/publish/validate_no_animation.py
@@ -1,11 +1,11 @@
+import pyblish.api
 from maya import cmds
 
-import pyblish.api
 import openpype.hosts.maya.api.action
 from openpype.pipeline.publish import (
-    ValidateContentsOrder,
     OptionalPyblishPluginMixin,
-    PublishValidationError
+    PublishValidationError,
+    ValidateContentsOrder,
 )
 
 

--- a/openpype/hosts/maya/plugins/publish/validate_no_default_camera.py
+++ b/openpype/hosts/maya/plugins/publish/validate_no_default_camera.py
@@ -1,10 +1,11 @@
+import pyblish.api
 from maya import cmds
 
-import pyblish.api
 import openpype.hosts.maya.api.action
 from openpype.pipeline.publish import (
+    OptionalPyblishPluginMixin,
+    PublishValidationError,
     ValidateContentsOrder,
-    PublishValidationError
 )
 
 
@@ -15,7 +16,8 @@ def _as_report_list(values, prefix="- ", suffix="\n"):
     return prefix + (suffix + prefix).join(values)
 
 
-class ValidateNoDefaultCameras(pyblish.api.InstancePlugin):
+class ValidateNoDefaultCameras(pyblish.api.InstancePlugin,
+                               OptionalPyblishPluginMixin):
     """Ensure no default (startup) cameras are in the instance.
 
     This might be unnecessary. In the past there were some issues with

--- a/openpype/hosts/maya/plugins/publish/validate_no_namespace.py
+++ b/openpype/hosts/maya/plugins/publish/validate_no_namespace.py
@@ -1,13 +1,13 @@
 import maya.cmds as cmds
-
 import pyblish.api
-from openpype.pipeline.publish import (
-    RepairAction,
-    ValidateContentsOrder,
-    PublishValidationError
-)
 
 import openpype.hosts.maya.api.action
+from openpype.pipeline.publish import (
+    OptionalPyblishPluginMixin,
+    PublishValidationError,
+    RepairAction,
+    ValidateContentsOrder,
+)
 
 
 def _as_report_list(values, prefix="- ", suffix="\n"):
@@ -24,7 +24,8 @@ def get_namespace(node_name):
     return node_name.rpartition(":")[0]
 
 
-class ValidateNoNamespace(pyblish.api.InstancePlugin):
+class ValidateNoNamespace(pyblish.api.InstancePlugin,
+                          OptionalPyblishPluginMixin):
     """Ensure the nodes don't have a namespace"""
 
     order = ValidateContentsOrder

--- a/openpype/hosts/maya/plugins/publish/validate_no_null_transforms.py
+++ b/openpype/hosts/maya/plugins/publish/validate_no_null_transforms.py
@@ -1,11 +1,12 @@
 import maya.cmds as cmds
-
 import pyblish.api
+
 import openpype.hosts.maya.api.action
 from openpype.pipeline.publish import (
+    OptionalPyblishPluginMixin,
+    PublishValidationError,
     RepairAction,
     ValidateContentsOrder,
-    PublishValidationError
 )
 
 
@@ -37,7 +38,8 @@ def has_shape_children(node):
     return True
 
 
-class ValidateNoNullTransforms(pyblish.api.InstancePlugin):
+class ValidateNoNullTransforms(pyblish.api.InstancePlugin,
+                               OptionalPyblishPluginMixin):
     """Ensure no null transforms are in the scene.
 
     Warning:

--- a/openpype/hosts/maya/plugins/publish/validate_no_unknown_nodes.py
+++ b/openpype/hosts/maya/plugins/publish/validate_no_unknown_nodes.py
@@ -1,11 +1,11 @@
+import pyblish.api
 from maya import cmds
 
-import pyblish.api
 import openpype.hosts.maya.api.action
 from openpype.pipeline.publish import (
-    ValidateContentsOrder,
     OptionalPyblishPluginMixin,
-    PublishValidationError
+    PublishValidationError,
+    ValidateContentsOrder,
 )
 
 

--- a/openpype/hosts/maya/plugins/publish/validate_no_vraymesh.py
+++ b/openpype/hosts/maya/plugins/publish/validate_no_vraymesh.py
@@ -1,6 +1,10 @@
 import pyblish.api
 from maya import cmds
-from openpype.pipeline.publish import PublishValidationError
+
+from openpype.pipeline.publish import (
+    OptionalPyblishPluginMixin,
+    PublishValidationError,
+)
 
 
 def _as_report_list(values, prefix="- ", suffix="\n"):
@@ -10,7 +14,8 @@ def _as_report_list(values, prefix="- ", suffix="\n"):
     return prefix + (suffix + prefix).join(values)
 
 
-class ValidateNoVRayMesh(pyblish.api.InstancePlugin):
+class ValidateNoVRayMesh(pyblish.api.InstancePlugin,
+                         OptionalPyblishPluginMixin):
     """Validate there are no VRayMesh objects in the instance"""
 
     order = pyblish.api.ValidatorOrder

--- a/openpype/hosts/maya/plugins/publish/validate_node_ids.py
+++ b/openpype/hosts/maya/plugins/publish/validate_node_ids.py
@@ -1,14 +1,15 @@
 import pyblish.api
 
-from openpype.pipeline.publish import (
-    ValidatePipelineOrder,
-    PublishXmlValidationError
-)
 import openpype.hosts.maya.api.action
 from openpype.hosts.maya.api import lib
+from openpype.pipeline.publish import (
+    OptionalPyblishPluginMixin,
+    PublishXmlValidationError,
+    ValidatePipelineOrder,
+)
 
 
-class ValidateNodeIDs(pyblish.api.InstancePlugin):
+class ValidateNodeIDs(pyblish.api.InstancePlugin, OptionalPyblishPluginMixin):
     """Validate nodes have a Colorbleed Id.
 
     When IDs are missing from nodes *save your scene* and they should be

--- a/openpype/hosts/maya/plugins/publish/validate_node_ids_deformed_shapes.py
+++ b/openpype/hosts/maya/plugins/publish/validate_node_ids_deformed_shapes.py
@@ -4,10 +4,15 @@ from maya import cmds
 import openpype.hosts.maya.api.action
 from openpype.hosts.maya.api import lib
 from openpype.pipeline.publish import (
-    PublishValidationError, RepairAction, ValidateContentsOrder)
+    OptionalPyblishPluginMixin,
+    PublishValidationError,
+    RepairAction,
+    ValidateContentsOrder,
+)
 
 
-class ValidateNodeIdsDeformedShape(pyblish.api.InstancePlugin):
+class ValidateNodeIdsDeformedShape(pyblish.api.InstancePlugin,
+                                   OptionalPyblishPluginMixin):
     """Validate if deformed shapes have related IDs to the original shapes.
 
     When a deformer is applied in the scene on a referenced mesh that already

--- a/openpype/hosts/maya/plugins/publish/validate_node_ids_in_database.py
+++ b/openpype/hosts/maya/plugins/publish/validate_node_ids_in_database.py
@@ -5,10 +5,14 @@ from openpype.client import get_assets
 from openpype.hosts.maya.api import lib
 from openpype.pipeline import legacy_io
 from openpype.pipeline.publish import (
-    PublishValidationError, ValidatePipelineOrder)
+    OptionalPyblishPluginMixin,
+    PublishValidationError,
+    ValidatePipelineOrder,
+)
 
 
-class ValidateNodeIdsInDatabase(pyblish.api.InstancePlugin):
+class ValidateNodeIdsInDatabase(pyblish.api.InstancePlugin,
+                                OptionalPyblishPluginMixin):
     """Validate if the CB Id is related to an asset in the database
 
     All nodes with the `cbId` attribute will be validated to ensure that

--- a/openpype/hosts/maya/plugins/publish/validate_node_ids_related.py
+++ b/openpype/hosts/maya/plugins/publish/validate_node_ids_related.py
@@ -3,7 +3,10 @@ import pyblish.api
 import openpype.hosts.maya.api.action
 from openpype.hosts.maya.api import lib
 from openpype.pipeline.publish import (
-    OptionalPyblishPluginMixin, PublishValidationError, ValidatePipelineOrder)
+    OptionalPyblishPluginMixin,
+    PublishValidationError,
+    ValidatePipelineOrder,
+)
 
 
 class ValidateNodeIDsRelated(pyblish.api.InstancePlugin,

--- a/openpype/hosts/maya/plugins/publish/validate_node_ids_unique.py
+++ b/openpype/hosts/maya/plugins/publish/validate_node_ids_unique.py
@@ -1,15 +1,18 @@
 from collections import defaultdict
 
 import pyblish.api
-from openpype.pipeline.publish import (
-    ValidatePipelineOrder,
-    PublishValidationError
-)
+
 import openpype.hosts.maya.api.action
 from openpype.hosts.maya.api import lib
+from openpype.pipeline.publish import (
+    OptionalPyblishPluginMixin,
+    PublishValidationError,
+    ValidatePipelineOrder,
+)
 
 
-class ValidateNodeIdsUnique(pyblish.api.InstancePlugin):
+class ValidateNodeIdsUnique(pyblish.api.InstancePlugin,
+                            OptionalPyblishPluginMixin):
     """Validate the nodes in the instance have a unique Colorbleed Id
 
     Here we ensure that what has been added to the instance is unique

--- a/openpype/hosts/maya/plugins/publish/validate_node_no_ghosting.py
+++ b/openpype/hosts/maya/plugins/publish/validate_node_no_ghosting.py
@@ -1,12 +1,15 @@
+import pyblish.api
 from maya import cmds
 
-import pyblish.api
-
 import openpype.hosts.maya.api.action
-from openpype.pipeline.publish import ValidateContentsOrder
+from openpype.pipeline.publish import (
+    OptionalPyblishPluginMixin,
+    ValidateContentsOrder,
+)
 
 
-class ValidateNodeNoGhosting(pyblish.api.InstancePlugin):
+class ValidateNodeNoGhosting(pyblish.api.InstancePlugin,
+                             OptionalPyblishPluginMixin):
     """Ensure nodes do not have ghosting enabled.
 
     If one would publish towards a non-Maya format it's likely that stats

--- a/openpype/hosts/maya/plugins/publish/validate_plugin_path_attributes.py
+++ b/openpype/hosts/maya/plugins/publish/validate_plugin_path_attributes.py
@@ -1,18 +1,19 @@
 import os
 
+import pyblish.api
 from maya import cmds
 
-import pyblish.api
-
-from openpype.hosts.maya.api.lib import pairwise
 from openpype.hosts.maya.api.action import SelectInvalidAction
+from openpype.hosts.maya.api.lib import pairwise
 from openpype.pipeline.publish import (
+    OptionalPyblishPluginMixin,
+    PublishValidationError,
     ValidateContentsOrder,
-    PublishValidationError
 )
 
 
-class ValidatePluginPathAttributes(pyblish.api.InstancePlugin):
+class ValidatePluginPathAttributes(pyblish.api.InstancePlugin,
+                                   OptionalPyblishPluginMixin):
     """
     Validate plug-in path attributes point to existing file paths.
     """

--- a/openpype/hosts/maya/plugins/publish/validate_render_image_rule.py
+++ b/openpype/hosts/maya/plugins/publish/validate_render_image_rule.py
@@ -2,10 +2,15 @@ import pyblish.api
 from maya import cmds
 
 from openpype.pipeline.publish import (
-    PublishValidationError, RepairAction, ValidateContentsOrder)
+    OptionalPyblishPluginMixin,
+    PublishValidationError,
+    RepairAction,
+    ValidateContentsOrder,
+)
 
 
-class ValidateRenderImageRule(pyblish.api.InstancePlugin):
+class ValidateRenderImageRule(pyblish.api.InstancePlugin,
+                              OptionalPyblishPluginMixin):
     """Validates Maya Workpace "images" file rule matches project settings.
 
     This validates against the configured default render image folder:

--- a/openpype/hosts/maya/plugins/publish/validate_render_no_default_cameras.py
+++ b/openpype/hosts/maya/plugins/publish/validate_render_no_default_cameras.py
@@ -1,15 +1,16 @@
-from maya import cmds
-
 import pyblish.api
+from maya import cmds
 
 import openpype.hosts.maya.api.action
 from openpype.pipeline.publish import (
-    ValidateContentsOrder,
+    OptionalPyblishPluginMixin,
     PublishValidationError,
+    ValidateContentsOrder,
 )
 
 
-class ValidateRenderNoDefaultCameras(pyblish.api.InstancePlugin):
+class ValidateRenderNoDefaultCameras(pyblish.api.InstancePlugin,
+                                     OptionalPyblishPluginMixin):
     """Ensure no default (startup) cameras are to be rendered."""
 
     order = ValidateContentsOrder

--- a/openpype/hosts/maya/plugins/publish/validate_render_single_camera.py
+++ b/openpype/hosts/maya/plugins/publish/validate_render_single_camera.py
@@ -6,12 +6,14 @@ from maya import cmds
 import openpype.hosts.maya.api.action
 from openpype.hosts.maya.api.lib_rendersettings import RenderSettings
 from openpype.pipeline.publish import (
+    OptionalPyblishPluginMixin,
+    PublishValidationError,
     ValidateContentsOrder,
-    PublishValidationError
 )
 
 
-class ValidateRenderSingleCamera(pyblish.api.InstancePlugin):
+class ValidateRenderSingleCamera(pyblish.api.InstancePlugin,
+                                 OptionalPyblishPluginMixin):
     """Validate renderable camera count for layer and <Camera> token.
 
     Pipeline is supporting multiple renderable cameras per layer, but image

--- a/openpype/hosts/maya/plugins/publish/validate_renderlayer_aovs.py
+++ b/openpype/hosts/maya/plugins/publish/validate_renderlayer_aovs.py
@@ -3,10 +3,14 @@ import pyblish.api
 import openpype.hosts.maya.api.action
 from openpype.client import get_subset_by_name
 from openpype.pipeline import legacy_io
-from openpype.pipeline.publish import PublishValidationError
+from openpype.pipeline.publish import (
+    OptionalPyblishPluginMixin,
+    PublishValidationError,
+)
 
 
-class ValidateRenderLayerAOVs(pyblish.api.InstancePlugin):
+class ValidateRenderLayerAOVs(pyblish.api.InstancePlugin,
+                              OptionalPyblishPluginMixin):
     """Validate created AOVs / RenderElement is registered in the database
 
     Each render element is registered as a subset which is formatted based on

--- a/openpype/hosts/maya/plugins/publish/validate_rendersettings.py
+++ b/openpype/hosts/maya/plugins/publish/validate_rendersettings.py
@@ -3,15 +3,16 @@
 import re
 from collections import OrderedDict
 
+import pyblish.api
 from maya import cmds, mel
 
-import pyblish.api
+from openpype.hosts.maya.api import lib
 from openpype.pipeline.publish import (
+    OptionalPyblishPluginMixin,
+    PublishValidationError,
     RepairAction,
     ValidateContentsOrder,
-    PublishValidationError,
 )
-from openpype.hosts.maya.api import lib
 
 
 def convert_to_int_or_float(string_value):
@@ -36,7 +37,8 @@ def get_redshift_image_format_labels():
     return mel.eval("{0}={0}".format(var))
 
 
-class ValidateRenderSettings(pyblish.api.InstancePlugin):
+class ValidateRenderSettings(pyblish.api.InstancePlugin,
+                             OptionalPyblishPluginMixin):
     """Validates the global render settings
 
     * File Name Prefix must start with: `<Scene>`

--- a/openpype/hosts/maya/plugins/publish/validate_resources.py
+++ b/openpype/hosts/maya/plugins/publish/validate_resources.py
@@ -2,13 +2,16 @@ import os
 from collections import defaultdict
 
 import pyblish.api
+
 from openpype.pipeline.publish import (
+    OptionalPyblishPluginMixin,
+    PublishValidationError,
     ValidateContentsOrder,
-    PublishValidationError
 )
 
 
-class ValidateResources(pyblish.api.InstancePlugin):
+class ValidateResources(pyblish.api.InstancePlugin,
+                        OptionalPyblishPluginMixin):
     """Validates mapped resources.
 
     These are external files to the current application, for example

--- a/openpype/hosts/maya/plugins/publish/validate_review.py
+++ b/openpype/hosts/maya/plugins/publish/validate_review.py
@@ -1,11 +1,13 @@
 import pyblish.api
 
 from openpype.pipeline.publish import (
-    ValidateContentsOrder, PublishValidationError
+    OptionalPyblishPluginMixin,
+    PublishValidationError,
+    ValidateContentsOrder,
 )
 
 
-class ValidateReview(pyblish.api.InstancePlugin):
+class ValidateReview(pyblish.api.InstancePlugin, OptionalPyblishPluginMixin):
     """Validate review."""
 
     order = ValidateContentsOrder

--- a/openpype/hosts/maya/plugins/publish/validate_rig_contents.py
+++ b/openpype/hosts/maya/plugins/publish/validate_rig_contents.py
@@ -2,10 +2,14 @@ import pyblish.api
 from maya import cmds
 
 from openpype.pipeline.publish import (
-    PublishValidationError, ValidateContentsOrder)
+    OptionalPyblishPluginMixin,
+    PublishValidationError,
+    ValidateContentsOrder,
+)
 
 
-class ValidateRigContents(pyblish.api.InstancePlugin):
+class ValidateRigContents(pyblish.api.InstancePlugin,
+                          OptionalPyblishPluginMixin):
     """Ensure rig contains pipeline-critical content
 
     Every rig must contain at least two object sets:

--- a/openpype/hosts/maya/plugins/publish/validate_rig_controllers.py
+++ b/openpype/hosts/maya/plugins/publish/validate_rig_controllers.py
@@ -1,17 +1,18 @@
+import pyblish.api
 from maya import cmds
 
-import pyblish.api
-
-from openpype.pipeline.publish import (
-    ValidateContentsOrder,
-    RepairAction,
-    PublishValidationError
-)
 import openpype.hosts.maya.api.action
 from openpype.hosts.maya.api.lib import undo_chunk
+from openpype.pipeline.publish import (
+    OptionalPyblishPluginMixin,
+    PublishValidationError,
+    RepairAction,
+    ValidateContentsOrder,
+)
 
 
-class ValidateRigControllers(pyblish.api.InstancePlugin):
+class ValidateRigControllers(pyblish.api.InstancePlugin,
+                             OptionalPyblishPluginMixin):
     """Validate rig controllers.
 
     Controls must have the transformation attributes on their default

--- a/openpype/hosts/maya/plugins/publish/validate_rig_controllers_arnold_attributes.py
+++ b/openpype/hosts/maya/plugins/publish/validate_rig_controllers_arnold_attributes.py
@@ -1,18 +1,18 @@
+import pyblish.api
 from maya import cmds
 
-import pyblish.api
-
+import openpype.hosts.maya.api.action
+from openpype.hosts.maya.api import lib
 from openpype.pipeline.publish import (
-    ValidateContentsOrder,
+    OptionalPyblishPluginMixin,
+    PublishValidationError,
     RepairAction,
-    PublishValidationError
+    ValidateContentsOrder,
 )
 
-from openpype.hosts.maya.api import lib
-import openpype.hosts.maya.api.action
 
-
-class ValidateRigControllersArnoldAttributes(pyblish.api.InstancePlugin):
+class ValidateRigControllersArnoldAttributes(pyblish.api.InstancePlugin,
+                                             OptionalPyblishPluginMixin):
     """Validate rig control curves have no keyable arnold attributes.
 
     The Arnold plug-in will create curve attributes like:

--- a/openpype/hosts/maya/plugins/publish/validate_rig_joints_hidden.py
+++ b/openpype/hosts/maya/plugins/publish/validate_rig_joints_hidden.py
@@ -1,16 +1,17 @@
-from maya import cmds
-
 import pyblish.api
+from maya import cmds
 
 import openpype.hosts.maya.api.action
 from openpype.hosts.maya.api import lib
 from openpype.pipeline.publish import (
+    OptionalPyblishPluginMixin,
     RepairAction,
     ValidateContentsOrder,
 )
 
 
-class ValidateRigJointsHidden(pyblish.api.InstancePlugin):
+class ValidateRigJointsHidden(pyblish.api.InstancePlugin,
+                              OptionalPyblishPluginMixin):
     """Validate all joints are hidden visually.
 
     This includes being hidden:

--- a/openpype/hosts/maya/plugins/publish/validate_rig_out_set_node_ids.py
+++ b/openpype/hosts/maya/plugins/publish/validate_rig_out_set_node_ids.py
@@ -1,17 +1,18 @@
 import maya.cmds as cmds
-
 import pyblish.api
 
 import openpype.hosts.maya.api.action
 from openpype.hosts.maya.api import lib
 from openpype.pipeline.publish import (
+    OptionalPyblishPluginMixin,
+    PublishValidationError,
     RepairAction,
     ValidateContentsOrder,
-    PublishValidationError
 )
 
 
-class ValidateRigOutSetNodeIds(pyblish.api.InstancePlugin):
+class ValidateRigOutSetNodeIds(pyblish.api.InstancePlugin,
+                               OptionalPyblishPluginMixin):
     """Validate if deformed shapes have related IDs to the original shapes.
 
     When a deformer is applied in the scene on a referenced mesh that already

--- a/openpype/hosts/maya/plugins/publish/validate_rig_output_ids.py
+++ b/openpype/hosts/maya/plugins/publish/validate_rig_output_ids.py
@@ -9,7 +9,8 @@ from openpype.hosts.maya.api.lib import get_id, set_id
 from openpype.pipeline.publish import (
     RepairAction,
     ValidateContentsOrder,
-    PublishValidationError
+    PublishValidationError,
+    OptionalPyblishPluginMixin
 )
 
 
@@ -18,7 +19,8 @@ def get_basename(node):
     return node.rsplit("|", 1)[-1].rsplit(":", 1)[-1]
 
 
-class ValidateRigOutputIds(pyblish.api.InstancePlugin):
+class ValidateRigOutputIds(pyblish.api.InstancePlugin,
+                           OptionalPyblishPluginMixin):
     """Validate rig output ids.
 
     Ids must share the same id as similarly named nodes in the scene. This is

--- a/openpype/hosts/maya/plugins/publish/validate_scene_set_workspace.py
+++ b/openpype/hosts/maya/plugins/publish/validate_scene_set_workspace.py
@@ -4,7 +4,10 @@ import maya.cmds as cmds
 import pyblish.api
 
 from openpype.pipeline.publish import (
-    PublishValidationError, ValidatePipelineOrder)
+    OptionalPyblishPluginMixin,
+    PublishValidationError,
+    ValidatePipelineOrder,
+)
 
 
 def is_subdir(path, root_dir):
@@ -26,7 +29,8 @@ def is_subdir(path, root_dir):
         return True
 
 
-class ValidateSceneSetWorkspace(pyblish.api.ContextPlugin):
+class ValidateSceneSetWorkspace(pyblish.api.ContextPlugin,
+                                OptionalPyblishPluginMixin):
     """Validate the scene is inside the currently set Maya workspace"""
 
     order = ValidatePipelineOrder

--- a/openpype/hosts/maya/plugins/publish/validate_setdress_root.py
+++ b/openpype/hosts/maya/plugins/publish/validate_setdress_root.py
@@ -1,8 +1,13 @@
 import pyblish.api
-from openpype.pipeline.publish import ValidateContentsOrder
+
+from openpype.pipeline.publish import (
+    OptionalPyblishPluginMixin,
+    ValidateContentsOrder,
+)
 
 
-class ValidateSetdressRoot(pyblish.api.InstancePlugin):
+class ValidateSetdressRoot(pyblish.api.InstancePlugin,
+                           OptionalPyblishPluginMixin):
     """Validate if set dress top root node is published."""
 
     order = ValidateContentsOrder

--- a/openpype/hosts/maya/plugins/publish/validate_shader_name.py
+++ b/openpype/hosts/maya/plugins/publish/validate_shader_name.py
@@ -5,7 +5,10 @@ from maya import cmds
 
 import openpype.hosts.maya.api.action
 from openpype.pipeline.publish import (
-    OptionalPyblishPluginMixin, PublishValidationError, ValidateContentsOrder)
+    OptionalPyblishPluginMixin,
+    PublishValidationError,
+    ValidateContentsOrder,
+)
 
 
 class ValidateShaderName(pyblish.api.InstancePlugin,

--- a/openpype/hosts/maya/plugins/publish/validate_shape_default_names.py
+++ b/openpype/hosts/maya/plugins/publish/validate_shape_default_names.py
@@ -1,14 +1,13 @@
 import re
 
-from maya import cmds
-
 import pyblish.api
+from maya import cmds
 
 import openpype.hosts.maya.api.action
 from openpype.pipeline.publish import (
-    ValidateContentsOrder,
+    OptionalPyblishPluginMixin,
     RepairAction,
-    OptionalPyblishPluginMixin
+    ValidateContentsOrder,
 )
 
 

--- a/openpype/hosts/maya/plugins/publish/validate_shape_render_stats.py
+++ b/openpype/hosts/maya/plugins/publish/validate_shape_render_stats.py
@@ -1,15 +1,16 @@
 import pyblish.api
-
 from maya import cmds
 
 import openpype.hosts.maya.api.action
 from openpype.pipeline.publish import (
+    OptionalPyblishPluginMixin,
     RepairAction,
     ValidateMeshOrder,
 )
 
 
-class ValidateShapeRenderStats(pyblish.api.Validator):
+class ValidateShapeRenderStats(pyblish.api.Validator,
+                               OptionalPyblishPluginMixin):
     """Ensure all render stats are set to the default values."""
 
     order = ValidateMeshOrder

--- a/openpype/hosts/maya/plugins/publish/validate_shape_zero.py
+++ b/openpype/hosts/maya/plugins/publish/validate_shape_zero.py
@@ -1,17 +1,17 @@
-from maya import cmds
-
 import pyblish.api
+from maya import cmds
 
 import openpype.hosts.maya.api.action
 from openpype.hosts.maya.api import lib
 from openpype.pipeline.publish import (
-    ValidateContentsOrder,
+    OptionalPyblishPluginMixin,
+    PublishValidationError,
     RepairAction,
-    PublishValidationError
+    ValidateContentsOrder,
 )
 
 
-class ValidateShapeZero(pyblish.api.Validator):
+class ValidateShapeZero(pyblish.api.Validator, OptionalPyblishPluginMixin):
     """Shape components may not have any "tweak" values
 
     To solve this issue, try freezing the shapes.

--- a/openpype/hosts/maya/plugins/publish/validate_single_assembly.py
+++ b/openpype/hosts/maya/plugins/publish/validate_single_assembly.py
@@ -1,8 +1,13 @@
 import pyblish.api
-from openpype.pipeline.publish import ValidateContentsOrder
+
+from openpype.pipeline.publish import (
+    OptionalPyblishPluginMixin,
+    ValidateContentsOrder,
+)
 
 
-class ValidateSingleAssembly(pyblish.api.InstancePlugin):
+class ValidateSingleAssembly(pyblish.api.InstancePlugin,
+                             OptionalPyblishPluginMixin):
     """Ensure the content of the instance is grouped in a single hierarchy
 
     The instance must have a single root node containing all the content.

--- a/openpype/hosts/maya/plugins/publish/validate_skeletalmesh_hierarchy.py
+++ b/openpype/hosts/maya/plugins/publish/validate_skeletalmesh_hierarchy.py
@@ -1,15 +1,16 @@
 # -*- coding: utf-8 -*-
 import pyblish.api
-
-from openpype.pipeline.publish import (
-    ValidateContentsOrder,
-    PublishXmlValidationError,
-)
-
 from maya import cmds
 
+from openpype.pipeline.publish import (
+    OptionalPyblishPluginMixin,
+    PublishXmlValidationError,
+    ValidateContentsOrder,
+)
 
-class ValidateSkeletalMeshHierarchy(pyblish.api.InstancePlugin):
+
+class ValidateSkeletalMeshHierarchy(pyblish.api.InstancePlugin,
+                                    OptionalPyblishPluginMixin):
     """Validates that nodes has common root."""
 
     order = ValidateContentsOrder

--- a/openpype/hosts/maya/plugins/publish/validate_skeletalmesh_triangulated.py
+++ b/openpype/hosts/maya/plugins/publish/validate_skeletalmesh_triangulated.py
@@ -1,20 +1,18 @@
 # -*- coding: utf-8 -*-
 import pyblish.api
-
-from openpype.hosts.maya.api.action import (
-    SelectInvalidAction,
-)
-from openpype.pipeline.publish import (
-    RepairAction,
-    ValidateContentsOrder,
-    PublishValidationError
-)
-
-
 from maya import cmds
 
+from openpype.hosts.maya.api.action import SelectInvalidAction
+from openpype.pipeline.publish import (
+    OptionalPyblishPluginMixin,
+    PublishValidationError,
+    RepairAction,
+    ValidateContentsOrder,
+)
 
-class ValidateSkeletalMeshTriangulated(pyblish.api.InstancePlugin):
+
+class ValidateSkeletalMeshTriangulated(pyblish.api.InstancePlugin,
+                                       OptionalPyblishPluginMixin):
     """Validates that the geometry has been triangulated."""
 
     order = ValidateContentsOrder

--- a/openpype/hosts/maya/plugins/publish/validate_skinCluster_deformer_set.py
+++ b/openpype/hosts/maya/plugins/publish/validate_skinCluster_deformer_set.py
@@ -1,12 +1,15 @@
+import pyblish.api
 from maya import cmds
 
-import pyblish.api
-
 import openpype.hosts.maya.api.action
-from openpype.pipeline.publish import ValidateContentsOrder
+from openpype.pipeline.publish import (
+    OptionalPyblishPluginMixin,
+    ValidateContentsOrder,
+)
 
 
-class ValidateSkinclusterDeformerSet(pyblish.api.InstancePlugin):
+class ValidateSkinclusterDeformerSet(pyblish.api.InstancePlugin,
+                                     OptionalPyblishPluginMixin):
     """Validate skinClusters on meshes have valid member relationships.
 
     In rare cases it can happen that a mesh has a skinCluster in its history

--- a/openpype/hosts/maya/plugins/publish/validate_step_size.py
+++ b/openpype/hosts/maya/plugins/publish/validate_step_size.py
@@ -2,12 +2,14 @@ import pyblish.api
 
 import openpype.hosts.maya.api.action
 from openpype.pipeline.publish import (
+    OptionalPyblishPluginMixin,
     PublishValidationError,
-    ValidateContentsOrder
+    ValidateContentsOrder,
 )
 
 
-class ValidateStepSize(pyblish.api.InstancePlugin):
+class ValidateStepSize(pyblish.api.InstancePlugin,
+                       OptionalPyblishPluginMixin):
     """Validates the step size for the instance is in a valid range.
 
     For example the `step` size should never be lower or equal to zero.

--- a/openpype/hosts/maya/plugins/publish/validate_transform_naming_suffix.py
+++ b/openpype/hosts/maya/plugins/publish/validate_transform_naming_suffix.py
@@ -1,14 +1,13 @@
 # -*- coding: utf-8 -*-
 """Plugin for validating naming conventions."""
-from maya import cmds
-
 import pyblish.api
+from maya import cmds
 
 import openpype.hosts.maya.api.action
 from openpype.pipeline.publish import (
-    ValidateContentsOrder,
     OptionalPyblishPluginMixin,
-    PublishValidationError
+    PublishValidationError,
+    ValidateContentsOrder,
 )
 
 

--- a/openpype/hosts/maya/plugins/publish/validate_transform_zero.py
+++ b/openpype/hosts/maya/plugins/publish/validate_transform_zero.py
@@ -1,15 +1,16 @@
-from maya import cmds
-
 import pyblish.api
+from maya import cmds
 
 import openpype.hosts.maya.api.action
 from openpype.pipeline.publish import (
+    OptionalPyblishPluginMixin,
+    PublishValidationError,
     ValidateContentsOrder,
-    PublishValidationError
 )
 
 
-class ValidateTransformZero(pyblish.api.Validator):
+class ValidateTransformZero(pyblish.api.Validator,
+                            OptionalPyblishPluginMixin):
     """Transforms can't have any values
 
     To solve this issue, try freezing the transforms. So long

--- a/openpype/hosts/maya/plugins/publish/validate_unique_names.py
+++ b/openpype/hosts/maya/plugins/publish/validate_unique_names.py
@@ -1,11 +1,14 @@
+import pyblish.api
 from maya import cmds
 
-import pyblish.api
 import openpype.hosts.maya.api.action
-from openpype.pipeline.publish import ValidateContentsOrder
+from openpype.pipeline.publish import (
+    OptionalPyblishPluginMixin,
+    ValidateContentsOrder,
+)
 
 
-class ValidateUniqueNames(pyblish.api.Validator):
+class ValidateUniqueNames(pyblish.api.Validator, OptionalPyblishPluginMixin):
     """transform names should be unique
 
     ie: using cmds.ls(someNodeName) should always return shortname

--- a/openpype/hosts/maya/plugins/publish/validate_unreal_mesh_triangulated.py
+++ b/openpype/hosts/maya/plugins/publish/validate_unreal_mesh_triangulated.py
@@ -1,13 +1,16 @@
 # -*- coding: utf-8 -*-
 
-from maya import cmds
 import pyblish.api
+from maya import cmds
 
-from openpype.pipeline.publish import ValidateMeshOrder
 import openpype.hosts.maya.api.action
+from openpype.pipeline.publish import (
+    OptionalPyblishPluginMixin,
+    ValidateMeshOrder,
+)
 
 
-class ValidateUnrealMeshTriangulated(pyblish.api.InstancePlugin):
+class ValidateUnrealMeshTriangulated(pyblish.api.InstancePlugin, OptionalPyblishPluginMixin):
     """Validate if mesh is made of triangles for Unreal Engine"""
 
     order = ValidateMeshOrder

--- a/openpype/hosts/maya/plugins/publish/validate_unreal_mesh_triangulated.py
+++ b/openpype/hosts/maya/plugins/publish/validate_unreal_mesh_triangulated.py
@@ -10,7 +10,8 @@ from openpype.pipeline.publish import (
 )
 
 
-class ValidateUnrealMeshTriangulated(pyblish.api.InstancePlugin, OptionalPyblishPluginMixin):
+class ValidateUnrealMeshTriangulated(pyblish.api.InstancePlugin,
+                                     OptionalPyblishPluginMixin):
     """Validate if mesh is made of triangles for Unreal Engine"""
 
     order = ValidateMeshOrder

--- a/openpype/hosts/maya/plugins/publish/validate_unreal_staticmesh_naming.py
+++ b/openpype/hosts/maya/plugins/publish/validate_unreal_staticmesh_naming.py
@@ -6,12 +6,12 @@ import pyblish.api
 
 import openpype.hosts.maya.api.action
 from openpype.pipeline import legacy_io
-from openpype.settings import get_project_settings
 from openpype.pipeline.publish import (
-    ValidateContentsOrder,
     OptionalPyblishPluginMixin,
-    PublishValidationError
+    PublishValidationError,
+    ValidateContentsOrder,
 )
+from openpype.settings import get_project_settings
 
 
 class ValidateUnrealStaticMeshName(pyblish.api.InstancePlugin,

--- a/openpype/hosts/maya/plugins/publish/validate_unreal_up_axis.py
+++ b/openpype/hosts/maya/plugins/publish/validate_unreal_up_axis.py
@@ -1,12 +1,12 @@
 # -*- coding: utf-8 -*-
 
-from maya import cmds
 import pyblish.api
+from maya import cmds
 
 from openpype.pipeline.publish import (
-    ValidateContentsOrder,
+    OptionalPyblishPluginMixin,
     RepairAction,
-    OptionalPyblishPluginMixin
+    ValidateContentsOrder,
 )
 
 

--- a/openpype/hosts/maya/plugins/publish/validate_visible_only.py
+++ b/openpype/hosts/maya/plugins/publish/validate_visible_only.py
@@ -1,14 +1,16 @@
 import pyblish.api
 
-from openpype.hosts.maya.api.lib import iter_visible_nodes_in_range
 import openpype.hosts.maya.api.action
+from openpype.hosts.maya.api.lib import iter_visible_nodes_in_range
 from openpype.pipeline.publish import (
+    OptionalPyblishPluginMixin,
+    PublishValidationError,
     ValidateContentsOrder,
-    PublishValidationError
 )
 
 
-class ValidateAlembicVisibleOnly(pyblish.api.InstancePlugin):
+class ValidateAlembicVisibleOnly(pyblish.api.InstancePlugin,
+                                 OptionalPyblishPluginMixin):
     """Validates at least a single node is visible in frame range.
 
     This validation only validates if the `visibleOnly` flag is enabled

--- a/openpype/hosts/maya/plugins/publish/validate_vray.py
+++ b/openpype/hosts/maya/plugins/publish/validate_vray.py
@@ -1,10 +1,13 @@
+import pyblish.api
 from maya import cmds
 
-import pyblish.api
-from openpype.pipeline.publish import PublishValidationError
+from openpype.pipeline.publish import (
+    OptionalPyblishPluginMixin,
+    PublishValidationError,
+)
 
 
-class ValidateVray(pyblish.api.InstancePlugin):
+class ValidateVray(pyblish.api.InstancePlugin, OptionalPyblishPluginMixin):
     """Validate general Vray setup."""
 
     order = pyblish.api.ValidatorOrder

--- a/openpype/hosts/maya/plugins/publish/validate_vray_distributed_rendering.py
+++ b/openpype/hosts/maya/plugins/publish/validate_vray_distributed_rendering.py
@@ -3,10 +3,15 @@ from maya import cmds
 
 from openpype.hosts.maya.api import lib
 from openpype.pipeline.publish import (
-    PublishValidationError, RepairAction, ValidateContentsOrder)
+    OptionalPyblishPluginMixin,
+    PublishValidationError,
+    RepairAction,
+    ValidateContentsOrder,
+)
 
 
-class ValidateVRayDistributedRendering(pyblish.api.InstancePlugin):
+class ValidateVRayDistributedRendering(pyblish.api.InstancePlugin,
+                                       OptionalPyblishPluginMixin):
     """Validate V-Ray Distributed Rendering is ignored in batch mode.
 
     Whenever Distributed Rendering is enabled for V-Ray in the render settings

--- a/openpype/hosts/maya/plugins/publish/validate_vray_referenced_aovs.py
+++ b/openpype/hosts/maya/plugins/publish/validate_vray_referenced_aovs.py
@@ -1,13 +1,18 @@
 # -*- coding: utf-8 -*-
 """Validate if there are AOVs pulled from references."""
-import pyblish.api
 import types
+
+import pyblish.api
 from maya import cmds
 
-from openpype.pipeline.publish import RepairContextAction
+from openpype.pipeline.publish import (
+    OptionalPyblishPluginMixin,
+    RepairContextAction,
+)
 
 
-class ValidateVrayReferencedAOVs(pyblish.api.InstancePlugin):
+class ValidateVrayReferencedAOVs(pyblish.api.InstancePlugin,
+                                 OptionalPyblishPluginMixin):
     """Validate whether the V-Ray Render Elements (AOVs) include references.
 
     This will check if there are AOVs pulled from references. If

--- a/openpype/hosts/maya/plugins/publish/validate_vray_translator_settings.py
+++ b/openpype/hosts/maya/plugins/publish/validate_vray_translator_settings.py
@@ -1,17 +1,19 @@
 # -*- coding: utf-8 -*-
 """Validate VRay Translator settings."""
 import pyblish.api
-from openpype.pipeline.publish import (
-    context_plugin_should_run,
-    RepairContextAction,
-    ValidateContentsOrder,
-    PublishValidationError
-)
-
 from maya import cmds
 
+from openpype.pipeline.publish import (
+    OptionalPyblishPluginMixin,
+    PublishValidationError,
+    RepairContextAction,
+    ValidateContentsOrder,
+    context_plugin_should_run,
+)
 
-class ValidateVRayTranslatorEnabled(pyblish.api.ContextPlugin):
+
+class ValidateVRayTranslatorEnabled(pyblish.api.ContextPlugin,
+                                    OptionalPyblishPluginMixin):
     """Validate VRay Translator settings for extracting vrscenes."""
 
     order = ValidateContentsOrder

--- a/openpype/hosts/maya/plugins/publish/validate_vrayproxy.py
+++ b/openpype/hosts/maya/plugins/publish/validate_vrayproxy.py
@@ -1,9 +1,10 @@
 import pyblish.api
 
-from openpype.pipeline import KnownPublishError
+from openpype.pipeline import KnownPublishError, OptionalPyblishPluginMixin
 
 
-class ValidateVrayProxy(pyblish.api.InstancePlugin):
+class ValidateVrayProxy(pyblish.api.InstancePlugin,
+                        OptionalPyblishPluginMixin):
 
     order = pyblish.api.ValidatorOrder
     label = "VRay Proxy Settings"

--- a/openpype/hosts/maya/plugins/publish/validate_vrayproxy_members.py
+++ b/openpype/hosts/maya/plugins/publish/validate_vrayproxy_members.py
@@ -1,15 +1,15 @@
 import pyblish.api
-
 from maya import cmds
 
 import openpype.hosts.maya.api.action
 from openpype.pipeline.publish import (
-    PublishValidationError
+    OptionalPyblishPluginMixin,
+    PublishValidationError,
 )
 
 
-
-class ValidateVrayProxyMembers(pyblish.api.InstancePlugin):
+class ValidateVrayProxyMembers(pyblish.api.InstancePlugin,
+                               OptionalPyblishPluginMixin):
     """Validate whether the V-Ray Proxy instance has shape members"""
 
     order = pyblish.api.ValidatorOrder

--- a/openpype/hosts/maya/plugins/publish/validate_xgen.py
+++ b/openpype/hosts/maya/plugins/publish/validate_xgen.py
@@ -1,13 +1,17 @@
 import json
 
 import maya.cmds as cmds
+import pyblish.api
 import xgenm
 
-import pyblish.api
-from openpype.pipeline.publish import PublishValidationError
+from openpype.pipeline.publish import (
+    OptionalPyblishPluginMixin,
+    PublishValidationError,
+)
 
 
-class ValidateXgen(pyblish.api.InstancePlugin):
+class ValidateXgen(pyblish.api.InstancePlugin,
+                   OptionalPyblishPluginMixin):
     """Validate Xgen data."""
 
     label = "Validate Xgen"

--- a/openpype/hosts/maya/plugins/publish/validate_yeti_renderscript_callbacks.py
+++ b/openpype/hosts/maya/plugins/publish/validate_yeti_renderscript_callbacks.py
@@ -1,10 +1,14 @@
+import pyblish.api
 from maya import cmds
 
-import pyblish.api
-from openpype.pipeline.publish import ValidateContentsOrder
+from openpype.pipeline.publish import (
+    OptionalPyblishPluginMixin,
+    ValidateContentsOrder,
+)
 
 
-class ValidateYetiRenderScriptCallbacks(pyblish.api.InstancePlugin):
+class ValidateYetiRenderScriptCallbacks(pyblish.api.InstancePlugin,
+                                        OptionalPyblishPluginMixin):
     """Check if the render script callbacks will be used during the rendering
 
     In order to ensure the render tasks are executed properly we need to check

--- a/openpype/hosts/maya/plugins/publish/validate_yeti_rig_cache_state.py
+++ b/openpype/hosts/maya/plugins/publish/validate_yeti_rig_cache_state.py
@@ -1,14 +1,16 @@
-import pyblish.api
 import maya.cmds as cmds
+import pyblish.api
+
 import openpype.hosts.maya.api.action
 from openpype.pipeline.publish import (
+    OptionalPyblishPluginMixin,
+    PublishValidationError,
     RepairAction,
-    PublishValidationError
 )
 
 
-
-class ValidateYetiRigCacheState(pyblish.api.InstancePlugin):
+class ValidateYetiRigCacheState(pyblish.api.InstancePlugin,
+                                OptionalPyblishPluginMixin):
     """Validate the I/O attributes of the node
 
     Every pgYetiMaya cache node per instance should have:

--- a/openpype/hosts/maya/plugins/publish/validate_yeti_rig_input_in_instance.py
+++ b/openpype/hosts/maya/plugins/publish/validate_yeti_rig_input_in_instance.py
@@ -1,15 +1,16 @@
-from maya import cmds
-
 import pyblish.api
+from maya import cmds
 
 import openpype.hosts.maya.api.action
 from openpype.pipeline.publish import (
+    OptionalPyblishPluginMixin,
+    PublishValidationError,
     ValidateContentsOrder,
-    PublishValidationError
 )
 
 
-class ValidateYetiRigInputShapesInInstance(pyblish.api.Validator):
+class ValidateYetiRigInputShapesInInstance(pyblish.api.Validator,
+                                           OptionalPyblishPluginMixin):
     """Validate if all input nodes are part of the instance's hierarchy"""
 
     order = ValidateContentsOrder

--- a/openpype/hosts/maya/plugins/publish/validate_yeti_rig_settings.py
+++ b/openpype/hosts/maya/plugins/publish/validate_yeti_rig_settings.py
@@ -1,9 +1,13 @@
 import pyblish.api
 
-from openpype.pipeline.publish import PublishValidationError
+from openpype.pipeline.publish import (
+    OptionalPyblishPluginMixin,
+    PublishValidationError,
+)
 
 
-class ValidateYetiRigSettings(pyblish.api.InstancePlugin):
+class ValidateYetiRigSettings(pyblish.api.InstancePlugin,
+                              OptionalPyblishPluginMixin):
     """Validate Yeti Rig Settings have collected input connections.
 
     The input connections are collected for the nodes in the `input_SET`.

--- a/setup.cfg
+++ b/setup.cfg
@@ -29,3 +29,10 @@ directory = ./coverage
 
 [tool:pytest]
 norecursedirs = repos/* openpype/modules/ftrack/*
+
+[isort]
+line_length = 79
+multi_line_output = 3
+include_trailing_comma = True
+force_grid_wrap = 0
+combine_as_imports = True


### PR DESCRIPTION
## Changelog Description
This PR is adding `OptionalPyblishPluginMixin` inheritance to all Maya validators. This fixes issues where validators are set as *Optional* in the Settings but that state is ignored on them.

## Additional info
Rationale to add `OptionalPyblishPluginMixin` to all validators is that it should be decided in the Settings if the plugin is optional or not - or at least on one place and currently there is no way to make Settings dynamic enough so that they will get that from the plugins itself. If this mixin is present, but the setting *Optional* in Settings is not, it won't allow anyone to disable even the important **"must-run"** validators. And at the same time, adding it to the Settings will make the validator settable to *Optional* state.

This is also re-sorted imports with [isort tools](https://pycqa.github.io/isort/) - for that I am truly sorry as it might complicate code review, but since I had to change import on most of these plugins anyway, I've chose to do it for the sake of consisten and more readable code. I've added default isort configuration in #5572.

## Testing notes:
1. Open Maya
2. Publish - validators that are set to be optional should behave so
