### PR TITLE
Nuke: Dont update node name on update

### DIFF
--- a/openpype/hosts/nuke/plugins/load/load_image.py
+++ b/openpype/hosts/nuke/plugins/load/load_image.py
@@ -204,8 +204,6 @@ class LoadImage(load.LoaderPlugin):
         last = first = int(frame_number)
 
         # Set the global in to the start frame of the sequence
-        read_name = self._get_node_name(representation)
-        node["name"].setValue(read_name)
         node["file"].setValue(file)
         node["origfirst"].setValue(first)
         node["first"].setValue(first)


### PR DESCRIPTION
## Changelog Description
When updating `Image` containers the code is trying to set the name of the node. This results in a warning message from Nuke shown below;

![Capture](https://github.com/ynput/OpenPype/assets/1860085/fee93f6c-a86a-470a-b56b-809f1a32b1b3)

Suggesting to not change the node name when updating.

## Testing notes:
1. Update an `image` container in Nuke with an existing node already called `LoadImage_png`.
