### PR TITLE
Nuke: loaders are filtering correctly

### DIFF
--- a/openpype/hosts/nuke/plugins/load/actions.py
+++ b/openpype/hosts/nuke/plugins/load/actions.py
@@ -17,7 +17,7 @@ class SetFrameRangeLoader(load.LoaderPlugin):
                 "yeticache",
                 "pointcache"]
     representations = ["*"]
-    extension = {"*"}
+    extensions = {"*"}
 
     label = "Set frame range"
     order = 11

--- a/openpype/hosts/nuke/plugins/load/load_backdrop.py
+++ b/openpype/hosts/nuke/plugins/load/load_backdrop.py
@@ -27,7 +27,7 @@ class LoadBackdropNodes(load.LoaderPlugin):
 
     families = ["workfile", "nukenodes"]
     representations = ["*"]
-    extension = {"nk"}
+    extensions = {"nk"}
 
     label = "Import Nuke Nodes"
     order = 0

--- a/openpype/hosts/nuke/plugins/load/load_camera_abc.py
+++ b/openpype/hosts/nuke/plugins/load/load_camera_abc.py
@@ -26,7 +26,7 @@ class AlembicCameraLoader(load.LoaderPlugin):
 
     families = ["camera"]
     representations = ["*"]
-    extension = {"abc"}
+    extensions = {"abc"}
 
     label = "Load Alembic Camera"
     icon = "camera"

--- a/openpype/hosts/nuke/plugins/load/load_effects.py
+++ b/openpype/hosts/nuke/plugins/load/load_effects.py
@@ -24,7 +24,7 @@ class LoadEffects(load.LoaderPlugin):
 
     families = ["effect"]
     representations = ["*"]
-    extension = {"json"}
+    extensions = {"json"}
 
     label = "Load Effects - nodes"
     order = 0

--- a/openpype/hosts/nuke/plugins/load/load_effects_ip.py
+++ b/openpype/hosts/nuke/plugins/load/load_effects_ip.py
@@ -25,7 +25,7 @@ class LoadEffectsInputProcess(load.LoaderPlugin):
 
     families = ["effect"]
     representations = ["*"]
-    extension = {"json"}
+    extensions = {"json"}
 
     label = "Load Effects - Input Process"
     order = 0

--- a/openpype/hosts/nuke/plugins/load/load_gizmo.py
+++ b/openpype/hosts/nuke/plugins/load/load_gizmo.py
@@ -26,7 +26,7 @@ class LoadGizmo(load.LoaderPlugin):
 
     families = ["gizmo"]
     representations = ["*"]
-    extension = {"gizmo"}
+    extensions = {"gizmo"}
 
     label = "Load Gizmo"
     order = 0

--- a/openpype/hosts/nuke/plugins/load/load_gizmo_ip.py
+++ b/openpype/hosts/nuke/plugins/load/load_gizmo_ip.py
@@ -28,7 +28,7 @@ class LoadGizmoInputProcess(load.LoaderPlugin):
 
     families = ["gizmo"]
     representations = ["*"]
-    extension = {"gizmo"}
+    extensions = {"gizmo"}
 
     label = "Load Gizmo - Input Process"
     order = 0

--- a/openpype/hosts/nuke/plugins/load/load_matchmove.py
+++ b/openpype/hosts/nuke/plugins/load/load_matchmove.py
@@ -9,7 +9,7 @@ class MatchmoveLoader(load.LoaderPlugin):
 
     families = ["matchmove"]
     representations = ["*"]
-    extension = {"py"}
+    extensions = {"py"}
 
     defaults = ["Camera", "Object"]
 

--- a/openpype/hosts/nuke/plugins/load/load_model.py
+++ b/openpype/hosts/nuke/plugins/load/load_model.py
@@ -24,7 +24,7 @@ class AlembicModelLoader(load.LoaderPlugin):
 
     families = ["model", "pointcache", "animation"]
     representations = ["*"]
-    extension = {"abc"}
+    extensions = {"abc"}
 
     label = "Load Alembic"
     icon = "cube"

--- a/openpype/hosts/nuke/plugins/load/load_script_precomp.py
+++ b/openpype/hosts/nuke/plugins/load/load_script_precomp.py
@@ -22,7 +22,7 @@ class LinkAsGroup(load.LoaderPlugin):
 
     families = ["workfile", "nukenodes"]
     representations = ["*"]
-    extension = {"nk"}
+    extensions = {"nk"}
 
     label = "Load Precomp"
     order = 0


### PR DESCRIPTION
## Changelog Description
Variable name for filtering by extensions were not correct - it suppose to be plural. It is fixed now and filtering is working as suppose to.

## Testing notes:
1. loaders should be now correctly offered on extensions