### PR TITLE
Chore: Lower click dependency version

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -560,17 +560,14 @@ files = [
 
 [[package]]
 name = "click"
-version = "8.1.3"
+version = "7.1.2"
 description = "Composable command line interface toolkit"
 optional = false
-python-versions = ">=3.7"
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
 files = [
-    {file = "click-8.1.3-py3-none-any.whl", hash = "sha256:bb4d8133cb15a609f44e8213d9b391b0809795062913b383c62be0ee95b1db48"},
-    {file = "click-8.1.3.tar.gz", hash = "sha256:7682dc8afb30297001674575ea00d1814d808d6a36af415a82bd481d37ba7b8e"},
+    {file = "click-7.1.2-py2.py3-none-any.whl", hash = "sha256:dacca89f4bfadd5de3d7489b7c8a566eee0d3676333fbb50030263894c38c0dc"},
+    {file = "click-7.1.2.tar.gz", hash = "sha256:d2b5255c7c6349bc1bd1e59e08cd12acbbd63ce649f2588755783aa94dfb6b1a"},
 ]
-
-[package.dependencies]
-colorama = {version = "*", markers = "platform_system == \"Windows\""}
 
 [[package]]
 name = "clique"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,7 @@ appdirs = { git = "https://github.com/ActiveState/appdirs.git", branch = "master
 blessed = "^1.17" # openpype terminal formatting
 coolname = "*"
 clique = "1.6.*"
-Click = "^8"
+Click = "7.1.2"
 dnspython = "^2.1.0"
 ftrack-python-api = "^2.3.3"
 arrow = "^0.17"


### PR DESCRIPTION
## Changelog Description
Lower click version to support older versions of python.

## Additional info
The newest version is only for python >=3.7 which cause issues with addons that have defined their cli methods.

## Testing notes:
1. Run create env
2. Run older DCC via OpenPype (ideally with Python 2.x)
3. Test publishing with addons that use click for cli commands (e.g. ftrack)
