### PR TITLE
Deadline: GlobalJobPreLoad Python 2 compatibility

### DIFF
--- a/openpype/modules/deadline/repository/custom/plugins/GlobalJobPreLoad.py
+++ b/openpype/modules/deadline/repository/custom/plugins/GlobalJobPreLoad.py
@@ -12,7 +12,6 @@ from Deadline.Scripting import (
     RepositoryUtils,
     FileUtils,
     DirectoryUtils,
-    ProcessUtils,
 )
 
 VERSION_REGEX = re.compile(
@@ -429,10 +428,10 @@ def inject_ayon_environment(deadlinePlugin):
 
         if not exe:
             raise RuntimeError((
-               "Ayon executable was not found in the semicolon "
-               "separated list \"{}\"."
-               "The path to the render executable can be configured"
-               " from the Plugin Configuration in the Deadline Monitor."
+                "Ayon executable was not found in the semicolon "
+                "separated list \"{}\"."
+                "The path to the render executable can be configured"
+                " from the Plugin Configuration in the Deadline Monitor."
             ).format(";".join(exe_list)))
 
         print("--- Ayon executable: {}".format(exe))
@@ -444,12 +443,12 @@ def inject_ayon_environment(deadlinePlugin):
 
         config = RepositoryUtils.GetPluginConfig("Ayon")
         ayon_server_url = (
-                job.GetJobEnvironmentKeyValue("AYON_SERVER_URL") or
-                config.GetConfigEntryWithDefault("AyonServerUrl", "")
+            job.GetJobEnvironmentKeyValue("AYON_SERVER_URL") or
+            config.GetConfigEntryWithDefault("AyonServerUrl", "")
         )
         ayon_api_key = (
-                job.GetJobEnvironmentKeyValue("AYON_API_KEY") or
-                config.GetConfigEntryWithDefault("AyonApiKey", "")
+            job.GetJobEnvironmentKeyValue("AYON_API_KEY") or
+            config.GetConfigEntryWithDefault("AyonApiKey", "")
         )
 
         if not all([ayon_server_url, ayon_api_key]):

--- a/openpype/modules/deadline/repository/custom/plugins/GlobalJobPreLoad.py
+++ b/openpype/modules/deadline/repository/custom/plugins/GlobalJobPreLoad.py
@@ -208,8 +208,8 @@ def get_openpype_versions(dir_list):
         if install_dir:
             print("--- Looking for OpenPype at: {}".format(install_dir))
             sub_dirs = [
-                f.path for f in os.scandir(install_dir)
-                if f.is_dir()
+                os.path.join(install_dir, x) for x in os.listdir(install_dir)
+                if os.path.isdir(os.path.join(install_dir, x))
             ]
             for subdir in sub_dirs:
                 version = get_openpype_version_from_path(subdir)
@@ -388,7 +388,11 @@ def inject_openpype_environment(deadlinePlugin):
         if "PATH" in contents:
             # Set os.environ[PATH] so studio settings' path entries
             # can be used to define search path for executables.
-            print(f">>> Setting 'PATH' Environment to: {contents['PATH']}")
+            print(
+                ">>> Setting 'PATH' Environment to: {}".format(
+                    contents['PATH']
+                )
+            )
             os.environ["PATH"] = contents["PATH"]
 
         script_url = job.GetJobPluginInfoKeyValue("ScriptFilename")
@@ -518,7 +522,11 @@ def inject_ayon_environment(deadlinePlugin):
         if "PATH" in contents:
             # Set os.environ[PATH] so studio settings' path entries
             # can be used to define search path for executables.
-            print(f">>> Setting 'PATH' Environment to: {contents['PATH']}")
+            print(
+                ">>> Setting 'PATH' Environment to: {}".format(
+                    contents['PATH']
+                )
+            )
             os.environ["PATH"] = contents["PATH"]
 
         script_url = job.GetJobPluginInfoKeyValue("ScriptFilename")


### PR DESCRIPTION
## Changelog Description
When using plugins like Nuke 11 which in Deadline defaults to Python 2, the GlobalJobPreLoad will error.

## Testing notes:
1. Submit Nuke 11 job to farm.
2. Validate GlobalJobPreLoad execute succesfully.
