### PR TITLE
AYON: Fix task type short name conversion

### DIFF
--- a/openpype/client/server/conversion_utils.py
+++ b/openpype/client/server/conversion_utils.py
@@ -235,6 +235,8 @@ def convert_v4_project_to_v3(project):
         new_task_types = {}
         for task_type in task_types:
             name = task_type.pop("name")
+            # Change 'shortName' to 'short_name'
+            task_type["short_name"] = task_type.pop("shortName", None)
             new_task_types[name] = task_type
 
         config["tasks"] = new_task_types

--- a/openpype/tools/ayon_workfiles/abstract.py
+++ b/openpype/tools/ayon_workfiles/abstract.py
@@ -443,6 +443,16 @@ class AbstractWorkfilesBackend(AbstractWorkfilesCommon):
         pass
 
     @abstractmethod
+    def get_project_entity(self):
+        """Get current project entity.
+
+        Returns:
+            dict[str, Any]: Project entity data.
+        """
+
+        pass
+
+    @abstractmethod
     def get_folder_entity(self, folder_id):
         """Get folder entity by id.
 

--- a/openpype/tools/ayon_workfiles/control.py
+++ b/openpype/tools/ayon_workfiles/control.py
@@ -193,6 +193,9 @@ class BaseWorkfileController(
             self._project_anatomy = Anatomy(self.get_current_project_name())
         return self._project_anatomy
 
+    def get_project_entity(self):
+        return self._entities_model.get_project_entity()
+
     def get_folder_entity(self, folder_id):
         return self._entities_model.get_folder_entity(folder_id)
 

--- a/openpype/tools/ayon_workfiles/models/hierarchy.py
+++ b/openpype/tools/ayon_workfiles/models/hierarchy.py
@@ -77,8 +77,11 @@ class EntitiesModel(object):
     event_source = "entities.model"
 
     def __init__(self, controller):
+        project_cache = CacheItem()
+        project_cache.set_invalid({})
         folders_cache = CacheItem()
         folders_cache.set_invalid({})
+        self._project_cache = project_cache
         self._folders_cache = folders_cache
         self._tasks_cache = {}
 
@@ -90,6 +93,7 @@ class EntitiesModel(object):
         self._controller = controller
 
     def reset(self):
+        self._project_cache.set_invalid({})
         self._folders_cache.set_invalid({})
         self._tasks_cache = {}
 
@@ -98,6 +102,13 @@ class EntitiesModel(object):
 
     def refresh(self):
         self._refresh_folders_cache()
+
+    def get_project_entity(self):
+        if not self._project_cache.is_valid:
+            project_name = self._controller.get_current_project_name()
+            project_entity = ayon_api.get_project(project_name)
+            self._project_cache.update_data(project_entity)
+        return self._project_cache.get_data()
 
     def get_folder_items(self, sender):
         if not self._folders_cache.is_valid:

--- a/openpype/tools/ayon_workfiles/models/workfiles.py
+++ b/openpype/tools/ayon_workfiles/models/workfiles.py
@@ -43,13 +43,21 @@ def get_folder_template_data(folder):
     }
 
 
-def get_task_template_data(task):
+def get_task_template_data(project_entity, task):
     if not task:
         return {}
+    short_name = None
+    task_type_name = task["taskType"]
+    for task_type_info in project_entity["config"]["taskTypes"]:
+        if task_type_info["name"] == task_type_name:
+            short_name = task_type_info["shortName"]
+            break
+
     return {
         "task": {
             "name": task["name"],
-            "type": task["taskType"]
+            "type": task_type_name,
+            "short": short_name,
         }
     }
 
@@ -145,12 +153,13 @@ class WorkareaModel:
             self._fill_data_by_folder_id[folder_id] = fill_data
         return copy.deepcopy(fill_data)
 
-    def _get_task_data(self, folder_id, task_id):
+    def _get_task_data(self, project_entity, folder_id, task_id):
         task_data = self._task_data_by_folder_id.setdefault(folder_id, {})
         if task_id not in task_data:
             task = self._controller.get_task_entity(task_id)
             if task:
-                task_data[task_id] = get_task_template_data(task)
+                task_data[task_id] = get_task_template_data(
+                    project_entity, task)
         return copy.deepcopy(task_data[task_id])
 
     def _prepare_fill_data(self, folder_id, task_id):
@@ -159,7 +168,8 @@ class WorkareaModel:
 
         base_data = self._get_base_data()
         folder_data = self._get_folder_data(folder_id)
-        task_data = self._get_task_data(folder_id, task_id)
+        project_entity = self._controller.get_project_entity()
+        task_data = self._get_task_data(project_entity, folder_id, task_id)
 
         base_data.update(folder_data)
         base_data.update(task_data)


### PR DESCRIPTION
## Changelog Description
Convert AYON task type short name for OpenPype correctly.

## Additional info
AYON has short name stored under `shortName` whereas in OpenPype is expected `short_name`.

## Testing notes:
1. Use `{task[short]}` in template (e.g. in workfile template)
2. Use the template so it is filled
