### PR TITLE
AYON: Small settings fixes

### DIFF
--- a/openpype/hosts/nuke/plugins/publish/extract_review_intermediates.py
+++ b/openpype/hosts/nuke/plugins/publish/extract_review_intermediates.py
@@ -33,11 +33,13 @@ class ExtractReviewIntermediates(publish.Extractor):
         """
         nuke_publish = project_settings["nuke"]["publish"]
         deprecated_setting = nuke_publish["ExtractReviewDataMov"]
-        current_setting = nuke_publish["ExtractReviewIntermediates"]
+        current_setting = nuke_publish.get("ExtractReviewIntermediates")
         if deprecated_setting["enabled"]:
             # Use deprecated settings if they are still enabled
             cls.viewer_lut_raw = deprecated_setting["viewer_lut_raw"]
             cls.outputs = deprecated_setting["outputs"]
+        elif current_setting is None:
+            pass
         elif current_setting["enabled"]:
             cls.viewer_lut_raw = current_setting["viewer_lut_raw"]
             cls.outputs = current_setting["outputs"]

--- a/openpype/settings/ayon_settings.py
+++ b/openpype/settings/ayon_settings.py
@@ -748,15 +748,17 @@ def _convert_nuke_project_settings(ayon_settings, output):
     )
 
     new_review_data_outputs = {}
-    outputs_settings = None
+    outputs_settings = []
     # Check deprecated ExtractReviewDataMov
     # settings for backwards compatibility
     deprecrated_review_settings = ayon_publish["ExtractReviewDataMov"]
     current_review_settings = (
-        ayon_publish["ExtractReviewIntermediates"]
+        ayon_publish.get("ExtractReviewIntermediates")
     )
     if deprecrated_review_settings["enabled"]:
         outputs_settings = deprecrated_review_settings["outputs"]
+    elif current_review_settings is None:
+        pass
     elif current_review_settings["enabled"]:
         outputs_settings = current_review_settings["outputs"]
 

--- a/server_addon/applications/server/applications.json
+++ b/server_addon/applications/server/applications.json
@@ -237,6 +237,7 @@
                 },
                 {
                     "name": "13-0",
+                    "label": "13.0",
                     "use_python_2": false,
                     "executables": {
                         "windows": [

--- a/server_addon/applications/server/applications.json
+++ b/server_addon/applications/server/applications.json
@@ -320,6 +320,7 @@
                 },
                 {
                     "name": "13-0",
+                    "label": "13.0",
                     "use_python_2": false,
                     "executables": {
                         "windows": [
@@ -406,6 +407,7 @@
                 },
                 {
                     "name": "13-0",
+                    "label": "13.0",
                     "use_python_2": false,
                     "executables": {
                         "windows": [
@@ -492,6 +494,7 @@
                 },
                 {
                     "name": "13-0",
+                    "label": "13.0",
                     "use_python_2": false,
                     "executables": {
                         "windows": [
@@ -578,6 +581,7 @@
                 },
                 {
                     "name": "13-0",
+                    "label": "13.0",
                     "use_python_2": false,
                     "executables": {
                         "windows": [


### PR DESCRIPTION
## Changelog Description
Small changes/fixes related to AYON settings. All foundry apps variant `13-0` has label `13.0`. Key `"ExtractReviewIntermediates"` is not mandatory in settings.

## Additional info
The label for `13-0` was missing for all variants (probably copy>paste issue). New settings `"ExtractReviewIntermediates"` does not work in backwards compatible way and always expects the key which breaks when new version of openpype addon is used with older nuke addon.

## Testing notes:
1. Check the labels in applications.
2. `"ExtractReviewIntermediates"` should not cause crashes of OpenPype addon with older version of nuke addon.
