### PR TITLE
AYON settings: Extract OIIO transcode settings

### DIFF
--- a/openpype/settings/ayon_settings.py
+++ b/openpype/settings/ayon_settings.py
@@ -1102,7 +1102,7 @@ def _convert_global_project_settings(ayon_settings, output, default_settings):
         "studio_name",
         "studio_code",
     ):
-        ayon_core.pop(key)
+        ayon_core.pop(key, None)
 
     # Publish conversion
     ayon_publish = ayon_core["publish"]
@@ -1138,6 +1138,27 @@ def _convert_global_project_settings(ayon_settings, output, default_settings):
             if "output_height" in output_def:
                 output_def["height"] = output_def.pop("output_height")
 
+        profile["outputs"] = new_outputs
+
+    # ExtractOIIOTranscode plugin
+    extract_oiio_transcode = ayon_publish["ExtractOIIOTranscode"]
+    extract_oiio_transcode_profiles = extract_oiio_transcode["profiles"]
+    for profile in extract_oiio_transcode_profiles:
+        new_outputs = {}
+        name_counter = {}
+        for output in profile["outputs"]:
+            if "name" in output:
+                name = output.pop("name")
+            else:
+                # Backwards compatibility for setting without 'name' in model
+                name = output["extension"]
+                if name in new_outputs:
+                    name_counter[name] += 1
+                    name = "{}_{}".format(name, name_counter[name])
+                else:
+                    name_counter[name] = 0
+
+            new_outputs[name] = output
         profile["outputs"] = new_outputs
 
     # Extract Burnin plugin

--- a/server_addon/core/server/settings/publish_plugins.py
+++ b/server_addon/core/server/settings/publish_plugins.py
@@ -116,6 +116,8 @@ class OIIOToolArgumentsModel(BaseSettingsModel):
 
 
 class ExtractOIIOTranscodeOutputModel(BaseSettingsModel):
+    _layout = "expanded"
+    name: str = Field("", title="Name")
     extension: str = Field("", title="Extension")
     transcoding_type: str = Field(
         "colorspace",
@@ -163,6 +165,11 @@ class ExtractOIIOTranscodeProfileModel(BaseSettingsModel):
         default_factory=list,
         title="Output Definitions",
     )
+
+    @validator("outputs")
+    def validate_unique_outputs(cls, value):
+        ensure_unique_names(value)
+        return value
 
 
 class ExtractOIIOTranscodeModel(BaseSettingsModel):


### PR DESCRIPTION
## Changelog Description
Output definitions of Extract OIIO transcode have name to match OpenPype settings, and the settings are converted to dictionary in settings conversion.

## Additional info
Added partial fix of older AYON settings.

## Testing notes:
1. Extract OIIO transcode plugin should work with filled profiles
