### PR TITLE
Unreal: Changed behaviour for updating assets

### DIFF
--- a/openpype/hosts/unreal/api/pipeline.py
+++ b/openpype/hosts/unreal/api/pipeline.py
@@ -683,6 +683,42 @@ def replace_static_mesh_actors(old_assets, new_assets):
         smes.replace_mesh_components_meshes(
             static_mesh_comps, old_mesh, new_mesh)
 
+
+def replace_skeletal_mesh_actors(old_assets, new_assets):
+    eas = unreal.get_editor_subsystem(unreal.EditorActorSubsystem)
+
+    comps = eas.get_all_level_actors_components()
+    skeletal_mesh_comps = [
+        c for c in comps if isinstance(c, unreal.SkeletalMeshComponent)
+    ]
+
+    # Get all the static meshes among the old assets in a dictionary with
+    # the name as key
+    old_meshes = {}
+    for a in old_assets:
+        asset = unreal.EditorAssetLibrary.load_asset(a)
+        if isinstance(asset, unreal.SkeletalMesh):
+            old_meshes[asset.get_name()] = asset
+
+    # Get all the static meshes among the new assets in a dictionary with
+    # the name as key
+    new_meshes = {}
+    for a in new_assets:
+        asset = unreal.EditorAssetLibrary.load_asset(a)
+        if isinstance(asset, unreal.SkeletalMesh):
+            new_meshes[asset.get_name()] = asset
+
+    for old_name, old_mesh in old_meshes.items():
+        new_mesh = new_meshes.get(old_name)
+
+        if not new_mesh:
+            continue
+
+        for comp in skeletal_mesh_comps:
+            if comp.get_skeletal_mesh_asset() == old_mesh:
+                comp.set_skeletal_mesh_asset(new_mesh)
+
+
 def delete_previous_asset_if_unused(container, asset_content):
     ar = unreal.AssetRegistryHelpers.get_asset_registry()
 

--- a/openpype/hosts/unreal/api/pipeline.py
+++ b/openpype/hosts/unreal/api/pipeline.py
@@ -30,6 +30,7 @@ import unreal  # noqa
 logger = logging.getLogger("openpype.hosts.unreal")
 
 AYON_CONTAINERS = "AyonContainers"
+AYON_ASSET_DIR = "/Game/Ayon/Assets"
 CONTEXT_CONTAINER = "Ayon/context.json"
 UNREAL_VERSION = semver.VersionInfo(
     *os.getenv("AYON_UNREAL_VERSION").split(".")

--- a/openpype/hosts/unreal/api/pipeline.py
+++ b/openpype/hosts/unreal/api/pipeline.py
@@ -654,13 +654,21 @@ def generate_sequence(h, h_dir):
 
 
 def _get_comps_and_assets(
-    component_class, asset_class, old_assets, new_assets
+    component_class, asset_class, old_assets, new_assets, selected
 ):
     eas = unreal.get_editor_subsystem(unreal.EditorActorSubsystem)
-    comps = eas.get_all_level_actors_components()
-    components = [
-        c for c in comps if isinstance(c, component_class)
-    ]
+
+    components = []
+    if selected:
+        sel_actors = eas.get_selected_level_actors()
+        for actor in sel_actors:
+            comps = actor.get_components_by_class(component_class)
+            components.extend(comps)
+    else:
+        comps = eas.get_all_level_actors_components()
+        components = [
+            c for c in comps if isinstance(c, component_class)
+        ]
 
     # Get all the static meshes among the old assets in a dictionary with
     # the name as key
@@ -681,14 +689,15 @@ def _get_comps_and_assets(
     return components, selected_old_assets, selected_new_assets
 
 
-def replace_static_mesh_actors(old_assets, new_assets):
+def replace_static_mesh_actors(old_assets, new_assets, selected):
     smes = unreal.get_editor_subsystem(unreal.StaticMeshEditorSubsystem)
 
     static_mesh_comps, old_meshes, new_meshes = _get_comps_and_assets(
         unreal.StaticMeshComponent,
         unreal.StaticMesh,
         old_assets,
-        new_assets
+        new_assets,
+        selected
     )
 
     for old_name, old_mesh in old_meshes.items():
@@ -701,12 +710,13 @@ def replace_static_mesh_actors(old_assets, new_assets):
             static_mesh_comps, old_mesh, new_mesh)
 
 
-def replace_skeletal_mesh_actors(old_assets, new_assets):
+def replace_skeletal_mesh_actors(old_assets, new_assets, selected):
     skeletal_mesh_comps, old_meshes, new_meshes = _get_comps_and_assets(
         unreal.SkeletalMeshComponent,
         unreal.SkeletalMesh,
         old_assets,
-        new_assets
+        new_assets,
+        selected
     )
 
     for old_name, old_mesh in old_meshes.items():
@@ -720,12 +730,13 @@ def replace_skeletal_mesh_actors(old_assets, new_assets):
                 comp.set_skeletal_mesh_asset(new_mesh)
 
 
-def replace_geometry_cache_actors(old_assets, new_assets):
+def replace_geometry_cache_actors(old_assets, new_assets, selected):
     geometry_cache_comps, old_caches, new_caches = _get_comps_and_assets(
         unreal.GeometryCacheComponent,
         unreal.GeometryCache,
         old_assets,
-        new_assets
+        new_assets,
+        selected
     )
 
     for old_name, old_mesh in old_caches.items():

--- a/openpype/hosts/unreal/api/pipeline.py
+++ b/openpype/hosts/unreal/api/pipeline.py
@@ -13,8 +13,10 @@ from openpype.client import get_asset_by_name, get_assets
 from openpype.pipeline import (
     register_loader_plugin_path,
     register_creator_plugin_path,
+    register_inventory_action_path,
     deregister_loader_plugin_path,
     deregister_creator_plugin_path,
+    deregister_inventory_action_path,
     AYON_CONTAINER_ID,
     legacy_io,
 )
@@ -127,6 +129,7 @@ def install():
     pyblish.api.register_plugin_path(str(PUBLISH_PATH))
     register_loader_plugin_path(str(LOAD_PATH))
     register_creator_plugin_path(str(CREATE_PATH))
+    register_inventory_action_path(str(INVENTORY_PATH))
     _register_callbacks()
     _register_events()
 
@@ -136,6 +139,7 @@ def uninstall():
     pyblish.api.deregister_plugin_path(str(PUBLISH_PATH))
     deregister_loader_plugin_path(str(LOAD_PATH))
     deregister_creator_plugin_path(str(CREATE_PATH))
+    deregister_inventory_action_path(str(INVENTORY_PATH))
 
 
 def _register_callbacks():

--- a/openpype/hosts/unreal/api/pipeline.py
+++ b/openpype/hosts/unreal/api/pipeline.py
@@ -750,7 +750,7 @@ def replace_geometry_cache_actors(old_assets, new_assets, selected):
                 comp.set_geometry_cache(new_mesh)
 
 
-def delete_previous_asset_if_unused(container, asset_content):
+def delete_asset_if_unused(container, asset_content):
     ar = unreal.AssetRegistryHelpers.get_asset_registry()
 
     references = set()

--- a/openpype/hosts/unreal/api/pipeline.py
+++ b/openpype/hosts/unreal/api/pipeline.py
@@ -722,8 +722,8 @@ def replace_skeletal_mesh_actors(old_assets, new_assets):
 
 def replace_geometry_cache_actors(old_assets, new_assets):
     geometry_cache_comps, old_caches, new_caches = _get_comps_and_assets(
-        unreal.SkeletalMeshComponent,
-        unreal.SkeletalMesh,
+        unreal.GeometryCacheComponent,
+        unreal.GeometryCache,
         old_assets,
         new_assets
     )

--- a/openpype/hosts/unreal/plugins/inventory/delete_unused_assets.py
+++ b/openpype/hosts/unreal/plugins/inventory/delete_unused_assets.py
@@ -1,8 +1,8 @@
 import unreal
 
+from openpype.hosts.unreal.api.tools_ui import qt_app_context
 from openpype.hosts.unreal.api.pipeline import delete_asset_if_unused
 from openpype.pipeline import InventoryAction
-
 
 
 class DeleteUnusedAssets(InventoryAction):
@@ -14,7 +14,9 @@ class DeleteUnusedAssets(InventoryAction):
     color = "red"
     order = 1
 
-    def process(self, containers):
+    dialog = None
+
+    def _delete_unused_assets(self, containers):
         allowed_families = ["model", "rig"]
 
         for container in containers:
@@ -29,3 +31,36 @@ class DeleteUnusedAssets(InventoryAction):
             )
 
             delete_asset_if_unused(container, asset_content)
+
+    def _show_confirmation_dialog(self, containers):
+        from qtpy import QtCore
+        from openpype.widgets import popup
+        from openpype.style import load_stylesheet
+
+        dialog = popup.Popup()
+        dialog.setWindowFlags(
+            QtCore.Qt.Window
+            | QtCore.Qt.WindowStaysOnTopHint
+        )
+        dialog.setFocusPolicy(QtCore.Qt.StrongFocus)
+        dialog.setWindowTitle("Delete all unused assets")
+        dialog.setMessage(
+            "You are about to delete all the assets in the project that \n"
+            "are not used in any level. Are you sure you want to continue?"
+        )
+        dialog.setButtonText("Delete")
+
+        dialog.on_clicked.connect(
+            lambda: self._delete_unused_assets(containers)
+        )
+
+        dialog.show()
+        dialog.raise_()
+        dialog.activateWindow()
+        dialog.setStyleSheet(load_stylesheet())
+
+        self.dialog = dialog
+
+    def process(self, containers):
+        with qt_app_context():
+            self._show_confirmation_dialog(containers)

