### PR TITLE
Enhancement : Houdini dynamic publish parameters

### DIFF
--- a/openpype/hosts/houdini/api/plugin.py
+++ b/openpype/hosts/houdini/api/plugin.py
@@ -182,7 +182,7 @@ class HoudiniCreator(NewCreator, HoudiniCreatorBase):
                 node_type = "geometry"
 
             instance_node = self.create_instance_node(
-                instance_data["variant"], "/out", node_type)
+                subset_name, "/out", node_type)
 
             self.customize_node_look(instance_node)
 
@@ -254,8 +254,8 @@ class HoudiniCreator(NewCreator, HoudiniCreatorBase):
     def imprint(self, node, values, update=False):
         # Update values to be dynamic
 
-        values["subset"] = '`chs("family")+chs("variant")`'
-        values["variant"] = '`opname(".")`'
+        values["subset"] = '`opname(".")`'
+        values["variant"] = '`strreplace(chs("subset"), chs("family"), "")`'
         values["instance_node"] = '`opfullpath(".")`'
         values["instance_id"]  = '`opfullpath(".")`'
 

--- a/openpype/hosts/houdini/api/plugin.py
+++ b/openpype/hosts/houdini/api/plugin.py
@@ -257,7 +257,7 @@ class HoudiniCreator(NewCreator, HoudiniCreatorBase):
         values["subset"] = '`opname(".")`'
         values["variant"] = '`strreplace(chs("subset"), chs("family"), "")`'
         values["instance_node"] = '`opfullpath(".")`'
-        values["instance_id"]  = '`opfullpath(".")`'
+        values["instance_id"] = '`opfullpath(".")`'
 
         imprint(node, values, update=update)
 

--- a/openpype/hosts/houdini/plugins/create/create_alembic_camera.py
+++ b/openpype/hosts/houdini/plugins/create/create_alembic_camera.py
@@ -26,9 +26,11 @@ class CreateAlembicCamera(plugin.HoudiniCreator):
             pre_create_data)  # type: CreatedInstance
 
         instance_node = hou.node(instance.get("instance_node"))
+        file_path = "{}/pyblish/`chs('subset')`.abc".format(
+            hou.text.expandString("$HIP")
+        )
         parms = {
-            "filename": hou.text.expandString(
-                "$HIP/pyblish/{}.abc".format(subset_name)),
+            "filename": file_path,
             "use_sop_path": False,
         }
 

--- a/openpype/hosts/houdini/plugins/create/create_arnold_ass.py
+++ b/openpype/hosts/houdini/plugins/create/create_arnold_ass.py
@@ -35,15 +35,15 @@ class CreateArnoldAss(plugin.HoudiniCreator):
         parm_template_group.hideFolder("Properties", True)
         instance_node.setParmTemplateGroup(parm_template_group)
 
