### PR TITLE
ayon-nuke: default factory to lists 

### DIFF
--- a/server_addon/nuke/server/settings/common.py
+++ b/server_addon/nuke/server/settings/common.py
@@ -89,12 +89,6 @@ knob_types_enum = [
 
 
 class KnobModel(BaseSettingsModel):
-    """# TODO: new data structure
-    - v3 was having type, name, value but
-    ayon is not able to make it the same. Current model is
-    defining `type` as `text` and instead of `value` the key is `text`.
-    So if `type` is `boolean` then key is `boolean` (value).
-    """
     _layout = "expanded"
 
     type: str = Field(

--- a/server_addon/nuke/server/settings/create_plugins.py
+++ b/server_addon/nuke/server/settings/create_plugins.py
@@ -37,6 +37,7 @@ class PrenodeModel(BaseSettingsModel):
     - We could not support v3 style of settings.
     """
     knobs: list[KnobModel] = Field(
+        default_factory=list,
         title="Knobs",
     )
 
@@ -66,6 +67,7 @@ class CreateWriteRenderModel(BaseSettingsModel):
       (we could not support v3 style of settings)
     """
     prenodes: list[PrenodeModel] = Field(
+        default_factory=list,
         title="Preceding nodes",
     )
 
@@ -95,6 +97,7 @@ class CreateWritePrerenderModel(BaseSettingsModel):
       (we could not support v3 style of settings)
     """
     prenodes: list[PrenodeModel] = Field(
+        default_factory=list,
         title="Preceding nodes",
     )
 
@@ -124,6 +127,7 @@ class CreateWriteImageModel(BaseSettingsModel):
       (we could not support v3 style of settings)
     """
     prenodes: list[PrenodeModel] = Field(
+        default_factory=list,
         title="Preceding nodes",
     )
 

--- a/server_addon/nuke/server/settings/create_plugins.py
+++ b/server_addon/nuke/server/settings/create_plugins.py
@@ -16,13 +16,10 @@ def instance_attributes_enum():
 
 
 class PrenodeModel(BaseSettingsModel):
-    # TODO: missing in host api
-    # - good for `dependency`
     name: str = Field(
         title="Node name"
     )
 
-    # TODO: `nodeclass` should be renamed to `nuke_node_class`
     nodeclass: str = Field(
         "",
         title="Node class"
@@ -32,10 +29,6 @@ class PrenodeModel(BaseSettingsModel):
         title="Incoming dependency"
     )
 
-    """# TODO: Changes in host api:
-    - Need complete rework of knob types in nuke integration.
-    - We could not support v3 style of settings.
-    """
     knobs: list[KnobModel] = Field(
         default_factory=list,
         title="Knobs",
@@ -62,10 +55,6 @@ class CreateWriteRenderModel(BaseSettingsModel):
         title="Instance attributes"
     )
 
-    """# TODO: Changes in host api:
-    - prenodes key was originally dict and now is list
-      (we could not support v3 style of settings)
-    """
     prenodes: list[PrenodeModel] = Field(
         default_factory=list,
         title="Preceding nodes",
@@ -92,10 +81,6 @@ class CreateWritePrerenderModel(BaseSettingsModel):
         title="Instance attributes"
     )
 
-    """# TODO: Changes in host api:
-    - prenodes key was originally dict and now is list
-      (we could not support v3 style of settings)
-    """
     prenodes: list[PrenodeModel] = Field(
         default_factory=list,
         title="Preceding nodes",
@@ -122,10 +107,6 @@ class CreateWriteImageModel(BaseSettingsModel):
         title="Instance attributes"
     )
 
-    """# TODO: Changes in host api:
-    - prenodes key was originally dict and now is list
-      (we could not support v3 style of settings)
-    """
     prenodes: list[PrenodeModel] = Field(
         default_factory=list,
         title="Preceding nodes",

--- a/server_addon/nuke/server/settings/dirmap.py
+++ b/server_addon/nuke/server/settings/dirmap.py
@@ -25,19 +25,6 @@ class DirmapSettings(BaseSettingsModel):
     )
 
 
-"""# TODO:
-nuke is having originally implemented
-following data inputs:
-
-"nuke-dirmap": {
-    "enabled": false,
-    "paths": {
-        "source-path": [],
-        "destination-path": []
-    }
-}
-"""
-
 DEFAULT_DIRMAP_SETTINGS = {
     "enabled": False,
     "paths": {

--- a/server_addon/nuke/server/settings/imageio.py
+++ b/server_addon/nuke/server/settings/imageio.py
@@ -9,22 +9,15 @@ from .common import KnobModel
 
 
 class NodesModel(BaseSettingsModel):
-    """# TODO: This needs to be somehow labeled in settings panel
-    or at least it could show gist of configuration
-    """
     _layout = "expanded"
     plugins: list[str] = Field(
         default_factory=list,
         title="Used in plugins"
     )
-    # TODO: rename `nukeNodeClass` to `nuke_node_class`
     nukeNodeClass: str = Field(
         title="Nuke Node Class",
     )
 
-    """ # TODO: Need complete rework of knob types
-    in nuke integration. We could not support v3 style of settings.
-    """
     knobs: list[KnobModel] = Field(
         default_factory=list,
         title="Knobs",
@@ -172,7 +165,7 @@ class ImageIOSettings(BaseSettingsModel):
     _isGroup: bool = True
 
     """# TODO: enhance settings with host api:
-    to restruture settings for simplification.
+    to restructure settings for simplification.
 
     now: nuke/imageio/viewer/viewerProcess
     future: nuke/imageio/viewer
@@ -195,7 +188,7 @@ class ImageIOSettings(BaseSettingsModel):
     )
 
     """# TODO: enhance settings with host api:
-    to restruture settings for simplification.
+    to restructure settings for simplification.
 
     now: nuke/imageio/baking/viewerProcess
     future: nuke/imageio/baking
@@ -217,9 +210,9 @@ class ImageIOSettings(BaseSettingsModel):
         title="Nodes"
     )
     """# TODO: enhance settings with host api:
-    - old settings are using `regexInputs` key but we
+    - [ ] old settings are using `regexInputs` key but we
       need to rename to `regex_inputs`
-    - no need for `inputs` middle part. It can stay
+    - [ ] no need for `inputs` middle part. It can stay
       directly on `regex_inputs`
     """
     regexInputs: RegexInputsModel = Field(

--- a/server_addon/nuke/server/settings/imageio.py
+++ b/server_addon/nuke/server/settings/imageio.py
@@ -14,6 +14,7 @@ class NodesModel(BaseSettingsModel):
     """
     _layout = "expanded"
     plugins: list[str] = Field(
+        default_factory=list,
         title="Used in plugins"
     )
     # TODO: rename `nukeNodeClass` to `nuke_node_class`
@@ -25,6 +26,7 @@ class NodesModel(BaseSettingsModel):
     in nuke integration. We could not support v3 style of settings.
     """
     knobs: list[KnobModel] = Field(
+        default_factory=list,
         title="Knobs",
     )
 

--- a/server_addon/nuke/server/settings/loader_plugins.py
+++ b/server_addon/nuke/server/settings/loader_plugins.py
@@ -6,10 +6,6 @@ class LoadImageModel(BaseSettingsModel):
     enabled: bool = Field(
         title="Enabled"
     )
-    """# TODO: v3 api used `_representation`
-    New api is hiding it so it had to be renamed
-    to `representations_include`
-    """
     representations_include: list[str] = Field(
         default_factory=list,
         title="Include representations"
@@ -33,10 +29,6 @@ class LoadClipModel(BaseSettingsModel):
     enabled: bool = Field(
         title="Enabled"
     )
-    """# TODO: v3 api used `_representation`
-    New api is hiding it so it had to be renamed
-    to `representations_include`
-    """
     representations_include: list[str] = Field(
         default_factory=list,
         title="Include representations"

--- a/server_addon/nuke/server/settings/main.py
+++ b/server_addon/nuke/server/settings/main.py
@@ -59,9 +59,7 @@ class NukeSettings(BaseSettingsModel):
         default_factory=ImageIOSettings,
         title="Color Management (imageio)",
     )
-    """# TODO: fix host api:
-    - rename  `nuke-dirmap` to `dirmap` was inevitable
-    """
+
     dirmap: DirmapSettings = Field(
         default_factory=DirmapSettings,
         title="Nuke Directory Mapping",

--- a/server_addon/nuke/server/settings/publish_plugins.py
+++ b/server_addon/nuke/server/settings/publish_plugins.py
@@ -46,6 +46,7 @@ class NodeModel(BaseSettingsModel):
     - We could not support v3 style of settings.
     """
     knobs: list[KnobModel] = Field(
+        default_factory=list,
         title="Knobs",
     )
 
@@ -105,6 +106,7 @@ class ExtractThumbnailModel(BaseSettingsModel):
     """
 
     nodes: list[NodeModel] = Field(
+        default_factory=list,
         title="Nodes (deprecated)"
     )
     reposition_nodes: list[ThumbnailRepositionNodeModel] = Field(
@@ -177,6 +179,7 @@ class ExtractReviewDataMovModel(BaseSettingsModel):
     enabled: bool = Field(title="Enabled")
     viewer_lut_raw: bool = Field(title="Viewer lut raw")
     outputs: list[BakingStreamModel] = Field(
+        default_factory=list,
         title="Baking streams"
     )
 

--- a/server_addon/nuke/server/settings/publish_plugins.py
+++ b/server_addon/nuke/server/settings/publish_plugins.py
@@ -28,11 +28,9 @@ def nuke_product_types_enum():
 
 
 class NodeModel(BaseSettingsModel):
-    # TODO: missing in host api
     name: str = Field(
         title="Node name"
     )
-    # TODO: `nodeclass` rename to `nuke_node_class`
     nodeclass: str = Field(
         "",
         title="Node class"
@@ -41,10 +39,6 @@ class NodeModel(BaseSettingsModel):
         "",
         title="Incoming dependency"
     )
-    """# TODO: Changes in host api:
-    - Need complete rework of knob types in nuke integration.
-    - We could not support v3 style of settings.
-    """
     knobs: list[KnobModel] = Field(
         default_factory=list,
         title="Knobs",
@@ -100,10 +94,6 @@ class ExtractThumbnailModel(BaseSettingsModel):
     use_rendered: bool = Field(title="Use rendered images")
     bake_viewer_process: bool = Field(title="Bake view process")
     bake_viewer_input_process: bool = Field(title="Bake viewer input process")
-    """# TODO: needs to rewrite from v3 to ayon
-    - `nodes` in v3 was dict but now `prenodes` is list of dict
-    - also later `nodes` should be `prenodes`
-    """
 
     nodes: list[NodeModel] = Field(
         default_factory=list,
@@ -216,12 +206,6 @@ class ExctractSlateFrameParamModel(BaseSettingsModel):
 
 class ExtractSlateFrameModel(BaseSettingsModel):
     viewer_lut_raw: bool = Field(title="Viewer lut raw")
-    """# TODO: v3 api different model:
-    - not possible to replicate v3 model:
-        {"name": [bool, str]}
-    - not it is:
-        {"name": {"enabled": bool, "template": str}}
-    """
     key_value_mapping: ExctractSlateFrameParamModel = Field(
         title="Key value mapping",
         default_factory=ExctractSlateFrameParamModel
@@ -290,7 +274,6 @@ class PublishPuginsModel(BaseSettingsModel):
         title="Extract Slate Frame",
         default_factory=ExtractSlateFrameModel
     )
-    # TODO: plugin should be renamed - `workfile` not `script`
     IncrementScriptVersion: IncrementScriptVersionModel = Field(
         title="Increment Workfile Version",
         default_factory=IncrementScriptVersionModel,

--- a/server_addon/nuke/server/settings/scriptsmenu.py
+++ b/server_addon/nuke/server/settings/scriptsmenu.py
@@ -17,7 +17,6 @@ class ScriptsmenuSettings(BaseSettingsModel):
     """Nuke script menu project settings."""
     _isGroup = True
 
-    # TODO: in api rename key `name` to `menu_name`
     name: str = Field(title="Menu Name")
     definition: list[ScriptsmenuSubmodel] = Field(
         default_factory=list,

--- a/server_addon/nuke/server/settings/templated_workfile_build.py
+++ b/server_addon/nuke/server/settings/templated_workfile_build.py
@@ -28,6 +28,7 @@ class TemplatedWorkfileProfileModel(BaseSettingsModel):
 
 
 class TemplatedWorkfileBuildModel(BaseSettingsModel):
+    """Settings for templated workfile builder."""
     profiles: list[TemplatedWorkfileProfileModel] = Field(
         default_factory=list
     )

--- a/server_addon/nuke/server/settings/workfile_builder.py
+++ b/server_addon/nuke/server/settings/workfile_builder.py
@@ -48,20 +48,30 @@ class BuilderProfileModel(BaseSettingsModel):
         title="Task names"
     )
     current_context: list[BuilderProfileItemModel] = Field(
-        title="Current context")
+        default_factory=list,
+        title="Current context"
+    )
     linked_assets: list[BuilderProfileItemModel] = Field(
-        title="Linked assets/shots")
+        default_factory=list,
+        title="Linked assets/shots"
+    )
 
 
 class WorkfileBuilderModel(BaseSettingsModel):
     create_first_version: bool = Field(
         title="Create first workfile")
     custom_templates: list[CustomTemplateModel] = Field(
-        title="Custom templates")
+        default_factory=list,
+        title="Custom templates"
+    )
     builder_on_start: bool = Field(
-        title="Run Builder at first workfile")
+        default=False,
+        title="Run Builder at first workfile"
+    )
     profiles: list[BuilderProfileModel] = Field(
-        title="Builder profiles")
+        default_factory=list,
+        title="Builder profiles"
+    )
 
 
 DEFAULT_WORKFILE_BUILDER_SETTINGS = {

--- a/server_addon/nuke/server/settings/workfile_builder.py
+++ b/server_addon/nuke/server/settings/workfile_builder.py
@@ -58,6 +58,8 @@ class BuilderProfileModel(BaseSettingsModel):
 
 
 class WorkfileBuilderModel(BaseSettingsModel):
+    """[deprecated] use Template Workfile Build Settings instead.
+    """
     create_first_version: bool = Field(
         title="Create first workfile")
     custom_templates: list[CustomTemplateModel] = Field(


### PR DESCRIPTION
## Changelog Description
Default factory were missing in settings schemas for complicated objects like lists and it was causing settings to be failing saving.

## Additional info
- Also clearing some already processed TODOs.
- improving of some docstrings

## Testing notes:
Just a code review should be ok.