### PR TITLE
AYON Workfiles Tool: Open workfile changes context

### DIFF
--- a/openpype/hosts/blender/api/ops.py
+++ b/openpype/hosts/blender/api/ops.py
@@ -16,6 +16,7 @@ import bpy
 import bpy.utils.previews
 
 from openpype import style
+from openpype import AYON_SERVER_ENABLED
 from openpype.pipeline import get_current_asset_name, get_current_task_name
 from openpype.tools.utils import host_tools
 
@@ -331,10 +332,11 @@ class LaunchWorkFiles(LaunchQtApp):
 
     def execute(self, context):
         result = super().execute(context)
-        self._window.set_context({
-            "asset": get_current_asset_name(),
-            "task": get_current_task_name()
-        })
+        if not AYON_SERVER_ENABLED:
+            self._window.set_context({
+                "asset": get_current_asset_name(),
+                "task": get_current_task_name()
+            })
         return result
 
     def before_window_show(self):

--- a/openpype/tools/ayon_workfiles/abstract.py
+++ b/openpype/tools/ayon_workfiles/abstract.py
@@ -914,10 +914,12 @@ class AbstractWorkfilesFrontend(AbstractWorkfilesCommon):
 
     # Controller actions
     @abstractmethod
-    def open_workfile(self, filepath):
-        """Open a workfile.
+    def open_workfile(self, folder_id, task_id, filepath):
+        """Open a workfile for context.
 
         Args:
