### PR TITLE
AfterEffects: fix imports of image sequences

### DIFF
--- a/openpype/hosts/aftereffects/plugins/load/load_file.py
+++ b/openpype/hosts/aftereffects/plugins/load/load_file.py
@@ -31,7 +31,7 @@ class FileLoader(api.AfterEffectsLoader):
 
         path = self.filepath_from_context(context)
 
-        if len(context["representation"].get("files")) > 1:
+        if isinstance(context["representation"].get("files"), list):
             import_options['sequence'] = True
 
         if not path:

--- a/openpype/hosts/aftereffects/plugins/load/load_file.py
+++ b/openpype/hosts/aftereffects/plugins/load/load_file.py
@@ -31,7 +31,7 @@ class FileLoader(api.AfterEffectsLoader):
 
         path = self.filepath_from_context(context)
 
-        if isinstance(context["representation"].get("files"), list):
+        if len(context["representation"]["files"]) > 1:
             import_options['sequence'] = True
 
         if not path:

--- a/openpype/hosts/aftereffects/plugins/load/load_file.py
+++ b/openpype/hosts/aftereffects/plugins/load/load_file.py
@@ -31,13 +31,8 @@ class FileLoader(api.AfterEffectsLoader):
 
         path = self.filepath_from_context(context)
 
-        repr_cont = context["representation"]["context"]
-        if "#" not in path:
-            frame = repr_cont.get("frame")
-            if frame:
-                padding = len(frame)
-                path = path.replace(frame, "#" * padding)
-                import_options['sequence'] = True
+        if len(context["representation"].get("files")) > 1:
+            import_options['sequence'] = True
 
         if not path:
             repr_id = context["representation"]["_id"]


### PR DESCRIPTION
## Changelog Description
#4602 broke imports of image sequences. 


## Testing notes:
1. try to load image sequence with multiple frames into AE
![AnyDeskMSI_XGdidR1jVs](https://github.com/ynput/OpenPype/assets/4457962/1679fa14-a86d-4ad9-92f0-101e4df7345e)
3. shouldn't fail
