### PR TITLE
Fix: Hardcoded main site and wrongly copied workfile

### DIFF
--- a/openpype/modules/sync_server/launch_hooks/pre_copy_last_published_workfile.py
+++ b/openpype/modules/sync_server/launch_hooks/pre_copy_last_published_workfile.py
@@ -207,59 +207,57 @@ class CopyLastPublishedWorkfile(PreLaunchHook):
         # Copy resources to the local resources directory
         for file in workfile_representation['files']:
             # Get resource main path
-            resource_main_path = file["path"].replace(
-                "{root[main]}", str(anatomy.roots["main"])
-            )
+            resource_main_path = anatomy.fill_root(file["path"])
+
+            # Get resource file basename
+            resource_basename = os.path.basename(resource_main_path)
 
             # Only copy if the resource file exists, and it's not the workfile
             if (
                 not os.path.exists(resource_main_path)
-                and not resource_main_path != last_published_workfile_path
+                or resource_basename == os.path.basename(
+                    last_published_workfile_path
+                )
             ):
                 continue
-
-            # Get resource file basename
-            resource_basename = os.path.basename(resource_main_path)
 
             # Get resource path in workfile folder
             resource_work_path = os.path.join(
                 resources_dir, resource_basename
             )
-            if not os.path.exists(resource_work_path):
-                continue
 
-            # Check if the resource file already exists
-            # in the workfile resources folder,
-            # and both files are the same.
-            if filecmp.cmp(resource_main_path, resource_work_path):
-                self.log.warning(
-                    'Resource "{}" already exists.'
-                    .format(resource_basename)
-                )
-                continue
-            else:
-                # Add `.old` to existing resource path
-                resource_path_old = resource_work_path + '.old'
-                if os.path.exists(resource_work_path + '.old'):
-                    for i in range(1, 100):
-                        p = resource_path_old + '%02d' % i
-                        if not os.path.exists(p):
-                            # Rename existing resource file to
-                            # `resource_name.old` + 2 digits
-                            shutil.move(resource_work_path, p)
-                            break
-                    else:
-                        self.log.warning(
-                            'There are a hundred old files for '
-                            'resource "{}". '
-                            'Perhaps is it time to clean up your '
-                            'resources folder'
-                            .format(resource_basename)
-                        )
-                        continue
+            # Check if the resource file already exists in the resources folder
+            if os.path.exists(resource_work_path):
+                # Check if both files are the same
+                if filecmp.cmp(resource_main_path, resource_work_path):
+                    self.log.warning(
+                        'Resource "{}" already exists.'
+                        .format(resource_basename)
+                    )
+                    continue
                 else:
-                    # Rename existing resource file to `resource_name.old`
-                    shutil.move(resource_work_path, resource_path_old)
+                    # Add `.old` to existing resource path
+                    resource_path_old = resource_work_path + '.old'
+                    if os.path.exists(resource_work_path + '.old'):
+                        for i in range(1, 100):
+                            p = resource_path_old + '%02d' % i
+                            if not os.path.exists(p):
+                                # Rename existing resource file to
+                                # `resource_name.old` + 2 digits
+                                shutil.move(resource_work_path, p)
+                                break
+                        else:
+                            self.log.warning(
+                                'There are a hundred old files for '
+                                'resource "{}". '
+                                'Perhaps is it time to clean up your '
+                                'resources folder'
+                                .format(resource_basename)
+                            )
+                            continue
+                    else:
+                        # Rename existing resource file to `resource_name.old`
+                        shutil.move(resource_work_path, resource_path_old)
 
-        # Copy resource file to workfile resources folder
-        shutil.copy(resource_main_path, resources_dir)
+            # Copy resource file to workfile resources folder
+            shutil.copy(resource_main_path, resources_dir)


### PR DESCRIPTION
## Changelog Description
Fixing these two issues:
- Hardcoded main site -> Replaced by `anatomy.fill_root`.
- Workfiles can sometimes be copied while they shouldn't.

## Testing notes
- Download a workfile by using the `Pre Copy Last Workfile` launch hook.
- You should get a `resources` folder in your local workdir containing all `resources` listed in the workfile data, except the workfile itself.

Note: If the asset you're testing this on is already downloaded, you can rename its task folder (for instance by appending `_old`) to force openpype to redownload it, or use the [Force download last workfile feature](https://github.com/ynput/OpenPype/pull/5660) if it's available.