### PR TITLE
Chore: AYON query functions arguments

### DIFF
--- a/openpype/client/server/entities.py
+++ b/openpype/client/server/entities.py
@@ -75,9 +75,9 @@ def _get_subsets(
         ):
             fields.add(key)
 
-    active = None
+    active = True
     if archived:
-        active = False
+        active = None
 
     for subset in con.get_products(
         project_name,

--- a/openpype/client/server/entities.py
+++ b/openpype/client/server/entities.py
@@ -196,7 +196,7 @@ def get_assets(
 
     active = True
     if archived:
-        active = False
+        active = None
 
     con = get_server_api_connection()
     fields = folder_fields_v3_to_v4(fields, con)


### PR DESCRIPTION
## Changelog Description
Fixed how `archived` argument is handled in get subsets/assets function.

## Additional info
The logic was not matching to implementation of mongo api function. If `archive` is set to `True` it does mean that both active and inactive should be queried instead of only non-active.

### How I discovered
The `archive=True` is used in scene inventory so there is a chance that scene inventory does not work in AYON mode at all.

## Testing notes:
1. Open Switch asset dialog in Scene Manager tool
2. It should fill the values as expected
