### PR TITLE
Nuke: Optional Deadline workfile dependency.

### DIFF
--- a/openpype/modules/deadline/plugins/publish/submit_nuke_deadline.py
+++ b/openpype/modules/deadline/plugins/publish/submit_nuke_deadline.py
@@ -48,6 +48,7 @@ class NukeSubmitDeadline(pyblish.api.InstancePlugin,
     use_gpu = False
     env_allowed_keys = []
     env_search_replace_values = {}
+    workfile_dependency = True
 
     @classmethod
     def get_attribute_defs(cls):
@@ -83,6 +84,11 @@ class NukeSubmitDeadline(pyblish.api.InstancePlugin,
                 "suspend_publish",
                 default=False,
                 label="Suspend publish"
+            ),
+            BoolDef(
+                "workfile_dependency",
+                default=True,
+                label="Workfile Dependency"
             )
         ]
 
@@ -312,6 +318,13 @@ class NukeSubmitDeadline(pyblish.api.InstancePlugin,
             # Mandatory for Deadline, may be empty
             "AuxFiles": []
         }
+
+        # Add workfile dependency.
+        workfile_dependency = instance.data["attributeValues"].get(
+            "workfile_dependency", self.workfile_dependency
+        )
+        if workfile_dependency:
+            payload["JobInfo"].update({"AssetDependency0": script_path})
 
         # TODO: rewrite for baking with sequences
         if baking_submission:


### PR DESCRIPTION
## Changelog Description
Adds option to add the workfile as dependency for the Deadline job.

Think it used to have something like this, but it disappeared. Usecase is for remote workflow where the Nuke script needs to be synced before the job can start.

## Testing notes:
1. Submit Nuke job with workfile dependency enabled.
2. Validate the workfile is an asset dependency of the Deadline job.
