### PR TITLE
Unreal: Yeti support

### DIFF
--- a/openpype/hosts/maya/plugins/create/create_unreal_yeticache.py
+++ b/openpype/hosts/maya/plugins/create/create_unreal_yeticache.py
@@ -10,7 +10,7 @@ class CreateYetiCache(plugin.MayaCreator):
 
     identifier = "io.openpype.creators.maya.unrealyeticache"
     label = "Unreal Yeti Cache"
-    family = "ue_yeticache"
+    family = "yeticacheUE"
     icon = "pagelines"
 
     def get_instance_attr_defs(self):

--- a/openpype/hosts/maya/plugins/create/create_unreal_yeticache.py
+++ b/openpype/hosts/maya/plugins/create/create_unreal_yeticache.py
@@ -9,7 +9,7 @@ class CreateYetiCache(plugin.MayaCreator):
     """Output for procedural plugin nodes of Yeti """
 
     identifier = "io.openpype.creators.maya.unrealyeticache"
-    label = "Unreal Yeti Cache"
+    label = "Unreal - Yeti Cache"
     family = "yeticacheUE"
     icon = "pagelines"
 

--- a/openpype/hosts/maya/plugins/create/create_unreal_yeticache.py
+++ b/openpype/hosts/maya/plugins/create/create_unreal_yeticache.py
@@ -1,0 +1,39 @@
+from openpype.hosts.maya.api import (
+    lib,
+    plugin
+)
+from openpype.lib import NumberDef
+
+
+class CreateYetiCache(plugin.MayaCreator):
+    """Output for procedural plugin nodes of Yeti """
+
+    identifier = "io.openpype.creators.maya.unrealyeticache"
+    label = "Unreal Yeti Cache"
+    family = "ue_yeticache"
+    icon = "pagelines"
+
+    def get_instance_attr_defs(self):
+
+        defs = [
+            NumberDef("preroll",
+                      label="Preroll",
+                      minimum=0,
+                      default=0,
+                      decimals=0)
+        ]
+
+        # Add animation data without step and handles
+        defs.extend(lib.collect_animation_defs())
+        remove = {"step", "handleStart", "handleEnd"}
+        defs = [attr_def for attr_def in defs if attr_def.key not in remove]
+
+        # Add samples after frame range
+        defs.append(
+            NumberDef("samples",
+                      label="Samples",
+                      default=3,
+                      decimals=0)
+        )
+
+        return defs

--- a/openpype/hosts/maya/plugins/publish/collect_yeti_cache.py
+++ b/openpype/hosts/maya/plugins/publish/collect_yeti_cache.py
@@ -39,7 +39,7 @@ class CollectYetiCache(pyblish.api.InstancePlugin):
 
     order = pyblish.api.CollectorOrder + 0.45
     label = "Collect Yeti Cache"
-    families = ["yetiRig", "yeticache"]
+    families = ["yetiRig", "yeticache", "ue_yeticache"]
     hosts = ["maya"]
 
     def process(self, instance):

--- a/openpype/hosts/maya/plugins/publish/collect_yeti_cache.py
+++ b/openpype/hosts/maya/plugins/publish/collect_yeti_cache.py
@@ -39,7 +39,7 @@ class CollectYetiCache(pyblish.api.InstancePlugin):
 
     order = pyblish.api.CollectorOrder + 0.45
     label = "Collect Yeti Cache"
-    families = ["yetiRig", "yeticache", "ue_yeticache"]
+    families = ["yetiRig", "yeticache", "yeticacheUE"]
     hosts = ["maya"]
 
     def process(self, instance):

