### PR TITLE
Blender: Add support to auto-install PySide2 in blender 4

### DIFF
--- a/openpype/hosts/blender/hooks/pre_pyside_install.py
+++ b/openpype/hosts/blender/hooks/pre_pyside_install.py
@@ -31,7 +31,7 @@ class InstallPySideToBlender(PreLaunchHook):
 
     def inner_execute(self):
         # Get blender's python directory
-        version_regex = re.compile(r"^[2-3]\.[0-9]+$")
+        version_regex = re.compile(r"^[2-4]\.[0-9]+$")
 
         platform = system().lower()
         executable = self.launch_context.executable.executable_path


### PR DESCRIPTION
## Changelog Description
Change version regex to support blender 4 subfolder.

## Testing notes:
1. Install brand new blender 4
2. Open Blender 4 via launcher
3. A PySide2 should be automatically installed