--- a/openpype/hosts/unreal/plugins/inventory/delete_unused_assets.py
+++ b/openpype/hosts/unreal/plugins/inventory/delete_unused_assets.py
@@ -1,0 +1,31 @@
+import unreal
+
+from openpype.hosts.unreal.api.pipeline import delete_asset_if_unused
+from openpype.pipeline import InventoryAction
+
+
+
+class DeleteUnusedAssets(InventoryAction):
+    """Delete all the assets that are not used in any level.
+    """
+
+    label = "Delete Unused Assets"
+    icon = "trash"
+    color = "red"
+    order = 1
+
+    def process(self, containers):
+        allowed_families = ["model", "rig"]
+
+        for container in containers:
+            container_dir = container.get("namespace")
+            if container.get("family") not in allowed_families:
+                unreal.log_warning(
+                    f"Container {container_dir} is not supported.")
+                continue
+
+            asset_content = unreal.EditorAssetLibrary.list_assets(
+                container_dir, recursive=True, include_folder=False
+            )
+
+            delete_asset_if_unused(container, asset_content)

--- a/openpype/hosts/unreal/plugins/inventory/update_actors.py
+++ b/openpype/hosts/unreal/plugins/inventory/update_actors.py
@@ -5,7 +5,6 @@ from openpype.hosts.unreal.api.pipeline import (
     replace_static_mesh_actors,
     replace_skeletal_mesh_actors,
     replace_geometry_cache_actors,
-    delete_asset_if_unused,
 )
 from openpype.pipeline import InventoryAction
 

--- a/openpype/hosts/unreal/plugins/inventory/update_actors.py
+++ b/openpype/hosts/unreal/plugins/inventory/update_actors.py
@@ -60,8 +60,6 @@ def update_assets(containers, selected):
 
             unreal.EditorLevelLibrary.save_current_level()
 
-            delete_asset_if_unused(sa_cont, old_content)
-
 
 class UpdateAllActors(InventoryAction):
     """Update all the Actors in the current level to the version of the asset

--- a/openpype/hosts/unreal/plugins/inventory/update_actors.py
+++ b/openpype/hosts/unreal/plugins/inventory/update_actors.py
@@ -1,0 +1,60 @@
+import unreal
+
+from openpype.hosts.unreal.api.pipeline import (
+    ls,
+    replace_static_mesh_actors,
+    replace_skeletal_mesh_actors,
+    delete_previous_asset_if_unused,
+)
+from openpype.pipeline import InventoryAction
+
+
+class UpdateActors(InventoryAction):
+    """Update Actors in level to this version.
+    """
+
+    label = "Update Actors in level to this version"
+    icon = "arrow-up"
+
+    def process(self, containers):
+        allowed_families = ["model", "rig"]
+
+        # Get all the containers in the Unreal Project
+        all_containers = ls()
+
+        for container in containers:
+            container_dir = container.get("namespace")
+            if container.get("family") not in allowed_families:
+                unreal.log_warning(
+                    f"Container {container_dir} is not supported.")
+                continue
+
+            # Get all containers with same asset_name but different objectName.
+            # These are the containers that need to be updated in the level.
+            sa_containers = [
+                i
+                for i in all_containers
+                if (
+                    i.get("asset_name") == container.get("asset_name") and
+                    i.get("objectName") != container.get("objectName")
+                )
+            ]
+
+            asset_content = unreal.EditorAssetLibrary.list_assets(
+                container_dir, recursive=True, include_folder=False
+            )
+
+            # Update all actors in level
+            for sa_cont in sa_containers:
+                sa_dir = sa_cont.get("namespace")
+                old_content = unreal.EditorAssetLibrary.list_assets(
+                    sa_dir, recursive=True, include_folder=False
+                )
+
+                if container.get("family") == "rig":
+                    replace_skeletal_mesh_actors(old_content, asset_content)
+                replace_static_mesh_actors(old_content, asset_content)
+
+                unreal.EditorLevelLibrary.save_current_level()
+
+                delete_previous_asset_if_unused(sa_cont, old_content)

--- a/openpype/hosts/unreal/plugins/inventory/update_actors.py
+++ b/openpype/hosts/unreal/plugins/inventory/update_actors.py
@@ -5,7 +5,7 @@ from openpype.hosts.unreal.api.pipeline import (
     replace_static_mesh_actors,
     replace_skeletal_mesh_actors,
     replace_geometry_cache_actors,
-    delete_previous_asset_if_unused,
+    delete_asset_if_unused,
 )
 from openpype.pipeline import InventoryAction
 
@@ -60,7 +60,7 @@ def update_assets(containers, selected):
 
             unreal.EditorLevelLibrary.save_current_level()
 
-            delete_previous_asset_if_unused(sa_cont, old_content)
+            delete_asset_if_unused(sa_cont, old_content)
 
 
 class UpdateAllActors(InventoryAction):

--- a/openpype/hosts/unreal/plugins/inventory/update_actors.py
+++ b/openpype/hosts/unreal/plugins/inventory/update_actors.py
@@ -4,6 +4,7 @@ from openpype.hosts.unreal.api.pipeline import (
     ls,
     replace_static_mesh_actors,
     replace_skeletal_mesh_actors,
+    replace_geometry_cache_actors,
     delete_previous_asset_if_unused,
 )
 from openpype.pipeline import InventoryAction
@@ -53,7 +54,13 @@ class UpdateActors(InventoryAction):
 
                 if container.get("family") == "rig":
                     replace_skeletal_mesh_actors(old_content, asset_content)
-                replace_static_mesh_actors(old_content, asset_content)
+                    replace_static_mesh_actors(old_content, asset_content)
+                elif container.get("family") == "model":
+                    if container.get("loader") == "PointCacheAlembicLoader":
+                        replace_geometry_cache_actors(
+                            old_content, asset_content)
+                    else:
+                        replace_static_mesh_actors(old_content, asset_content)
 
                 unreal.EditorLevelLibrary.save_current_level()
 

--- a/openpype/hosts/unreal/plugins/inventory/update_actors.py
+++ b/openpype/hosts/unreal/plugins/inventory/update_actors.py
@@ -10,58 +10,78 @@ from openpype.hosts.unreal.api.pipeline import (
 from openpype.pipeline import InventoryAction
 
 
-class UpdateActors(InventoryAction):
-    """Update Actors in level to this version.
+def update_assets(containers, selected):
+    allowed_families = ["model", "rig"]
+
+    # Get all the containers in the Unreal Project
+    all_containers = ls()
+
+    for container in containers:
+        container_dir = container.get("namespace")
+        if container.get("family") not in allowed_families:
+            unreal.log_warning(
+                f"Container {container_dir} is not supported.")
+            continue
+
+        # Get all containers with same asset_name but different objectName.
+        # These are the containers that need to be updated in the level.
+        sa_containers = [
+            i
+            for i in all_containers
+            if (
+                i.get("asset_name") == container.get("asset_name") and
+                i.get("objectName") != container.get("objectName")
+            )
+        ]
+
+        asset_content = unreal.EditorAssetLibrary.list_assets(
+            container_dir, recursive=True, include_folder=False
+        )
+
+        # Update all actors in level
+        for sa_cont in sa_containers:
+            sa_dir = sa_cont.get("namespace")
+            old_content = unreal.EditorAssetLibrary.list_assets(
+                sa_dir, recursive=True, include_folder=False
+            )
+
+            if container.get("family") == "rig":
+                replace_skeletal_mesh_actors(
+                    old_content, asset_content, selected)
+                replace_static_mesh_actors(
+                    old_content, asset_content, selected)
+            elif container.get("family") == "model":
+                if container.get("loader") == "PointCacheAlembicLoader":
+                    replace_geometry_cache_actors(
+                        old_content, asset_content, selected)
+                else:
+                    replace_static_mesh_actors(
+                        old_content, asset_content, selected)
+
+            unreal.EditorLevelLibrary.save_current_level()
+
+            delete_previous_asset_if_unused(sa_cont, old_content)
+
+
+class UpdateAllActors(InventoryAction):
+    """Update all the Actors in the current level to the version of the asset
+    selected in the scene manager.
     """
 
-    label = "Update Actors in level to this version"
+    label = "Replace all Actors in level to this version"
     icon = "arrow-up"
 
     def process(self, containers):
-        allowed_families = ["model", "rig"]
+        update_assets(containers, False)
 
-        # Get all the containers in the Unreal Project
-        all_containers = ls()
 
-        for container in containers:
-            container_dir = container.get("namespace")
-            if container.get("family") not in allowed_families:
-                unreal.log_warning(
-                    f"Container {container_dir} is not supported.")
-                continue
+class UpdateSelectedActors(InventoryAction):
+    """Update only the selected Actors in the current level to the version
+    of the asset selected in the scene manager.
+    """
 
-            # Get all containers with same asset_name but different objectName.
-            # These are the containers that need to be updated in the level.
-            sa_containers = [
-                i
-                for i in all_containers
-                if (
-                    i.get("asset_name") == container.get("asset_name") and
-                    i.get("objectName") != container.get("objectName")
-                )
-            ]
+    label = "Replace selected Actors in level to this version"
+    icon = "arrow-up"
 
-            asset_content = unreal.EditorAssetLibrary.list_assets(
-                container_dir, recursive=True, include_folder=False
-            )
-
-            # Update all actors in level
-            for sa_cont in sa_containers:
-                sa_dir = sa_cont.get("namespace")
-                old_content = unreal.EditorAssetLibrary.list_assets(
-                    sa_dir, recursive=True, include_folder=False
-                )
-
-                if container.get("family") == "rig":
-                    replace_skeletal_mesh_actors(old_content, asset_content)
-                    replace_static_mesh_actors(old_content, asset_content)
-                elif container.get("family") == "model":
-                    if container.get("loader") == "PointCacheAlembicLoader":
-                        replace_geometry_cache_actors(
-                            old_content, asset_content)
-                    else:
-                        replace_static_mesh_actors(old_content, asset_content)
-
-                unreal.EditorLevelLibrary.save_current_level()
-
-                delete_previous_asset_if_unused(sa_cont, old_content)
+    def process(self, containers):
+        update_assets(containers, True)

