### PR TITLE
Maya: Fix look assigner showing no asset if 'not found' representations are present

### DIFF
--- a/openpype/hosts/maya/tools/mayalookassigner/commands.py
+++ b/openpype/hosts/maya/tools/mayalookassigner/commands.py
@@ -138,8 +138,13 @@ def create_items_from_nodes(nodes):
         asset_doc = asset_docs_by_id.get(asset_id)
         # Skip if asset id is not found
         if not asset_doc:
-            log.warning("Id not found in the database, skipping '%s'." % _id)
-            log.warning("Nodes: %s" % id_nodes)
+            log.warning(
+                "Id found on {num} nodes for which no asset is found database,"
+                " skipping '{asset_id}'".format(
+                    num=len(nodes),
+                    asset_id=asset_id
+                )
+            )
             continue
 
         # Collect available look subsets for this asset


### PR DESCRIPTION
## Changelog Description

Fix Maya Look assigner failing to show any content if it finds an invalid container for which it can't find the asset in the current project. (This can happen when e.g. loading something from a library project).

There was logic already to avoid this but there was a bug where it used variable `_id` which did not exist and likely had to be `asset_id`. 

I've fixed that and improved the logged message a bit, e.g.:
```
// Warning: openpype.hosts.maya.tools.mayalookassigner.commands : Id found on 22 nodes for which no asset is found database, skipping '641d78ec85c3c5b102e836b0'
```

Example not found representation in Loader:
![image](https://github.com/ynput/OpenPype/assets/2439881/79a2587e-84f5-48cd-9ffc-185d303d383f)

The issue isn't necessarily related to NOT FOUND representations but in essence boils down to finding nodes with asset ids that do not exist in the current project which could very well just be local meshes in your scene.

**Note:**

I've excluded logging the nodes themselves because that tends to be a very long list of nodes. Only downside to removing that is that it's unclear which nodes are related to that `id`. If there are any ideas on how to still provide a concise informational message about that that'd be great so I could add it. Things I had considered:
1. Report the containers, issue here is that it's about asset ids on nodes which don't HAVE to be in containers - it could be local geometry
2. Report the namespaces, issue here is that it could be nodes without namespaces (plus potentially not about ALL nodes in a namespace)
3. Report the short names of the nodes; it's shorter and readable but still likely a lot of nodes.

@tokejepsen @LiborBatek any other ideas?

## Testing notes:

1. Load something with invalid asset ids (not existing in current project)
    - e.g. load from another library project
    - or secretly change the `cbId` value on nodes changing the asset part of the id (which is the part BEFORE the `:` separator)
2. In Look Manager try to list the looks for all nodes (or selected nodes when having the faulty nodes selected)