--- a/openpype/hosts/maya/plugins/publish/extract_unreal_yeticache.py
+++ b/openpype/hosts/maya/plugins/publish/extract_unreal_yeticache.py
@@ -1,0 +1,62 @@
+import os
+import json
+
+from maya import cmds
+
+from openpype.pipeline import publish
+
+
+class ExtractYetiCache(publish.Extractor):
+    """Producing Yeti cache files using scene time range.
+
+    This will extract Yeti cache file sequence and fur settings.
+    """
+
+    label = "Extract Yeti Cache"
+    hosts = ["maya"]
+    families = ["ue_yeticache"]
+
+    def process(self, instance):
+
+        yeti_nodes = cmds.ls(instance, type="pgYetiMaya")
+        if not yeti_nodes:
+            raise RuntimeError("No pgYetiMaya nodes found in the instance")
+
+        # Define extract output file path
+        dirname = self.staging_dir(instance)
+
+        # Collect information for writing cache
+        start_frame = instance.data["frameStartHandle"]
+        end_frame = instance.data["frameEndHandle"]
+        preroll = instance.data["preroll"]
+        if preroll > 0:
+            start_frame -= preroll
+
+        kwargs = {}
+        samples = instance.data.get("samples", 0)
+        if samples == 0:
+            kwargs.update({"sampleTimes": "0.0 1.0"})
+        else:
+            kwargs.update({"samples": samples})
+
+        self.log.debug(f"Writing out cache {start_frame} - {end_frame}")
+        filename = "{0}.abc".format(instance.name)
+        path = os.path.join(dirname, filename)
+        cmds.pgYetiCommand(yeti_nodes,
+                           writeAlembic=path,
+                           range=(start_frame, end_frame),
+                           asUnrealAbc=True,
+                           **kwargs)
+
+        if "representations" not in instance.data:
+            instance.data["representations"] = []
+
+        representation = {
+            'name': 'abc',
+            'ext': 'abc',
+            'files': filename,
+            'stagingDir': dirname
+        }
+        instance.data["representations"].append(representation)
+
+        self.log.debug(f"Extracted {instance} to {dirname}")

--- a/openpype/hosts/maya/plugins/publish/extract_unreal_yeticache.py
+++ b/openpype/hosts/maya/plugins/publish/extract_unreal_yeticache.py
@@ -39,7 +39,7 @@ class ExtractYetiCache(publish.Extractor):
             kwargs.update({"samples": samples})
 
         self.log.debug(f"Writing out cache {start_frame} - {end_frame}")
-        filename = "{0}.abc".format(instance.name)
+        filename = f"{instance.name}.abc"
         path = os.path.join(dirname, filename)
         cmds.pgYetiCommand(yeti_nodes,
                            writeAlembic=path,

--- a/openpype/hosts/maya/plugins/publish/extract_unreal_yeticache.py
+++ b/openpype/hosts/maya/plugins/publish/extract_unreal_yeticache.py
@@ -1,5 +1,4 @@
 import os
-import json
 
 from maya import cmds
 

--- a/openpype/hosts/maya/plugins/publish/extract_unreal_yeticache.py
+++ b/openpype/hosts/maya/plugins/publish/extract_unreal_yeticache.py
@@ -13,7 +13,7 @@ class ExtractYetiCache(publish.Extractor):
 
     label = "Extract Yeti Cache"
     hosts = ["maya"]
-    families = ["ue_yeticache"]
+    families = ["yeticacheUE"]
 
     def process(self, instance):
 

--- a/openpype/hosts/unreal/plugins/load/load_yeticache.py
+++ b/openpype/hosts/unreal/plugins/load/load_yeticache.py
@@ -90,18 +90,20 @@ class YetiLoader(plugin.Loader):
         asset = context.get('asset').get('name')
         suffix = "_CON"
         asset_name = f"{asset}_{name}" if asset else f"{name}"
-        version = context.get('version')
-        # Check if version is hero version and use different name
-        if not version.get("name") and version.get('type') == "hero_version":
-            name_version = f"{name}_hero"
-        else:
-            name_version = f"{name}_v{version.get('name'):03d}"
 
         tools = unreal.AssetToolsHelpers().get_asset_tools()
         asset_dir, container_name = tools.create_unique_asset_name(
-            f"{root}/{asset}/{name_version}", suffix="")
+            f"{root}/{asset}/{name}", suffix="")
 
-        container_name += suffix
+        unique_number = 1
+        while unreal.EditorAssetLibrary.does_directory_exist(
+            f"{asset_dir}_{unique_number:02}"
+        ):
+            unique_number += 1
+
+        asset_dir = f"{asset_dir}_{unique_number:02}"
+        container_name = f"{container_name}_{unique_number:02}{suffix}"
+
 
         if not unreal.EditorAssetLibrary.does_directory_exist(asset_dir):
             unreal.EditorAssetLibrary.make_directory(asset_dir)