--- a/openpype/hosts/unreal/plugins/load/load_alembic_animation.py
+++ b/openpype/hosts/unreal/plugins/load/load_alembic_animation.py
@@ -69,7 +69,7 @@ class AnimationAlembicLoader(plugin.Loader):
         """
 
         # Create directory for asset and ayon container
-        root = "/Game/Ayon/Assets"
+        root = unreal_pipeline.AYON_ASSET_DIR
         asset = context.get('asset').get('name')
         suffix = "_CON"
         if asset:

--- a/openpype/hosts/unreal/plugins/load/load_geometrycache_abc.py
+++ b/openpype/hosts/unreal/plugins/load/load_geometrycache_abc.py
@@ -147,7 +147,6 @@ class PointCacheAlembicLoader(plugin.Loader):
         if not unreal.EditorAssetLibrary.does_directory_exist(asset_dir):
             path = self.filepath_from_context(context)
 
-
             self.import_and_containerize(
                 path, asset_dir, asset_name, container_name,
                 frame_start, frame_end)

--- a/openpype/hosts/unreal/plugins/load/load_geometrycache_abc.py
+++ b/openpype/hosts/unreal/plugins/load/load_geometrycache_abc.py
@@ -7,7 +7,12 @@ from openpype.pipeline import (
     AYON_CONTAINER_ID
 )
 from openpype.hosts.unreal.api import plugin
-from openpype.hosts.unreal.api import pipeline as unreal_pipeline
+from openpype.hosts.unreal.api.pipeline import (
+    create_container,
+    imprint,
+    replace_geometry_cache_actors,
+    delete_previous_asset_if_unused,
+)
 
 import unreal  # noqa
 
@@ -21,8 +26,11 @@ class PointCacheAlembicLoader(plugin.Loader):
     icon = "cube"
     color = "orange"
 
+    root = "/Game/Ayon/Assets"
+
+    @staticmethod
     def get_task(
-        self, filename, asset_dir, asset_name, replace,
+        filename, asset_dir, asset_name, replace,
         frame_start=None, frame_end=None
     ):
         task = unreal.AssetImportTask()
@@ -38,8 +46,6 @@ class PointCacheAlembicLoader(plugin.Loader):
         task.set_editor_property('automated', True)
         task.set_editor_property('save', True)
 
-        # set import options here
-        # Unreal 4.24 ignores the settings. It works with Unreal 4.26
         options.set_editor_property(
             'import_type', unreal.AlembicImportType.GEOMETRY_CACHE)
 
@@ -64,13 +70,42 @@ class PointCacheAlembicLoader(plugin.Loader):
 
         return task
 
-    def load(self, context, name, namespace, data):
-        """Load and containerise representation into Content Browser.
+    def import_and_containerize(
+        self, filepath, asset_dir, asset_name, container_name,
+        frame_start, frame_end
+    ):
+        unreal.EditorAssetLibrary.make_directory(asset_dir)
 
-        This is two step process. First, import FBX to temporary path and
-        then call `containerise()` on it - this moves all content to new
-        directory and then it will create AssetContainer there and imprint it
-        with metadata. This will mark this path as container.
+        task = self.get_task(
+            filepath, asset_dir, asset_name, False, frame_start, frame_end)
+
+        unreal.AssetToolsHelpers.get_asset_tools().import_asset_tasks([task])
+
+        # Create Asset Container
+        create_container(container=container_name, path=asset_dir)
+
+    def imprint(
+        self, asset, asset_dir, container_name, asset_name, representation,
+        frame_start, frame_end
+    ):
+        data = {
+            "schema": "ayon:container-2.0",
+            "id": AYON_CONTAINER_ID,
+            "asset": asset,
+            "namespace": asset_dir,
+            "container_name": container_name,
+            "asset_name": asset_name,
+            "loader": str(self.__class__.__name__),
+            "representation": representation["_id"],
+            "parent": representation["parent"],
+            "family": representation["context"]["family"],
+            "frame_start": frame_start,
+            "frame_end": frame_end
+        }
+        imprint(f"{asset_dir}/{container_name}", data)
+
+    def load(self, context, name, namespace, options):
+        """Load and containerise representation into Content Browser.
 
         Args:
             context (dict): application context
@@ -79,29 +114,27 @@ class PointCacheAlembicLoader(plugin.Loader):
                              This is not passed here, so namespace is set
                              by `containerise()` because only then we know
                              real path.
-            data (dict): Those would be data to be imprinted. This is not used
-                         now, data are imprinted by `containerise()`.
+            data (dict): Those would be data to be imprinted.
 
         Returns:
             list(str): list of container content
-
         """
         # Create directory for asset and Ayon container
-        root = "/Game/Ayon/Assets"
         asset = context.get('asset').get('name')
         suffix = "_CON"
-        if asset:
-            asset_name = "{}_{}".format(asset, name)
+        asset_name = f"{asset}_{name}" if asset else f"{name}"
+        version = context.get('version')
+        # Check if version is hero version and use different name
+        if not version.get("name") and version.get('type') == "hero_version":
+            name_version = f"{name}_hero"
         else:
-            asset_name = "{}".format(name)
+            name_version = f"{name}_v{version.get('name'):03d}"
 
         tools = unreal.AssetToolsHelpers().get_asset_tools()
         asset_dir, container_name = tools.create_unique_asset_name(
-            "{}/{}/{}".format(root, asset, name), suffix="")
+            f"{self.root}/{asset}/{name_version}", suffix="")
 
         container_name += suffix
-
-        unreal.EditorAssetLibrary.make_directory(asset_dir)
 
         frame_start = context.get('asset').get('data').get('frameStart')
         frame_end = context.get('asset').get('data').get('frameEnd')
@@ -111,30 +144,17 @@ class PointCacheAlembicLoader(plugin.Loader):
         if frame_start == frame_end:
             frame_end += 1
 
-        path = self.filepath_from_context(context)
-        task = self.get_task(
-            path, asset_dir, asset_name, False, frame_start, frame_end)
+        if not unreal.EditorAssetLibrary.does_directory_exist(asset_dir):
+            path = self.filepath_from_context(context)
 
-        unreal.AssetToolsHelpers.get_asset_tools().import_asset_tasks([task])  # noqa: E501
 
-        # Create Asset Container
-        unreal_pipeline.create_container(
-            container=container_name, path=asset_dir)
+            self.import_and_containerize(
+                path, asset_dir, asset_name, container_name,
+                frame_start, frame_end)
 
