### PR TITLE
AYON: Ignore separated modules

### DIFF
--- a/openpype/modules/base.py
+++ b/openpype/modules/base.py
@@ -401,7 +401,7 @@ def _load_ayon_addons(openpype_modules, modules_key, log):
         addon_dir = os.path.join(addons_dir, folder_name)
         if not os.path.exists(addon_dir):
             log.debug((
-                "Addon {} {} does not have available code."
+                "No localized client code found for addon {} {}."
             ).format(addon_name, addon_version))
             continue
 

--- a/openpype/modules/base.py
+++ b/openpype/modules/base.py
@@ -400,9 +400,9 @@ def _load_ayon_addons(openpype_modules, modules_key, log):
         folder_name = "{}_{}".format(addon_name, addon_version)
         addon_dir = os.path.join(addons_dir, folder_name)
         if not os.path.exists(addon_dir):
-            log.warning((
-                "Directory for addon {} {} does not exists. Path \"{}\""
-            ).format(addon_name, addon_version, addon_dir))
+            log.debug((
+                "Addon {} {} does not have available code."
+            ).format(addon_name, addon_version))
             continue
 
         sys.path.insert(0, addon_dir)

--- a/openpype/modules/base.py
+++ b/openpype/modules/base.py
@@ -59,6 +59,14 @@ IGNORED_DEFAULT_FILENAMES = (
     "example_addons",
     "default_modules",
 )
+# Modules that won't be loaded in AYON mode from "./openpype/modules"
+# - the same modules are ignored in "./server_addon/create_ayon_addons.py"
+IGNORED_FILENAMES_IN_AYON = {
+    "ftrack",
+    "shotgrid",
+    "sync_server",
+    "slack",
+}
 
 
 # Inherit from `object` for Python 2 hosts
@@ -483,6 +491,10 @@ def _load_modules():
 
         is_in_current_dir = dirpath == current_dir
         is_in_host_dir = dirpath == hosts_dir
+        ignored_current_dir_filenames = set(IGNORED_DEFAULT_FILENAMES)
+        if AYON_SERVER_ENABLED:
+            ignored_current_dir_filenames |= IGNORED_FILENAMES_IN_AYON
+
         for filename in os.listdir(dirpath):
             # Ignore filenames
             if filename in IGNORED_FILENAMES:
@@ -490,7 +502,7 @@ def _load_modules():
 
             if (
                 is_in_current_dir
-                and filename in IGNORED_DEFAULT_FILENAMES
+                and filename in ignored_current_dir_filenames
             ):
                 continue
 


### PR DESCRIPTION
## Changelog Description
Do not load already separated modules from default directory.

## Additional info
The modules are not in client code when created using `create_ayon_addon.py` script, but for testing of PRs is usually copied whole openpype into local app data which causes troubles when these modules are loaded.

## Testing notes:
1. All ignored addons should be loaded in OpenPype (ftrack, shotgrid, slack, sync_server)
2. The same addons should not be loaded in AYON mode from OpenPype