-        filepath = "{}{}".format(
-            hou.text.expandString("$HIP/pyblish/"),
-            "{}.$F4{}".format(subset_name, self.ext)
+        file_path = "{}/pyblish/`chs('subset')`.$F4.{}".format(
+            hou.text.expandString("$HIP"),
+            self.ext
         )
         parms = {
             # Render frame range
             "trange": 1,
             # Arnold ROP settings
-            "ar_ass_file": filepath,
+            "ar_ass_file": file_path,
             "ar_ass_export_enable": 1
         }
 

--- a/openpype/hosts/houdini/plugins/create/create_arnold_rop.py
+++ b/openpype/hosts/houdini/plugins/create/create_arnold_rop.py
@@ -34,9 +34,12 @@ class CreateArnoldRop(plugin.HoudiniCreator):
 
         ext = pre_create_data.get("image_format")
 
-        file_path = "{}/pyblish/renders/`chs('subset')`/`chs('subset')`.$F4.{}".format(
-            hou.text.expandString("$HIP"),
-            ext
+        file_path = (
+            "{}/pyblish/renders/`chs('subset')`/"
+            "`chs('subset')`.$F4.{}".format(
+                hou.text.expandString("$HIP"),
+                ext
+            )
         )
         parms = {
             # Render frame range

--- a/openpype/hosts/houdini/plugins/create/create_arnold_rop.py
+++ b/openpype/hosts/houdini/plugins/create/create_arnold_rop.py
@@ -34,17 +34,16 @@ class CreateArnoldRop(plugin.HoudiniCreator):
 
         ext = pre_create_data.get("image_format")
 
-        filepath = "{renders_dir}{subset_name}/{subset_name}.$F4.{ext}".format(
-            renders_dir=hou.text.expandString("$HIP/pyblish/renders/"),
-            subset_name=subset_name,
-            ext=ext,
+        file_path = "{}/pyblish/renders/`chs('subset')`/`chs('subset')`.$F4.{}".format(
+            hou.text.expandString("$HIP"),
+            ext
         )
         parms = {
             # Render frame range
             "trange": 1,
 
             # Arnold ROP settings
-            "ar_picture": filepath,
+            "ar_picture": file_path,
             "ar_exr_half_precision": 1           # half precision
         }
 

--- a/openpype/hosts/houdini/plugins/create/create_bgeo.py
+++ b/openpype/hosts/houdini/plugins/create/create_bgeo.py
@@ -26,11 +26,9 @@ class CreateBGEO(plugin.HoudiniCreator):
 
         instance_node = hou.node(instance.get("instance_node"))
 
-        file_path = "{}{}".format(
-            hou.text.expandString("$HIP/pyblish/"),
-            "{}.$F4.{}".format(
-                subset_name,
-                pre_create_data.get("bgeo_type") or "bgeo.sc")
+        file_path = "{}/`chs('subset')`.$F4.{}".format(
+            hou.text.expandString("$HIP/pyblish"),
+            pre_create_data.get("bgeo_type") or "bgeo.sc"
         )
         parms = {
             "sopoutput": file_path

--- a/openpype/hosts/houdini/plugins/create/create_bgeo.py
+++ b/openpype/hosts/houdini/plugins/create/create_bgeo.py
@@ -26,8 +26,8 @@ class CreateBGEO(plugin.HoudiniCreator):
 
         instance_node = hou.node(instance.get("instance_node"))
 
-        file_path = "{}/`chs('subset')`.$F4.{}".format(
-            hou.text.expandString("$HIP/pyblish"),
+        file_path = "{}/pyblish/`chs('subset')`.$F4.{}".format(
+            hou.text.expandString("$HIP"),
             pre_create_data.get("bgeo_type") or "bgeo.sc"
         )
         parms = {

--- a/openpype/hosts/houdini/plugins/create/create_composite.py
+++ b/openpype/hosts/houdini/plugins/create/create_composite.py
@@ -28,13 +28,13 @@ class CreateCompositeSequence(plugin.HoudiniCreator):
             pre_create_data)  # type: CreatedInstance
 
         instance_node = hou.node(instance.get("instance_node"))
-        filepath = "{}{}".format(
-            hou.text.expandString("$HIP/pyblish/"),
-            "{}.$F4{}".format(subset_name, self.ext)
+        file_path = "{}/pyblish/`chs('subset')`.$F4.{}".format(
+            hou.text.expandString("$HIP"),
+            self.ext
         )
         parms = {
             "trange": 1,
-            "copoutput": filepath
+            "copoutput": file_path
         }
 
         if self.selected_nodes:

--- a/openpype/hosts/houdini/plugins/create/create_hda.py
+++ b/openpype/hosts/houdini/plugins/create/create_hda.py
@@ -55,10 +55,13 @@ class CreateHDA(plugin.HoudiniCreator):
             if not to_hda.canCreateDigitalAsset():
                 raise plugin.OpenPypeCreatorError(
                     "cannot create hda from node {}".format(to_hda))
-
+            file_path = "{}/{}.hda".format(
+            hou.text.expandString("$HIP"),
+            node_name
+        )
             hda_node = to_hda.createDigitalAsset(
                 name=node_name,
-                hda_file_name="$HIP/{}.hda".format(node_name)
+                hda_file_name=file_path
             )
             hda_node.layoutChildren()
         elif self._check_existing(node_name):

--- a/openpype/hosts/houdini/plugins/create/create_hda.py
+++ b/openpype/hosts/houdini/plugins/create/create_hda.py
@@ -55,10 +55,11 @@ class CreateHDA(plugin.HoudiniCreator):
             if not to_hda.canCreateDigitalAsset():
                 raise plugin.OpenPypeCreatorError(
                     "cannot create hda from node {}".format(to_hda))
+
             file_path = "{}/{}.hda".format(
-            hou.text.expandString("$HIP"),
-            node_name
-        )
+                hou.text.expandString("$HIP"),
+                node_name
+            )
             hda_node = to_hda.createDigitalAsset(
                 name=node_name,
                 hda_file_name=file_path

--- a/openpype/hosts/houdini/plugins/create/create_karma_rop.py
+++ b/openpype/hosts/houdini/plugins/create/create_karma_rop.py
@@ -31,18 +31,24 @@ class CreateKarmaROP(plugin.HoudiniCreator):
 
         ext = pre_create_data.get("image_format")
 
-        file_path = "{}/pyblish/renders/`chs('subset')`/`chs('subset')`.$F4.{}".format(
-            hou.text.expandString("$HIP"),
-            ext
+        file_path = (
+            "{}/pyblish/renders/`chs('subset')`/"
+            "`chs('subset')`.$F4.{}".format(
+                hou.text.expandString("$HIP"),
+                ext
+            )
         )
-        checkpoint = "{cp_dir}{subset_name}.$F4.checkpoint".format(
-            cp_dir=hou.text.expandString("$HIP/pyblish/"),
-            subset_name=subset_name
+        checkpoint = (
+            "{}/pyblish/`chs('subset')`.$F4.checkpoint".format(
+                hou.text.expandString("$HIP"),
+            )
         )
 
-        usd_directory = "{usd_dir}{subset_name}_$RENDERID".format(
-            usd_dir=hou.text.expandString("$HIP/pyblish/renders/usd_renders/"),     # noqa
-            subset_name=subset_name
+        usd_directory = (
+            "{}/pyblish/renders/usd_renders/`chs('subset')`"
+            "_$RENDERID".format(
+                hou.text.expandString("$HIP")
+            )
         )
 
         parms = {

--- a/openpype/hosts/houdini/plugins/create/create_karma_rop.py
+++ b/openpype/hosts/houdini/plugins/create/create_karma_rop.py
@@ -31,10 +31,9 @@ class CreateKarmaROP(plugin.HoudiniCreator):
 
         ext = pre_create_data.get("image_format")
 
-        filepath = "{renders_dir}{subset_name}/{subset_name}.$F4.{ext}".format(
-            renders_dir=hou.text.expandString("$HIP/pyblish/renders/"),
-            subset_name=subset_name,
-            ext=ext,
+        file_path = "{}/pyblish/renders/`chs('subset')`/`chs('subset')`.$F4.{}".format(
+            hou.text.expandString("$HIP"),
+            ext
         )
         checkpoint = "{cp_dir}{subset_name}.$F4.checkpoint".format(
             cp_dir=hou.text.expandString("$HIP/pyblish/"),
@@ -50,7 +49,7 @@ class CreateKarmaROP(plugin.HoudiniCreator):
             # Render Frame Range
             "trange": 1,
             # Karma ROP Setting
-            "picture": filepath,
+            "picture": file_path,
             # Karma Checkpoint Setting
             "productName": checkpoint,
             # USD Output Directory

--- a/openpype/hosts/houdini/plugins/create/create_mantra_rop.py
+++ b/openpype/hosts/houdini/plugins/create/create_mantra_rop.py
@@ -31,9 +31,12 @@ class CreateMantraROP(plugin.HoudiniCreator):
 
         ext = pre_create_data.get("image_format")
 
-        file_path = "{}/pyblish/renders/`chs('subset')`/`chs('subset')`.$F4.{}".format(
-            hou.text.expandString("$HIP"),
-            ext
+        file_path = (
+            "{}/pyblish/renders/`chs('subset')`/"
+            "`chs('subset')`.$F4.{}".format(
+                hou.text.expandString("$HIP"),
+                ext
+            )
         )
 
         parms = {

--- a/openpype/hosts/houdini/plugins/create/create_mantra_rop.py
+++ b/openpype/hosts/houdini/plugins/create/create_mantra_rop.py
@@ -31,17 +31,16 @@ class CreateMantraROP(plugin.HoudiniCreator):
 
         ext = pre_create_data.get("image_format")
 
-        filepath = "{renders_dir}{subset_name}/{subset_name}.$F4.{ext}".format(
-            renders_dir=hou.text.expandString("$HIP/pyblish/renders/"),
-            subset_name=subset_name,
-            ext=ext,
+        file_path = "{}/pyblish/renders/`chs('subset')`/`chs('subset')`.$F4.{}".format(
+            hou.text.expandString("$HIP"),
+            ext
         )
 
         parms = {
             # Render Frame Range
             "trange": 1,
             # Mantra ROP Setting
-            "vm_picture": filepath,
+            "vm_picture": file_path,
         }
 
         if self.selected_nodes:

--- a/openpype/hosts/houdini/plugins/create/create_pointcache.py
+++ b/openpype/hosts/houdini/plugins/create/create_pointcache.py
@@ -22,9 +22,8 @@ class CreatePointCache(plugin.HoudiniCreator):
             pre_create_data)
 
         instance_node = hou.node(instance.get("instance_node"))
-        file_path = "{}{}".format(
-            hou.text.expandString("$HIP/pyblish"),
-            "/`chs('subset')`.abc"
+        file_path = "{}/pyblish/`chs('subset')`.abc".format(
+            hou.text.expandString("$HIP")
         )
         parms = {
             "use_sop_path": True,

--- a/openpype/hosts/houdini/plugins/create/create_pointcache.py
+++ b/openpype/hosts/houdini/plugins/create/create_pointcache.py
@@ -32,7 +32,7 @@ class CreatePointCache(plugin.HoudiniCreator):
             "prim_to_detail_pattern": "cbId",
             "format": 2,
             "facesets": 0,
-            "filename":  file_path
+            "filename": file_path
         }
 
         if self.selected_nodes:

--- a/openpype/hosts/houdini/plugins/create/create_pointcache.py
+++ b/openpype/hosts/houdini/plugins/create/create_pointcache.py
@@ -22,6 +22,10 @@ class CreatePointCache(plugin.HoudiniCreator):
             pre_create_data)
 
         instance_node = hou.node(instance.get("instance_node"))
+        file_path = "{}{}".format(
+            hou.text.expandString("$HIP/pyblish"),
+            "/`chs('subset')`.abc"
+        )
         parms = {
             "use_sop_path": True,
             "build_from_path": True,
@@ -29,8 +33,7 @@ class CreatePointCache(plugin.HoudiniCreator):
             "prim_to_detail_pattern": "cbId",
             "format": 2,
             "facesets": 0,
-            "filename": hou.text.expandString(
-                "$HIP/pyblish/{}.abc".format(subset_name))
+            "filename":  file_path
         }
 
         if self.selected_nodes:

--- a/openpype/hosts/houdini/plugins/create/create_redshift_proxy.py
+++ b/openpype/hosts/houdini/plugins/create/create_redshift_proxy.py
@@ -31,9 +31,11 @@ class CreateRedshiftProxy(plugin.HoudiniCreator):
             pre_create_data)  # type: CreatedInstance
 
         instance_node = hou.node(instance.get("instance_node"))
-
+        file_path = "{}/pyblish/`chs('subset')`.$F4.rs".format(
+            hou.text.expandString("$HIP")
+        )
         parms = {
-            "RS_archive_file": '$HIP/pyblish/{}.$F4.rs'.format(subset_name),
+            "RS_archive_file": file_path,
         }
 
         if self.selected_nodes:

--- a/openpype/hosts/houdini/plugins/create/create_redshift_rop.py
+++ b/openpype/hosts/houdini/plugins/create/create_redshift_rop.py
@@ -50,10 +50,9 @@ class CreateRedshiftROP(plugin.HoudiniCreator):
         ipr_rop.parm("linked_rop").set(instance_node.path())
 
         ext = pre_create_data.get("image_format")
-        filepath = "{renders_dir}{subset_name}/{subset_name}.{fmt}".format(
-            renders_dir=hou.text.expandString("$HIP/pyblish/renders/"),
-            subset_name=subset_name,
-            fmt="${aov}.$F4.{ext}".format(aov="AOV", ext=ext)
+        file_path = "{}/pyblish/renders/`chs('subset')`/`chs('subset')`.$AOV.$F4.{}".format(
+            hou.text.expandString("$HIP"),
+            ext
         )
 
         ext_format_index = {"exr": 0, "tif": 1, "jpg": 2, "png": 3}
@@ -62,7 +61,7 @@ class CreateRedshiftROP(plugin.HoudiniCreator):
             # Render frame range
             "trange": 1,
             # Redshift ROP settings
-            "RS_outputFileNamePrefix": filepath,
+            "RS_outputFileNamePrefix": file_path,
             "RS_outputMultilayerMode": "1",  # no multi-layered exr
             "RS_outputBeautyAOVSuffix": "beauty",
             "RS_outputFileFormat": ext_format_index[ext],

--- a/openpype/hosts/houdini/plugins/create/create_redshift_rop.py
+++ b/openpype/hosts/houdini/plugins/create/create_redshift_rop.py
@@ -50,9 +50,12 @@ class CreateRedshiftROP(plugin.HoudiniCreator):
         ipr_rop.parm("linked_rop").set(instance_node.path())
 
         ext = pre_create_data.get("image_format")
-        file_path = "{}/pyblish/renders/`chs('subset')`/`chs('subset')`.$AOV.$F4.{}".format(
-            hou.text.expandString("$HIP"),
-            ext
+        file_path = (
+            "{}/pyblish/renders/`chs('subset')`/`chs('subset')`"
+            ".$AOV.$F4.{}".format(
+                hou.text.expandString("$HIP"),
+                ext
+            )
         )
 
         ext_format_index = {"exr": 0, "tif": 1, "jpg": 2, "png": 3}

--- a/openpype/hosts/houdini/plugins/create/create_review.py
+++ b/openpype/hosts/houdini/plugins/create/create_review.py
@@ -31,14 +31,13 @@ class CreateReview(plugin.HoudiniCreator):
 
         frame_range = hou.playbar.frameRange()
 
-        filepath = "{root}/{subset}/{subset}.$F4.{ext}".format(
-            root=hou.text.expandString("$HIP/pyblish"),
-            subset="`chs(\"subset\")`",  # keep dynamic link to subset
-            ext=pre_create_data.get("image_format") or "png"
+        file_path = "{}/pyblish/`chs('subset')`/`chs('subset')`.$F4.{}".format(
+            hou.text.expandString("$HIP"),
+            pre_create_data.get("image_format") or "png"
         )
 
         parms = {
-            "picture": filepath,
+            "picture": file_path,
 
             "trange": 1,
 

--- a/openpype/hosts/houdini/plugins/create/create_staticmesh.py
+++ b/openpype/hosts/houdini/plugins/create/create_staticmesh.py
@@ -29,8 +29,9 @@ class CreateStaticMesh(plugin.HoudiniCreator):
         instance_node = hou.node(instance.get("instance_node"))
 
         # prepare parms
-        output_path = hou.text.expandString(
-            "$HIP/pyblish/{}.fbx".format(subset_name)
+        output_path = "{}{}".format(
+            hou.text.expandString("$HIP/pyblish"),
+            "/`chs('subset')`.fbx"
         )
 
         parms = {

--- a/openpype/hosts/houdini/plugins/create/create_staticmesh.py
+++ b/openpype/hosts/houdini/plugins/create/create_staticmesh.py
@@ -29,14 +29,12 @@ class CreateStaticMesh(plugin.HoudiniCreator):
         instance_node = hou.node(instance.get("instance_node"))
 
         # prepare parms
-        output_path = "{}{}".format(
-            hou.text.expandString("$HIP/pyblish"),
-            "/`chs('subset')`.fbx"
+        file_path = "{}/pyblish/`chs('subset')`.fbx".format(
+            hou.text.expandString("$HIP")
         )
-
         parms = {
             "startnode": self.get_selection(),
-            "sopoutput": output_path,
+            "sopoutput": file_path,
             # vertex cache format
             "vcformat": pre_create_data.get("vcformat"),
             "convertunits": pre_create_data.get("convertunits"),

--- a/openpype/hosts/houdini/plugins/create/create_usd.py
+++ b/openpype/hosts/houdini/plugins/create/create_usd.py
@@ -25,9 +25,11 @@ class CreateUSD(plugin.HoudiniCreator):
             pre_create_data)  # type: CreatedInstance
 
         instance_node = hou.node(instance.get("instance_node"))
-
+        file_path = "{}/pyblish/`chs('subset')`.usd".format(
+            hou.text.expandString("$HIP")
+        )
         parms = {
-            "lopoutput": "$HIP/pyblish/{}.usd".format(subset_name),
+            "lopoutput": file_path,
             "enableoutputprocessor_simplerelativepaths": False,
         }
 

--- a/openpype/hosts/houdini/plugins/create/create_vbd_cache.py
+++ b/openpype/hosts/houdini/plugins/create/create_vbd_cache.py
@@ -26,8 +26,11 @@ class CreateVDBCache(plugin.HoudiniCreator):
             pre_create_data)  # type: CreatedInstance
 
         instance_node = hou.node(instance.get("instance_node"))
+        file_path = "{}/pyblish/`chs('subset')`.$F4.vdb".format(
+            hou.text.expandString("$HIP")
+        )
         parms = {
-            "sopoutput": "$HIP/pyblish/{}.$F4.vdb".format(subset_name),
+            "sopoutput": file_path,
             "initsim": True,
             "trange": 1
         }

--- a/openpype/hosts/houdini/plugins/create/create_vray_rop.py
+++ b/openpype/hosts/houdini/plugins/create/create_vray_rop.py
@@ -88,9 +88,12 @@ class CreateVrayROP(plugin.HoudiniCreator):
             })
 
         else:
-            file_path = "{}/pyblish/renders/`chs('subset')`/`chs('subset')`.$F4.{}".format(
-                hou.text.expandString("$HIP"),
-                ext
+            file_path = (
+                "{}/pyblish/renders/`chs('subset')`/"
+                "`chs('subset')`.$F4.{}".format(
+                    hou.text.expandString("$HIP"),
+                    ext
+                )
             )
             parms.update({
                 "use_render_channels": 0,

--- a/openpype/hosts/houdini/plugins/create/create_vray_rop.py
+++ b/openpype/hosts/houdini/plugins/create/create_vray_rop.py
@@ -67,18 +67,13 @@ class CreateVrayROP(plugin.HoudiniCreator):
         instance_data["RenderElement"] = pre_create_data.get("render_element_enabled")         # noqa
         if pre_create_data.get("render_element_enabled", True):
             # Vray has its own tag for AOV file output
-            filepath = "{renders_dir}{subset_name}/{subset_name}.{fmt}".format(
-                renders_dir=hou.text.expandString("$HIP/pyblish/renders/"),
-                subset_name=subset_name,
-                fmt="${aov}.$F4.{ext}".format(aov="AOV",
-                                              ext=ext)
+            file_path = "{}/pyblish/renders/`chs('subset')`/`chs('subset')`.$AOV.$F4.{}".format(
+                hou.text.expandString("$HIP"),
+                ext
             )
-            filepath = "{}{}".format(
-                hou.text.expandString("$HIP/pyblish/renders/"),
-                "{}/{}.${}.$F4.{}".format(subset_name,
-                                          subset_name,
-                                          "AOV",
-                                          ext)
+            file_path = "{}/pyblish/renders/`chs('subset')`/`chs('subset')`.$AOV.$F4.{}".format(
+                hou.text.expandString("$HIP"),
+                ext
             )
             re_rop = instance_node.parent().createNode(
                 "vray_render_channels",
@@ -89,19 +84,18 @@ class CreateVrayROP(plugin.HoudiniCreator):
             re_path = re_rop.path()
             parms.update({
                 "use_render_channels": 1,
-                "SettingsOutput_img_file_path": filepath,
+                "SettingsOutput_img_file_path": file_path,
                 "render_network_render_channels": re_path
             })
 
         else:
-            filepath = "{renders_dir}{subset_name}/{subset_name}.{fmt}".format(
-                renders_dir=hou.text.expandString("$HIP/pyblish/renders/"),
-                subset_name=subset_name,
-                fmt="$F4.{ext}".format(ext=ext)
+            file_path = "{}/pyblish/renders/`chs('subset')`/`chs('subset')`.$F4.{}".format(
+                hou.text.expandString("$HIP"),
+                ext
             )
             parms.update({
                 "use_render_channels": 0,
-                "SettingsOutput_img_file_path": filepath
+                "SettingsOutput_img_file_path": file_path
             })
 
         custom_res = pre_create_data.get("override_resolution")

--- a/openpype/hosts/houdini/plugins/create/create_vray_rop.py
+++ b/openpype/hosts/houdini/plugins/create/create_vray_rop.py
@@ -67,13 +67,12 @@ class CreateVrayROP(plugin.HoudiniCreator):
         instance_data["RenderElement"] = pre_create_data.get("render_element_enabled")         # noqa
         if pre_create_data.get("render_element_enabled", True):
             # Vray has its own tag for AOV file output
-            file_path = "{}/pyblish/renders/`chs('subset')`/`chs('subset')`.$AOV.$F4.{}".format(
-                hou.text.expandString("$HIP"),
-                ext
-            )
-            file_path = "{}/pyblish/renders/`chs('subset')`/`chs('subset')`.$AOV.$F4.{}".format(
-                hou.text.expandString("$HIP"),
-                ext
+            file_path = (
+                "{}/pyblish/renders/`chs('subset')`/"
+                "`chs('subset')`.$AOV.$F4.{}".format(
+                    hou.text.expandString("$HIP"),
+                    ext
+                )
             )
             re_rop = instance_node.parent().createNode(
                 "vray_render_channels",


### PR DESCRIPTION
## Changelog Description
I was exploring Houdini ideas/issues/PRs and came across allow houdini publish instances duplication. 
I ~stole some code from~ was inspired by these two PRs https://github.com/ynput/OpenPype/pull/5490 and https://github.com/ynput/OpenPype/pull/5616 

I was abstracting their ideas and trying imitating their functionalities by Houdini expressions. 
one interesting thing that when houdini evaluates the value of a parameter it also evaluate any expressions used inside it. 
so, this is actually works! 

This is my first test, where I edited manually these parameters 
> one limitation is that family must be included in the node's name because you can have the same variant for multiple families
> and that's why I can't use node's name for variant value

- subset name = `opname(".")`
- variant = `strreplace(chs("subset"), chs("family"), "")`
- instance_node = `opfullpath(".")`
- instance_id = `opfullpath(".")`
- use `chs('subset')`

> and that's a thing that you can try it yourself without pulling this branch! 
 
![image](https://github.com/ynput/OpenPype/assets/20871534/e083a46a-712e-4e1a-b8d2-cc42893d0a77)

Here are some tests from this branch 

https://github.com/ynput/OpenPype/assets/20871534/e9d01f86-53e9-40cc-b29b-61d9d357198d

https://github.com/ynput/OpenPype/assets/20871534/be5e2758-0e6a-427f-8018-b5233847be78



## Testing notes:
1. Create publish instances
2. Duplicate them as many as you want
3. publish
