### PR TITLE
Houdini: Fix Show in usdview loader action

### DIFF
--- a/openpype/hosts/houdini/plugins/load/show_usdview.py
+++ b/openpype/hosts/houdini/plugins/load/show_usdview.py
@@ -1,4 +1,5 @@
 import os
+import platform
 import subprocess
 
 from openpype.lib.vendor_bin_utils import find_executable
@@ -8,17 +9,31 @@ from openpype.pipeline import load
 class ShowInUsdview(load.LoaderPlugin):
     """Open USD file in usdview"""
 
-    families = ["colorbleed.usd"]
     label = "Show in usdview"
-    representations = ["usd", "usda", "usdlc", "usdnc"]
-    order = 10
+    representations = ["*"]
+    families = ["*"]
+    extensions = {"usd", "usda", "usdlc", "usdnc", "abc"}
+    order = 15
 
     icon = "code-fork"
     color = "white"
 
     def load(self, context, name=None, namespace=None, data=None):
+        from pathlib import Path
 
-        usdview = find_executable("usdview")
+        if platform.system() == "Windows":
+            executable = "usdview.bat"
+        else:
+            executable = "usdview"
+
+        usdview = find_executable(executable)
+        if not usdview:
+            raise RuntimeError("Unable to find usdview")
+
+        # For some reason Windows can return the path like:
+        # C:/PROGRA~1/SIDEEF~1/HOUDIN~1.435/bin/usdview
+        # convert to resolved path so `subprocess` can take it
+        usdview = str(Path(usdview).resolve().as_posix())
 
         filepath = self.filepath_from_context(context)
         filepath = os.path.normpath(filepath)
@@ -30,14 +45,4 @@ class ShowInUsdview(load.LoaderPlugin):
 
         self.log.info("Start houdini variant of usdview...")
 
-        # For now avoid some pipeline environment variables that initialize
-        # Avalon in Houdini as it is redundant for usdview and slows boot time
-        env = os.environ.copy()
-        env.pop("PYTHONPATH", None)
-        env.pop("HOUDINI_SCRIPT_PATH", None)
-        env.pop("HOUDINI_MENU_PATH", None)
-
-        # Force string to avoid unicode issues
-        env = {str(key): str(value) for key, value in env.items()}
-
-        subprocess.Popen([usdview, filepath, "--renderer", "GL"], env=env)
+        subprocess.Popen([usdview, filepath, "--renderer", "GL"])


### PR DESCRIPTION
## Changelog Description

Fix the "Show in USD View" loader to show up in Houdini

## Additional info

Previous loader would never show since family does not exist within OpenPype.

## Testing notes:

1. Launch Houdini
2. In loader use "Show in USD View" action (also works with alembic files)
