### PR TITLE
Fix - _id key used instead of id in get_last_version_by_subset_name

### DIFF
--- a/openpype/client/server/entities.py
+++ b/openpype/client/server/entities.py
@@ -422,7 +422,7 @@ def get_last_version_by_subset_name(
     if not subset:
         return None
     return get_last_version_by_subset_id(
-        project_name, subset["id"], fields=fields
+        project_name, subset["_id"], fields=fields
     )
 
 


### PR DESCRIPTION
## Changelog Description
Just 'id' is not returned because value in fields. Caused KeyError.