### PR TITLE
Nuke: (Non) Existing Files

### DIFF
--- a/openpype/hosts/nuke/plugins/publish/collect_writes.py
+++ b/openpype/hosts/nuke/plugins/publish/collect_writes.py
@@ -68,12 +68,13 @@ class CollectNukeWrites(pyblish.api.InstancePlugin,
         representation = self._get_existing_frames_representation(
             instance, collected_frames
         )
-
-        # inject colorspace data
-        self.set_representation_colorspace(
-            representation, instance.context,
-            colorspace=colorspace
-        )
+        files = representation["files"]
+        if isinstance(files, list) and files:
+            # inject colorspace data
+            self.set_representation_colorspace(
+                representation, instance.context,
+                colorspace=colorspace
+            )
 
         instance.data["representations"].append(representation)
 

--- a/openpype/hosts/nuke/plugins/publish/collect_writes.py
+++ b/openpype/hosts/nuke/plugins/publish/collect_writes.py
@@ -69,7 +69,7 @@ class CollectNukeWrites(pyblish.api.InstancePlugin,
             instance, collected_frames
         )
 
-        # To avoid errors only try injecting colorspace 
+        # To avoid errors only try injecting colorspace
         # if any existing files were found on disk
         if representation["files"]:
             # inject colorspace data

--- a/openpype/hosts/nuke/plugins/publish/collect_writes.py
+++ b/openpype/hosts/nuke/plugins/publish/collect_writes.py
@@ -68,8 +68,14 @@ class CollectNukeWrites(pyblish.api.InstancePlugin,
         representation = self._get_existing_frames_representation(
             instance, collected_frames
         )
+
+        set_colorspace = True
+
         files = representation["files"]
-        if isinstance(files, list) and files:
+        if isinstance(files, list) and not files:
+            set_colorspace = False
+
+        if set_colorspace:
             # inject colorspace data
             self.set_representation_colorspace(
                 representation, instance.context,

--- a/openpype/hosts/nuke/plugins/publish/collect_writes.py
+++ b/openpype/hosts/nuke/plugins/publish/collect_writes.py
@@ -69,13 +69,9 @@ class CollectNukeWrites(pyblish.api.InstancePlugin,
             instance, collected_frames
         )
 
-        set_colorspace = True
-
-        files = representation["files"]
-        if isinstance(files, list) and not files:
-            set_colorspace = False
-
-        if set_colorspace:
+        # To avoid errors only try injecting colorspace 
+        # if any existing files were found on disk
+        if representation["files"]:
             # inject colorspace data
             self.set_representation_colorspace(
                 representation, instance.context,

--- a/openpype/hosts/nuke/plugins/publish/validate_rendered_frames.py
+++ b/openpype/hosts/nuke/plugins/publish/validate_rendered_frames.py
@@ -64,7 +64,7 @@ class ValidateRenderedFrames(pyblish.api.InstancePlugin):
         for repre in instance.data["representations"]:
 
             if not repre.get("files"):
-                msg = ("no frames were collected, "
+                msg = ("No frames were collected, "
                        "you need to render them.\n"
                        "Check properties of write node (group) and "
                        "select 'Local' option in 'Publish' dropdown.")

--- a/openpype/hosts/nuke/plugins/publish/validate_rendered_frames.py
+++ b/openpype/hosts/nuke/plugins/publish/validate_rendered_frames.py
@@ -66,7 +66,7 @@ class ValidateRenderedFrames(pyblish.api.InstancePlugin):
             if not repre.get("files"):
                 msg = ("no frames were collected, "
                        "you need to render them.\n"
-                       "Check properties of write node (group) and"
+                       "Check properties of write node (group) and "
                        "select 'Local' option in 'Publish' dropdown.")
                 self.log.error(msg)
                 raise PublishXmlValidationError(


### PR DESCRIPTION
## Changelog Description
When a write instance is set to "existing files", the collection will error with the message below:

```
Traceback (most recent call last):
  File "C:\Users\tokejepsen\bumpybox_development\OpenPype\.venv\lib\site-packages\pyblish\[plugin.py](http://plugin.py/)", line 527, in __explicit_process
    runner(*args)
  File "C:\Users\tokejepsen\bumpybox_development\OpenPype\openpype\hosts\nuke\plugins\publish\[collect_writes.py](http://collect_writes.py/)", line 40, in process
  File "C:\Users\tokejepsen\bumpybox_development\OpenPype\openpype\hosts\nuke\plugins\publish\[collect_writes.py](http://collect_writes.py/)", line 76, in _set_existing_files_data
  File "C:\Users\tokejepsen\bumpybox_development\OpenPype\openpype\pipeline\publish\[publish_plugins.py](http://publish_plugins.py/)", line 350, in set_representation_colorspace
    log=self.log
  File "C:\Users\tokejepsen\bumpybox_development\OpenPype\openpype\pipeline\[colorspace.py](http://colorspace.py/)", line 705, in set_colorspace_data_to_representation
    filename = filename[0]
IndexError: list index out of range
```

This PR will skip setting the colorspace when there are no files, so existing files validation can kick in later with a more user-friendly error report.

## Testing notes:
1. Setup write instance in Nuke with "existing files" option.
2. Publish and ensure validation kicks in.
