### PR TITLE
Unreal: Parent Qt UI to Window main Unreal

### DIFF
--- a/openpype/hosts/unreal/api/tools_ui.py
+++ b/openpype/hosts/unreal/api/tools_ui.py
@@ -62,6 +62,7 @@ class ToolsBtnsWidget(QtWidgets.QWidget):
 
 class ToolsDialog(QtWidgets.QDialog):
     """Dialog with tool buttons that will stay opened until user close it."""
+
     def __init__(self, *args, **kwargs):
         super(ToolsDialog, self).__init__(*args, **kwargs)
 
@@ -98,6 +99,7 @@ class ToolsDialog(QtWidgets.QDialog):
 
 class ToolsPopup(ToolsDialog):
     """Popup with tool buttons that will close when loose focus."""
+
     def __init__(self, *args, **kwargs):
         super(ToolsPopup, self).__init__(*args, **kwargs)
 
@@ -134,7 +136,8 @@ class WindowCache:
 
             cls._popup.show()
             unreal.parent_external_window_to_slate(
-                cls._popup.winId(), unreal.SlateParentWindowSearchMethod.ACTIVE_WINDOW)
+                cls._popup.winId(), 
+                unreal.SlateParentWindowSearchMethod.ACTIVE_WINDOW)
 
     @classmethod
     def show_dialog(cls):
@@ -147,7 +150,8 @@ class WindowCache:
             cls._dialog.raise_()
             cls._dialog.activateWindow()
             unreal.parent_external_window_to_slate(
-                cls._dialog.winId(), unreal.SlateParentWindowSearchMethod.ACTIVE_WINDOW)
+                cls._dialog.winId(), 
+                unreal.SlateParentWindowSearchMethod.ACTIVE_WINDOW)
 
 
 def show_tools_popup():

--- a/openpype/hosts/unreal/api/tools_ui.py
+++ b/openpype/hosts/unreal/api/tools_ui.py
@@ -1,4 +1,5 @@
 import sys
+import unreal
 from qtpy import QtWidgets, QtCore, QtGui
 
 from openpype import (
@@ -68,10 +69,6 @@ class ToolsDialog(QtWidgets.QDialog):
         icon = QtGui.QIcon(resources.get_openpype_icon_filepath())
         self.setWindowIcon(icon)
 
-        self.setWindowFlags(
-            QtCore.Qt.Window
-            | QtCore.Qt.WindowStaysOnTopHint
-        )
         self.setFocusPolicy(QtCore.Qt.StrongFocus)
 
         tools_widget = ToolsBtnsWidget(self)
@@ -103,11 +100,6 @@ class ToolsPopup(ToolsDialog):
     """Popup with tool buttons that will close when loose focus."""
     def __init__(self, *args, **kwargs):
         super(ToolsPopup, self).__init__(*args, **kwargs)
-
-        self.setWindowFlags(
-            QtCore.Qt.FramelessWindowHint
-            | QtCore.Qt.Popup
-        )
 
     def showEvent(self, event):
         super(ToolsPopup, self).showEvent(event)
@@ -141,6 +133,8 @@ class WindowCache:
                 cls._popup = ToolsPopup()
 
             cls._popup.show()
+            unreal.parent_external_window_to_slate(
+                cls._popup.winId(), unreal.SlateParentWindowSearchMethod.ACTIVE_WINDOW)
 
     @classmethod
     def show_dialog(cls):
@@ -152,6 +146,8 @@ class WindowCache:
             cls._dialog.show()
             cls._dialog.raise_()
             cls._dialog.activateWindow()
+            unreal.parent_external_window_to_slate(
+                cls._dialog.winId(), unreal.SlateParentWindowSearchMethod.ACTIVE_WINDOW)
 
 
 def show_tools_popup():

--- a/openpype/hosts/unreal/api/tools_ui.py
+++ b/openpype/hosts/unreal/api/tools_ui.py
@@ -136,7 +136,7 @@ class WindowCache:
 
             cls._popup.show()
             unreal.parent_external_window_to_slate(
-                cls._popup.winId(), 
+                cls._popup.winId(),
                 unreal.SlateParentWindowSearchMethod.ACTIVE_WINDOW)
 
     @classmethod
@@ -150,7 +150,7 @@ class WindowCache:
             cls._dialog.raise_()
             cls._dialog.activateWindow()
             unreal.parent_external_window_to_slate(
-                cls._dialog.winId(), 
+                cls._dialog.winId(),
                 unreal.SlateParentWindowSearchMethod.ACTIVE_WINDOW)
 
 


### PR DESCRIPTION
## Changelog Description
Improved Qt window parenting for Unreal window. I disabled the setWindowFlags : WindowStaysOnTopHint and I use this function : unreal.parent_external_window_to_slate

## Additional info
Test with Unreal 5.3

## Testing notes:
1. Open Unreal
2. Click on Ayon Menu
3. The popup UI is now correctly parent with unreal
