### PR TITLE
Chore: Maya reduce get project settings calls

### DIFF
--- a/openpype/hosts/maya/api/pipeline.py
+++ b/openpype/hosts/maya/api/pipeline.py
@@ -28,8 +28,6 @@ from openpype.lib import (
 from openpype.pipeline import (
     legacy_io,
     get_current_project_name,
-    get_current_asset_name,
-    get_current_task_name,
     register_loader_plugin_path,
     register_inventory_action_path,
     register_creator_plugin_path,

--- a/openpype/hosts/maya/api/pipeline.py
+++ b/openpype/hosts/maya/api/pipeline.py
@@ -106,7 +106,7 @@ class MayaHost(HostBase, IWorkfileHost, ILoadHost, IPublishHost):
         _set_project()
         self._register_callbacks()
 
-        menu.install()
+        menu.install(project_settings)
 
         register_event_callback("save", on_save)
         register_event_callback("open", on_open)

--- a/openpype/hosts/maya/api/plugin.py
+++ b/openpype/hosts/maya/api/plugin.py
@@ -601,6 +601,13 @@ class RenderlayerCreator(NewCreator, MayaCreatorBase):
 class Loader(LoaderPlugin):
     hosts = ["maya"]
 
+    load_settings = {}  # defined in settings
+
+    @classmethod
+    def apply_settings(cls, project_settings, system_settings):
+        super(Loader, cls).apply_settings(project_settings, system_settings)
+        cls.load_settings = project_settings['maya']['load']
+
     def get_custom_namespace_and_group(self, context, options, loader_key):
         """Queries Settings to get custom template for namespace and group.
 
@@ -613,12 +620,9 @@ class Loader(LoaderPlugin):
             loader_key (str): key to get separate configuration from Settings
                 ('reference_loader'|'import_loader')
         """
-        options["attach_to_root"] = True
 
-        asset = context['asset']
-        subset = context['subset']
-        settings = get_project_settings(context['project']['name'])
-        custom_naming = settings['maya']['load'][loader_key]
+        options["attach_to_root"] = True
+        custom_naming = self.load_settings[loader_key]
 
         if not custom_naming['namespace']:
             raise LoadError("No namespace specified in "
@@ -627,6 +631,8 @@ class Loader(LoaderPlugin):
             self.log.debug("No custom group_name, no group will be created.")
             options["attach_to_root"] = False
 
+        asset = context['asset']
+        subset = context['subset']
         formatting_data = {
             "asset_name": asset['name'],
             "asset_type": asset['type'],

--- a/openpype/hosts/maya/plugins/publish/validate_unreal_staticmesh_naming.py
+++ b/openpype/hosts/maya/plugins/publish/validate_unreal_staticmesh_naming.py
@@ -69,11 +69,8 @@ class ValidateUnrealStaticMeshName(pyblish.api.InstancePlugin,
 
         invalid = []
 
-        project_settings = get_project_settings(
-            legacy_io.Session["AVALON_PROJECT"]
-        )
         collision_prefixes = (
-            project_settings
+            instance.context.data["project_settings"]
             ["maya"]
             ["create"]
             ["CreateUnrealStaticMesh"]

--- a/openpype/modules/muster/plugins/publish/submit_maya_muster.py
+++ b/openpype/modules/muster/plugins/publish/submit_maya_muster.py
@@ -25,6 +25,7 @@ def _get_template_id(renderer):
     :rtype: int
     """
 
+    # TODO: Use setings from context?
     templates = get_system_settings()["modules"]["muster"]["templates_mapping"]
     if not templates:
         raise RuntimeError(("Muster template mapping missing in "

--- a/openpype/modules/muster/plugins/publish/submit_maya_muster.py
+++ b/openpype/modules/muster/plugins/publish/submit_maya_muster.py
@@ -25,7 +25,7 @@ def _get_template_id(renderer):
     :rtype: int
     """
 
-    # TODO: Use setings from context?
+    # TODO: Use settings from context?
     templates = get_system_settings()["modules"]["muster"]["templates_mapping"]
     if not templates:
         raise RuntimeError(("Muster template mapping missing in "


### PR DESCRIPTION
## Changelog Description

Re-use system settings / project settings where we can instead of requerying.

### Additional Info

Note: Moved the Muster-specific submitter for maya into the muster module

## Testing notes:

1. Maya should launch ok
2. Maya menu should install ok
3. Muster submissions should still work from maya
4. Custom naming for import and reference loaders should this be configurable in `project_settings/maya/load/import_loader` and `project_settings/maya/load/reference_loader` and should still work as intended.

