### PR TITLE
Maya: Add Maya 2024 and remove pre 2022.

### DIFF
--- a/openpype/settings/defaults/system_settings/applications.json
+++ b/openpype/settings/defaults/system_settings/applications.json
@@ -12,6 +12,26 @@
             "LC_ALL": "C"
         },
         "variants": {
+            "2024": {
+                "use_python_2": false,
+                "executables": {
+                    "windows": [
+                        "C:\\Program Files\\Autodesk\\Maya2024\\bin\\maya.exe"
+                    ],
+                    "darwin": [],
+                    "linux": [
+                        "/usr/autodesk/maya2024/bin/maya"
+                    ]
+                },
+                "arguments": {
+                    "windows": [],
+                    "darwin": [],
+                    "linux": []
+                },
+                "environment": {
+                    "MAYA_VERSION": "2024"
+                }
+            },
             "2023": {
                 "use_python_2": false,
                 "executables": {
@@ -50,66 +70,6 @@
                 },
                 "environment": {
                     "MAYA_VERSION": "2022"
-                }
-            },
-            "2020": {
-                "use_python_2": true,
-                "executables": {
-                    "windows": [
-                        "C:\\Program Files\\Autodesk\\Maya2020\\bin\\maya.exe"
-                    ],
-                    "darwin": [],
-                    "linux": [
-                        "/usr/autodesk/maya2020/bin/maya"
-                    ]
-                },
-                "arguments": {
-                    "windows": [],
-                    "darwin": [],
-                    "linux": []
-                },
-                "environment": {
-                    "MAYA_VERSION": "2020"
-                }
-            },
-            "2019": {
-                "use_python_2": true,
-                "executables": {
-                    "windows": [
-                        "C:\\Program Files\\Autodesk\\Maya2019\\bin\\maya.exe"
-                    ],
-                    "darwin": [],
-                    "linux": [
-                        "/usr/autodesk/maya2019/bin/maya"
-                    ]
-                },
-                "arguments": {
-                    "windows": [],
-                    "darwin": [],
-                    "linux": []
-                },
-                "environment": {
-                    "MAYA_VERSION": "2019"
-                }
-            },
-            "2018": {
-                "use_python_2": true,
-                "executables": {
-                    "windows": [
-                        "C:\\Program Files\\Autodesk\\Maya2018\\bin\\maya.exe"
-                    ],
-                    "darwin": [],
-                    "linux": [
-                        "/usr/autodesk/maya2018/bin/maya"
-                    ]
-                },
-                "arguments": {
-                    "windows": [],
-                    "darwin": [],
-                    "linux": []
-                },
-                "environment": {
-                    "MAYA_VERSION": "2018"
                 }
             }
         }

--- a/server_addon/applications/server/applications.json
+++ b/server_addon/applications/server/applications.json
@@ -8,6 +8,26 @@
             "environment": "{\n  \"MAYA_DISABLE_CLIC_IPM\": \"Yes\",\n  \"MAYA_DISABLE_CIP\": \"Yes\",\n  \"MAYA_DISABLE_CER\": \"Yes\",\n  \"PYMEL_SKIP_MEL_INIT\": \"Yes\",\n  \"LC_ALL\": \"C\"\n}\n",
             "variants": [
                 {
+                    "name": "2024",
+                    "label": "2024",
+                    "executables": {
+                        "windows": [
+                            "C:\\Program Files\\Autodesk\\Maya2024\\bin\\maya.exe"
+                        ],
+                        "darwin": [],
+                        "linux": [
+                            "/usr/autodesk/maya2024/bin/maya"
+                        ]
+                    },
+                    "arguments": {
+                        "windows": [],
+                        "darwin": [],
+                        "linux": []
+                    },
+                    "environment": "{\n  \"MAYA_VERSION\": \"2024\"\n}",
+                    "use_python_2": false
+                },
+                {
                     "name": "2023",
                     "label": "2023",
                     "executables": {
@@ -45,66 +65,6 @@
                         "linux": []
                     },
                     "environment": "{\n  \"MAYA_VERSION\": \"2022\"\n}",
-                    "use_python_2": false
-                },
-                {
-                    "name": "2020",
-                    "label": "2020",
-                    "executables": {
-                        "windows": [
-                            "C:\\Program Files\\Autodesk\\Maya2020\\bin\\maya.exe"
-                        ],
-                        "darwin": [],
-                        "linux": [
-                            "/usr/autodesk/maya2020/bin/maya"
-                        ]
-                    },
-                    "arguments": {
-                        "windows": [],
-                        "darwin": [],
-                        "linux": []
-                    },
-                    "environment": "{\n  \"MAYA_VERSION\": \"2020\"\n}",
-                    "use_python_2": true
-                },
-                {
-                    "name": "2019",
-                    "label": "2019",
-                    "executables": {
-                        "windows": [
-                            "C:\\Program Files\\Autodesk\\Maya2019\\bin\\maya.exe"
-                        ],
-                        "darwin": [],
-                        "linux": [
-                            "/usr/autodesk/maya2019/bin/maya"
-                        ]
-                    },
-                    "arguments": {
-                        "windows": [],
-                        "darwin": [],
-                        "linux": []
-                    },
-                    "environment": "{\n  \"MAYA_VERSION\": \"2019\"\n}",
-                    "use_python_2": true
-                },
-                {
-                    "name": "2018",
-                    "label": "2018",
-                    "executables": {
-                        "windows": [
-                            "C:\\Program Files\\Autodesk\\Maya2018\\bin\\maya.exe"
-                        ],
-                        "darwin": [],
-                        "linux": [
-                            "/usr/autodesk/maya2018/bin/maya"
-                        ]
-                    },
-                    "arguments": {
-                        "windows": [],
-                        "darwin": [],
-                        "linux": []
-                    },
-                    "environment": "{\n  \"MAYA_VERSION\": \"2018\"\n}",
                     "use_python_2": true
                 }
             ]


### PR DESCRIPTION
## Changelog Description
Adding Maya 2024 as default application variant.

Removing Maya 2020 and older, as these are not supported anymore.

## Testing notes:
1. Launch settings with a new database and validate only Maya 2024-2022 is present.

Split from https://github.com/ynput/OpenPype/pull/5644
