### PR TITLE
General: Avoid fallback if value is 0 for handle start/end

### DIFF
--- a/openpype/pipeline/farm/pyblish_functions.py
+++ b/openpype/pipeline/farm/pyblish_functions.py
@@ -112,6 +112,7 @@ def get_time_data_from_instance_or_context(instance):
         start=instance.data.get("frameStart", context.data.get("frameStart")),
         end=instance.data.get("frameEnd", context.data.get("frameEnd")),
         fps=instance.data.get("fps", context.data.get("fps")),
+        step=instance.data.get("byFrameStep", instance.data.get("step", 1)),
         handle_start=instance.data.get(
             "handleStart", context.data.get("handleStart")
         ),

--- a/openpype/pipeline/farm/pyblish_functions.py
+++ b/openpype/pipeline/farm/pyblish_functions.py
@@ -107,21 +107,16 @@ def get_time_data_from_instance_or_context(instance):
         TimeData: dataclass holding time information.
 
     """
+    context = instance.context
     return TimeData(
-        start=instance.data.get(
-            "frameStart", instance.context.data.get("frameStart")
-        ),
-        end=instance.data.get(
-            "frameEnd", instance.context.data.get("frameEnd")
-        ),
-        fps=instance.data.get(
-            "fps", instance.context.data.get("fps")
-        ),
+        start=instance.data.get("frameStart", context.data.get("frameStart")),
+        end=instance.data.get("frameEnd", context.data.get("frameEnd")),
+        fps=instance.data.get("fps", context.data.get("fps")),
         handle_start=instance.data.get(
-            "handleStart", instance.context.data.get("handleStart")
+            "handleStart", context.data.get("handleStart")
         ),
         handle_end=instance.data.get(
-            "handleEnd", instance.context.data.get("handleEnd")
+            "handleEnd", context.data.get("handleEnd")
         )
     )
 

--- a/openpype/pipeline/farm/pyblish_functions.py
+++ b/openpype/pipeline/farm/pyblish_functions.py
@@ -114,10 +114,12 @@ def get_time_data_from_instance_or_context(instance):
              instance.context.data.get("frameEnd")),
         fps=(instance.data.get("fps") or
              instance.context.data.get("fps")),
-        handle_start=(instance.data.get("handleStart") or
-                      instance.context.data.get("handleStart")),  # noqa: E501
-        handle_end=(instance.data.get("handleEnd") or
-                    instance.context.data.get("handleEnd"))
+        handle_start=instance.data.get(
+            "handleStart", instance.context.data.get("handleStart")
+        ),
+        handle_end=instance.data.get(
+            "handleEnd", instance.context.data.get("handleEnd")
+        )
     )
 
 

--- a/openpype/pipeline/farm/pyblish_functions.py
+++ b/openpype/pipeline/farm/pyblish_functions.py
@@ -108,12 +108,15 @@ def get_time_data_from_instance_or_context(instance):
 
     """
     return TimeData(
-        start=(instance.data.get("frameStart") or
-               instance.context.data.get("frameStart")),
-        end=(instance.data.get("frameEnd") or
-             instance.context.data.get("frameEnd")),
-        fps=(instance.data.get("fps") or
-             instance.context.data.get("fps")),
+        start=instance.data.get(
+            "frameStart", instance.context.data.get("frameStart")
+        ),
+        end=instance.data.get(
+            "frameEnd", instance.context.data.get("frameEnd")
+        ),
+        fps=instance.data.get(
+            "fps", instance.context.data.get("fps")
+        ),
         handle_start=instance.data.get(
             "handleStart", instance.context.data.get("handleStart")
         ),


### PR DESCRIPTION
## Changelog Description
There's a bug on the `pyblish_functions.get_time_data_from_instance_or_context` where if `handleStart` or `handleEnd` on the instance are set to value 0 it's falling back to grabbing the handles from the instance context. Instead, the logic should be that it only falls back to the `instance.context` if the key doesn't exist.

This change was only affecting me on the `handleStart`/`handleEnd` and it's unlikely it could cause issues on `frameStart`, `frameEnd` or `fps` but regardless, the `get` logic is wrong.

## Testing notes:
1. Assign handleStart/handleEnd value to 0 on the instance and some other value on the context data
2. Run a publish to the farm and check that the handleStart/handleEnd are set to 0
