### PR TITLE
Maya: problem ppublishing camera from workfile template builder

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -35,6 +35,7 @@ body:
       label: Version
       description: What version are you running? Look to OpenPype Tray
       options:
+        - 3.16.5
         - 3.16.5-nightly.5
         - 3.16.5-nightly.4
         - 3.16.5-nightly.3
@@ -134,7 +135,6 @@ body:
         - 3.14.9-nightly.3
         - 3.14.9-nightly.2
         - 3.14.9-nightly.1
-        - 3.14.8
     validations:
       required: true
   - type: dropdown

--- a/openpype/hosts/maya/plugins/publish/extract_camera_mayaScene.py
+++ b/openpype/hosts/maya/plugins/publish/extract_camera_mayaScene.py
@@ -133,8 +133,7 @@ class ExtractCameraMayaScene(publish.Extractor):
         # get cameras
         members = cmds.ls(instance.data['setMembers'], leaf=True, shapes=True,
                           long=True, dag=True)
-        cameras = cmds.ls(members, leaf=True, shapes=True, long=True,
-                          dag=True, type="camera")
+        cameras = cmds.ls(members, type="camera")
 
         # validate required settings
         assert isinstance(step, float), "Step must be a float value"


### PR DESCRIPTION
## Changelog Description
When importing camera from template workfile builder, there's an error at the publishing because the maya commands take the placeholder as a camera and publish it instead of the actual camera.

## Additional info
The maya command cmds.ls(camera, type="camera") doen't work properly if any other flag is set in this command. With any other flag, the command ignore completely the "type" flag.

## Testing notes:
1. Import a camera with the template build workfile
2. Animate the camera (or camera rig)
3. Publish the camera
4. Load the camera (you will see that the loaded camera lost its animation)
