### PR TITLE
Publisher: Fix screenshot widget

### DIFF
--- a/openpype/tools/publisher/widgets/screenshot_widget.py
+++ b/openpype/tools/publisher/widgets/screenshot_widget.py
@@ -84,7 +84,6 @@ class ScreenMarquee(QtWidgets.QDialog):
         painter.setPen(pen)
 
         # Draw cropping markers at click position
-        rect = event.rect()
         if click_pos is not None:
             painter.drawLine(
                 rect.left(), click_pos.y(),
@@ -104,6 +103,7 @@ class ScreenMarquee(QtWidgets.QDialog):
             mouse_pos.x(), rect.top(),
             mouse_pos.x(), rect.bottom()
         )
+        painter.end()
 
     def mousePressEvent(self, event):
         """Mouse click event"""
@@ -134,6 +134,7 @@ class ScreenMarquee(QtWidgets.QDialog):
         if event.key() == QtCore.Qt.Key_Escape:
             self._click_pos = None
             self._capture_rect = None
+            event.accept()
             self.close()
             return
         return super(ScreenMarquee, self).keyPressEvent(event)


### PR DESCRIPTION
## Changelog Description
Use correct super method name.

EDITED:
Removed fade animation which is not triggered at some cases, e.g. in Nuke the animation does not start. I do expect that is caused by `exec_` on the dialog, which blocks event processing to the animation, even when I've added the window as parent it still didn't trigger registered callback.

Modified how the "empty" space is not filled by using paths instead of clear mode on painter. Added render hints to add antialiasing.

## Testing notes:
1. Use take a screenshot feature in publisher
2. Press any keyboard key
3. It should not crash
