### PR TITLE
Bugfix: create symlinks for ssl libs on Centos 7

### DIFF
--- a/Dockerfile.centos7
+++ b/Dockerfile.centos7
@@ -109,6 +109,8 @@ RUN source $HOME/.bashrc \
 RUN cp /usr/lib64/libffi* ./build/exe.linux-x86_64-3.9/lib \
     && cp /usr/lib64/openssl11/libssl* ./build/exe.linux-x86_64-3.9/lib \
     && cp /usr/lib64/openssl11/libcrypto* ./build/exe.linux-x86_64-3.9/lib \
+    && ln -sr ./build/exe.linux-x86_64-3.9/lib/libssl.so ./build/exe.linux-x86_64-3.9/lib/libssl.1.1.so \
+    && ln -sr ./build/exe.linux-x86_64-3.9/lib/libcrypto.so ./build/exe.linux-x86_64-3.9/lib/libcrypto.1.1.so \
     && cp /root/.pyenv/versions/${OPENPYPE_PYTHON_VERSION}/lib/libpython* ./build/exe.linux-x86_64-3.9/lib \
     && cp /usr/lib64/libxcb* ./build/exe.linux-x86_64-3.9/vendor/python/PySide2/Qt/lib
 


### PR DESCRIPTION
## Changelog Description
Docker build was missing `libssl.1.1.so` and `libcrypto.1.1.so` symlinks needed by the executable itself, because Python is now explicitly built with OpenSSL 1.1.1

## Additional info
This just creating symlinks, but to already copied libraries, but it should be probably handled more gracefuly.

## Testing notes:
1. Build Centos 7 variant
2. Run it on vanilla Centos 7 system
