### PR TITLE
Publisher: Screenshot opacity value fix

### DIFF
--- a/openpype/tools/publisher/widgets/screenshot_widget.py
+++ b/openpype/tools/publisher/widgets/screenshot_widget.py
@@ -46,7 +46,7 @@ class ScreenMarquee(QtWidgets.QDialog):
         for screen in QtWidgets.QApplication.screens():
             screen.geometryChanged.connect(self._fit_screen_geometry)
 
-        self._opacity = fade_anim.currentValue()
+        self._opacity = fade_anim.startValue()
         self._click_pos = None
         self._capture_rect = None
 

--- a/openpype/tools/publisher/widgets/screenshot_widget.py
+++ b/openpype/tools/publisher/widgets/screenshot_widget.py
@@ -31,7 +31,6 @@ class ScreenMarquee(QtWidgets.QDialog):
         fade_anim.setEndValue(50)
         fade_anim.setDuration(200)
         fade_anim.setEasingCurve(QtCore.QEasingCurve.OutCubic)
-        fade_anim.start(QtCore.QAbstractAnimation.DeleteWhenStopped)
 
         fade_anim.valueChanged.connect(self._on_fade_anim)
 


### PR DESCRIPTION
## Changelog Description
Fix opacity value.

## Additional info
Current value of animation until it starts is `None`.

### Traceback
```
Traceback (most recent call last):
  File "C:\Users\<user>\AppData\Local\Ynput\AYON\addons\openpype_3.16.5-nightly.1\openpype\tools\publisher\widgets\screenshot_widget.py", line 74, in paintEvent
    painter.setBrush(QtGui.QColor(0, 0, 0, self._opacity))
TypeError: 'PySide2.QtGui.QColor' called with wrong argument types:
  PySide2.QtGui.QColor(int, int, int, NoneType)
Supported signatures:
  PySide2.QtGui.QColor()
  PySide2.QtGui.QColor(typing.Any)
  PySide2.QtGui.QColor(PySide2.QtCore.Qt.GlobalColor)
  PySide2.QtGui.QColor(PySide2.QtGui.QColor)
  PySide2.QtGui.QColor(str)
  PySide2.QtGui.QColor(int, int, int, int = 255)
  PySide2.QtGui.QColor(int)
```

## Testing notes:
1. Open Publisher tool
2. Take screenshot in thumbnails widget
