### PR TITLE
AYON: Mark deprecated settings in Maya

### DIFF
--- a/server_addon/maya/server/settings/imageio.py
+++ b/server_addon/maya/server/settings/imageio.py
@@ -40,7 +40,6 @@ class ImageIOFileRulesModel(BaseSettingsModel):
 
 class ColorManagementPreferenceV2Model(BaseSettingsModel):
     """Color Management Preference v2 (Maya 2022+)."""
-    _layout = "expanded"
 
     enabled: bool = Field(True, title="Use Color Management Preference v2")
 
@@ -51,7 +50,6 @@ class ColorManagementPreferenceV2Model(BaseSettingsModel):
 
 class ColorManagementPreferenceModel(BaseSettingsModel):
     """Color Management Preference (legacy)."""
-    _layout = "expanded"
 
     renderSpace: str = Field(title="Rendering Space")
     viewTransform: str = Field(title="Viewer Transform ")
@@ -89,11 +87,11 @@ class ImageIOSettings(BaseSettingsModel):
     # Deprecated
     colorManagementPreference_v2: ColorManagementPreferenceV2Model = Field(
         default_factory=ColorManagementPreferenceV2Model,
-        title="Color Management Preference v2 (Maya 2022+)"
+        title="DEPRECATED: Color Management Preference v2 (Maya 2022+)"
     )
     colorManagementPreference: ColorManagementPreferenceModel = Field(
         default_factory=ColorManagementPreferenceModel,
-        title="Color Management Preference (legacy)"
+        title="DEPRECATED: Color Management Preference"
     )
 
 

--- a/server_addon/maya/server/settings/imageio.py
+++ b/server_addon/maya/server/settings/imageio.py
@@ -39,7 +39,10 @@ class ImageIOFileRulesModel(BaseSettingsModel):
 
 
 class ColorManagementPreferenceV2Model(BaseSettingsModel):
-    """Color Management Preference v2 (Maya 2022+)."""
+    """Color Management Preference v2 (Maya 2022+).
+
+    Please migrate all to 'imageio/workfile' and enable it.
+    """
 
     enabled: bool = Field(True, title="Use Color Management Preference v2")
 
@@ -91,7 +94,7 @@ class ImageIOSettings(BaseSettingsModel):
     )
     colorManagementPreference: ColorManagementPreferenceModel = Field(
         default_factory=ColorManagementPreferenceModel,
-        title="DEPRECATED: Color Management Preference"
+        title="DEPRECATED: Color Management Preference (legacy)"
     )
 
 


### PR DESCRIPTION
## Changelog Description
Added deprecated info to docstrings of maya colormanagement settings.

Resolves: https://github.com/ynput/OpenPype/issues/5556