### PR TITLE
Nuke: workfile version synchronization settings fixed

### DIFF
--- a/openpype/hosts/nuke/plugins/publish/collect_nuke_instance_data.py
+++ b/openpype/hosts/nuke/plugins/publish/collect_nuke_instance_data.py
@@ -2,7 +2,7 @@ import nuke
 import pyblish.api
 
 
-class CollectNukeInstanceData(pyblish.api.InstancePlugin):
+class CollectInstanceData(pyblish.api.InstancePlugin):
     """Collect Nuke instance data
 
     """


### PR DESCRIPTION
## Changelog Description
Settings for synchronizing workfile version to published products is fixed.

## Additional info
- settings were broken by renaming plugin name to `CollectNukeInstanceData` here https://github.com/ynput/OpenPype/pull/5409

## Testing notes:
1. publish new render instance and make sure current workfile version is set to more than first version.
2. notice that the published version of render is aligned with workfile version.

Closed #5661