### PR TITLE
Chore: Fix subst paths handling

### DIFF
--- a/start.py
+++ b/start.py
@@ -366,8 +366,8 @@ def run_disk_mapping_commands(settings):
             destination = destination.replace("/", "\\").rstrip("\\")
             source = source.replace("/", "\\").rstrip("\\")
             # Add slash after ':' ('G:' -> 'G:\')
-            if destination.endswith(":"):
-                destination += "\\"
+            if source.endswith(":"):
+                source += "\\"
         else:
             destination = destination.rstrip("/")
             source = source.rstrip("/")


### PR DESCRIPTION
## Changelog Description
Make sure that source disk ends with `\` instead of destination disk.

## Additional info
Destination disk should be just `<letter>:` but we were adding `\` to the end which does not work. That should be forced for source path where it must be `C:\`.

## Testing notes:
Make sure that you build OpenPype, or run it from code for testing of this PR.
1. Change settings to map e.g. `C:\` to `T:\`
2. Start OpenPype
3. Validate the mapping happened 

NOTE: To remove the new disk open powershell and pass in `subst T: /d` (replace T with your disk letter).