### PR TITLE
Add openpype_mongo command flag for testing.

### DIFF
--- a/openpype/cli.py
+++ b/openpype/cli.py
@@ -290,11 +290,15 @@ def run(script):
               "--setup_only",
               help="Only create dbs, do not run tests",
               default=None)
+@click.option("--openpype_mongo",
+              help="MongoDB for testing.",
+              default=None)
 def runtests(folder, mark, pyargs, test_data_folder, persist, app_variant,
-             timeout, setup_only):
+             timeout, setup_only, openpype_mongo):
     """Run all automatic tests after proper initialization via start.py"""
     PypeCommands().run_tests(folder, mark, pyargs, test_data_folder,
-                             persist, app_variant, timeout, setup_only)
+                             persist, app_variant, timeout, setup_only,
+                             openpype_mongo)
 
 
 @main.command(help="DEPRECATED - run sync server")

--- a/openpype/cli.py
+++ b/openpype/cli.py
@@ -290,15 +290,15 @@ def run(script):
               "--setup_only",
               help="Only create dbs, do not run tests",
               default=None)
-@click.option("--openpype_mongo",
+@click.option("--mongo_url",
               help="MongoDB for testing.",
               default=None)
 def runtests(folder, mark, pyargs, test_data_folder, persist, app_variant,
-             timeout, setup_only, openpype_mongo):
+             timeout, setup_only, mongo_url):
     """Run all automatic tests after proper initialization via start.py"""
     PypeCommands().run_tests(folder, mark, pyargs, test_data_folder,
                              persist, app_variant, timeout, setup_only,
-                             openpype_mongo)
+                             mongo_url)
 
 
 @main.command(help="DEPRECATED - run sync server")

--- a/openpype/pype_commands.py
+++ b/openpype/pype_commands.py
@@ -213,7 +213,8 @@ class PypeCommands:
         pass
 
     def run_tests(self, folder, mark, pyargs,
-                  test_data_folder, persist, app_variant, timeout, setup_only):
+                  test_data_folder, persist, app_variant, timeout, setup_only,
+                  openpype_mongo):
         """
             Runs tests from 'folder'
 
@@ -263,6 +264,15 @@ class PypeCommands:
 
         if setup_only:
             args.extend(["--setup_only", setup_only])
+
+        if openpype_mongo:
+            args.extend(["--openpype_mongo", openpype_mongo])
+        else:
+            msg = (
+                "Either provide uri to MongoDB through environment variable"
+                " OPENPYPE_MONGO or the command flag --openpype_mongo"
+            )
+            assert not os.environ.get("OPENPYPE_MONGO"), msg
 
         print("run_tests args: {}".format(args))
         import pytest

--- a/openpype/pype_commands.py
+++ b/openpype/pype_commands.py
@@ -214,7 +214,7 @@ class PypeCommands:
 
     def run_tests(self, folder, mark, pyargs,
                   test_data_folder, persist, app_variant, timeout, setup_only,
-                  openpype_mongo):
+                  mongo_url):
         """
             Runs tests from 'folder'
 
@@ -227,6 +227,10 @@ class PypeCommands:
                     end
                 app_variant (str): variant (eg 2020 for AE), empty if use
                     latest installed version
+                timeout (int): explicit timeout for single test
+                setup_only (bool): if only preparation steps should be
+                    triggered, no tests (useful for debugging/development)
+                mongo_url (str): url to Openpype Mongo database
         """
         print("run_tests")
         if folder:
@@ -265,12 +269,12 @@ class PypeCommands:
         if setup_only:
             args.extend(["--setup_only", setup_only])
 
-        if openpype_mongo:
-            args.extend(["--openpype_mongo", openpype_mongo])
+        if mongo_url:
+            args.extend(["--mongo_url", mongo_url])
         else:
             msg = (
                 "Either provide uri to MongoDB through environment variable"
-                " OPENPYPE_MONGO or the command flag --openpype_mongo"
+                " OPENPYPE_MONGO or the command flag --mongo_url"
             )
             assert not os.environ.get("OPENPYPE_MONGO"), msg
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -29,6 +29,11 @@ def pytest_addoption(parser):
         help="True - only setup test, do not run any tests"
     )
 
+    parser.addoption(
+        "--openpype_mongo", action="store", default=None,
+        help="Provide url of the Mongo database."
+    )
+
 
 @pytest.fixture(scope="module")
 def test_data_folder(request):
@@ -53,6 +58,10 @@ def timeout(request):
 @pytest.fixture(scope="module")
 def setup_only(request):
     return request.config.getoption("--setup_only")
+
+
+def openpype_mongo(request):
+    return request.config.getoption("--openpype_mongo")
 
 
 @pytest.hookimpl(tryfirst=True, hookwrapper=True)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -60,6 +60,7 @@ def setup_only(request):
     return request.config.getoption("--setup_only")
 
 
+@pytest.fixture(scope="module")
 def openpype_mongo(request):
     return request.config.getoption("--openpype_mongo")
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -30,7 +30,7 @@ def pytest_addoption(parser):
     )
 
     parser.addoption(
-        "--openpype_mongo", action="store", default=None,
+        "--mongo_url", action="store", default=None,
         help="Provide url of the Mongo database."
     )
 
@@ -61,8 +61,8 @@ def setup_only(request):
 
 
 @pytest.fixture(scope="module")
-def openpype_mongo(request):
-    return request.config.getoption("--openpype_mongo")
+def mongo_url(request):
+    return request.config.getoption("--mongo_url")
 
 
 @pytest.hookimpl(tryfirst=True, hookwrapper=True)

--- a/tests/lib/testing_classes.py
+++ b/tests/lib/testing_classes.py
@@ -40,7 +40,7 @@ class ModuleUnitTest(BaseTest):
     """
     PERSIST = False  # True to not purge temporary folder nor test DB
 
