### PR TITLE
traypublisher: missing `assetEntity` in context data

### DIFF
--- a/openpype/hosts/traypublisher/plugins/publish/collect_frame_data_from_asset_entity.py
+++ b/openpype/hosts/traypublisher/plugins/publish/collect_frame_data_from_asset_entity.py
@@ -2,18 +2,18 @@ import pyblish.api
 from openpype.pipeline import OptionalPyblishPluginMixin
 
 
-class CollectMissingFrameDataFromAssetEntity(
+class CollectFrameDataFromAssetEntity(
     pyblish.api.InstancePlugin,
     OptionalPyblishPluginMixin
 ):
-    """Collect Missing Frame Range data From Asset Entity
+    """Collect Frame Data From AssetEntity found in context
 
     Frame range data will only be collected if the keys
     are not yet collected for the instance.
     """
 
     order = pyblish.api.CollectorOrder + 0.491
-    label = "Collect Missing Frame Data From Asset Entity"
+    label = "Collect Frame Data From Asset"
     families = ["plate", "pointcache",
                 "vdbcache", "online",
                 "render"]
@@ -23,7 +23,9 @@ class CollectMissingFrameDataFromAssetEntity(
     def process(self, instance):
         if not self.is_active(instance.data):
             return
-        missing_keys = []
+
+        asset_data = instance.data["assetEntity"]["data"]
+
         for key in (
             "fps",
             "frameStart",
@@ -31,14 +33,5 @@ class CollectMissingFrameDataFromAssetEntity(
             "handleStart",
             "handleEnd"
         ):
-            if key not in instance.data:
-                missing_keys.append(key)
-        keys_set = []
-        for key in missing_keys:
-            asset_data = instance.data["assetEntity"]["data"]
-            if key in asset_data:
-                instance.data[key] = asset_data[key]
-                keys_set.append(key)
-        if keys_set:
-            self.log.debug(f"Frame range data {keys_set} "
-                           "has been collected from asset entity.")
+            instance.data[key] = asset_data[key]
+            self.log.debug(f"Collected Frame range data '{key}':{asset_data[key]} ")

--- a/openpype/hosts/traypublisher/plugins/publish/collect_frame_data_from_asset_entity.py
+++ b/openpype/hosts/traypublisher/plugins/publish/collect_frame_data_from_asset_entity.py
@@ -34,4 +34,5 @@ class CollectFrameDataFromAssetEntity(
             "handleEnd"
         ):
             instance.data[key] = asset_data[key]
-            self.log.debug(f"Collected Frame range data '{key}':{asset_data[key]} ")
+            self.log.debug(
+                f"Collected Frame range data '{key}':{asset_data[key]} ")

--- a/openpype/hosts/traypublisher/plugins/publish/collect_frame_data_from_asset_entity.py
+++ b/openpype/hosts/traypublisher/plugins/publish/collect_frame_data_from_asset_entity.py
@@ -9,7 +9,7 @@ class CollectFrameDataFromAssetEntity(pyblish.api.InstancePlugin):
     """
 
     order = pyblish.api.CollectorOrder + 0.491
-    label = "Collect Frame Data From Asset"
+    label = "Collect Missing Frame Data From Asset"
     families = ["plate", "pointcache",
                 "vdbcache", "online",
                 "render"]

--- a/openpype/hosts/traypublisher/plugins/publish/collect_sequence_frame_data.py
+++ b/openpype/hosts/traypublisher/plugins/publish/collect_sequence_frame_data.py
@@ -1,22 +1,32 @@
 import pyblish.api
 import clique
 
+from openpype.pipeline import OptionalPyblishPluginMixin
 
-class CollectSequenceFrameData(pyblish.api.InstancePlugin):
-    """Collect Sequence Frame Data
+
+class CollectSequenceFrameData(
+    pyblish.api.InstancePlugin,
+    OptionalPyblishPluginMixin
+):
+    """Collect Original Sequence Frame Data
+
     If the representation includes files with frame numbers,
     then set `frameStart` and `frameEnd` for the instance to the
     start and end frame respectively
     """
 
-    order = pyblish.api.CollectorOrder + 0.490
-    label = "Collect Sequence Frame Data"
+    order = pyblish.api.CollectorOrder + 0.4905
+    label = "Collect Original Sequence Frame Data"
     families = ["plate", "pointcache",
                 "vdbcache", "online",
                 "render"]
     hosts = ["traypublisher"]
+    optional = True
 
     def process(self, instance):
+        if not self.is_active(instance.data):
+            return
+
         frame_data = self.get_frame_data_from_repre_sequence(instance)
 
         if not frame_data:

--- a/openpype/plugins/publish/collect_sequence_frame_data.py
+++ b/openpype/plugins/publish/collect_sequence_frame_data.py
@@ -28,10 +28,12 @@ class CollectSequenceFrameData(pyblish.api.InstancePlugin):
 
     def get_frame_data_from_repre_sequence(self, instance):
         repres = instance.data.get("representations")
-        parent_entity = (
-            instance.data.get("assetEntity")
-            or instance.context.data["projectEntity"]
-        )
+        parent_entity = instance.data.get("assetEntity")
+
+        if not parent_entity:
+            self.log.warning("Cannot find parent entity data")
+            return
+
         if repres:
             first_repre = repres[0]
             if "ext" not in first_repre:
@@ -40,7 +42,7 @@ class CollectSequenceFrameData(pyblish.api.InstancePlugin):
                 return
 
             files = first_repre["files"]
-            collections, remainder = clique.assemble(files)
+            collections, _ = clique.assemble(files)
             if not collections:
                 # No sequences detected and we can't retrieve
                 # frame range

--- a/openpype/plugins/publish/collect_sequence_frame_data.py
+++ b/openpype/plugins/publish/collect_sequence_frame_data.py
@@ -28,6 +28,10 @@ class CollectSequenceFrameData(pyblish.api.InstancePlugin):
 
     def get_frame_data_from_repre_sequence(self, instance):
         repres = instance.data.get("representations")
+        parent_entity = (
+            instance.context.data.get("assetEntity")
+            or instance.context.data["projectEntity"]
+        )
         if repres:
             first_repre = repres[0]
             if "ext" not in first_repre:
@@ -52,5 +56,5 @@ class CollectSequenceFrameData(pyblish.api.InstancePlugin):
                 "frameEnd": repres_frames[-1],
                 "handleStart": 0,
                 "handleEnd": 0,
-                "fps": instance.context.data["assetEntity"]["data"]["fps"]
+                "fps": parent_entity["data"]["fps"]
             }

--- a/openpype/plugins/publish/collect_sequence_frame_data.py
+++ b/openpype/plugins/publish/collect_sequence_frame_data.py
@@ -29,7 +29,7 @@ class CollectSequenceFrameData(pyblish.api.InstancePlugin):
     def get_frame_data_from_repre_sequence(self, instance):
         repres = instance.data.get("representations")
         parent_entity = (
-            instance.context.data.get("assetEntity")
+            instance.data.get("assetEntity")
             or instance.context.data["projectEntity"]
         )
         if repres:

--- a/openpype/plugins/publish/collect_sequence_frame_data.py
+++ b/openpype/plugins/publish/collect_sequence_frame_data.py
@@ -9,7 +9,7 @@ class CollectSequenceFrameData(pyblish.api.InstancePlugin):
     start and end frame respectively
     """
 
-    order = pyblish.api.CollectorOrder + 0.2
+    order = pyblish.api.CollectorOrder + 0.490
     label = "Collect Sequence Frame Data"
     families = ["plate", "pointcache",
                 "vdbcache", "online",
@@ -18,21 +18,22 @@ class CollectSequenceFrameData(pyblish.api.InstancePlugin):
 
     def process(self, instance):
         frame_data = self.get_frame_data_from_repre_sequence(instance)
+
         if not frame_data:
             # if no dict data skip collecting the frame range data
             return
+
         for key, value in frame_data.items():
-            if key not in instance.data:
-                instance.data[key] = value
-                self.log.debug(f"Collected Frame range data '{key}':{value} ")
+            instance.data[key] = value
+            self.log.debug(f"Collected Frame range data '{key}':{value} ")
+
+        test_keys = {key: value for key, value in instance.data.items() if key in frame_data}
+        self.log.debug(f"Final Instance frame data: {test_keys}")
+
 
     def get_frame_data_from_repre_sequence(self, instance):
         repres = instance.data.get("representations")
-        parent_entity = instance.data.get("assetEntity")
-
-        if not parent_entity:
-            self.log.warning("Cannot find parent entity data")
-            return
+        asset_data = instance.data["assetEntity"]["data"]
 
         if repres:
             first_repre = repres[0]
@@ -58,5 +59,5 @@ class CollectSequenceFrameData(pyblish.api.InstancePlugin):
                 "frameEnd": repres_frames[-1],
                 "handleStart": 0,
                 "handleEnd": 0,
-                "fps": parent_entity["data"]["fps"]
+                "fps": asset_data["fps"]
             }

--- a/openpype/plugins/publish/collect_sequence_frame_data.py
+++ b/openpype/plugins/publish/collect_sequence_frame_data.py
@@ -27,9 +27,6 @@ class CollectSequenceFrameData(pyblish.api.InstancePlugin):
             instance.data[key] = value
             self.log.debug(f"Collected Frame range data '{key}':{value} ")
 
-        test_keys = {key: value for key, value in instance.data.items() if key in frame_data}
-        self.log.debug(f"Final Instance frame data: {test_keys}")
-
 
     def get_frame_data_from_repre_sequence(self, instance):
         repres = instance.data.get("representations")

--- a/openpype/settings/defaults/project_settings/traypublisher.json
+++ b/openpype/settings/defaults/project_settings/traypublisher.json
@@ -346,10 +346,10 @@
         }
     },
     "publish": {
-        "CollectFrameDataFromAssetEntity": {
+        "CollectSequenceFrameData": {
             "enabled": true,
             "optional": true,
-            "active": true
+            "active": false
         },
         "ValidateFrameRange": {
             "enabled": true,

--- a/openpype/settings/entities/schemas/projects_schema/schema_project_traypublisher.json
+++ b/openpype/settings/entities/schemas/projects_schema/schema_project_traypublisher.json
@@ -350,8 +350,8 @@
                     "name": "template_validate_plugin",
                     "template_data": [
                         {
-                            "key": "CollectFrameDataFromAssetEntity",
-                            "label": "Collect frame range from asset entity"
+                            "key": "CollectSequenceFrameData",
+                            "label": "Collect Original Sequence Frame Data"
                         },
                         {
                             "key": "ValidateFrameRange",


### PR DESCRIPTION
## Changelog Description
Issue with missing `assetEnity` key in context data is not problem anymore. 


## Testing notes:
1. Try to publish plate imagesequence in traypublisher
2. enable `Collect Original Sequence Frame Data` toggle on instance and publish
3. Open Tray Loader and check the framerange is inherited form original sequence and handles are set to 0
4. reload the tray publishing context
5. desable`Collect Original Sequence Frame Data` toggle on instance and publish
6. publish again 
7. Open Tray Loader and check the framerange is inherited form asset frame range including handles