### PR TITLE
Nuke: minor docstring and code tweaks for ExtractReviewMov

### DIFF
--- a/openpype/hosts/nuke/api/lib.py
+++ b/openpype/hosts/nuke/api/lib.py
@@ -3425,17 +3425,15 @@ def create_viewer_profile_string(viewer, display=None, path_like=False):
     return "{} ({})".format(viewer, display)
 
 
-def get_head_filename_without_hashes(original_path, name):
-    """Function to get the renamed head filename without frame hashes
-    To avoid the system being confused on finding the filename with
-    frame hashes if the head of the filename has the hashed symbol
+def prepend_name_before_hashed_frame(original_path, name):
+    """Function to prepend an extra name before the hashed frame numbers
 
     Examples:
-        >>> get_head_filename_without_hashes("render.####.exr", "baking")
+        >>> prepend_name_before_hashed_frame("render.####.exr", "baking")
         render.baking.####.exr
-        >>> get_head_filename_without_hashes("render.%04d.exr", "tag")
+        >>> prepend_name_before_hashed_frame("render.%04d.exr", "tag")
         render.tag.%d.exr
-        >>> get_head_filename_without_hashes("exr.####.exr", "foo")
+        >>> prepend_name_before_hashed_frame("exr.####.exr", "foo")
         exr.foo.%04d.exr
 
     Args:

--- a/openpype/hosts/nuke/api/lib.py
+++ b/openpype/hosts/nuke/api/lib.py
@@ -3425,32 +3425,6 @@ def create_viewer_profile_string(viewer, display=None, path_like=False):
     return "{} ({})".format(viewer, display)
 
 
