### PR TITLE
Publisher: Fix report maker memory leak + optimize lookups using set

### DIFF
--- a/openpype/tools/publisher/control.py
+++ b/openpype/tools/publisher/control.py
@@ -179,7 +179,7 @@ class PublishReportMaker:
         self._plugin_data = []
         self._plugin_data_with_plugin = []
 
-        self._stored_plugins = []
+        self._stored_plugins = set()
         self._current_plugin_data = []
         self._all_instances_by_id = {}
         self._current_context = None
@@ -194,7 +194,7 @@ class PublishReportMaker:
         self._publish_discover_result = create_context.publish_discover_result
         self._plugin_data = []
         self._plugin_data_with_plugin = []
-        self._stored_plugins = []
+        self._stored_plugins = set()
         self._current_plugin_data = {}
         self._all_instances_by_id = {}
         self._current_context = context
@@ -230,7 +230,7 @@ class PublishReportMaker:
             raise ValueError(
                 "Plugin '{}' is already stored".format(str(plugin)))
 
-        self._stored_plugins.append(plugin)
+        self._stored_plugins.add(plugin)
 
         plugin_data_item = self._create_plugin_data_item(plugin)
 

--- a/openpype/tools/publisher/control.py
+++ b/openpype/tools/publisher/control.py
@@ -194,6 +194,7 @@ class PublishReportMaker:
         self._publish_discover_result = create_context.publish_discover_result
         self._plugin_data = []
         self._plugin_data_with_plugin = []
+        self._stored_plugins = []
         self._current_plugin_data = {}
         self._all_instances_by_id = {}
         self._current_context = context


### PR DESCRIPTION
## Changelog Description

Fixes a memory leak where resetting publisher does not clear the stored plugins for the Publish Report Maker.
Also changes the stored plugins to a `set` to optimize the lookup speeds.

## Additional info

Reported the bug on discord [here](https://discord.com/channels/517362899170230292/517382145552154634/1158139604831059968)

> I think I've found a **'memory leak' in the new publisher.**
> 
> Shouldn't `reset` on the Publisher's Report maker controller also clear the `_stored_plugins` here: https://github.com/ynput/OpenPype/blob/6e69d3a87f3c8ec6168c59bbf7e7d7fdadd58b61/openpype/tools/publisher/control.py#L187
> 
> The only reason why currently *this* https://github.com/ynput/OpenPype/blob/6e69d3a87f3c8ec6168c59bbf7e7d7fdadd58b61/openpype/tools/publisher/control.py#L225-L231 isn't occuring on refreshes/resets of the publisher is because the Discover logic dynamically reloads the plugins from disk each time as such (each plugin is basically a new class and not the original class from the previous load)
> 
> So I did a quick test run and just added a `print(len(self._stored_plugins))` in that `reset` and it continuously gets larger and larger - see attached screenshot. On just doing a reset it doesn't seem to increment much, but it does increment. Closing the publisher and reopening it doesn't release it either.
> 
> But doing an actual publish once, and then again, and then again will have it go to massive increments since of course it'd contain all plugins. In maya for example after five publishes it's 1000+ :stuck_out_tongue:

## Testing notes:

1. Use Publisher
2. Reset, publish, reset, publish, reset :)
