### PR TITLE
Extract Review: Multilayer specification for ffmpeg

### DIFF
--- a/openpype/lib/transcoding.py
+++ b/openpype/lib/transcoding.py
@@ -409,7 +409,7 @@ def get_convert_rgb_channels(channel_names):
     # Ideal situation
     channels_info: [
         "R", "G", "B", "A"
-    }
+    ]
     ```
     Result will be `("R", "G", "B", "A")`
 
@@ -426,9 +426,6 @@ def get_convert_rgb_channels(channel_names):
 
     Args:
         channel_names (list[str]): List of channel names.
-        preferred_layer_names (Optional[list[str]]): List of layer names that
-            should be used as preferred. If None, then first layer with RGB
-            is used.
 
     Returns:
         Union[NoneType, tuple[str, str, str, Union[str, None]]]: Tuple of

--- a/openpype/lib/transcoding.py
+++ b/openpype/lib/transcoding.py
@@ -417,18 +417,23 @@ def get_convert_rgb_channels(channel_names):
     # Not ideal situation
     channels_info: [
         "beauty.red",
-        "beuaty.green",
+        "beauty.green",
         "beauty.blue",
         "depth.Z"
     ]
     ```
     Result will be `("beauty.red", "beauty.green", "beauty.blue", None)`
 
+    Args:
+        channel_names (list[str]): List of channel names.
+        preferred_layer_names (Optional[list[str]]): List of layer names that
+            should be used as preferred. If None, then first layer with RGB
+            is used.
+
     Returns:
-        NoneType: There is not channel combination that matches RGB
-            combination.
-        tuple: Tuple of 4 channel names defying channel names for R, G, B, A
-            where A can be None.
+        Union[NoneType, tuple[str, str, str, Union[str, None]]]: Tuple of
+            4 channel names defying channel names for R, G, B, A or None
+            if there is not any layer with RGB combination.
     """
 
     channels_info = get_review_info_by_layer_name(channel_names)

--- a/openpype/plugins/publish/extract_review.py
+++ b/openpype/plugins/publish/extract_review.py
@@ -21,6 +21,7 @@ from openpype.lib.transcoding import (
     IMAGE_EXTENSIONS,
     get_ffprobe_streams,
     should_convert_for_ffmpeg,
+    get_review_layer_name,
     convert_input_paths_for_ffmpeg,
     get_transcode_temp_directory,
 )
@@ -266,6 +267,8 @@ class ExtractReview(pyblish.api.InstancePlugin):
                 ))
                 continue
 
+            layer_name = get_review_layer_name(first_input_path)
+
             # Do conversion if needed
             #   - change staging dir of source representation
             #   - must be set back after output definitions processing
@@ -284,7 +287,8 @@ class ExtractReview(pyblish.api.InstancePlugin):
                     instance,
                     repre,
                     src_repre_staging_dir,
-                    filtered_output_defs
+                    filtered_output_defs,
+                    layer_name
                 )
 
             finally:
@@ -298,7 +302,12 @@ class ExtractReview(pyblish.api.InstancePlugin):
                         shutil.rmtree(new_staging_dir)
 
     def _render_output_definitions(
-        self, instance, repre, src_repre_staging_dir, output_definitions
+        self,
+        instance,
+        repre,
+        src_repre_staging_dir,
+        output_definitions,
+        layer_name
     ):
         fill_data = copy.deepcopy(instance.data["anatomyData"])
         for _output_def in output_definitions:
@@ -370,7 +379,12 @@ class ExtractReview(pyblish.api.InstancePlugin):
 
             try:  # temporary until oiiotool is supported cross platform
                 ffmpeg_args = self._ffmpeg_arguments(
-                    output_def, instance, new_repre, temp_data, fill_data
+                    output_def,
+                    instance,
+                    new_repre,
+                    temp_data,
+                    fill_data,
+                    layer_name,
                 )
             except ZeroDivisionError:
                 # TODO recalculate width and height using OIIO before
@@ -531,7 +545,13 @@ class ExtractReview(pyblish.api.InstancePlugin):
         }
 
     def _ffmpeg_arguments(
-        self, output_def, instance, new_repre, temp_data, fill_data
+        self,
+        output_def,
+        instance,
+        new_repre,
+        temp_data,
+        fill_data,
+        layer_name
     ):
         """Prepares ffmpeg arguments for expected extraction.
 
@@ -598,6 +618,10 @@ class ExtractReview(pyblish.api.InstancePlugin):
             )
 
         duration_seconds = float(output_frames_len / temp_data["fps"])
+
+        # Define which layer should be used
+        if layer_name:
+            ffmpeg_input_args.extend(["-layer", layer_name])
 
         if temp_data["input_is_sequence"]:
             # Set start frame of input sequence (just frame in filename)


### PR DESCRIPTION
## Changelog Description
Extract review is specifying layer name when exr is multilayer.

## Additional info
This issue was discovered with renders from blender where output exr had channels `['Main.AOV.R', 'Main.AOV.G', 'Main.AOV.B', 'Main.AOV.A', 'Main.Combined.R', 'Main.Combined.G', 'Main.Combined.B', 'Main.Combined.A', 'Main.Normal.X', 'Main.Normal.Y', 'Main.Normal.Z', 'Main.Test.X']` which failed in ffmpeg.

## Testing notes:
1. First of all, any other current exr processing should still work (e.g. multipart exrs from maya)
2. Render from blender (testing for @simonebarbieri )
