### PR TITLE
Chore: Explore here action can work without task

### DIFF
--- a/openpype/plugins/actions/open_file_explorer.py
+++ b/openpype/plugins/actions/open_file_explorer.py
@@ -91,7 +91,7 @@ class OpenTaskPath(LauncherAction):
             valid_workdir = os.path.normpath(valid_workdir)
             if os.path.exists(valid_workdir):
                 return valid_workdir
-        raise AssertionError("Folder does not exist.")
+        raise AssertionError("Folder does not exist yet.")
 
     @staticmethod
     def open_in_explorer(path):

--- a/openpype/plugins/actions/open_file_explorer.py
+++ b/openpype/plugins/actions/open_file_explorer.py
@@ -83,10 +83,6 @@ class OpenTaskPath(LauncherAction):
         if os.path.exists(valid_workdir):
             return valid_workdir
 
-        # If task was selected, try to find asset path only to asset
-        if not task_name:
-            raise AssertionError("Folder does not exist.")
-
         data.pop("task", None)
         workdir = anatomy.templates_obj["work"]["folder"].format(data)
         valid_workdir = self._find_first_filled_path(workdir)


### PR DESCRIPTION
## Changelog Description
Explore here action does not crash when task is not selected, and change error message a little.

## Testing notes:
1. Run explore here action when only asset is selected
2. If there is some relevant folder it should open explorer.
