### PR TITLE
Testing: Ingest Maya userSetup

### DIFF
--- a/tests/integration/hosts/maya/input/startup/userSetup.py
+++ b/tests/integration/hosts/maya/input/startup/userSetup.py
@@ -8,13 +8,13 @@ import pyblish.util
 
 def setup_pyblish_logging():
     log = logging.getLogger("pyblish")
-    hnd = logging.StreamHandler(sys.stdout)
-    fmt = logging.Formatter(
+    handler = logging.StreamHandler(sys.stdout)
+    formatter = logging.Formatter(
         "pyblish (%(levelname)s) (line: %(lineno)d) %(name)s:"
         "\n%(message)s"
     )
-    hnd.setFormatter(fmt)
-    log.addHandler(hnd)
+    handler.setFormatter(formatter)
+    log.addHandler(handler)
 
 
 def _run_publish_test_deferred():

--- a/tests/integration/hosts/maya/input/startup/userSetup.py
+++ b/tests/integration/hosts/maya/input/startup/userSetup.py
@@ -19,10 +19,10 @@ def setup_pyblish_logging():
 
 def _run_publish_test_deferred():
     try:
+        setup_pyblish_logging()
         pyblish.util.publish()
     finally:
         cmds.quit(force=True)
 
 
-cmds.evalDeferred("setup_pyblish_logging()", evaluateNext=True)
 cmds.evalDeferred("_run_publish_test_deferred()", lowestPriority=True)

--- a/tests/integration/hosts/maya/input/startup/userSetup.py
+++ b/tests/integration/hosts/maya/input/startup/userSetup.py
@@ -3,6 +3,8 @@ import sys
 
 from maya import cmds
 
+import pyblish.util
+
 
 def setup_pyblish_logging():
     log = logging.getLogger("pyblish")
@@ -15,12 +17,12 @@ def setup_pyblish_logging():
     log.addHandler(hnd)
 
 
-def main():
-    cmds.evalDeferred("setup_pyblish_logging()", evaluateNext=True)
-    cmds.evalDeferred(
-        "import pyblish.util;pyblish.util.publish()", lowestPriority=True
-    )
-    cmds.evalDeferred("cmds.quit(force=True)", lowestPriority=True)
+def _run_publish_test_deferred():
+    try:
+        pyblish.util.publish()
+    finally:
+        cmds.quit(force=True)
 
 
-main()
+cmds.evalDeferred("setup_pyblish_logging()", evaluateNext=True)
+cmds.evalDeferred("_run_publish_test_deferred()", lowestPriority=True)

--- a/tests/integration/hosts/maya/input/startup/userSetup.py
+++ b/tests/integration/hosts/maya/input/startup/userSetup.py
@@ -1,0 +1,26 @@
+import logging
+import sys
+
+from maya import cmds
+
+
+def setup_pyblish_logging():
+    log = logging.getLogger("pyblish")
+    hnd = logging.StreamHandler(sys.stdout)
+    fmt = logging.Formatter(
+        "pyblish (%(levelname)s) (line: %(lineno)d) %(name)s:"
+        "\n%(message)s"
+    )
+    hnd.setFormatter(fmt)
+    log.addHandler(hnd)
+
+
+def main():
+    cmds.evalDeferred("setup_pyblish_logging()", evaluateNext=True)
+    cmds.evalDeferred(
+        "import pyblish.util;pyblish.util.publish()", lowestPriority=True
+    )
+    cmds.evalDeferred("cmds.quit(force=True)", lowestPriority=True)
+
+
+main()

--- a/tests/integration/hosts/maya/lib.py
+++ b/tests/integration/hosts/maya/lib.py
@@ -33,16 +33,16 @@ class MayaHostFixtures(HostFixtures):
         yield dest_path
 
     @pytest.fixture(scope="module")
-    def startup_scripts(self, monkeypatch_session, download_test_data):
+    def startup_scripts(self, monkeypatch_session):
         """Points Maya to userSetup file from input data"""
-        startup_path = os.path.join(download_test_data,
-                                    "input",
-                                    "startup")
+        startup_path = os.path.join(
+            os.path.dirname(__file__), "input", "startup"
+        )
         original_pythonpath = os.environ.get("PYTHONPATH")
-        monkeypatch_session.setenv("PYTHONPATH",
-                                   "{}{}{}".format(startup_path,
-                                                   os.pathsep,
-                                                   original_pythonpath))
+        monkeypatch_session.setenv(
+            "PYTHONPATH",
+            "{}{}{}".format(startup_path, os.pathsep, original_pythonpath)
+        )
 
     @pytest.fixture(scope="module")
     def skip_compare_folders(self):


### PR DESCRIPTION
## Changelog Description
Suggesting to ingest `userSetup.py` startup script for easier collaboration and transparency of testing.

## Testing notes:
1. Run Maya testing `.\tools\openpype_console.bat runtests C:\Users\tokejepsen\OpenPype\tests\integration\hosts\maya\test_publish_in_maya.py`
2. Comment out `tests\integration\hosts\maya\lib.py` line 42 and validate Maya only launches.

Split from https://github.com/ynput/OpenPype/pull/5644