### PR TITLE
3ds max: small tweaks to obj extractor and model publishing flow

### DIFF
--- a/openpype/hosts/max/plugins/publish/extract_model_obj.py
+++ b/openpype/hosts/max/plugins/publish/extract_model_obj.py
@@ -3,6 +3,7 @@ import pyblish.api
 from openpype.pipeline import publish, OptionalPyblishPluginMixin
 from pymxs import runtime as rt
 from openpype.hosts.max.api import maintained_selection
+from openpype.pipeline.publish import KnownPublishError
 
 
 class ExtractModelObj(publish.Extractor, OptionalPyblishPluginMixin):
@@ -27,6 +28,7 @@ class ExtractModelObj(publish.Extractor, OptionalPyblishPluginMixin):
         filepath = os.path.join(stagingdir, filename)
         self.log.info("Writing OBJ '%s' to '%s'" % (filepath, stagingdir))
 
+        self.log.info("Performing Extraction ...")
         with maintained_selection():
             # select and export
             node_list = instance.data["members"]
@@ -38,7 +40,10 @@ class ExtractModelObj(publish.Extractor, OptionalPyblishPluginMixin):
                 using=rt.ObjExp,
             )
 
-        self.log.info("Performing Extraction ...")
+        if not os.path.exists(filepath):
+            raise KnownPublishError(
+                "File {} wasn't produced by 3ds max, please check the logs.")
+
         if "representations" not in instance.data:
             instance.data["representations"] = []
 

--- a/openpype/hosts/max/plugins/publish/validate_usd_plugin.py
+++ b/openpype/hosts/max/plugins/publish/validate_usd_plugin.py
@@ -1,8 +1,12 @@
 # -*- coding: utf-8 -*-
 """Validator for USD plugin."""
-from openpype.pipeline import PublishValidationError
 from pyblish.api import InstancePlugin, ValidatorOrder
 from pymxs import runtime as rt
+
+from openpype.pipeline import (
+    OptionalPyblishPluginMixin,
+    PublishValidationError
+)
 
 
 def get_plugins() -> list:
@@ -17,16 +21,24 @@ def get_plugins() -> list:
     return plugin_info_list
 
 
-class ValidateUSDPlugin(InstancePlugin):
+class ValidateUSDPlugin(OptionalPyblishPluginMixin,
+                        InstancePlugin):
     """Validates if USD plugin is installed or loaded in 3ds max."""
 
     order = ValidatorOrder - 0.01
     families = ["model"]
     hosts = ["max"]
-    label = "USD Plugin"
+    label = "Validate USD Plugin loaded"
+    optional = True
 
     def process(self, instance):
         """Plugin entry point."""
+
+        for sc in ValidateUSDPlugin.__subclasses__():
+            self.log.info(sc)
+
+        if not self.is_active(instance.data):
+            return
 
         plugin_info = get_plugins()
         usd_import = "usdimport.dli"


### PR DESCRIPTION
## Changelog Description
There migh be situation where OBJ Extractor passes without failure, but no obj file is produced. This is adding simple check directly into the extractor to catch it earlier then in the integration phase. Also switched `Validate USD Plugin` to optional, because it was always run no matter if the Extract USD was enabled or not, hindering testing (and publishing).

## Additional info
Apart of simple check for the file, this is modifying seemingly unrelated Validate USD Plugin. This was really needed without actually installing it into the max because of the above mentioned reason. I think we should look into #5602 to amend that properly.

## Testing notes:
Publishing model from Max should work as before when `Extract obj` is switched on. The validator for USD Plugin should be optional too.

