### PR TITLE
Houdini: Add self publish button

### DIFF
--- a/openpype/hosts/houdini/api/plugin.py
+++ b/openpype/hosts/houdini/api/plugin.py
@@ -13,7 +13,7 @@ from openpype.pipeline import (
     CreatedInstance
 )
 from openpype.lib import BoolDef
-from .lib import imprint, read, lsattr
+from .lib import imprint, read, lsattr, add_self_publish_button
 
 
 class OpenPypeCreatorError(CreatorError):
@@ -194,6 +194,7 @@ class HoudiniCreator(NewCreator, HoudiniCreatorBase):
                 self)
             self._add_instance_to_context(instance)
             imprint(instance_node, instance.data_to_store())
+            add_self_publish_button(instance_node)
             return instance
 
         except hou.Error as er:


### PR DESCRIPTION
## Changelog Description
This PR allow publishing single instance from publish rop nodes in Houdini 
![image](https://github.com/ynput/OpenPype/assets/20871534/42992e5c-ab06-49e4-8a7f-93aa645b5ec0)
![image](https://github.com/ynput/OpenPype/assets/20871534/b3fa2b3a-c5a8-4df7-999b-21d1dd5d0627)

## Additional info1
This PR was made to prototype Fabia's idea about publishing one instance in houdini, [discord discussion](https://discord.com/channels/517362899170230292/517382145552154634/1151589724914454679)

## Additional info2 
I made this PR as a prototype. 
and I have no idea if it will be beneficial to the production or cause confusion for the artists. 

## Testing notes:
1. Create multiple publish instances in houdini 
2. try publishing from the button