### PR TITLE
Blender: Fix remove/update in new layout instance

### DIFF
--- a/openpype/hosts/blender/plugins/load/load_blend.py
+++ b/openpype/hosts/blender/plugins/load/load_blend.py
@@ -244,7 +244,7 @@ class BlendLoader(plugin.AssetLoader):
         for parent in parent_containers:
             parent.get(AVALON_PROPERTY)["members"] = list(filter(
                 lambda i: i not in members,
-                parent.get(AVALON_PROPERTY)["members"]))
+                parent.get(AVALON_PROPERTY).get("members", [])))
 
         for attr in attrs:
             for data in getattr(bpy.data, attr):


### PR DESCRIPTION
## Changelog Description
Fixes an error that occurs when removing or updating an asset in a new layout instance.

## Additional info
When updating or removing the assets, it looks for `members` in the parent container, which doesn't exist (it exists in loaded layouts, not in instances).

## Testing notes:
1. Create a new layout instance in Blender.
2. Try updating or removing one of the assets in the layout.
