### PR TITLE
AYON Launcher tool: Fix skip last workfile boolean

### DIFF
--- a/openpype/tools/ayon_launcher/abstract.py
+++ b/openpype/tools/ayon_launcher/abstract.py
@@ -272,7 +272,7 @@ class AbstractLauncherFrontEnd(AbstractLauncherCommon):
 
     @abstractmethod
     def set_application_force_not_open_workfile(
-        self, project_name, folder_id, task_id, action_id, enabled
+        self, project_name, folder_id, task_id, action_ids, enabled
     ):
         """This is application action related to force not open last workfile.
 
@@ -280,7 +280,7 @@ class AbstractLauncherFrontEnd(AbstractLauncherCommon):
             project_name (Union[str, None]): Project name.
             folder_id (Union[str, None]): Folder id.
             task_id (Union[str, None]): Task id.
-            action_id (str): Action identifier.
+            action_id (Iterable[str]): Action identifiers.
             enabled (bool): New value of force not open workfile.
         """
 

--- a/openpype/tools/ayon_launcher/control.py
+++ b/openpype/tools/ayon_launcher/control.py
@@ -121,10 +121,10 @@ class BaseLauncherController(
             project_name, folder_id, task_id)
 
     def set_application_force_not_open_workfile(
-        self, project_name, folder_id, task_id, action_id, enabled
+        self, project_name, folder_id, task_id, action_ids, enabled
     ):
         self._actions_model.set_application_force_not_open_workfile(
-            project_name, folder_id, task_id, action_id, enabled
+            project_name, folder_id, task_id, action_ids, enabled
         )
 
     def trigger_action(self, project_name, folder_id, task_id, identifier):

--- a/openpype/tools/ayon_launcher/models/actions.py
+++ b/openpype/tools/ayon_launcher/models/actions.py
@@ -359,9 +359,10 @@ class ActionsModel:
                     project_name, folder_id, task_id
                 )
                 force_not_open_workfile = per_action.get(identifier, False)
-                action.data["start_last_workfile"] = (
-                    not force_not_open_workfile
-                )
+                if force_not_open_workfile:
+                    action.data["start_last_workfile"] = False
+                else:
+                    action.data.pop("start_last_workfile", None)
             action.process(session)
         except Exception as exc:
             self.log.warning("Action trigger failed.", exc_info=True)

--- a/openpype/tools/ayon_launcher/models/actions.py
+++ b/openpype/tools/ayon_launcher/models/actions.py
@@ -326,13 +326,14 @@ class ActionsModel:
         return output
 
     def set_application_force_not_open_workfile(
-        self, project_name, folder_id, task_id, action_id, enabled
+        self, project_name, folder_id, task_id, action_ids, enabled
     ):
         no_workfile_reg_data = self._get_no_last_workfile_reg_data()
         project_data = no_workfile_reg_data.setdefault(project_name, {})
         folder_data = project_data.setdefault(folder_id, {})
         task_data = folder_data.setdefault(task_id, {})
-        task_data[action_id] = enabled
+        for action_id in action_ids:
+            task_data[action_id] = enabled
         self._launcher_tool_reg.set_item(
             self._not_open_workfile_reg_key, no_workfile_reg_data
         )

--- a/openpype/tools/ayon_launcher/models/actions.py
+++ b/openpype/tools/ayon_launcher/models/actions.py
@@ -359,7 +359,9 @@ class ActionsModel:
                     project_name, folder_id, task_id
                 )
                 force_not_open_workfile = per_action.get(identifier, False)
-                action.data["start_last_workfile"] = force_not_open_workfile
+                action.data["start_last_workfile"] = (
+                    not force_not_open_workfile
+                )
             action.process(session)
         except Exception as exc:
             self.log.warning("Action trigger failed.", exc_info=True)

--- a/openpype/tools/ayon_launcher/ui/actions_widget.py
+++ b/openpype/tools/ayon_launcher/ui/actions_widget.py
@@ -19,6 +19,21 @@ ANIMATION_STATE_ROLE = QtCore.Qt.UserRole + 6
 FORCE_NOT_OPEN_WORKFILE_ROLE = QtCore.Qt.UserRole + 7
 
 
+def _variant_label_sort_getter(action_item):
+    """Get variant label value for sorting.
+
+    Make sure the output value is a string.
+
+    Args:
+        action_item (ActionItem): Action item.
+
+    Returns:
+        str: Variant label or empty string.
+    """
+
+    return action_item.variant_label or ""
+
+
 class ActionsQtModel(QtGui.QStandardItemModel):
     """Qt model for actions.
 
@@ -106,8 +121,7 @@ class ActionsQtModel(QtGui.QStandardItemModel):
 
         groups_by_id = {}
         for action_items in items_by_label.values():
-            action_items.sort(key=lambda x: x.variant_label)
-            action_items.reverse()
+            action_items.sort(key=_variant_label_sort_getter, reverse=True)
             first_item = next(iter(action_items))
             all_action_items_info.append((first_item, len(action_items) > 1))
             groups_by_id[first_item.identifier] = action_items


### PR DESCRIPTION
## Changelog Description
Skip last workfile boolean works as expected.

## Additional info
The value was reversed, so it skipped last workfile when should use it and vica versa.

## Testing notes:
1. Open host and task of your choice and make sure it has a workfile.
2. Close it.
3. Make sure `Skip last workfile` is not checked in launcher tool.
4. Launch it again, it should open host with last workfile.
5. Close it.
6. Make sure `Skip last workfile` is checked in launcher tool.
7. Launch it again, it should not open a workfile.