### PR TITLE
Publisher: Refactor Report Maker plugin data storage to be a dict by plugin.id

### DIFF
--- a/openpype/tools/publisher/control.py
+++ b/openpype/tools/publisher/control.py
@@ -176,11 +176,10 @@ class PublishReportMaker:
         self._create_discover_result = None
         self._convert_discover_result = None
         self._publish_discover_result = None
-        self._plugin_data = []
-        self._plugin_data_with_plugin = []
 
-        self._stored_plugins = set()
-        self._current_plugin_data = []
+        self._plugin_data_by_plugin_id = {}
+        self._current_plugin = None
+        self._current_plugin_data = {}
         self._all_instances_by_id = {}
         self._current_context = None
 
@@ -192,9 +191,9 @@ class PublishReportMaker:
             create_context.convertor_discover_result
         )
         self._publish_discover_result = create_context.publish_discover_result
-        self._plugin_data = []
-        self._plugin_data_with_plugin = []
-        self._stored_plugins = set()
+
+        self._plugin_data_by_plugin_id = {}
+        self._current_plugin = None
         self._current_plugin_data = {}
         self._all_instances_by_id = {}
         self._current_context = context
@@ -211,18 +210,11 @@ class PublishReportMaker:
         if self._current_plugin_data:
             self._current_plugin_data["passed"] = True
 
+        self._current_plugin = plugin
         self._current_plugin_data = self._add_plugin_data_item(plugin)
 
-    def _get_plugin_data_item(self, plugin):
-        store_item = None
-        for item in self._plugin_data_with_plugin:
-            if item["plugin"] is plugin:
-                store_item = item["data"]
-                break
-        return store_item
-
     def _add_plugin_data_item(self, plugin):
-        if plugin in self._stored_plugins:
+        if plugin.id in self._plugin_data_by_plugin_id:
             # A plugin would be processed more than once. What can cause it:
             #   - there is a bug in controller
             #   - plugin class is imported into multiple files
@@ -230,15 +222,9 @@ class PublishReportMaker:
             raise ValueError(
                 "Plugin '{}' is already stored".format(str(plugin)))
 
-        self._stored_plugins.add(plugin)
-
         plugin_data_item = self._create_plugin_data_item(plugin)
+        self._plugin_data_by_plugin_id[plugin.id] = plugin_data_item
 
-        self._plugin_data_with_plugin.append({
-            "plugin": plugin,
-            "data": plugin_data_item
-        })
-        self._plugin_data.append(plugin_data_item)
         return plugin_data_item
 
     def _create_plugin_data_item(self, plugin):
@@ -279,7 +265,7 @@ class PublishReportMaker:
         """Add result of single action."""
         plugin = result["plugin"]
 
-        store_item = self._get_plugin_data_item(plugin)
+        store_item = self._plugin_data_by_plugin_id.get(plugin.id)
         if store_item is None:
             store_item = self._add_plugin_data_item(plugin)
 
@@ -301,14 +287,24 @@ class PublishReportMaker:
                 instance, instance in self._current_context
             )
 
-        plugins_data = copy.deepcopy(self._plugin_data)
-        if plugins_data and not plugins_data[-1]["passed"]:
-            plugins_data[-1]["passed"] = True
+        plugins_data_by_plugin_id = copy.deepcopy(
+            self._plugin_data_by_plugin_id
+        )
+
+        # Ensure the current plug-in is marked as `passed` in the result
+        # so that it shows on reports for paused publishes
+        if self._current_plugin is not None:
+            current_plugins_data = plugins_data_by_plugin_id.get(
+                self._current_plugin.id
+            )
+            if current_plugins_data and not current_plugins_data["passed"]:
+                current_plugins_data["passed"] = True
 
         if publish_plugins:
             for plugin in publish_plugins:
-                if plugin not in self._stored_plugins:
-                    plugins_data.append(self._create_plugin_data_item(plugin))
+                if plugin.id not in plugins_data_by_plugin_id:
+                    plugins_data_by_plugin_id[plugin.id] = \
+                        self._create_plugin_data_item(plugin)
 
         reports = []
         if self._create_discover_result is not None:
@@ -329,7 +325,7 @@ class PublishReportMaker:
                 )
 
         return {
-            "plugins_data": plugins_data,
+            "plugins_data": list(plugins_data_by_plugin_id.values()),
             "instances": instances_details,
             "context": self._extract_context_data(self._current_context),
             "crashed_file_paths": crashed_file_paths,


### PR DESCRIPTION
## Changelog Description

Refactor Report Maker plugin data storage to be a dict by `plugin.id`

Also fixes `_current_plugin_data` type on `__init__`

## Additional info

Avoids the need for _stored plugins_, _plugin data_ and _plugin data with plugin to be stored separately.

Should be faster because `_get_plugin_data_item`  can now be replaced with O1 lookup instead of requiring to iterate all plugin data items.

## Testing notes:

1. Use publisher, reset, validate, publish, view the different reports, use actions.

**Preferably test in different DCCs with different Python versions.**