### PR TITLE
Fix Missing Publish Job During Job Mantra Publishing Process

### DIFF
--- a/openpype/modules/deadline/plugins/publish/submit_houdini_render_deadline.py
+++ b/openpype/modules/deadline/plugins/publish/submit_houdini_render_deadline.py
@@ -141,3 +141,4 @@ class HoudiniSubmitDeadline(abstract_submit_deadline.AbstractSubmitDeadline):
         # Store output dir for unified publisher (filesequence)
         output_dir = os.path.dirname(instance.data["files"][0])
         instance.data["outputDir"] = output_dir
+        instance.data["toBeRenderedOn"] = "deadline"


### PR DESCRIPTION
### Summary:
- This Pull Request addresses a bug where a Publish job in Deadline is not created during the process of publishing a Job Mantra.

### Details:
- The issue was identified during the process of publishing a Job Mantra in Houdini, where the expected behavior of having two jobs created (the Mantra Job and the Ayon Publish job) was not observed.
- Upon investigation, it was found that a specific attribute, `toBeRenderedOn`, was missing, which affected the job creation process for publishing.
- The fix involves adding the value attribute in the process function to ensure the Publish job is created correctly during the Job Mantra publishing process.

### How to Test:
- Publish a Job Mantra in Houdini.
- Observe the creation of two jobs: the Mantra Job and the Ayon Publish job.
- Ensure that the Ayon Publish job is created seamlessly after the Mantra Job, allowing for successful publishing upon rendering completion.

### Fixes:
- Resolves the issue #5707  where the Ayon Publish job was not being created during the Job Mantra publishing process due to a missing attribute in the function responsible for job creation. 
