### PR TITLE
AYON Settings: Fix global overrides

### DIFF
--- a/openpype/settings/ayon_settings.py
+++ b/openpype/settings/ayon_settings.py
@@ -1164,19 +1164,19 @@ def _convert_global_project_settings(ayon_settings, output, default_settings):
     for profile in extract_oiio_transcode_profiles:
         new_outputs = {}
         name_counter = {}
-        for output in profile["outputs"]:
-            if "name" in output:
-                name = output.pop("name")
+        for profile_output in profile["outputs"]:
+            if "name" in profile_output:
+                name = profile_output.pop("name")
             else:
                 # Backwards compatibility for setting without 'name' in model
-                name = output["extension"]
+                name = profile_output["extension"]
                 if name in new_outputs:
                     name_counter[name] += 1
                     name = "{}_{}".format(name, name_counter[name])
                 else:
                     name_counter[name] = 0
 
-            new_outputs[name] = output
+            new_outputs[name] = profile_output
         profile["outputs"] = new_outputs
 
     # Extract Burnin plugin


### PR DESCRIPTION
## Changelog Description
The `output` dictionary that gets passed into `ayon_settings._convert_global_project_settings` gets replaced when converting the settings for `ExtractOIIOTranscode`. This results in `global` not being in the output dictionary and thus the defaults being used and not the project overrides.
