### PR TITLE
Ftrack: Less verbose logs for Ftrack integration in artist facing logs

### DIFF
--- a/openpype/lib/transcoding.py
+++ b/openpype/lib/transcoding.py
@@ -724,7 +724,7 @@ def get_ffprobe_data(path_to_file, logger=None):
     """
     if not logger:
         logger = logging.getLogger(__name__)
-    logger.info(
+    logger.debug(
         "Getting information about input \"{}\".".format(path_to_file)
     )
     ffprobe_args = get_ffmpeg_tool_args("ffprobe")

--- a/openpype/modules/ftrack/plugins/publish/integrate_ftrack_api.py
+++ b/openpype/modules/ftrack/plugins/publish/integrate_ftrack_api.py
@@ -27,8 +27,8 @@ class IntegrateFtrackApi(pyblish.api.InstancePlugin):
     def process(self, instance):
         component_list = instance.data.get("ftrackComponentsList")
         if not component_list:
-            self.log.info(
-                "Instance don't have components to integrate to Ftrack."
+            self.log.debug(
+                "Instance doesn't have components to integrate to Ftrack."
                 " Skipping."
             )
             return
@@ -37,7 +37,7 @@ class IntegrateFtrackApi(pyblish.api.InstancePlugin):
         task_entity, parent_entity = self.get_instance_entities(
             instance, context)
         if parent_entity is None:
-            self.log.info((
+            self.log.debug((
                 "Skipping ftrack integration. Instance \"{}\" does not"
                 " have specified ftrack entities."
             ).format(str(instance)))
@@ -323,7 +323,7 @@ class IntegrateFtrackApi(pyblish.api.InstancePlugin):
             "type_id": asset_type_id,
             "context_id": parent_id
         }
-        self.log.info("Created new Asset with data: {}.".format(asset_data))
+        self.log.debug("Created new Asset with data: {}.".format(asset_data))
         session.create("Asset", asset_data)
         session.commit()
         return self._query_asset(session, asset_name, asset_type_id, parent_id)
@@ -384,7 +384,7 @@ class IntegrateFtrackApi(pyblish.api.InstancePlugin):
             if comment:
                 new_asset_version_data["comment"] = comment
 
-            self.log.info("Created new AssetVersion with data {}".format(
+            self.log.debug("Created new AssetVersion with data {}".format(
                 new_asset_version_data
             ))
             session.create("AssetVersion", new_asset_version_data)
@@ -555,7 +555,7 @@ class IntegrateFtrackApi(pyblish.api.InstancePlugin):
                 location=location
             )
             data["component"] = component_entity
-            self.log.info(
+            self.log.debug(
                 (
                     "Created new Component with path: {0}, data: {1},"
                     " metadata: {2}, location: {3}"

--- a/openpype/modules/ftrack/plugins/publish/integrate_ftrack_description.py
+++ b/openpype/modules/ftrack/plugins/publish/integrate_ftrack_description.py
@@ -40,7 +40,7 @@ class IntegrateFtrackDescription(pyblish.api.InstancePlugin):
 
         comment = instance.data["comment"]
         if not comment:
-            self.log.info("Comment is not set.")
+            self.log.debug("Comment is not set.")
         else:
             self.log.debug("Comment is set to `{}`".format(comment))
 

--- a/openpype/modules/ftrack/plugins/publish/integrate_ftrack_note.py
+++ b/openpype/modules/ftrack/plugins/publish/integrate_ftrack_note.py
@@ -47,7 +47,7 @@ class IntegrateFtrackNote(pyblish.api.InstancePlugin):
         app_label = context.data["appLabel"]
         comment = instance.data["comment"]
         if not comment:
-            self.log.info("Comment is not set.")
+            self.log.debug("Comment is not set.")
         else:
             self.log.debug("Comment is set to `{}`".format(comment))
 
@@ -127,14 +127,14 @@ class IntegrateFtrackNote(pyblish.api.InstancePlugin):
 
             note_text = StringTemplate.format_template(template, format_data)
             if not note_text.solved:
-                self.log.warning((
+                self.log.debug((
                     "Note template require more keys then can be provided."
                     "\nTemplate: {}\nMissing values for keys:{}\nData: {}"
                 ).format(template, note_text.missing_keys, format_data))
                 continue
 
             if not note_text:
-                self.log.info((
+                self.log.debug((
                     "Note for AssetVersion {} would be empty. Skipping."
                     "\nTemplate: {}\nData: {}"
                 ).format(asset_version["id"], template, format_data))

--- a/openpype/modules/kitsu/plugins/publish/integrate_kitsu_note.py
+++ b/openpype/modules/kitsu/plugins/publish/integrate_kitsu_note.py
@@ -121,7 +121,7 @@ class IntegrateKitsuNote(pyblish.api.ContextPlugin):
                 publish_comment = self.format_publish_comment(instance)
 
             if not publish_comment:
-                self.log.info("Comment is not set.")
+                self.log.debug("Comment is not set.")
             else:
                 self.log.debug("Comment is `{}`".format(publish_comment))
 


### PR DESCRIPTION
## Changelog Description

- Reduce artist-facing logs for component integration for Ftrack 
- Avoid "Comment is not set" log in artist facing report for Kitsu and Ftrack
- Remove info log about `ffprobe` inspecting a file (changed to debug log)
    - interesting to see however that it ffprobes the same jpeg twice - but maybe once for thumbnail?

## Additional info

Here's an example how it was before:
![overly_verbose_artist_facing_report](https://github.com/ynput/OpenPype/assets/2439881/21c1fb78-0a45-404e-a3d9-bde38ce30c87)

## Testing notes:

1. See the code changes (likely easiest)
