### PR TITLE
Maya: change label in the render settings to be more readable

### DIFF
--- a/openpype/settings/entities/schemas/projects_schema/schemas/schema_maya_render_settings.json
+++ b/openpype/settings/entities/schemas/projects_schema/schemas/schema_maya_render_settings.json
@@ -145,7 +145,7 @@
                 },
                 {
                   "type": "label",
-                  "label": "Add additional options - put attribute and value, like <code>defaultArnoldRenderOptions.AASamples</code> = <code>4</code>"
+                  "label": "Add additional options - put attribute and value, like <code>defaultArnoldRenderOptions.AASamples</code> for attribute and to next field value <code>4</code>"
                 },
                 {
                   "type": "dict-modifiable",
@@ -283,7 +283,7 @@
                 },
                 {
                   "type": "label",
-                  "label": "Add additional options - put attribute and value, like <code>vraySettings.aaFilterSize</code> = <code>1.5</code>"
+                  "label": "Add additional options - put attribute and value, like <code>vraySettings.aaFilterSize</code> for attribute and to next field value <code>1.5</code>"
                 },
                 {
                   "type": "dict-modifiable",
@@ -410,7 +410,7 @@
               },
               {
                   "type": "label",
-                  "label": "Add additional options - put attribute and value, like <code>redshiftOptions.reflectionMaxTraceDepth</code> = <code>3</code>"
+                  "label": "Add additional options - put attribute and value, like <code>redshiftOptions.reflectionMaxTraceDepth</code> for attribute and to next field value <code>3</code>"
               },
               {
                   "type": "dict-modifiable",


### PR DESCRIPTION
## Changelog Description
Fixing labels in Maya Render Settings where the labels could be misleading about how to enter values.

