### PR TITLE
AYON: Workfiles tool save button works

### DIFF
--- a/openpype/tools/ayon_workfiles/models/workfiles.py
+++ b/openpype/tools/ayon_workfiles/models/workfiles.py
@@ -48,7 +48,7 @@ def get_task_template_data(project_entity, task):
         return {}
     short_name = None
     task_type_name = task["taskType"]
-    for task_type_info in project_entity["config"]["taskTypes"]:
+    for task_type_info in project_entity["taskTypes"]:
         if task_type_info["name"] == task_type_name:
             short_name = task_type_info["shortName"]
             break


### PR DESCRIPTION
## Changelog Description
Fix save as button in workfiles tool.

(It is mystery why this stopped to work??)

## Testing notes:
1. Start AYON
2. Launch DCC from launcher (your choice)
3. Open workfiles tool
4. Save workfile
5. Happy end