--- a/openpype/hosts/unreal/plugins/load/load_yeticache.py
+++ b/openpype/hosts/unreal/plugins/load/load_yeticache.py
@@ -104,7 +104,6 @@ class YetiLoader(plugin.Loader):
         asset_dir = f"{asset_dir}_{unique_number:02}"
         container_name = f"{container_name}_{unique_number:02}{suffix}"
 
-
         if not unreal.EditorAssetLibrary.does_directory_exist(asset_dir):
             unreal.EditorAssetLibrary.make_directory(asset_dir)
 

--- a/openpype/hosts/unreal/plugins/load/load_yeticache.py
+++ b/openpype/hosts/unreal/plugins/load/load_yeticache.py
@@ -14,7 +14,7 @@ import unreal  # noqa
 class YetiLoader(plugin.Loader):
     """Load Yeti Cache"""
 
-    families = ["ue_yeticache"]
+    families = ["yeticacheUE"]
     label = "Import Yeti"
     representations = ["abc"]
     icon = "pagelines"

--- a/openpype/hosts/unreal/plugins/load/load_yeticache.py
+++ b/openpype/hosts/unreal/plugins/load/load_yeticache.py
@@ -1,0 +1,151 @@
+# -*- coding: utf-8 -*-
+"""Loader for Yeti Cache."""
+import os
+
+from openpype.pipeline import (
+    get_representation_path,
+    AYON_CONTAINER_ID
+)
+from openpype.hosts.unreal.api import plugin
+from openpype.hosts.unreal.api import pipeline as unreal_pipeline
+import unreal  # noqa
+
+
+class YetiLoader(plugin.Loader):
+    """Load Yeti Cache"""
+
+    families = ["ue_yeticache"]
+    label = "Import Yeti"
+    representations = ["abc"]
+    icon = "pagelines"
+    color = "orange"
+
+    @staticmethod
+    def get_task(filename, asset_dir, asset_name, replace):
+        task = unreal.AssetImportTask()
+        options = unreal.AbcImportSettings()
+
+        task.set_editor_property('filename', filename)
+        task.set_editor_property('destination_path', asset_dir)
+        task.set_editor_property('destination_name', asset_name)
+        task.set_editor_property('replace_existing', replace)
+        task.set_editor_property('automated', True)
+        task.set_editor_property('save', True)
+
+        task.options = options
+
+        return task
+
+    def load(self, context, name, namespace, options):
+        """Load and containerise representation into Content Browser.
+
+        This is two step process. First, import FBX to temporary path and
+        then call `containerise()` on it - this moves all content to new
+        directory and then it will create AssetContainer there and imprint it
+        with metadata. This will mark this path as container.
+
+        Args:
+            context (dict): application context
+            name (str): subset name
+            namespace (str): in Unreal this is basically path to container.
+                             This is not passed here, so namespace is set
+                             by `containerise()` because only then we know
+                             real path.
+            data (dict): Those would be data to be imprinted. This is not used
+                         now, data are imprinted by `containerise()`.
+
+        Returns:
+            list(str): list of container content
+
+        """
+        # Create directory for asset and Ayon container
+        root = "/Game/Ayon/Assets"
+        asset = context.get('asset').get('name')
+        suffix = "_CON"
+        asset_name = f"{asset}_{name}" if asset else f"{name}"
+        version = context.get('version')
+        # Check if version is hero version and use different name
+        if not version.get("name") and version.get('type') == "hero_version":
+            name_version = f"{name}_hero"
+        else:
+            name_version = f"{name}_v{version.get('name'):03d}"
+
+        tools = unreal.AssetToolsHelpers().get_asset_tools()
+        asset_dir, container_name = tools.create_unique_asset_name(
+            f"{root}/{asset}/{name_version}", suffix="")
+
+        container_name += suffix
+
+        if not unreal.EditorAssetLibrary.does_directory_exist(asset_dir):
+            unreal.EditorAssetLibrary.make_directory(asset_dir)
+
+            path = self.filepath_from_context(context)
+            task = self.get_task(path, asset_dir, asset_name, False)
+
+            unreal.AssetToolsHelpers.get_asset_tools().import_asset_tasks([task])  # noqa: E501
+
+            # Create Asset Container
+            unreal_pipeline.create_container(
+                container=container_name, path=asset_dir)
+
+        data = {
+            "schema": "ayon:container-2.0",
+            "id": AYON_CONTAINER_ID,
+            "asset": asset,
+            "namespace": asset_dir,
+            "container_name": container_name,
+            "asset_name": asset_name,
+            "loader": str(self.__class__.__name__),
+            "representation": context["representation"]["_id"],
+            "parent": context["representation"]["parent"],
+            "family": context["representation"]["context"]["family"]
+        }
+        unreal_pipeline.imprint(f"{asset_dir}/{container_name}", data)
+
+        asset_content = unreal.EditorAssetLibrary.list_assets(
+            asset_dir, recursive=True, include_folder=True
+        )
+
+        for a in asset_content:
+            unreal.EditorAssetLibrary.save_asset(a)
+
+        return asset_content
+
+    def update(self, container, representation):
+        name = container["asset_name"]
+        source_path = get_representation_path(representation)
+        destination_path = container["namespace"]
+
+        task = self.get_task(source_path, destination_path, name, True)
+
+        # do import fbx and replace existing data
+        unreal.AssetToolsHelpers.get_asset_tools().import_asset_tasks([task])
+
+        container_path = f'{container["namespace"]}/{container["objectName"]}'
+        # update metadata
+        unreal_pipeline.imprint(
+            container_path,
+            {
+                "representation": str(representation["_id"]),
+                "parent": str(representation["parent"])
+            })
+
+        asset_content = unreal.EditorAssetLibrary.list_assets(
+            destination_path, recursive=True, include_folder=True
+        )
+
+        for a in asset_content:
+            unreal.EditorAssetLibrary.save_asset(a)
+
+    def remove(self, container):
+        path = container["namespace"]
+        parent_path = os.path.dirname(path)
+
+        unreal.EditorAssetLibrary.delete_directory(path)
+
+        asset_content = unreal.EditorAssetLibrary.list_assets(
+            parent_path, recursive=False
+        )
+
+        if len(asset_content) == 0:
+            unreal.EditorAssetLibrary.delete_directory(parent_path)

