### PR TITLE
Deadline: handle all valid paths in RenderExecutable

### DIFF
--- a/openpype/modules/deadline/repository/custom/plugins/Ayon/Ayon.py
+++ b/openpype/modules/deadline/repository/custom/plugins/Ayon/Ayon.py
@@ -96,7 +96,7 @@ class AyonDeadlinePlugin(DeadlinePlugin):
         for path in exe_list.split(";"):
             if path.startswith("~"):
                 path = os.path.expanduser(path)
-                expanded_paths.append(path)
+            expanded_paths.append(path)  # Always append the path after potential expansion
         exe = FileUtils.SearchFileList(";".join(expanded_paths))
 
         if exe == "":

--- a/openpype/modules/deadline/repository/custom/plugins/Ayon/Ayon.py
+++ b/openpype/modules/deadline/repository/custom/plugins/Ayon/Ayon.py
@@ -96,7 +96,7 @@ class AyonDeadlinePlugin(DeadlinePlugin):
         for path in exe_list.split(";"):
             if path.startswith("~"):
                 path = os.path.expanduser(path)
-            expanded_paths.append(path)  # Always append the path after potential expansion
+            expanded_paths.append(path)
         exe = FileUtils.SearchFileList(";".join(expanded_paths))
 
         if exe == "":


### PR DESCRIPTION
## Changelog Description
This commit enhances the path resolution mechanism in the RenderExecutable function of the Ayon plugin. Previously, the function only considered paths starting with a tilde (~), ignoring other valid paths listed in exe_list. This limitation led to an empty expanded_paths list when none of the paths in exe_list started with a tilde, causing the function to fail in finding the Ayon executable.

With this fix, the RenderExecutable function now correctly processes and includes all valid paths from exe_list, improving its reliability and preventing unnecessary errors related to Ayon executable location.

## Additional info
Resolves: #5675 