-        data = {
-            "schema": "ayon:container-2.0",
-            "id": AYON_CONTAINER_ID,
-            "asset": asset,
-            "namespace": asset_dir,
-            "container_name": container_name,
-            "asset_name": asset_name,
-            "loader": str(self.__class__.__name__),
-            "representation": context["representation"]["_id"],
-            "parent": context["representation"]["parent"],
-            "family": context["representation"]["context"]["family"]
-        }
-        unreal_pipeline.imprint(
-            "{}/{}".format(asset_dir, container_name), data)
+        self.imprint(
+            asset, asset_dir, container_name, asset_name,
+            context["representation"], frame_start, frame_end)
 
         asset_content = unreal.EditorAssetLibrary.list_assets(
             asset_dir, recursive=True, include_folder=True
@@ -146,31 +166,57 @@ class PointCacheAlembicLoader(plugin.Loader):
         return asset_content
 
     def update(self, container, representation):
-        name = container["asset_name"]
-        source_path = get_representation_path(representation)
-        destination_path = container["namespace"]
-        representation["context"]
+        context = representation.get("context", {})
 
-        task = self.get_task(source_path, destination_path, name, False)
-        # do import fbx and replace existing data
-        unreal.AssetToolsHelpers.get_asset_tools().import_asset_tasks([task])
+        unreal.log_warning(context)
 
-        container_path = "{}/{}".format(container["namespace"],
-                                        container["objectName"])
-        # update metadata
-        unreal_pipeline.imprint(
-            container_path,
-            {
-                "representation": str(representation["_id"]),
-                "parent": str(representation["parent"])
-            })
+        if not context:
+            raise RuntimeError("No context found in representation")
+
+        # Create directory for asset and Ayon container
+        asset = context.get('asset')
+        name = context.get('subset')
+        suffix = "_CON"
+        asset_name = f"{asset}_{name}" if asset else f"{name}"
+        version = context.get('version')
+        # Check if version is hero version and use different name
+        name_version = f"{name}_v{version:03d}" if version else f"{name}_hero"
+        tools = unreal.AssetToolsHelpers().get_asset_tools()
+        asset_dir, container_name = tools.create_unique_asset_name(
+            f"{self.root}/{asset}/{name_version}", suffix="")
+
+        container_name += suffix
+
+        frame_start = int(container.get("frame_start"))
+        frame_end = int(container.get("frame_end"))
+
+        if not unreal.EditorAssetLibrary.does_directory_exist(asset_dir):
+            path = get_representation_path(representation)
+
+            self.import_and_containerize(
+                path, asset_dir, asset_name, container_name,
+                frame_start, frame_end)
+
+        self.imprint(
+            asset, asset_dir, container_name, asset_name, representation,
+            frame_start, frame_end)
 
         asset_content = unreal.EditorAssetLibrary.list_assets(
-            destination_path, recursive=True, include_folder=True
+            asset_dir, recursive=True, include_folder=False
         )
 
         for a in asset_content:
             unreal.EditorAssetLibrary.save_asset(a)
+
+        old_assets = unreal.EditorAssetLibrary.list_assets(
+            container["namespace"], recursive=True, include_folder=False
+        )
+
+        replace_geometry_cache_actors(old_assets, asset_content)
+
+        unreal.EditorLevelLibrary.save_current_level()
+
+        delete_previous_asset_if_unused(container, old_assets)
 
     def remove(self, container):
         path = container["namespace"]

--- a/openpype/hosts/unreal/plugins/load/load_geometrycache_abc.py
+++ b/openpype/hosts/unreal/plugins/load/load_geometrycache_abc.py
@@ -207,16 +207,6 @@ class PointCacheAlembicLoader(plugin.Loader):
         for a in asset_content:
             unreal.EditorAssetLibrary.save_asset(a)
 
-        old_assets = unreal.EditorAssetLibrary.list_assets(
-            container["namespace"], recursive=True, include_folder=False
-        )
-
-        replace_geometry_cache_actors(old_assets, asset_content)
-
-        unreal.EditorLevelLibrary.save_current_level()
-
-        delete_previous_asset_if_unused(container, old_assets)
-
     def remove(self, container):
         path = container["namespace"]
         parent_path = os.path.dirname(path)

--- a/openpype/hosts/unreal/plugins/load/load_geometrycache_abc.py
+++ b/openpype/hosts/unreal/plugins/load/load_geometrycache_abc.py
@@ -10,8 +10,6 @@ from openpype.hosts.unreal.api import plugin
 from openpype.hosts.unreal.api.pipeline import (
     create_container,
     imprint,
-    replace_geometry_cache_actors,
-    delete_previous_asset_if_unused,
 )
 
 import unreal  # noqa

--- a/openpype/hosts/unreal/plugins/load/load_geometrycache_abc.py
+++ b/openpype/hosts/unreal/plugins/load/load_geometrycache_abc.py
@@ -8,6 +8,7 @@ from openpype.pipeline import (
 )
 from openpype.hosts.unreal.api import plugin
 from openpype.hosts.unreal.api.pipeline import (
+    AYON_ASSET_DIR,
     create_container,
     imprint,
 )
@@ -24,7 +25,7 @@ class PointCacheAlembicLoader(plugin.Loader):
     icon = "cube"
     color = "orange"
 
-    root = "/Game/Ayon/Assets"
+    root = AYON_ASSET_DIR
 
     @staticmethod
     def get_task(

--- a/openpype/hosts/unreal/plugins/load/load_skeletalmesh_abc.py
+++ b/openpype/hosts/unreal/plugins/load/load_skeletalmesh_abc.py
@@ -7,7 +7,13 @@ from openpype.pipeline import (
     AYON_CONTAINER_ID
 )
 from openpype.hosts.unreal.api import plugin
-from openpype.hosts.unreal.api import pipeline as unreal_pipeline
+from openpype.hosts.unreal.api.pipeline import (
+    create_container,
+    imprint,
+    replace_static_mesh_actors,
+    replace_skeletal_mesh_actors,
+    delete_previous_asset_if_unused,
+)
 import unreal  # noqa
 
 
@@ -20,10 +26,12 @@ class SkeletalMeshAlembicLoader(plugin.Loader):
     icon = "cube"
     color = "orange"
 
-    def get_task(self, filename, asset_dir, asset_name, replace):
+    root = "/Game/Ayon/Assets"
+
+    @staticmethod
+    def get_task(filename, asset_dir, asset_name, replace, default_conversion):
         task = unreal.AssetImportTask()
         options = unreal.AbcImportSettings()
-        sm_settings = unreal.AbcStaticMeshSettings()
         conversion_settings = unreal.AbcConversionSettings(
             preset=unreal.AbcConversionPreset.CUSTOM,
             flip_u=False, flip_v=False,
@@ -37,72 +45,38 @@ class SkeletalMeshAlembicLoader(plugin.Loader):
         task.set_editor_property('automated', True)
         task.set_editor_property('save', True)
 
-        # set import options here
-        # Unreal 4.24 ignores the settings. It works with Unreal 4.26
         options.set_editor_property(
             'import_type', unreal.AlembicImportType.SKELETAL)
 
-        options.static_mesh_settings = sm_settings
-        options.conversion_settings = conversion_settings
+        if not default_conversion:
+            conversion_settings = unreal.AbcConversionSettings(
+                preset=unreal.AbcConversionPreset.CUSTOM,
+                flip_u=False, flip_v=False,
+                rotation=[0.0, 0.0, 0.0],
+                scale=[1.0, 1.0, 1.0])
+            options.conversion_settings = conversion_settings
+
         task.options = options
 
         return task
 
-    def load(self, context, name, namespace, data):
-        """Load and containerise representation into Content Browser.
+    def import_and_containerize(
+        self, filepath, asset_dir, asset_name, container_name,
+        default_conversion=False
+    ):
+        unreal.EditorAssetLibrary.make_directory(asset_dir)
 
-        This is two step process. First, import FBX to temporary path and
-        then call `containerise()` on it - this moves all content to new
-        directory and then it will create AssetContainer there and imprint it
-        with metadata. This will mark this path as container.
+        task = self.get_task(
+            filepath, asset_dir, asset_name, False, default_conversion)
 
-        Args:
-            context (dict): application context
-            name (str): subset name
-            namespace (str): in Unreal this is basically path to container.
-                             This is not passed here, so namespace is set
-                             by `containerise()` because only then we know
-                             real path.
-            data (dict): Those would be data to be imprinted. This is not used
-                         now, data are imprinted by `containerise()`.
+        unreal.AssetToolsHelpers.get_asset_tools().import_asset_tasks([task])
 
-        Returns:
-            list(str): list of container content
-        """
+        # Create Asset Container
+        create_container(container=container_name, path=asset_dir)
 
-        # Create directory for asset and ayon container
-        root = "/Game/Ayon/Assets"
-        asset = context.get('asset').get('name')
-        suffix = "_CON"
-        if asset:
-            asset_name = "{}_{}".format(asset, name)
-        else:
-            asset_name = "{}".format(name)
-        version = context.get('version')
-        # Check if version is hero version and use different name
-        if not version.get("name") and version.get('type') == "hero_version":
-            name_version = f"{name}_hero"
-        else:
-            name_version = f"{name}_v{version.get('name'):03d}"
-
-        tools = unreal.AssetToolsHelpers().get_asset_tools()
-        asset_dir, container_name = tools.create_unique_asset_name(
-            f"{root}/{asset}/{name_version}", suffix="")
-
-        container_name += suffix
-
-        if not unreal.EditorAssetLibrary.does_directory_exist(asset_dir):
-            unreal.EditorAssetLibrary.make_directory(asset_dir)
-
-            path = self.filepath_from_context(context)
-            task = self.get_task(path, asset_dir, asset_name, False)
-
-            unreal.AssetToolsHelpers.get_asset_tools().import_asset_tasks([task])  # noqa: E501
-
-            # Create Asset Container
-            unreal_pipeline.create_container(
-                container=container_name, path=asset_dir)
-
+    def imprint(
+        self, asset, asset_dir, container_name, asset_name, representation
+    ):
         data = {
             "schema": "ayon:container-2.0",
             "id": AYON_CONTAINER_ID,
@@ -111,12 +85,57 @@ class SkeletalMeshAlembicLoader(plugin.Loader):
             "container_name": container_name,
             "asset_name": asset_name,
             "loader": str(self.__class__.__name__),
-            "representation": context["representation"]["_id"],
-            "parent": context["representation"]["parent"],
-            "family": context["representation"]["context"]["family"]
+            "representation": representation["_id"],
+            "parent": representation["parent"],
+            "family": representation["context"]["family"]
         }
-        unreal_pipeline.imprint(
-            f"{asset_dir}/{container_name}", data)
+        imprint(f"{asset_dir}/{container_name}", data)
+
+    def load(self, context, name, namespace, options):
+        """Load and containerise representation into Content Browser.
+
+        Args:
+            context (dict): application context
+            name (str): subset name
+            namespace (str): in Unreal this is basically path to container.
+                             This is not passed here, so namespace is set
+                             by `containerise()` because only then we know
+                             real path.
+            data (dict): Those would be data to be imprinted.
+
+        Returns:
+            list(str): list of container content
+        """
+        # Create directory for asset and ayon container
+        asset = context.get('asset').get('name')
+        suffix = "_CON"
+        asset_name = f"{asset}_{name}" if asset else f"{name}"
+        version = context.get('version')
+        # Check if version is hero version and use different name
+        if not version.get("name") and version.get('type') == "hero_version":
+            name_version = f"{name}_hero"
+        else:
+            name_version = f"{name}_v{version.get('name'):03d}"
+
+        default_conversion = False
+        if options.get("default_conversion"):
+            default_conversion = options.get("default_conversion")
+
+        tools = unreal.AssetToolsHelpers().get_asset_tools()
+        asset_dir, container_name = tools.create_unique_asset_name(
+            f"{self.root}/{asset}/{name_version}", suffix="")
+
+        container_name += suffix
+
+        if not unreal.EditorAssetLibrary.does_directory_exist(asset_dir):
+            path = self.filepath_from_context(context)
+
+            self.import_and_containerize(path, asset_dir, asset_name,
+                                         container_name, default_conversion)
+
+        self.imprint(
+            asset, asset_dir, container_name, asset_name,
+            context["representation"])
 
         asset_content = unreal.EditorAssetLibrary.list_assets(
             asset_dir, recursive=True, include_folder=True
@@ -128,30 +147,51 @@ class SkeletalMeshAlembicLoader(plugin.Loader):
         return asset_content
 
     def update(self, container, representation):
-        name = container["asset_name"]
-        source_path = get_representation_path(representation)
-        destination_path = container["namespace"]
+        context = representation.get("context", {})
 
-        task = self.get_task(source_path, destination_path, name, True)
+        if not context:
+            raise RuntimeError("No context found in representation")
 
-        # do import fbx and replace existing data
-        unreal.AssetToolsHelpers.get_asset_tools().import_asset_tasks([task])
-        container_path = "{}/{}".format(container["namespace"],
-                                        container["objectName"])
-        # update metadata
-        unreal_pipeline.imprint(
-            container_path,
-            {
-                "representation": str(representation["_id"]),
-                "parent": str(representation["parent"])
-            })
+        # Create directory for asset and Ayon container
+        asset = context.get('asset')
+        name = context.get('subset')
+        suffix = "_CON"
+        asset_name = f"{asset}_{name}" if asset else f"{name}"
+        version = context.get('version')
+        # Check if version is hero version and use different name
+        name_version = f"{name}_v{version:03d}" if version else f"{name}_hero"
+        tools = unreal.AssetToolsHelpers().get_asset_tools()
+        asset_dir, container_name = tools.create_unique_asset_name(
+            f"{self.root}/{asset}/{name_version}", suffix="")
+
+        container_name += suffix
+
+        if not unreal.EditorAssetLibrary.does_directory_exist(asset_dir):
+            path = get_representation_path(representation)
+
+            self.import_and_containerize(path, asset_dir, asset_name,
+                                         container_name)
+
+        self.imprint(
+            asset, asset_dir, container_name, asset_name, representation)
 
         asset_content = unreal.EditorAssetLibrary.list_assets(
-            destination_path, recursive=True, include_folder=True
+            asset_dir, recursive=True, include_folder=False
         )
 
         for a in asset_content:
             unreal.EditorAssetLibrary.save_asset(a)
+
+        old_assets = unreal.EditorAssetLibrary.list_assets(
+            container["namespace"], recursive=True, include_folder=False
+        )
+
+        replace_static_mesh_actors(old_assets, asset_content)
+        replace_skeletal_mesh_actors(old_assets, asset_content)
+
+        unreal.EditorLevelLibrary.save_current_level()
+
+        delete_previous_asset_if_unused(container, old_assets)
 
     def remove(self, container):
         path = container["namespace"]

--- a/openpype/hosts/unreal/plugins/load/load_skeletalmesh_abc.py
+++ b/openpype/hosts/unreal/plugins/load/load_skeletalmesh_abc.py
@@ -10,9 +10,6 @@ from openpype.hosts.unreal.api import plugin
 from openpype.hosts.unreal.api.pipeline import (
     create_container,
     imprint,
-    replace_static_mesh_actors,
-    replace_skeletal_mesh_actors,
-    delete_previous_asset_if_unused,
 )
 import unreal  # noqa
 

--- a/openpype/hosts/unreal/plugins/load/load_skeletalmesh_abc.py
+++ b/openpype/hosts/unreal/plugins/load/load_skeletalmesh_abc.py
@@ -182,17 +182,6 @@ class SkeletalMeshAlembicLoader(plugin.Loader):
         for a in asset_content:
             unreal.EditorAssetLibrary.save_asset(a)
 
-        old_assets = unreal.EditorAssetLibrary.list_assets(
-            container["namespace"], recursive=True, include_folder=False
-        )
-
-        replace_static_mesh_actors(old_assets, asset_content)
-        replace_skeletal_mesh_actors(old_assets, asset_content)
-
-        unreal.EditorLevelLibrary.save_current_level()
-
-        delete_previous_asset_if_unused(container, old_assets)
-
     def remove(self, container):
         path = container["namespace"]
         parent_path = os.path.dirname(path)

--- a/openpype/hosts/unreal/plugins/load/load_skeletalmesh_abc.py
+++ b/openpype/hosts/unreal/plugins/load/load_skeletalmesh_abc.py
@@ -8,6 +8,7 @@ from openpype.pipeline import (
 )
 from openpype.hosts.unreal.api import plugin
 from openpype.hosts.unreal.api.pipeline import (
+    AYON_ASSET_DIR,
     create_container,
     imprint,
 )
@@ -23,7 +24,7 @@ class SkeletalMeshAlembicLoader(plugin.Loader):
     icon = "cube"
     color = "orange"
 
-    root = "/Game/Ayon/Assets"
+    root = AYON_ASSET_DIR
 
     @staticmethod
     def get_task(filename, asset_dir, asset_name, replace, default_conversion):

--- a/openpype/hosts/unreal/plugins/load/load_skeletalmesh_fbx.py
+++ b/openpype/hosts/unreal/plugins/load/load_skeletalmesh_fbx.py
@@ -7,7 +7,13 @@ from openpype.pipeline import (
     AYON_CONTAINER_ID
 )
 from openpype.hosts.unreal.api import plugin
-from openpype.hosts.unreal.api import pipeline as unreal_pipeline
+from openpype.hosts.unreal.api.pipeline import (
+    create_container,
+    imprint,
+    replace_static_mesh_actors,
+    replace_skeletal_mesh_actors,
+    delete_previous_asset_if_unused,
+)
 import unreal  # noqa
 
 
@@ -20,13 +26,78 @@ class SkeletalMeshFBXLoader(plugin.Loader):
     icon = "cube"
     color = "orange"
 
+    root = "/Game/Ayon/Assets"
+
+    @staticmethod
+    def get_task(filename, asset_dir, asset_name, replace):
+        task = unreal.AssetImportTask()
+        options = unreal.FbxImportUI()
+
+        task.set_editor_property('filename', filename)
+        task.set_editor_property('destination_path', asset_dir)
+        task.set_editor_property('destination_name', asset_name)
+        task.set_editor_property('replace_existing', replace)
+        task.set_editor_property('automated', True)
+        task.set_editor_property('save', True)
+
+        options.set_editor_property(
+            'automated_import_should_detect_type', False)
+        options.set_editor_property('import_as_skeletal', True)
+        options.set_editor_property('import_animations', False)
+        options.set_editor_property('import_mesh', True)
+        options.set_editor_property('import_materials', False)
+        options.set_editor_property('import_textures', False)
+        options.set_editor_property('skeleton', None)
+        options.set_editor_property('create_physics_asset', False)
+
+        options.set_editor_property(
+            'mesh_type_to_import',
+            unreal.FBXImportType.FBXIT_SKELETAL_MESH)
+
+        options.skeletal_mesh_import_data.set_editor_property(
+            'import_content_type',
+            unreal.FBXImportContentType.FBXICT_ALL)
+
+        options.skeletal_mesh_import_data.set_editor_property(
+            'normal_import_method',
+            unreal.FBXNormalImportMethod.FBXNIM_IMPORT_NORMALS)
+
+        task.options = options
+
+        return task
+
+    def import_and_containerize(
+        self, filepath, asset_dir, asset_name, container_name
+    ):
+        unreal.EditorAssetLibrary.make_directory(asset_dir)
+
+        task = self.get_task(
+            filepath, asset_dir, asset_name, False)
+
+        unreal.AssetToolsHelpers.get_asset_tools().import_asset_tasks([task])
+
+        # Create Asset Container
+        create_container(container=container_name, path=asset_dir)
+
+    def imprint(
+        self, asset, asset_dir, container_name, asset_name, representation
+    ):
+        data = {
+            "schema": "ayon:container-2.0",
+            "id": AYON_CONTAINER_ID,
+            "asset": asset,
+            "namespace": asset_dir,
+            "container_name": container_name,
+            "asset_name": asset_name,
+            "loader": str(self.__class__.__name__),
+            "representation": representation["_id"],
+            "parent": representation["parent"],
+            "family": representation["context"]["family"]
+        }
+        imprint(f"{asset_dir}/{container_name}", data)
+
     def load(self, context, name, namespace, options):
         """Load and containerise representation into Content Browser.
-
-        This is a two step process. First, import FBX to temporary path and
-        then call `containerise()` on it - this moves all content to new
-        directory and then it will create AssetContainer there and imprint it
-        with metadata. This will mark this path as container.
 
         Args:
             context (dict): application context
@@ -35,23 +106,15 @@ class SkeletalMeshFBXLoader(plugin.Loader):
                              This is not passed here, so namespace is set
                              by `containerise()` because only then we know
                              real path.
-            options (dict): Those would be data to be imprinted. This is not
-                used now, data are imprinted by `containerise()`.
+            data (dict): Those would be data to be imprinted.
 
         Returns:
             list(str): list of container content
-
         """
         # Create directory for asset and Ayon container
-        root = "/Game/Ayon/Assets"
-        if options and options.get("asset_dir"):
-            root = options["asset_dir"]
         asset = context.get('asset').get('name')
         suffix = "_CON"
-        if asset:
-            asset_name = "{}_{}".format(asset, name)
-        else:
-            asset_name = "{}".format(name)
+        asset_name = f"{asset}_{name}" if asset else f"{name}"
         version = context.get('version')
         # Check if version is hero version and use different name
         if not version.get("name") and version.get('type') == "hero_version":
@@ -61,67 +124,20 @@ class SkeletalMeshFBXLoader(plugin.Loader):
 
         tools = unreal.AssetToolsHelpers().get_asset_tools()
         asset_dir, container_name = tools.create_unique_asset_name(
-            f"{root}/{asset}/{name_version}", suffix="")
+            f"{self.root}/{asset}/{name_version}", suffix=""
+        )
 
         container_name += suffix
 
         if not unreal.EditorAssetLibrary.does_directory_exist(asset_dir):
-            unreal.EditorAssetLibrary.make_directory(asset_dir)
-
-            task = unreal.AssetImportTask()
-
             path = self.filepath_from_context(context)
-            task.set_editor_property('filename', path)
-            task.set_editor_property('destination_path', asset_dir)
-            task.set_editor_property('destination_name', asset_name)
-            task.set_editor_property('replace_existing', False)
-            task.set_editor_property('automated', True)
-            task.set_editor_property('save', False)
 
-            # set import options here
-            options = unreal.FbxImportUI()
-            options.set_editor_property('import_as_skeletal', True)
-            options.set_editor_property('import_animations', False)
-            options.set_editor_property('import_mesh', True)
-            options.set_editor_property('import_materials', False)
-            options.set_editor_property('import_textures', False)
-            options.set_editor_property('skeleton', None)
-            options.set_editor_property('create_physics_asset', False)
+            self.import_and_containerize(
+                path, asset_dir, asset_name, container_name)
 
-            options.set_editor_property(
-                'mesh_type_to_import',
-                unreal.FBXImportType.FBXIT_SKELETAL_MESH)
-
-            options.skeletal_mesh_import_data.set_editor_property(
-                'import_content_type',
-                unreal.FBXImportContentType.FBXICT_ALL)
-            # set to import normals, otherwise Unreal will compute them
-            # and it will take a long time, depending on the size of the mesh
-            options.skeletal_mesh_import_data.set_editor_property(
-                'normal_import_method',
-                unreal.FBXNormalImportMethod.FBXNIM_IMPORT_NORMALS)
-
-            task.options = options
-            unreal.AssetToolsHelpers.get_asset_tools().import_asset_tasks([task])  # noqa: E501
-
-            # Create Asset Container
-            unreal_pipeline.create_container(
-                container=container_name, path=asset_dir)
-
-        data = {
-            "schema": "ayon:container-2.0",
-            "id": AYON_CONTAINER_ID,
-            "asset": asset,
-            "namespace": asset_dir,
-            "container_name": container_name,
-            "asset_name": asset_name,
-            "loader": str(self.__class__.__name__),
-            "representation": context["representation"]["_id"],
-            "parent": context["representation"]["parent"],
-            "family": context["representation"]["context"]["family"]
-        }
-        unreal_pipeline.imprint(
-            f"{asset_dir}/{container_name}", data)
+        self.imprint(
+            asset, asset_dir, container_name, asset_name,
+            context["representation"])
 
         asset_content = unreal.EditorAssetLibrary.list_assets(
             asset_dir, recursive=True, include_folder=True
@@ -133,62 +149,51 @@ class SkeletalMeshFBXLoader(plugin.Loader):
         return asset_content
 
     def update(self, container, representation):
-        name = container["asset_name"]
-        source_path = get_representation_path(representation)
-        destination_path = container["namespace"]
+        context = representation.get("context", {})
 
-        task = unreal.AssetImportTask()
+        if not context:
+            raise RuntimeError("No context found in representation")
 
-        task.set_editor_property('filename', source_path)
-        task.set_editor_property('destination_path', destination_path)
-        task.set_editor_property('destination_name', name)
-        task.set_editor_property('replace_existing', True)
-        task.set_editor_property('automated', True)
-        task.set_editor_property('save', True)
+        # Create directory for asset and Ayon container
+        asset = context.get('asset')
+        name = context.get('subset')
+        suffix = "_CON"
+        asset_name = f"{asset}_{name}" if asset else f"{name}"
+        version = context.get('version')
+        # Check if version is hero version and use different name
+        name_version = f"{name}_v{version:03d}" if version else f"{name}_hero"
+        tools = unreal.AssetToolsHelpers().get_asset_tools()
+        asset_dir, container_name = tools.create_unique_asset_name(
+            f"{self.root}/{asset}/{name_version}", suffix="")
 
-        # set import options here
-        options = unreal.FbxImportUI()
-        options.set_editor_property('import_as_skeletal', True)
-        options.set_editor_property('import_animations', False)
-        options.set_editor_property('import_mesh', True)
-        options.set_editor_property('import_materials', True)
-        options.set_editor_property('import_textures', True)
-        options.set_editor_property('skeleton', None)
-        options.set_editor_property('create_physics_asset', False)
+        container_name += suffix
 
-        options.set_editor_property('mesh_type_to_import',
-                                    unreal.FBXImportType.FBXIT_SKELETAL_MESH)
+        if not unreal.EditorAssetLibrary.does_directory_exist(asset_dir):
+            path = get_representation_path(representation)
 
-        options.skeletal_mesh_import_data.set_editor_property(
-            'import_content_type',
-            unreal.FBXImportContentType.FBXICT_ALL
-        )
-        # set to import normals, otherwise Unreal will compute them
-        # and it will take a long time, depending on the size of the mesh
-        options.skeletal_mesh_import_data.set_editor_property(
-            'normal_import_method',
-            unreal.FBXNormalImportMethod.FBXNIM_IMPORT_NORMALS
-        )
+            self.import_and_containerize(
+                path, asset_dir, asset_name, container_name)
 
-        task.options = options
-        # do import fbx and replace existing data
-        unreal.AssetToolsHelpers.get_asset_tools().import_asset_tasks([task])  # noqa: E501
-        container_path = "{}/{}".format(container["namespace"],
-                                        container["objectName"])
-        # update metadata
-        unreal_pipeline.imprint(
-            container_path,
-            {
-                "representation": str(representation["_id"]),
-                "parent": str(representation["parent"])
-            })
+        self.imprint(
+            asset, asset_dir, container_name, asset_name, representation)
 
         asset_content = unreal.EditorAssetLibrary.list_assets(
-            destination_path, recursive=True, include_folder=True
+            asset_dir, recursive=True, include_folder=False
         )
 
         for a in asset_content:
             unreal.EditorAssetLibrary.save_asset(a)
+
+        old_assets = unreal.EditorAssetLibrary.list_assets(
+            container["namespace"], recursive=True, include_folder=False
+        )
+
+        replace_static_mesh_actors(old_assets, asset_content)
+        replace_skeletal_mesh_actors(old_assets, asset_content)
+
+        unreal.EditorLevelLibrary.save_current_level()
+
+        delete_previous_asset_if_unused(container, old_assets)
 
     def remove(self, container):
         path = container["namespace"]

--- a/openpype/hosts/unreal/plugins/load/load_skeletalmesh_fbx.py
+++ b/openpype/hosts/unreal/plugins/load/load_skeletalmesh_fbx.py
@@ -8,6 +8,7 @@ from openpype.pipeline import (
 )
 from openpype.hosts.unreal.api import plugin
 from openpype.hosts.unreal.api.pipeline import (
+    AYON_ASSET_DIR,
     create_container,
     imprint,
 )
@@ -23,7 +24,7 @@ class SkeletalMeshFBXLoader(plugin.Loader):
     icon = "cube"
     color = "orange"
 
-    root = "/Game/Ayon/Assets"
+    root = AYON_ASSET_DIR
 
     @staticmethod
     def get_task(filename, asset_dir, asset_name, replace):

--- a/openpype/hosts/unreal/plugins/load/load_skeletalmesh_fbx.py
+++ b/openpype/hosts/unreal/plugins/load/load_skeletalmesh_fbx.py
@@ -10,9 +10,6 @@ from openpype.hosts.unreal.api import plugin
 from openpype.hosts.unreal.api.pipeline import (
     create_container,
     imprint,
-    replace_static_mesh_actors,
-    replace_skeletal_mesh_actors,
-    delete_previous_asset_if_unused,
 )
 import unreal  # noqa
 

--- a/openpype/hosts/unreal/plugins/load/load_skeletalmesh_fbx.py
+++ b/openpype/hosts/unreal/plugins/load/load_skeletalmesh_fbx.py
@@ -184,17 +184,6 @@ class SkeletalMeshFBXLoader(plugin.Loader):
         for a in asset_content:
             unreal.EditorAssetLibrary.save_asset(a)
 
-        old_assets = unreal.EditorAssetLibrary.list_assets(
-            container["namespace"], recursive=True, include_folder=False
-        )
-
-        replace_static_mesh_actors(old_assets, asset_content)
-        replace_skeletal_mesh_actors(old_assets, asset_content)
-
-        unreal.EditorLevelLibrary.save_current_level()
-
-        delete_previous_asset_if_unused(container, old_assets)
-
     def remove(self, container):
         path = container["namespace"]
         parent_path = os.path.dirname(path)

--- a/openpype/hosts/unreal/plugins/load/load_staticmesh_abc.py
+++ b/openpype/hosts/unreal/plugins/load/load_staticmesh_abc.py
@@ -105,7 +105,6 @@ class StaticMeshAlembicLoader(plugin.Loader):
 
         Returns:
             list(str): list of container content
-
         """
         # Create directory for asset and Ayon container
         asset = context.get('asset').get('name')

--- a/openpype/hosts/unreal/plugins/load/load_staticmesh_abc.py
+++ b/openpype/hosts/unreal/plugins/load/load_staticmesh_abc.py
@@ -7,7 +7,12 @@ from openpype.pipeline import (
     AYON_CONTAINER_ID
 )
 from openpype.hosts.unreal.api import plugin
-from openpype.hosts.unreal.api import pipeline as unreal_pipeline
+from openpype.hosts.unreal.api.pipeline import (
+    create_container,
+    imprint,
+    replace_static_mesh_actors,
+    delete_previous_asset_if_unused,
+)
 import unreal  # noqa
 
 
@@ -19,6 +24,8 @@ class StaticMeshAlembicLoader(plugin.Loader):
     representations = ["abc"]
     icon = "cube"
     color = "orange"
+
+    root = "/Game/Ayon/Assets"
 
     @staticmethod
     def get_task(filename, asset_dir, asset_name, replace, default_conversion):
@@ -53,13 +60,39 @@ class StaticMeshAlembicLoader(plugin.Loader):
 
         return task
 
+    def import_and_containerize(
+        self, filepath, asset_dir, asset_name, container_name,
+        default_conversion=False
+    ):
+        unreal.EditorAssetLibrary.make_directory(asset_dir)
+
+        task = self.get_task(
+            filepath, asset_dir, asset_name, False, default_conversion)
+
+        unreal.AssetToolsHelpers.get_asset_tools().import_asset_tasks([task])
+
+        # Create Asset Container
+        create_container(container=container_name, path=asset_dir)
+
+    def imprint(
+        self, asset, asset_dir, container_name, asset_name, representation
+    ):
+        data = {
+            "schema": "ayon:container-2.0",
+            "id": AYON_CONTAINER_ID,
+            "asset": asset,
+            "namespace": asset_dir,
+            "container_name": container_name,
+            "asset_name": asset_name,
+            "loader": str(self.__class__.__name__),
+            "representation": representation["_id"],
+            "parent": representation["parent"],
+            "family": representation["context"]["family"]
+        }
+        imprint(f"{asset_dir}/{container_name}", data)
+
     def load(self, context, name, namespace, options):
         """Load and containerise representation into Content Browser.
-
-        This is two step process. First, import FBX to temporary path and
-        then call `containerise()` on it - this moves all content to new
-        directory and then it will create AssetContainer there and imprint it
-        with metadata. This will mark this path as container.
 
         Args:
             context (dict): application context
@@ -68,15 +101,13 @@ class StaticMeshAlembicLoader(plugin.Loader):
                              This is not passed here, so namespace is set
                              by `containerise()` because only then we know
                              real path.
-            data (dict): Those would be data to be imprinted. This is not used
-                         now, data are imprinted by `containerise()`.
+            data (dict): Those would be data to be imprinted.
 
         Returns:
             list(str): list of container content
 
         """
         # Create directory for asset and Ayon container
-        root = "/Game/Ayon/Assets"
         asset = context.get('asset').get('name')
         suffix = "_CON"
         asset_name = f"{asset}_{name}" if asset else f"{name}"
@@ -93,39 +124,22 @@ class StaticMeshAlembicLoader(plugin.Loader):
 
         tools = unreal.AssetToolsHelpers().get_asset_tools()
         asset_dir, container_name = tools.create_unique_asset_name(
-            f"{root}/{asset}/{name_version}", suffix="")
+            f"{self.root}/{asset}/{name_version}", suffix="")
 
         container_name += suffix
 
         if not unreal.EditorAssetLibrary.does_directory_exist(asset_dir):
-            unreal.EditorAssetLibrary.make_directory(asset_dir)
-
             path = self.filepath_from_context(context)
-            task = self.get_task(
-                path, asset_dir, asset_name, False, default_conversion)
 
-            unreal.AssetToolsHelpers.get_asset_tools().import_asset_tasks([task])  # noqa: E501
+            self.import_and_containerize(path, asset_dir, asset_name,
+                                         container_name, default_conversion)
 
-            # Create Asset Container
-            unreal_pipeline.create_container(
-                container=container_name, path=asset_dir)
-
-        data = {
-            "schema": "ayon:container-2.0",
-            "id": AYON_CONTAINER_ID,
-            "asset": asset,
-            "namespace": asset_dir,
-            "container_name": container_name,
-            "asset_name": asset_name,
-            "loader": str(self.__class__.__name__),
-            "representation": context["representation"]["_id"],
-            "parent": context["representation"]["parent"],
-            "family": context["representation"]["context"]["family"]
-        }
-        unreal_pipeline.imprint(f"{asset_dir}/{container_name}", data)
+        self.imprint(
+            asset, asset_dir, container_name, asset_name,
+            context["representation"])
 
         asset_content = unreal.EditorAssetLibrary.list_assets(
-            asset_dir, recursive=True, include_folder=True
+            asset_dir, recursive=True, include_folder=False
         )
 
         for a in asset_content:
@@ -134,31 +148,50 @@ class StaticMeshAlembicLoader(plugin.Loader):
         return asset_content
 
     def update(self, container, representation):
-        name = container["asset_name"]
-        source_path = get_representation_path(representation)
-        destination_path = container["namespace"]
+        context = representation.get("context", {})
 
-        task = self.get_task(source_path, destination_path, name, True, False)
+        if not context:
+            raise RuntimeError("No context found in representation")
 
-        # do import fbx and replace existing data
-        unreal.AssetToolsHelpers.get_asset_tools().import_asset_tasks([task])
+        # Create directory for asset and Ayon container
+        asset = context.get('asset')
+        name = context.get('subset')
+        suffix = "_CON"
+        asset_name = f"{asset}_{name}" if asset else f"{name}"
+        version = context.get('version')
+        # Check if version is hero version and use different name
+        name_version = f"{name}_v{version:03d}" if version else f"{name}_hero"
+        tools = unreal.AssetToolsHelpers().get_asset_tools()
+        asset_dir, container_name = tools.create_unique_asset_name(
+            f"{self.root}/{asset}/{name_version}", suffix="")
 
-        container_path = "{}/{}".format(container["namespace"],
-                                        container["objectName"])
-        # update metadata
-        unreal_pipeline.imprint(
-            container_path,
-            {
-                "representation": str(representation["_id"]),
-                "parent": str(representation["parent"])
-            })
+        container_name += suffix
+
+        if not unreal.EditorAssetLibrary.does_directory_exist(asset_dir):
+            path = get_representation_path(representation)
+
+            self.import_and_containerize(path, asset_dir, asset_name,
+                                         container_name)
+
+        self.imprint(
+            asset, asset_dir, container_name, asset_name, representation)
 
         asset_content = unreal.EditorAssetLibrary.list_assets(
-            destination_path, recursive=True, include_folder=True
+            asset_dir, recursive=True, include_folder=False
         )
 
         for a in asset_content:
             unreal.EditorAssetLibrary.save_asset(a)
+
+        old_assets = unreal.EditorAssetLibrary.list_assets(
+            container["namespace"], recursive=True, include_folder=False
+        )
+
+        replace_static_mesh_actors(old_assets, asset_content)
+
+        unreal.EditorLevelLibrary.save_current_level()
+
+        delete_previous_asset_if_unused(container, old_assets)
 
     def remove(self, container):
         path = container["namespace"]

--- a/openpype/hosts/unreal/plugins/load/load_staticmesh_abc.py
+++ b/openpype/hosts/unreal/plugins/load/load_staticmesh_abc.py
@@ -182,16 +182,6 @@ class StaticMeshAlembicLoader(plugin.Loader):
         for a in asset_content:
             unreal.EditorAssetLibrary.save_asset(a)
 
-        old_assets = unreal.EditorAssetLibrary.list_assets(
-            container["namespace"], recursive=True, include_folder=False
-        )
-
-        replace_static_mesh_actors(old_assets, asset_content)
-
-        unreal.EditorLevelLibrary.save_current_level()
-
-        delete_previous_asset_if_unused(container, old_assets)
-
     def remove(self, container):
         path = container["namespace"]
         parent_path = os.path.dirname(path)

--- a/openpype/hosts/unreal/plugins/load/load_staticmesh_abc.py
+++ b/openpype/hosts/unreal/plugins/load/load_staticmesh_abc.py
@@ -8,6 +8,7 @@ from openpype.pipeline import (
 )
 from openpype.hosts.unreal.api import plugin
 from openpype.hosts.unreal.api.pipeline import (
+    AYON_ASSET_DIR,
     create_container,
     imprint,
 )
@@ -23,7 +24,7 @@ class StaticMeshAlembicLoader(plugin.Loader):
     icon = "cube"
     color = "orange"
 
-    root = "/Game/Ayon/Assets"
+    root = AYON_ASSET_DIR
 
     @staticmethod
     def get_task(filename, asset_dir, asset_name, replace, default_conversion):

--- a/openpype/hosts/unreal/plugins/load/load_staticmesh_abc.py
+++ b/openpype/hosts/unreal/plugins/load/load_staticmesh_abc.py
@@ -10,8 +10,6 @@ from openpype.hosts.unreal.api import plugin
 from openpype.hosts.unreal.api.pipeline import (
     create_container,
     imprint,
-    replace_static_mesh_actors,
-    delete_previous_asset_if_unused,
 )
 import unreal  # noqa
 

--- a/openpype/hosts/unreal/plugins/load/load_staticmesh_fbx.py
+++ b/openpype/hosts/unreal/plugins/load/load_staticmesh_fbx.py
@@ -98,7 +98,6 @@ class StaticMeshFBXLoader(plugin.Loader):
         Returns:
             list(str): list of container content
         """
-
         # Create directory for asset and Ayon container
         asset = context.get('asset').get('name')
         suffix = "_CON"

--- a/openpype/hosts/unreal/plugins/load/load_staticmesh_fbx.py
+++ b/openpype/hosts/unreal/plugins/load/load_staticmesh_fbx.py
@@ -7,7 +7,12 @@ from openpype.pipeline import (
     AYON_CONTAINER_ID
 )
 from openpype.hosts.unreal.api import plugin
-from openpype.hosts.unreal.api import pipeline as unreal_pipeline
+from openpype.hosts.unreal.api.pipeline import (
+    create_container,
+    imprint,
+    replace_static_mesh_actors,
+    delete_previous_asset_if_unused,
+)
 import unreal  # noqa
 
 
@@ -19,6 +24,8 @@ class StaticMeshFBXLoader(plugin.Loader):
     representations = ["fbx"]
     icon = "cube"
     color = "orange"
+
+    root = "/Game/Ayon/Assets"
 
     @staticmethod
     def get_task(filename, asset_dir, asset_name, replace):
@@ -46,13 +53,38 @@ class StaticMeshFBXLoader(plugin.Loader):
 
         return task
 
+    def import_and_containerize(
+        self, filepath, asset_dir, asset_name, container_name
+    ):
+        unreal.EditorAssetLibrary.make_directory(asset_dir)
+
+        task = self.get_task(
+            filepath, asset_dir, asset_name, False)
+
+        unreal.AssetToolsHelpers.get_asset_tools().import_asset_tasks([task])
+
+        # Create Asset Container
+        create_container(container=container_name, path=asset_dir)
+
+    def imprint(
+        self, asset, asset_dir, container_name, asset_name, representation
+    ):
+        data = {
+            "schema": "ayon:container-2.0",
+            "id": AYON_CONTAINER_ID,
+            "asset": asset,
+            "namespace": asset_dir,
+            "container_name": container_name,
+            "asset_name": asset_name,
+            "loader": str(self.__class__.__name__),
+            "representation": representation["_id"],
+            "parent": representation["parent"],
+            "family": representation["context"]["family"]
+        }
+        imprint(f"{asset_dir}/{container_name}", data)
+
     def load(self, context, name, namespace, options):
         """Load and containerise representation into Content Browser.
-
-        This is two step process. First, import FBX to temporary path and
-        then call `containerise()` on it - this moves all content to new
-        directory and then it will create AssetContainer there and imprint it
-        with metadata. This will mark this path as container.
 
         Args:
             context (dict): application context
@@ -61,23 +93,16 @@ class StaticMeshFBXLoader(plugin.Loader):
                              This is not passed here, so namespace is set
                              by `containerise()` because only then we know
                              real path.
-            options (dict): Those would be data to be imprinted. This is not
-                used now, data are imprinted by `containerise()`.
+            options (dict): Those would be data to be imprinted.
 
         Returns:
             list(str): list of container content
         """
 
         # Create directory for asset and Ayon container
-        root = "/Game/Ayon/Assets"
-        if options and options.get("asset_dir"):
-            root = options["asset_dir"]
         asset = context.get('asset').get('name')
         suffix = "_CON"
-        if asset:
-            asset_name = "{}_{}".format(asset, name)
-        else:
-            asset_name = "{}".format(name)
+        asset_name = f"{asset}_{name}" if asset else f"{name}"
         version = context.get('version')
         # Check if version is hero version and use different name
         if not version.get("name") and version.get('type') == "hero_version":
@@ -87,35 +112,20 @@ class StaticMeshFBXLoader(plugin.Loader):
 
         tools = unreal.AssetToolsHelpers().get_asset_tools()
         asset_dir, container_name = tools.create_unique_asset_name(
-            f"{root}/{asset}/{name_version}", suffix=""
+            f"{self.root}/{asset}/{name_version}", suffix=""
         )
 
         container_name += suffix
 
-        unreal.EditorAssetLibrary.make_directory(asset_dir)
+        if not unreal.EditorAssetLibrary.does_directory_exist(asset_dir):
+            path = self.filepath_from_context(context)
 
-        path = self.filepath_from_context(context)
-        task = self.get_task(path, asset_dir, asset_name, False)
+            self.import_and_containerize(
+                path, asset_dir, asset_name, container_name)
 
-        unreal.AssetToolsHelpers.get_asset_tools().import_asset_tasks([task])  # noqa: E501
-
-        # Create Asset Container
-        unreal_pipeline.create_container(
-            container=container_name, path=asset_dir)
-
-        data = {
-            "schema": "ayon:container-2.0",
-            "id": AYON_CONTAINER_ID,
-            "asset": asset,
-            "namespace": asset_dir,
-            "container_name": container_name,
-            "asset_name": asset_name,
-            "loader": str(self.__class__.__name__),
-            "representation": context["representation"]["_id"],
-            "parent": context["representation"]["parent"],
-            "family": context["representation"]["context"]["family"]
-        }
-        unreal_pipeline.imprint(f"{asset_dir}/{container_name}", data)
+        self.imprint(
+            asset, asset_dir, container_name, asset_name,
+            context["representation"])
 
         asset_content = unreal.EditorAssetLibrary.list_assets(
             asset_dir, recursive=True, include_folder=True
@@ -127,31 +137,50 @@ class StaticMeshFBXLoader(plugin.Loader):
         return asset_content
 
     def update(self, container, representation):
-        name = container["asset_name"]
-        source_path = get_representation_path(representation)
-        destination_path = container["namespace"]
+        context = representation.get("context", {})
 
-        task = self.get_task(source_path, destination_path, name, True)
+        if not context:
+            raise RuntimeError("No context found in representation")
 
-        # do import fbx and replace existing data
-        unreal.AssetToolsHelpers.get_asset_tools().import_asset_tasks([task])
+        # Create directory for asset and Ayon container
+        asset = context.get('asset')
+        name = context.get('subset')
+        suffix = "_CON"
+        asset_name = f"{asset}_{name}" if asset else f"{name}"
+        version = context.get('version')
+        # Check if version is hero version and use different name
+        name_version = f"{name}_v{version:03d}" if version else f"{name}_hero"
+        tools = unreal.AssetToolsHelpers().get_asset_tools()
+        asset_dir, container_name = tools.create_unique_asset_name(
+            f"{self.root}/{asset}/{name_version}", suffix="")
 
-        container_path = "{}/{}".format(container["namespace"],
-                                        container["objectName"])
-        # update metadata
-        unreal_pipeline.imprint(
-            container_path,
-            {
-                "representation": str(representation["_id"]),
-                "parent": str(representation["parent"])
-            })
+        container_name += suffix
+
+        if not unreal.EditorAssetLibrary.does_directory_exist(asset_dir):
+            path = get_representation_path(representation)
+
+            self.import_and_containerize(
+                path, asset_dir, asset_name, container_name)
+
+        self.imprint(
+            asset, asset_dir, container_name, asset_name, representation)
 
         asset_content = unreal.EditorAssetLibrary.list_assets(
-            destination_path, recursive=True, include_folder=True
+            asset_dir, recursive=True, include_folder=False
         )
 
         for a in asset_content:
             unreal.EditorAssetLibrary.save_asset(a)
+
+        old_assets = unreal.EditorAssetLibrary.list_assets(
+            container["namespace"], recursive=True, include_folder=False
+        )
+
+        replace_static_mesh_actors(old_assets, asset_content)
+
+        unreal.EditorLevelLibrary.save_current_level()
+
+        delete_previous_asset_if_unused(container, old_assets)
 
     def remove(self, container):
         path = container["namespace"]

--- a/openpype/hosts/unreal/plugins/load/load_staticmesh_fbx.py
+++ b/openpype/hosts/unreal/plugins/load/load_staticmesh_fbx.py
@@ -10,8 +10,6 @@ from openpype.hosts.unreal.api import plugin
 from openpype.hosts.unreal.api.pipeline import (
     create_container,
     imprint,
-    replace_static_mesh_actors,
-    delete_previous_asset_if_unused,
 )
 import unreal  # noqa
 

--- a/openpype/hosts/unreal/plugins/load/load_staticmesh_fbx.py
+++ b/openpype/hosts/unreal/plugins/load/load_staticmesh_fbx.py
@@ -8,6 +8,7 @@ from openpype.pipeline import (
 )
 from openpype.hosts.unreal.api import plugin
 from openpype.hosts.unreal.api.pipeline import (
+    AYON_ASSET_DIR,
     create_container,
     imprint,
 )
@@ -23,7 +24,7 @@ class StaticMeshFBXLoader(plugin.Loader):
     icon = "cube"
     color = "orange"
 
-    root = "/Game/Ayon/Assets"
+    root = AYON_ASSET_DIR
 
     @staticmethod
     def get_task(filename, asset_dir, asset_name, replace):

--- a/openpype/hosts/unreal/plugins/load/load_staticmesh_fbx.py
+++ b/openpype/hosts/unreal/plugins/load/load_staticmesh_fbx.py
@@ -171,16 +171,6 @@ class StaticMeshFBXLoader(plugin.Loader):
         for a in asset_content:
             unreal.EditorAssetLibrary.save_asset(a)
 
-        old_assets = unreal.EditorAssetLibrary.list_assets(
-            container["namespace"], recursive=True, include_folder=False
-        )
-
-        replace_static_mesh_actors(old_assets, asset_content)
-
-        unreal.EditorLevelLibrary.save_current_level()
-
-        delete_previous_asset_if_unused(container, old_assets)
-
     def remove(self, container):
         path = container["namespace"]
         parent_path = os.path.dirname(path)

--- a/openpype/hosts/unreal/plugins/load/load_uasset.py
+++ b/openpype/hosts/unreal/plugins/load/load_uasset.py
@@ -41,7 +41,7 @@ class UAssetLoader(plugin.Loader):
         """
 
         # Create directory for asset and Ayon container
-        root = "/Game/Ayon/Assets"
+        root = unreal_pipeline.AYON_ASSET_DIR
         asset = context.get('asset').get('name')
         suffix = "_CON"
         asset_name = f"{asset}_{name}" if asset else f"{name}"

--- a/openpype/hosts/unreal/plugins/load/load_yeticache.py
+++ b/openpype/hosts/unreal/plugins/load/load_yeticache.py
@@ -86,7 +86,7 @@ class YetiLoader(plugin.Loader):
             raise RuntimeError("Groom plugin is not activated.")
 
         # Create directory for asset and Ayon container
-        root = "/Game/Ayon/Assets"
+        root = unreal_pipeline.AYON_ASSET_DIR
         asset = context.get('asset').get('name')
         suffix = "_CON"
         asset_name = f"{asset}_{name}" if asset else f"{name}"


### PR DESCRIPTION
## Changelog Description
Changed how assets are updated in Unreal.

## Additional info
When updating assets in Unreal, instead of completely replacing the old version, the new version is loaded in a different folder (it is checked beforehand if it was already loaded), and replaces the asset in the current level. Then, we check if the old asset is used in any other level. If it isn't we remove the previous version.

Updated:
- Static Meshes (FBX and ABC).
- Skeletal Meshes (FBX and ABC).
- Geometry Caches.

## Testing notes:
1. Load an asset.
2. Add it to a level and save it.
3. Try changing the version of the asset.