### PR TITLE
Unreal: Improved error reporting for Sequence Frame Validator

### DIFF
--- a/openpype/hosts/unreal/plugins/publish/validate_sequence_frames.py
+++ b/openpype/hosts/unreal/plugins/publish/validate_sequence_frames.py
@@ -46,8 +46,10 @@ class ValidateSequenceFrames(pyblish.api.InstancePlugin):
                     f"Invalid files: {remainder}")
             if not collections:
                 raise PublishValidationError(
-                    "No collections found. There should be a single "
-                    "collection per representation.")
+                    "We have been unable to find a sequence in the "
+                    "files. Please ensure the files are named "
+                    "appropriately. "
+                    f"Files: {repr_files}")
             if len(collections) > 1:
                 raise PublishValidationError(
                     "Multiple collections detected. There should be a single "

--- a/openpype/hosts/unreal/plugins/publish/validate_sequence_frames.py
+++ b/openpype/hosts/unreal/plugins/publish/validate_sequence_frames.py
@@ -68,8 +68,9 @@ class ValidateSequenceFrames(pyblish.api.InstancePlugin):
                               data["clipOut"])
 
             if current_range != required_range:
-                raise PublishValidationError(f"Invalid frame range: {current_range} - "
-                                 f"expected: {required_range}")
+                raise PublishValidationError(
+                    f"Invalid frame range: {current_range} - "
+                    f"expected: {required_range}")
 
             missing = collection.holes().indexes
             if missing:

--- a/openpype/hosts/unreal/plugins/publish/validate_sequence_frames.py
+++ b/openpype/hosts/unreal/plugins/publish/validate_sequence_frames.py
@@ -3,6 +3,7 @@ import os
 import re
 
 import pyblish.api
+from openpype.pipeline.publish import PublishValidationError
 
 
 class ValidateSequenceFrames(pyblish.api.InstancePlugin):
@@ -40,15 +41,15 @@ class ValidateSequenceFrames(pyblish.api.InstancePlugin):
                 repr["files"], minimum_items=1, patterns=patterns)
 
             if remainder:
-                raise ValueError(
+                raise PublishValidationError(
                     "Some files have been found outside a sequence. "
                     f"Invalid files: {remainder}")
             if not collections:
-                raise ValueError(
+                raise PublishValidationError(
                     "No collections found. There should be a single "
                     "collection per representation.")
             if len(collections) > 1:
-                raise ValueError(
+                raise PublishValidationError(
                     "Multiple collections detected. There should be a single "
                     "collection per representation. "
                     f"Collections identified: {collections}")
@@ -65,11 +66,11 @@ class ValidateSequenceFrames(pyblish.api.InstancePlugin):
                               data["clipOut"])
 
             if current_range != required_range:
-                raise ValueError(f"Invalid frame range: {current_range} - "
+                raise PublishValidationError(f"Invalid frame range: {current_range} - "
                                  f"expected: {required_range}")
 
             missing = collection.holes().indexes
             if missing:
-                raise ValueError(
+                raise PublishValidationError(
                     "Missing frames have been detected. "
                     f"Missing frames: {missing}")

--- a/openpype/hosts/unreal/plugins/publish/validate_sequence_frames.py
+++ b/openpype/hosts/unreal/plugins/publish/validate_sequence_frames.py
@@ -39,8 +39,20 @@ class ValidateSequenceFrames(pyblish.api.InstancePlugin):
             collections, remainder = clique.assemble(
                 repr["files"], minimum_items=1, patterns=patterns)
 
-            assert not remainder, "Must not have remainder"
-            assert len(collections) == 1, "Must detect single collection"
+            if remainder:
+                raise ValueError(
+                    "Some files have been found outside a sequence."
+                    f"Invalid files: {remainder}")
+            if not collections:
+                raise ValueError(
+                    "No collections found. There should be a single "
+                    "collection per representation.")
+            if len(collections) > 1:
+                raise ValueError(
+                    "Multiple collections detected. There should be a single"
+                    "collection per representation."
+                    f"Collections identified: {collections}")
+
             collection = collections[0]
             frames = list(collection.indexes)
 
@@ -57,4 +69,7 @@ class ValidateSequenceFrames(pyblish.api.InstancePlugin):
                                  f"expected: {required_range}")
 
             missing = collection.holes().indexes
-            assert not missing, "Missing frames: %s" % (missing,)
+            if missing:
+                raise ValueError(
+                    "Missing frames have been detected."
+                    f"Missing frames: {missing}")

--- a/openpype/hosts/unreal/plugins/publish/validate_sequence_frames.py
+++ b/openpype/hosts/unreal/plugins/publish/validate_sequence_frames.py
@@ -41,7 +41,7 @@ class ValidateSequenceFrames(pyblish.api.InstancePlugin):
 
             if remainder:
                 raise ValueError(
-                    "Some files have been found outside a sequence."
+                    "Some files have been found outside a sequence. "
                     f"Invalid files: {remainder}")
             if not collections:
                 raise ValueError(
@@ -49,8 +49,8 @@ class ValidateSequenceFrames(pyblish.api.InstancePlugin):
                     "collection per representation.")
             if len(collections) > 1:
                 raise ValueError(
-                    "Multiple collections detected. There should be a single"
-                    "collection per representation."
+                    "Multiple collections detected. There should be a single "
+                    "collection per representation. "
                     f"Collections identified: {collections}")
 
             collection = collections[0]
@@ -71,5 +71,5 @@ class ValidateSequenceFrames(pyblish.api.InstancePlugin):
             missing = collection.holes().indexes
             if missing:
                 raise ValueError(
-                    "Missing frames have been detected."
+                    "Missing frames have been detected. "
                     f"Missing frames: {missing}")


### PR DESCRIPTION
## Changelog Description
Improved error reporting for Sequence Frame Validator.

## Additional info
This validator was using only `asserts` to report errors, and those were missing essential information about the offending files that were causing the validation to fail.

## Testing notes:
1. Prepare a render to publish.
2. Remove some of the files, and add another sequence from another render.
3. Test that the validator fails, and check that the reports inform clearly on what the problem is.