### PR TITLE
TVPaint: Fix review family extraction

### DIFF
--- a/openpype/hosts/tvpaint/plugins/publish/extract_sequence.py
+++ b/openpype/hosts/tvpaint/plugins/publish/extract_sequence.py
@@ -108,11 +108,16 @@ class ExtractSequence(pyblish.api.Extractor):
             "Files will be rendered to folder: {}".format(output_dir)
         )
 
+        # Fill tags and new families from project settings
+        tags = []
         if instance.data["family"] == "review":
+            tags.append("review")
             result = self.render_review(
                 output_dir, mark_in, mark_out, scene_bg_color
             )
         else:
+            if "review" in instance.data["families"]:
+                tags.append("review")
             # Render output
             result = self.render(
                 output_dir,
@@ -138,11 +143,6 @@ class ExtractSequence(pyblish.api.Extractor):
             mark_out,
             output_frame_start
         )
-
-        # Fill tags and new families from project settings
-        tags = []
-        if "review" in instance.data["families"]:
-            tags.append("review")
 
         # Sequence of one frame
         single_file = len(repre_files) == 1

--- a/openpype/hosts/tvpaint/plugins/publish/extract_sequence.py
+++ b/openpype/hosts/tvpaint/plugins/publish/extract_sequence.py
@@ -6,7 +6,10 @@ from PIL import Image
 
 import pyblish.api
 
-from openpype.pipeline.publish import KnownPublishError
+from openpype.pipeline.publish import (
+    KnownPublishError,
+    get_publish_instance_families,
+)
 from openpype.hosts.tvpaint.api.lib import (
     execute_george,
     execute_george_through_file,
@@ -108,16 +111,11 @@ class ExtractSequence(pyblish.api.Extractor):
             "Files will be rendered to folder: {}".format(output_dir)
         )
 
-        # Fill tags and new families from project settings
-        tags = []
         if instance.data["family"] == "review":
-            tags.append("review")
             result = self.render_review(
                 output_dir, mark_in, mark_out, scene_bg_color
             )
         else:
-            if "review" in instance.data["families"]:
-                tags.append("review")
             # Render output
             result = self.render(
                 output_dir,
@@ -143,6 +141,12 @@ class ExtractSequence(pyblish.api.Extractor):
             mark_out,
             output_frame_start
         )
+
+        # Fill tags and new families from project settings
+        instance_families = get_publish_instance_families(instance)
+        tags = []
+        if "review" in instance_families:
+            tags.append("review")
 
         # Sequence of one frame
         single_file = len(repre_files) == 1

--- a/openpype/pipeline/publish/__init__.py
+++ b/openpype/pipeline/publish/__init__.py
@@ -40,6 +40,7 @@ from .lib import (
     apply_plugin_settings_automatically,
     get_plugin_settings,
     get_publish_instance_label,
+    get_publish_instance_families,
 )
 
 from .abstract_expected_files import ExpectedFiles
@@ -87,6 +88,7 @@ __all__ = (
     "apply_plugin_settings_automatically",
     "get_plugin_settings",
     "get_publish_instance_label",
+    "get_publish_instance_families",
 
     "ExpectedFiles",
 

--- a/openpype/pipeline/publish/lib.py
+++ b/openpype/pipeline/publish/lib.py
@@ -1002,3 +1002,27 @@ def get_publish_instance_label(instance):
         or instance.data.get("name")
         or str(instance)
     )
+
+
+def get_publish_instance_families(instance):
+    """Get all families of the instance.
+
+    Look for families under 'family' and 'families' keys in instance data.
+    Value of 'family' is used as first family and then all other families
+    in random order.
+
+    Args:
+        pyblish.api.Instance: Instance to get families from.
+
+    Returns:
+        list[str]: List of families.
+    """
+
+    family = instance.data.get("family")
+    families = set(instance.data.get("families") or [])
+    output = []
+    if family:
+        output.append(family)
+        families.discard(family)
+    output.extend(families)
+    return output


### PR DESCRIPTION
## Changelog Description
Extractor marks representation of review instance with review tag.

## Testing notes:
1. Open TVPaint
2. Review auto-creator should create an instance
3. Enable the instance
4. Publish
5. Extract review should catch the representation and create review (based on settings)
