### PR TITLE
Resolve: Add otio timeline import loader

### DIFF
--- a/openpype/hosts/resolve/plugins/load/load_otio_timeline.py
+++ b/openpype/hosts/resolve/plugins/load/load_otio_timeline.py
@@ -1,0 +1,54 @@
+from openpype.hosts.resolve.api import lib, plugin
+from openpype.lib import BoolDef
+
+
+class LoadOtioTimeline(plugin.TimelineItemLoader):
+    """Load OTIO as timeline (unmanaged after import)"""
+
+    families = ["*"]
+    representations = ["*"]
+    extensions = {"otio"}
+
+    label = "Import OTIO timeline"
+    order = -10
+    icon = "code-fork"
+    color = "orange"
+
+    options = [
+        BoolDef("importSourceClips",
+                label="Import source clips",
+                tooltip="Automatically import source clips into media pool",
+                default=True)
+    ]
+
+    def load(self, context, name, namespace, options):
+
+        project = lib.get_current_project()
+        if not project:
+            raise RuntimeError("Must have active project to load timeline")
+
+        media_pool = project.GetMediaPool()
+        path = self.filepath_from_context(context)
+
+        # Ensure a unique name, because the timeline name must be unique
+        # within the current media pool folder otherwise no import will occur
+        # and no error gets raised either
+        clips = media_pool.GetCurrentFolder().GetClipList()
+        clip_names = {clip.GetName() for clip in clips}
+        if name in clip_names:
+            self.log.debug(f"Renaming to unique clip name for: {name}")
+            i = 1
+            while "{}{}".format(name, i) in clip_names:
+                i += 1
+            name = "{}{}".format(name, i)
+
+        # It seems `importSourceClips` does not work as intended by Resolve API
+        # See: https://forum.blackmagicdesign.com/viewtopic.php?f=21&t=189958
+        timeline = media_pool.ImportTimelineFromFile(
+            path, {
+                "timelineName": name,
+                "importSourceClips": options.get("importSourceClips", True)
+            }
+        )
+        if not timeline:
+            raise RuntimeError("Failed to import timeline")


### PR DESCRIPTION
## Changelog Description

Add otio timeline import loader to Resolve.

Note that the import is 'unmanaged' since it'd be hard to keep the timeline 'in sync' with updating the clips/edit but also allowing user edits to persist on updating - as such I figured just load/import is the best first step.
 
## Additional info

It seems however due to a current bug (or missing documentation?) on the Resolve function to import an OpenTimelineIO timeline into the current project it is unable to also automatically import the source media for the OTIO file. I've also reported that bug [here](https://forum.blackmagicdesign.com/viewtopic.php?f=21&t=189958). Setting it as **draft** due to this bug.

## Testing notes:

1. Launch Resolve
2. Load OTIO timeline
