### PR TITLE
Enhancement: Get last workfile representation method

### DIFF
--- a/openpype/modules/sync_server/launch_hooks/pre_copy_last_published_workfile.py
+++ b/openpype/modules/sync_server/launch_hooks/pre_copy_last_published_workfile.py
@@ -115,7 +115,7 @@ class CopyLastPublishedWorkfile(PreLaunchHook):
             project_name,
             asset_name,
             task_name,
-            host_name=host_name,
+            host_name,
         )
         if not workfile_representation:
             self.log.debug(

--- a/openpype/modules/sync_server/launch_hooks/pre_copy_last_published_workfile.py
+++ b/openpype/modules/sync_server/launch_hooks/pre_copy_last_published_workfile.py
@@ -122,7 +122,7 @@ class CopyLastPublishedWorkfile(PreLaunchHook):
             self.log.debug(
                 'No published workfile for task "{}" and host "{}".'.format(
                     task_name, host_name
-                )   
+                )
             )
             return
 

--- a/openpype/modules/sync_server/launch_hooks/pre_copy_last_published_workfile.py
+++ b/openpype/modules/sync_server/launch_hooks/pre_copy_last_published_workfile.py
@@ -109,14 +109,12 @@ class CopyLastPublishedWorkfile(PreLaunchHook):
 
         self.log.info("Trying to fetch last published workfile...")
 
-        asset_doc = self.data.get("asset_doc")
         anatomy = self.data.get("anatomy")
 
         workfile_representation = get_last_workfile_representation(
             project_name,
             asset_name,
             task_name,
-            asset_doc=asset_doc,
             host_name=host_name,
         )
         if not workfile_representation:
@@ -151,7 +149,7 @@ class CopyLastPublishedWorkfile(PreLaunchHook):
 
         # Get workfile data
         workfile_data = get_template_data(
-            project_doc, asset_doc, task_name, host_name
+            project_doc, self.data.get("asset_doc"), task_name, host_name
         )
 
         extension = last_published_workfile_path.split(".")[-1]

--- a/openpype/modules/sync_server/launch_hooks/pre_copy_last_published_workfile.py
+++ b/openpype/modules/sync_server/launch_hooks/pre_copy_last_published_workfile.py
@@ -116,7 +116,11 @@ class CopyLastPublishedWorkfile(PreLaunchHook):
             project_name,
             asset_name,
             task_name,
+            asset_doc=asset_doc,
         )
+        if not workfile_representation:
+            self.log.debug("No workfile representation found.")
+            return
 
         # Copy file and substitute path
         last_published_workfile_path = download_last_published_workfile(

--- a/openpype/modules/sync_server/launch_hooks/pre_copy_last_published_workfile.py
+++ b/openpype/modules/sync_server/launch_hooks/pre_copy_last_published_workfile.py
@@ -119,7 +119,11 @@ class CopyLastPublishedWorkfile(PreLaunchHook):
             asset_doc=asset_doc,
         )
         if not workfile_representation:
-            self.log.debug("No workfile representation found.")
+            self.log.debug(
+                'No published workfile for task "{}" and host "{}".'.format(
+                    task_name, host_name
+                )   
+            )
             return
 
         # Copy file and substitute path

--- a/openpype/modules/sync_server/launch_hooks/pre_copy_last_published_workfile.py
+++ b/openpype/modules/sync_server/launch_hooks/pre_copy_last_published_workfile.py
@@ -117,6 +117,7 @@ class CopyLastPublishedWorkfile(PreLaunchHook):
             asset_name,
             task_name,
             asset_doc=asset_doc,
