### PR TITLE
Extended error message when getting subset name

### DIFF
--- a/openpype/pipeline/create/subset_name.py
+++ b/openpype/pipeline/create/subset_name.py
@@ -112,6 +112,10 @@ def get_subset_name(
             for project. Settings are queried if not passed.
         family_filter (Optional[str]): Use different family for subset template
             filtering. Value of 'family' is used when not passed.
+
+    Raises:
+        KeyError if filled template contains placeholder key which is not
+            collected.
     """
 
     if not family:
@@ -154,4 +158,10 @@ def get_subset_name(
         for key, value in dynamic_data.items():
             fill_pairs[key] = value
 
-    return template.format(**prepare_template_data(fill_pairs))
+    try:
+        return template.format(**prepare_template_data(fill_pairs))
+    except KeyError as exp:
+        error = "Value for '{}' key is missing in template '{}'.".format(
+            str(exp), template)
+        error += "Collected values are {}".format(fill_pairs)
+        raise KeyError(error)


### PR DESCRIPTION
## Changelog Description
Each Creator is using `get_subset_name` functions which collects context data and fills configured template with placeholders.
If any key is missing in the template, non descriptive error is thrown.
![Discord_vbHC59nQ1t](https://github.com/ynput/OpenPype/assets/4457962/848b61d8-ece7-4331-89a3-c552aeee9153)


This should provide more verbose message:
![AnyDeskMSI_HEl3Q0LbPq](https://github.com/ynput/OpenPype/assets/4457962/78617b45-caf1-4628-906e-950f167236a9)

## Testing notes:
1. configure `project_settings/global/tools/creator/subset_name_profiles` for particular host and add there non existent placeholder value
2. open Publisher and create instance that will use that template
