### PR TITLE
Maya: Bug in validate Plug-in Path Attribute

### DIFF
--- a/openpype/hosts/maya/plugins/publish/validate_plugin_path_attributes.py
+++ b/openpype/hosts/maya/plugins/publish/validate_plugin_path_attributes.py
@@ -30,18 +30,18 @@ class ValidatePluginPathAttributes(pyblish.api.InstancePlugin):
     def get_invalid(cls, instance):
         invalid = list()
 
-        file_attr = cls.attribute
-        if not file_attr:
+        file_attrs = cls.attribute
+        if not file_attrs:
             return invalid
 
         # Consider only valid node types to avoid "Unknown object type" warning
         all_node_types = set(cmds.allNodeTypes())
-        node_types = [key for key in file_attr.keys() if key in all_node_types]
+        node_types = [key for key in file_attrs.keys() if key in all_node_types]
 
         for node, node_type in pairwise(cmds.ls(type=node_types,
                                                 showType=True)):
             # get the filepath
-            file_attr = "{}.{}".format(node, file_attr[node_type])
+            file_attr = "{}.{}".format(node, file_attrs[node_type])
             filepath = cmds.getAttr(file_attr)
 
             if filepath and not os.path.exists(filepath):

--- a/openpype/hosts/maya/plugins/publish/validate_plugin_path_attributes.py
+++ b/openpype/hosts/maya/plugins/publish/validate_plugin_path_attributes.py
@@ -36,7 +36,10 @@ class ValidatePluginPathAttributes(pyblish.api.InstancePlugin):
 
         # Consider only valid node types to avoid "Unknown object type" warning
         all_node_types = set(cmds.allNodeTypes())
-        node_types = [key for key in file_attrs.keys() if key in all_node_types]
+        node_types = [
+            key for key in file_attrs.keys()
+            if key in all_node_types
+        ]
 
         for node, node_type in pairwise(cmds.ls(type=node_types,
                                                 showType=True)):


### PR DESCRIPTION
## Changelog Description
Overwriting list with string is causing `TypeError: string indices must be integers` in subsequent iterations, crashing the validator plugin.

## Testing notes:
1. Plugin should work as expected

