### PR TITLE
Fusion - added missing env vars to Deadline submission

### DIFF
--- a/openpype/modules/deadline/plugins/publish/submit_fusion_deadline.py
+++ b/openpype/modules/deadline/plugins/publish/submit_fusion_deadline.py
@@ -6,6 +6,7 @@ import requests
 
 import pyblish.api
 
+from openpype import AYON_SERVER_ENABLED
 from openpype.pipeline import legacy_io
 from openpype.pipeline.publish import (
     OpenPypePyblishPluginMixin
@@ -221,10 +222,29 @@ class FusionSubmitDeadline(
             # submitter is on Windows.
             "PYTHONPATH",
             "OFX_PLUGIN_PATH",
-            "FUSION9_MasterPrefs"
+            "FUSION9_MasterPrefs",
+            "FTRACK_API_KEY",
+            "FTRACK_API_USER",
+            "FTRACK_SERVER",
+            "AVALON_PROJECT",
+            "AVALON_ASSET",
+            "AVALON_TASK",
+            "AVALON_APP_NAME",
+            "OPENPYPE_DEV",
+            "OPENPYPE_LOG_NO_COLORS",
+            "IS_TEST"
         ]
         environment = dict({key: os.environ[key] for key in keys
                             if key in os.environ}, **legacy_io.Session)
+
+        # to recognize render jobs
+        if AYON_SERVER_ENABLED:
+            environment["AYON_BUNDLE_NAME"] = os.environ["AYON_BUNDLE_NAME"]
+            render_job_label = "AYON_RENDER_JOB"
+        else:
+            render_job_label = "OPENPYPE_RENDER_JOB"
+
+        environment[render_job_label] = "1"
 
         payload["JobInfo"].update({
             "EnvironmentKeyValue%d" % index: "{key}={value}".format(


### PR DESCRIPTION
## Changelog Description
Environment variables discerning type of job was missing. Without this injection of environment variables won't start.

## Testing notes:
1. Publish something set on farm publishing from Fusion