--- a/openpype/plugins/publish/collect_resources_path.py
+++ b/openpype/plugins/publish/collect_resources_path.py
@@ -62,7 +62,8 @@ class CollectResourcesPath(pyblish.api.InstancePlugin):
                 "effect",
                 "staticMesh",
                 "skeletalMesh",
-                "xgen"
+                "xgen",
+                "ue_yeticache"
                 ]
 
     def process(self, instance):

--- a/openpype/plugins/publish/collect_resources_path.py
+++ b/openpype/plugins/publish/collect_resources_path.py
@@ -63,7 +63,7 @@ class CollectResourcesPath(pyblish.api.InstancePlugin):
                 "staticMesh",
                 "skeletalMesh",
                 "xgen",
-                "ue_yeticache"
+                "yeticacheUE"
                 ]
 
     def process(self, instance):

--- a/openpype/plugins/publish/integrate.py
+++ b/openpype/plugins/publish/integrate.py
@@ -139,7 +139,8 @@ class IntegrateAsset(pyblish.api.InstancePlugin):
                 "simpleUnrealTexture",
                 "online",
                 "uasset",
-                "blendScene"
+                "blendScene",
+                "ue_yeticache"
                 ]
 
     default_template_name = "publish"

--- a/openpype/plugins/publish/integrate.py
+++ b/openpype/plugins/publish/integrate.py
@@ -140,7 +140,7 @@ class IntegrateAsset(pyblish.api.InstancePlugin):
                 "online",
                 "uasset",
                 "blendScene",
-                "ue_yeticache"
+                "yeticacheUE"
                 ]
 
     default_template_name = "publish"


### PR DESCRIPTION
## Changelog Description
Implemented Yeti support for Unreal.

## Additional info
A new family has been implemented, `ue_yeticache`, to differentiate from the existing `yeticache`. Yeti has different exporter to be compatible with the Unreal built-in Groom system, so it needs a different extractor.

## Testing notes:
1. In Maya, import or create a Yeti Node
2. Create a new instance of family Unreal Yeti Cache and publish.
3. In Unreal, load the published asset.
