### PR TITLE
Bugfix: ServerDeleteOperation asset -> folder conversion typo

### DIFF
--- a/openpype/client/server/operations.py
+++ b/openpype/client/server/operations.py
@@ -422,7 +422,7 @@ def failed_json_default(value):
 
 
 class ServerCreateOperation(CreateOperation):
-    """Opeartion to create an entity.
+    """Operation to create an entity.
 
     Args:
         project_name (str): On which project operation will happen.
@@ -634,7 +634,7 @@ class ServerUpdateOperation(UpdateOperation):
 
 
 class ServerDeleteOperation(DeleteOperation):
-    """Opeartion to delete an entity.
+    """Operation to delete an entity.
 
     Args:
         project_name (str): On which project operation will happen.

--- a/openpype/client/server/operations.py
+++ b/openpype/client/server/operations.py
@@ -647,7 +647,7 @@ class ServerDeleteOperation(DeleteOperation):
         self._session = session
 
         if entity_type == "asset":
-            entity_type == "folder"
+            entity_type = "folder"
 
         elif entity_type == "hero_version":
             entity_type = "version"


### PR DESCRIPTION
## Changelog Description

Fix ServerDeleteOperation asset -> folder conversion typo

## Additional info

Pretty sure this was a bug.
Also took along two typos in docstring in the same file.

## Testing notes:

Not sure what this influences - so not sure what to test.
