### PR TITLE
Chore: Loader log deprecation warning for 'fname' attribute

### DIFF
--- a/openpype/hosts/blender/plugins/load/load_blend.py
+++ b/openpype/hosts/blender/plugins/load/load_blend.py
@@ -119,7 +119,7 @@ class BlendLoader(plugin.AssetLoader):
             context: Full parenthood of representation to load
             options: Additional settings dictionary
         """
-        libpath = self.fname
+        libpath = self.filepath_from_context(context)
         asset = context["asset"]["name"]
         subset = context["subset"]["name"]
 

--- a/openpype/pipeline/load/plugins.py
+++ b/openpype/pipeline/load/plugins.py
@@ -234,6 +234,19 @@ class LoaderPlugin(list):
         """
         return cls.options or []
 
+    @property
+    def fname(self):
+        """Backwards compatibility with deprecation warning"""
+
+        self.log.warning((
+            "DEPRECATION WARNING: Source - Loader plugin {}."
+            " The 'fname' property on the Loader plugin will be removed in"
+            " future versions of OpenPype. Planned version to drop the support"
+            " is 3.16.6 or 3.17.0."
+        ).format(self.__class__.__name__))
+        if hasattr(self, "_fname"):
+            return self._fname
+
 
 class SubsetLoaderPlugin(LoaderPlugin):
     """Load subset into host application

--- a/openpype/pipeline/load/utils.py
+++ b/openpype/pipeline/load/utils.py
@@ -318,7 +318,8 @@ def load_with_repre_context(
 
     # Backwards compatibility: Originally the loader's __init__ required the
     # representation context to set `fname` attribute to the filename to load
-    loader.fname = get_representation_path_from_context(repre_context)
+    # Deprecated - to be removed in OpenPype 3.16.6 or 3.17.0.
+    loader._fname = get_representation_path_from_context(repre_context)
 
     return loader.load(repre_context, name, namespace, options)
 


### PR DESCRIPTION
## Changelog Description

Since https://github.com/ynput/OpenPype/pull/4602 the `fname` attribute on the `LoaderPlugin` should've been deprecated and set for removal over time. However, no deprecation warning was logged whatsoever and thus one usage appears to have sneaked in (fixed with this PR) and a new one tried to sneak in with [a recent PR](https://github.com/ynput/OpenPype/pull/5584#discussion_r1317740936) 

## Testing notes:

1. Add usage of `self.fname` in a loader plugin
2. Ensure the deprecation warning is logged
3. Ensure also that loaders work fine without usage of `self.fname`