-def prepend_name_before_hashed_frame(original_path, name):
-    """Function to prepend an extra name before the hashed frame numbers
-
-    Examples:
-        >>> prepend_name_before_hashed_frame("render.####.exr", "baking")
-        render.baking.####.exr
-        >>> prepend_name_before_hashed_frame("render.%04d.exr", "tag")
-        render.tag.%d.exr
-        >>> prepend_name_before_hashed_frame("exr.####.exr", "foo")
-        exr.foo.%04d.exr
-
-    Args:
-        original_path (str): the filename with frame hashes
-        name (str): the name of the tags
-
-    Returns:
-        str: the renamed filename with the tag
-    """
-    filename = os.path.basename(original_path)
-
-    def insert_name(matchobj):
-        return "{}.{}".format(name, matchobj.group(0))
-
-    return re.sub(r"(%\d*d)|#+", insert_name, filename)
-
-
 def get_filenames_without_hash(filename, frame_start, frame_end):
     """Get filenames without frame hash
         i.e. "renderCompositingMain.baking.0001.exr"

--- a/openpype/hosts/nuke/api/plugin.py
+++ b/openpype/hosts/nuke/api/plugin.py
@@ -819,6 +819,11 @@ class ExporterReviewMov(ExporterReview):
             self.file = "{}{}.{}".format(
                 self.fhead, self.name, self.ext)
         else:
+            # Output is image (or image sequence)
+            # When the file is an image it's possible it
+            # has extra information after the `fhead` that
+            # we want to preserve, e.g. like frame numbers
+            # or frames hashes like `####`
             filename_no_ext = os.path.splitext(
                 os.path.basename(self.path_in))[0]
             after_head = filename_no_ext[len(self.fhead):]

--- a/openpype/hosts/nuke/api/plugin.py
+++ b/openpype/hosts/nuke/api/plugin.py
@@ -39,7 +39,7 @@ from .lib import (
     get_view_process_node,
     get_viewer_config_from_string,
     deprecated,
-    get_head_filename_without_hashes,
+    prepend_name_before_hashed_frame,
     get_filenames_without_hash
 )
 from .pipeline import (
@@ -820,12 +820,12 @@ class ExporterReviewMov(ExporterReview):
         if ".{}".format(self.ext) not in VIDEO_EXTENSIONS:
             # filename would be with frame hashes if
             # the file extension is not in video format
-            filename = get_head_filename_without_hashes(
+            filename = prepend_name_before_hashed_frame(
                 self.path_in, self.name)
             self.file = filename
             # make sure the filename are in
             # correct image output format
-            if ".{}".format(self.ext) not in self.file:
+            if not self.file.endswith(".{}".format(ext)):
                 filename_no_ext, _ = os.path.splitext(filename)
                 self.file = "{}.{}".format(filename_no_ext, self.ext)
 

--- a/openpype/hosts/nuke/api/plugin.py
+++ b/openpype/hosts/nuke/api/plugin.py
@@ -39,7 +39,6 @@ from .lib import (
     get_view_process_node,
     get_viewer_config_from_string,
     deprecated,
-    prepend_name_before_hashed_frame,
     get_filenames_without_hash
 )
 from .pipeline import (
@@ -818,15 +817,14 @@ class ExporterReviewMov(ExporterReview):
 
         self.file = self.fhead + self.name + ".{}".format(self.ext)
         if ".{}".format(self.ext) not in VIDEO_EXTENSIONS:
-            # filename would be with frame hashes if
-            # the file extension is not in video format
-            filename = prepend_name_before_hashed_frame(
-                self.path_in, self.name)
-            self.file = filename
+            filename = os.path.basename(self.path_in)
+            self.file = self.fhead + self.name + ".{}".format(
+                filename.split(".", 1)[-1]
+            )
             # make sure the filename are in
             # correct image output format
             if not self.file.endswith(".{}".format(ext)):
-                filename_no_ext, _ = os.path.splitext(filename)
+                filename_no_ext, _ = os.path.splitext(self.file)
                 self.file = "{}.{}".format(filename_no_ext, self.ext)
 
         self.path = os.path.join(

--- a/openpype/hosts/nuke/api/plugin.py
+++ b/openpype/hosts/nuke/api/plugin.py
@@ -818,9 +818,8 @@ class ExporterReviewMov(ExporterReview):
         self.file = self.fhead + self.name + ".{}".format(self.ext)
         if ".{}".format(self.ext) not in VIDEO_EXTENSIONS:
             filename = os.path.basename(self.path_in)
-            self.file = self.fhead + self.name + ".{}".format(
-                filename.split(".", 1)[-1]
-            )
+            self.file = re.sub(
+                self.fhead, self.fhead + self.name + ".", filename)
             # make sure the filename are in
             # correct image output format
             if not self.file.endswith(".{}".format(ext)):

--- a/openpype/hosts/nuke/api/plugin.py
+++ b/openpype/hosts/nuke/api/plugin.py
@@ -817,15 +817,11 @@ class ExporterReviewMov(ExporterReview):
 
         self.file = self.fhead + self.name + ".{}".format(self.ext)
         if ".{}".format(self.ext) not in VIDEO_EXTENSIONS:
-            filename = os.path.basename(self.path_in)
-            self.file = re.sub(
-                self.fhead, self.fhead + self.name + ".", filename)
-            # make sure the filename are in
-            # correct image output format
-            if not self.file.endswith(".{}".format(ext)):
-                filename_no_ext, _ = os.path.splitext(self.file)
-                self.file = "{}.{}".format(filename_no_ext, self.ext)
-
+            filename_no_ext = os.path.splitext(
+                os.path.basename(self.path_in))[0]
+            after_head = filename_no_ext[len(self.fhead):]
+            self.file = "{}{}.{}.{}".format(
+                self.fhead, self.name, after_head, self.ext)
         self.path = os.path.join(
             self.staging_dir, self.file).replace("\\", "/")
 

--- a/openpype/hosts/nuke/api/plugin.py
+++ b/openpype/hosts/nuke/api/plugin.py
@@ -815,8 +815,10 @@ class ExporterReviewMov(ExporterReview):
 
         self.log.info("File info was set...")
 
-        self.file = self.fhead + self.name + ".{}".format(self.ext)
-        if ".{}".format(self.ext) not in VIDEO_EXTENSIONS:
+        if ".{}".format(self.ext) in VIDEO_EXTENSIONS:
+            self.file = "{}{}.{}".format(
+                self.fhead, self.name, self.ext)
+        else:
             filename_no_ext = os.path.splitext(
                 os.path.basename(self.path_in))[0]
             after_head = filename_no_ext[len(self.fhead):]


### PR DESCRIPTION
## Changelog Description
Code and docstring tweaks on https://github.com/ynput/OpenPype/pull/5623

## Additional info
n/a

## Testing notes:
1. add `png` to the settings `project_settings/nuke/publish/ExtractReviewDataBakingStreams/outputs/baking/extension`
2. publish review from nuke
