### PR TITLE
Blender: Remove Hardcoded Subset Name for Reviews

### DIFF
--- a/openpype/hosts/blender/plugins/publish/collect_review.py
+++ b/openpype/hosts/blender/plugins/publish/collect_review.py
@@ -39,15 +39,11 @@ class CollectReview(pyblish.api.InstancePlugin):
         ]
 
         if not instance.data.get("remove"):
-
-            task = instance.context.data["task"]
-
             # Store focal length in `burninDataMembers`
             burninData = instance.data.setdefault("burninDataMembers", {})
             burninData["focalLength"] = focal_length
 
             instance.data.update({
-                "subset": f"{task}Review",
                 "review_camera": camera,
                 "frameStart": instance.context.data["frameStart"],
                 "frameEnd": instance.context.data["frameEnd"],


### PR DESCRIPTION
## Changelog Description
Fixes hardcoded subset name for Reviews in Blender.

## Testing notes:
1. Create a review instance and publish it.
2. Check if it is published with the right subset name.
