### PR TITLE
Unreal: Fix Layout missing support for staticMesh and skeletalMesh families

### DIFF
--- a/openpype/hosts/unreal/plugins/load/load_layout.py
+++ b/openpype/hosts/unreal/plugins/load/load_layout.py
@@ -67,9 +67,9 @@ class LayoutLoader(plugin.Loader):
     @staticmethod
     def _get_fbx_loader(loaders, family):
         name = ""
-        if family == 'rig':
+        if family in ['rig', 'skeletalMesh']:
             name = "SkeletalMeshFBXLoader"
-        elif family == 'model':
+        elif family in ['model', 'staticMesh']:
             name = "StaticMeshFBXLoader"
         elif family == 'camera':
             name = "CameraLoader"
@@ -86,7 +86,7 @@ class LayoutLoader(plugin.Loader):
     @staticmethod
     def _get_abc_loader(loaders, family):
         name = ""
-        if family == 'rig':
+        if family in ['rig', 'skeletalMesh']:
             name = "SkeletalMeshAlembicLoader"
         elif family == 'model':
             name = "StaticMeshAlembicLoader"


### PR DESCRIPTION
## Changelog Description
Fix missing support for `staticMesh` and `skeletalMesh` families in layouts.

## Testing notes:
1. Publish from Maya a layout that includes `staticMesh` and/or `skeletalMesh` assets.
2. Try loading it in Unreal.
