### PR TITLE
Nuke: removing redundant workfile colorspace attributes

### DIFF
--- a/openpype/settings/defaults/project_settings/nuke.json
+++ b/openpype/settings/defaults/project_settings/nuke.json
@@ -28,11 +28,7 @@
             "colorManagement": "Nuke",
             "OCIO_config": "nuke-default",
             "workingSpaceLUT": "linear",
-            "monitorLut": "sRGB",
-            "int8Lut": "sRGB",
-            "int16Lut": "sRGB",
-            "logLut": "Cineon",
-            "floatLut": "linear"
+            "monitorLut": "sRGB"
         },
         "nodes": {
             "requiredNodes": [

--- a/openpype/settings/entities/schemas/projects_schema/schemas/schema_nuke_imageio.json
+++ b/openpype/settings/entities/schemas/projects_schema/schemas/schema_nuke_imageio.json
@@ -106,26 +106,6 @@
                             "type": "text",
                             "key": "monitorLut",
                             "label": "monitor"
-                        },
-                        {
-                            "type": "text",
-                            "key": "int8Lut",
-                            "label": "8-bit files"
-                        },
-                        {
-                            "type": "text",
-                            "key": "int16Lut",
-                            "label": "16-bit files"
-                        },
-                        {
-                            "type": "text",
-                            "key": "logLut",
-                            "label": "log files"
-                        },
-                        {
-                            "type": "text",
-                            "key": "floatLut",
-                            "label": "float files"
                         }
                     ]
                 }

--- a/server_addon/nuke/server/settings/imageio.py
+++ b/server_addon/nuke/server/settings/imageio.py
@@ -66,22 +66,6 @@ def ocio_configs_switcher_enum():
 
 class WorkfileColorspaceSettings(BaseSettingsModel):
     """Nuke workfile colorspace preset. """
-    """# TODO: enhance settings with host api:
-    we need to add mapping to resolve properly keys.
-    Nuke is excpecting camel case key names,
-    but for better code consistency we need to
-    be  using snake_case:
-
-    color_management = colorManagement
-    ocio_config = OCIO_config
-    working_space_name = workingSpaceLUT
-    monitor_name = monitorLut
-    monitor_out_name = monitorOutLut
-    int_8_name = int8Lut
-    int_16_name = int16Lut
-    log_name = logLut
-    float_name = floatLut
-    """
 
     colorManagement: Literal["Nuke", "OCIO"] = Field(
         title="Color Management"
@@ -99,18 +83,6 @@ class WorkfileColorspaceSettings(BaseSettingsModel):
     )
     monitorLut: str = Field(
         title="Monitor"
-    )
-    int8Lut: str = Field(
-        title="8-bit files"
-    )
-    int16Lut: str = Field(
-        title="16-bit files"
-    )
-    logLut: str = Field(
-        title="Log files"
-    )
-    floatLut: str = Field(
-        title="Float files"
     )
 
 
@@ -238,10 +210,6 @@ DEFAULT_IMAGEIO_SETTINGS = {
         "OCIO_config": "nuke-default",
         "workingSpaceLUT": "linear",
         "monitorLut": "sRGB",
-        "int8Lut": "sRGB",
-        "int16Lut": "sRGB",
-        "logLut": "Cineon",
-        "floatLut": "linear"
     },
     "nodes": {
         "requiredNodes": [


### PR DESCRIPTION
## Changelog Description
Nuke root workfile colorspace data type knobs are long time configured automatically via config roles or the default values are also working well. Therefore there is no need for pipeline managed knobs. 

## Additional info
- removed in OpenPype
- removed in server addon

## Testing notes:
1. Open nuke with color-managed enabled and see all works as expected