-    TEST_OPENPYPE_MONGO = "mongodb://localhost:27017"
+    OPENPYPE_MONGO = "mongodb://localhost:27017"
     TEST_DB_NAME = "avalon_tests"
     TEST_PROJECT_NAME = "test_project"
     TEST_OPENPYPE_NAME = "openpype_tests"
@@ -147,11 +147,11 @@ class ModuleUnitTest(BaseTest):
 
     @pytest.fixture(scope="module")
     def db_setup(self, download_test_data, env_var, monkeypatch_session,
-                 request):
+                 request, openpype):
         """Restore prepared MongoDB dumps into selected DB."""
         backup_dir = os.path.join(download_test_data, "input", "dumps")
 
-        uri = os.environ.get("OPENPYPE_MONGO")
+        uri = os.environ.get("OPENPYPE_MONGO", openpype)
         db_handler = DBHandler(uri)
         db_handler.setup_from_dump(self.TEST_DB_NAME, backup_dir,
                                    overwrite=True,

--- a/tests/lib/testing_classes.py
+++ b/tests/lib/testing_classes.py
@@ -147,11 +147,11 @@ class ModuleUnitTest(BaseTest):
 
     @pytest.fixture(scope="module")
     def db_setup(self, download_test_data, env_var, monkeypatch_session,
-                 request, openpype):
+                 request, openpype_mongo):
         """Restore prepared MongoDB dumps into selected DB."""
         backup_dir = os.path.join(download_test_data, "input", "dumps")
 
-        uri = os.environ.get("OPENPYPE_MONGO", openpype)
+        uri = openpype_mongo or os.environ.get("OPENPYPE_MONGO")
         db_handler = DBHandler(uri)
         db_handler.setup_from_dump(self.TEST_DB_NAME, backup_dir,
                                    overwrite=True,

--- a/tests/lib/testing_classes.py
+++ b/tests/lib/testing_classes.py
@@ -40,7 +40,7 @@ class ModuleUnitTest(BaseTest):
     """
     PERSIST = False  # True to not purge temporary folder nor test DB
 
-    OPENPYPE_MONGO = "mongodb://localhost:27017"
+    TEST_OPENPYPE_MONGO = "mongodb://localhost:27017"
     TEST_DB_NAME = "avalon_tests"
     TEST_PROJECT_NAME = "test_project"
     TEST_OPENPYPE_NAME = "openpype_tests"

--- a/tests/lib/testing_classes.py
+++ b/tests/lib/testing_classes.py
@@ -147,11 +147,11 @@ class ModuleUnitTest(BaseTest):
 
     @pytest.fixture(scope="module")
     def db_setup(self, download_test_data, env_var, monkeypatch_session,
-                 request, openpype_mongo):
+                 request, mongo_url):
         """Restore prepared MongoDB dumps into selected DB."""
         backup_dir = os.path.join(download_test_data, "input", "dumps")
 
-        uri = openpype_mongo or os.environ.get("OPENPYPE_MONGO")
+        uri = mongo_url or os.environ.get("OPENPYPE_MONGO")
         db_handler = DBHandler(uri)
         db_handler.setup_from_dump(self.TEST_DB_NAME, backup_dir,
                                    overwrite=True,


### PR DESCRIPTION
## Changelog Description
Instead of changing the environment, this command flag allows for changing the database.

## Testing notes:
1. Run test suite with command flag `--openpype_mongo [URI]`.