+            folder_id (str): Folder id.
+            task_id (str): Task id.
             filepath (str): Workfile path.
         """
 

--- a/openpype/tools/ayon_workfiles/control.py
+++ b/openpype/tools/ayon_workfiles/control.py
@@ -1,4 +1,5 @@
 import os
+import copy
 import shutil
 
 import ayon_api
@@ -452,12 +453,12 @@ class BaseWorkfileController(
         self._emit_event("controller.refresh.finished")
 
     # Controller actions
-    def open_workfile(self, filepath):
+    def open_workfile(self, folder_id, task_id, filepath):
         self._emit_event("open_workfile.started")
 
         failed = False
         try:
-            self._host_open_workfile(filepath)
+            self._open_workfile(folder_id, task_id, filepath)
 
         except Exception:
             failed = True
@@ -575,6 +576,53 @@ class BaseWorkfileController(
             self._expected_selection.get_expected_selection_data(),
         )
 
+    def _get_event_context_data(
+        self, project_name, folder_id, task_id, folder=None, task=None
+    ):
+        if folder is None:
+            folder = self.get_folder_entity(folder_id)
+        if task is None:
+            task = self.get_task_entity(task_id)
+        # NOTE keys should be OpenPype compatible
+        return {
+            "project_name": project_name,
+            "folder_id": folder_id,
+            "asset_id": folder_id,
+            "asset_name": folder["name"],
+            "task_id": task_id,
+            "task_name": task["name"],
+            "host_name": self.get_host_name(),
+        }
+
+    def _open_workfile(self, folder_id, task_id, filepath):
+        project_name = self.get_current_project_name()
+        event_data = self._get_event_context_data(
+            project_name, folder_id, task_id
+        )
+        event_data["filepath"] = filepath
+
+        emit_event("workfile.open.before", event_data, source="workfiles.tool")
+
+        # Change context
+        task_name = event_data["task_name"]
+        if (
+            folder_id != self.get_current_folder_id()
+            or task_name != self.get_current_task_name()
+        ):
+            # Use OpenPype asset-like object
+            asset_doc = get_asset_by_id(
+                event_data["project_name"],
+                event_data["folder_id"],
+            )
+            change_current_context(
+                asset_doc,
+                event_data["task_name"]
+            )
+
+        self._host_open_workfile(filepath)
+
+        emit_event("workfile.open.after", event_data, source="workfiles.tool")
+
     def _save_as_workfile(
         self,
         folder_id,
@@ -591,18 +639,14 @@ class BaseWorkfileController(
         task_name = task["name"]
 
         # QUESTION should the data be different for 'before' and 'after'?
-        # NOTE keys should be OpenPype compatible
-        event_data = {
-            "project_name": project_name,
-            "folder_id": folder_id,
-            "asset_id": folder_id,
-            "asset_name": folder["name"],
-            "task_id": task_id,
-            "task_name": task_name,
-            "host_name": self.get_host_name(),
+        event_data = self._get_event_context_data(
+            project_name, folder_id, task_id, folder, task
+        )
+        event_data.update({
             "filename": filename,
             "workdir_path": workdir,
-        }
+        })
+
         emit_event("workfile.save.before", event_data, source="workfiles.tool")
 
         # Create workfiles root folder

--- a/openpype/tools/ayon_workfiles/widgets/files_widget.py
+++ b/openpype/tools/ayon_workfiles/widgets/files_widget.py
@@ -106,7 +106,8 @@ class FilesWidget(QtWidgets.QWidget):
             self._on_published_cancel_clicked)
 
         self._selected_folder_id = None
-        self._selected_tak_name = None
+        self._selected_task_id = None
+        self._selected_task_name = None
 
         self._pre_select_folder_id = None
         self._pre_select_task_name = None
@@ -178,7 +179,7 @@ class FilesWidget(QtWidgets.QWidget):
     # -------------------------------------------------------------
     # Workarea workfiles
     # -------------------------------------------------------------
-    def _open_workfile(self, filepath):
+    def _open_workfile(self, folder_id, task_name, filepath):
         if self._controller.has_unsaved_changes():
             result = self._save_changes_prompt()
             if result is None:
@@ -186,12 +187,15 @@ class FilesWidget(QtWidgets.QWidget):
 
             if result:
                 self._controller.save_current_workfile()
-        self._controller.open_workfile(filepath)
+        self._controller.open_workfile(folder_id, task_name, filepath)
 
     def _on_workarea_open_clicked(self):
         path = self._workarea_widget.get_selected_path()
-        if path:
-            self._open_workfile(path)
+        if not path:
+            return
+        folder_id = self._selected_folder_id
+        task_id = self._selected_task_id
+        self._open_workfile(folder_id, task_id, path)
 
     def _on_current_open_requests(self):
         self._on_workarea_open_clicked()
@@ -238,8 +242,12 @@ class FilesWidget(QtWidgets.QWidget):
         }
 
         filepath = QtWidgets.QFileDialog.getOpenFileName(**kwargs)[0]
-        if filepath:
-            self._open_workfile(filepath)
+        if not filepath:
+            return
+
+        folder_id = self._selected_folder_id
+        task_id = self._selected_task_id
+        self._open_workfile(folder_id, task_id, filepath)
 
     def _on_workarea_save_clicked(self):
         result = self._exec_save_as_dialog()
@@ -279,10 +287,11 @@ class FilesWidget(QtWidgets.QWidget):
 
     def _on_task_changed(self, event):
         self._selected_folder_id = event["folder_id"]
-        self._selected_tak_name = event["task_name"]
+        self._selected_task_id = event["task_id"]
+        self._selected_task_name = event["task_name"]
         self._valid_selected_context = (
             self._selected_folder_id is not None
-            and self._selected_tak_name is not None
+            and self._selected_task_id is not None
         )
         self._update_published_btns_state()
 
@@ -311,7 +320,7 @@ class FilesWidget(QtWidgets.QWidget):
 
         if enabled:
             self._pre_select_folder_id = self._selected_folder_id
-            self._pre_select_task_name = self._selected_tak_name
+            self._pre_select_task_name = self._selected_task_name
         else:
             self._pre_select_folder_id = None
             self._pre_select_task_name = None
@@ -334,7 +343,7 @@ class FilesWidget(QtWidgets.QWidget):
             return True
         if self._pre_select_task_name is None:
             return False
-        return self._pre_select_task_name != self._selected_tak_name
+        return self._pre_select_task_name != self._selected_task_name
 
     def _on_published_cancel_clicked(self):
         folder_id = self._pre_select_folder_id


### PR DESCRIPTION
## Changelog Description
Change context when workfile is opened.

## Additional info
Open workfile did not handle opening of workfile in different context. Also trigger events on context change.

## Testing notes:
1. Launch a DCC via AYON launcher
2. Open workfiles tool
3. Select different context
4. Open workfile from the context (do not save, just open)
5. Validate contect changed (e.g. in AYON menu is context action)