+            host_name=host_name,
         )
         if not workfile_representation:
             self.log.debug(

--- a/openpype/pipeline/workfile/__init__.py
+++ b/openpype/pipeline/workfile/__init__.py
@@ -6,6 +6,7 @@ from .path_resolving import (
 
     get_last_workfile_with_version,
     get_last_workfile,
+    get_last_workfile_representation,
 
     get_custom_workfile_template,
     get_custom_workfile_template_by_string_context,
@@ -24,6 +25,7 @@ __all__ = (
 
     "get_last_workfile_with_version",
     "get_last_workfile",
+    "get_last_workfile_representation",
 
     "get_custom_workfile_template",
     "get_custom_workfile_template_by_string_context",

--- a/openpype/pipeline/workfile/path_resolving.py
+++ b/openpype/pipeline/workfile/path_resolving.py
@@ -573,7 +573,7 @@ def get_last_workfile_representation(
         project_name,
         get_subset_name(
             "workfile",
-            "",
+            "main",
             task_name,
             asset_doc,
             project_name=project_name,

--- a/openpype/pipeline/workfile/path_resolving.py
+++ b/openpype/pipeline/workfile/path_resolving.py
@@ -3,7 +3,11 @@ import re
 import copy
 import platform
 
-from openpype.client import get_project, get_asset_by_name
+from openpype.client import (
+    get_project,
+    get_asset_by_name,
+    get_representations,
+)
 from openpype.settings import get_project_settings
 from openpype.lib import (
     filter_profiles,
@@ -534,3 +538,36 @@ def create_workdir_extra_folders(
         fullpath = os.path.join(workdir, subfolder)
         if not os.path.exists(fullpath):
             os.makedirs(fullpath)
+
+
+def get_last_workfile_representation(
+    project_name: str,
+    asset_name: str,
+    task_name: str,
+) -> dict:
+    """Get last published workfile representation.
+
+    Args:
+        project_name(str): Project name.
+        asset_name(str): Asset/Shot name.
+        task_name(str): Task name.
+
+    Returns:
+        dict: Last workfile representation.
+    """
+    return max(
+        filter(
+            lambda r: r["context"].get("version") is not None,
+            list(
+                get_representations(
+                    project_name,
+                    context_filters={
+                        "asset": asset_name,
+                        "family": "workfile",
+                        "task": {"name": task_name},
+                    },
+                )
+            ),
+        ),
+        key=lambda r: r["context"]["version"],
+    )

--- a/openpype/pipeline/workfile/path_resolving.py
+++ b/openpype/pipeline/workfile/path_resolving.py
@@ -2,7 +2,6 @@ import os
 import re
 import copy
 import platform
-from typing import Iterable
 
 from openpype.client import (
     get_project,

--- a/openpype/pipeline/workfile/path_resolving.py
+++ b/openpype/pipeline/workfile/path_resolving.py
@@ -549,6 +549,7 @@ def get_last_workfile_representation(
     task_name,
     asset_id=None,
     asset_doc=None,
+    host_name=None,
     fields=None,
 ):
     """Get last published workfile representation.
@@ -560,6 +561,7 @@ def get_last_workfile_representation(
         asset_id (Optional[Union[str, ObjectId]]): Asset id.
             subset name. Defaults to None.
         asset_doc (Optional[dict]): Asset doc. Defaults to None.
+        host_name (Optional[str]): Host name.
         fields (Optional[Iterable[str]]): Fields that should be returned.
             Defaults to None.
 
@@ -577,6 +579,7 @@ def get_last_workfile_representation(
             task_name,
             asset_doc,
             project_name=project_name,
+            host_name=host_name,
         ),
         asset_id=asset_id,
         asset_name=asset_name,

--- a/openpype/pipeline/workfile/path_resolving.py
+++ b/openpype/pipeline/workfile/path_resolving.py
@@ -585,6 +585,9 @@ def get_last_workfile_representation(
         fields=["_id"],
     )
 
+    if not last_version:
+        return
+
     return get_representations(
         project_name,
         version_ids=[last_version["_id"]],

--- a/openpype/pipeline/workfile/path_resolving.py
+++ b/openpype/pipeline/workfile/path_resolving.py
@@ -545,7 +545,7 @@ def get_last_workfile_representation(
     project_name,
     asset_name,
     task_name,
-    host_name=None,
+    host_name,
     fields=None,
 ):
     """Get last published workfile representation.
@@ -554,7 +554,7 @@ def get_last_workfile_representation(
         project_name(str): Project name.
         asset_name(str): Asset/Shot name.
         task_name (str): Task name.
-        host_name (Optional[str]): Host name.
+        host_name (str): Host name.
         fields (Optional[Iterable[str]]): Fields that should be returned.
             Defaults to None.
 

--- a/openpype/pipeline/workfile/path_resolving.py
+++ b/openpype/pipeline/workfile/path_resolving.py
@@ -544,13 +544,13 @@ def create_workdir_extra_folders(
 
 
 def get_last_workfile_representation(
-    project_name: str,
-    asset_name: str,
-    task_name: str,
+    project_name,
+    asset_name,
+    task_name,
     asset_id=None,
-    asset_doc: dict = None,
-    fields: Iterable[str] = None,
-) -> dict:
+    asset_doc=None,
+    fields=None,
+):
     """Get last published workfile representation.
 
     Args:


### PR DESCRIPTION
## Changelog Description
Adding a method to easily get last published workfile representation. I'm doing some work downstream that required me to do this a bunch of times, so I made this method to reduce redundancy. I think it can be pretty useful when handling published workfiles so I'm proposing it as an enhancement.

## Testing notes:
- Download last workfile with the `Copy Last Published Workfile` pre launch hook (either choose an asset you don't have locally, append `_old` to its task directory to trick OpenPype into redownloading it or use `Force Download Last Workfile` if available).
- It should have the same behavior as it usually has.