### PR TITLE
Blender: Remove 'update_hierarchy'

### DIFF
--- a/openpype/hosts/blender/api/pipeline.py
+++ b/openpype/hosts/blender/api/pipeline.py
@@ -460,36 +460,6 @@ def ls() -> Iterator:
         yield parse_container(container)
 
 
-def update_hierarchy(containers):
-    """Hierarchical container support
-
-    This is the function to support Scene Inventory to draw hierarchical
-    view for containers.
-
-    We need both parent and children to visualize the graph.
-
-    """
-
-    all_containers = set(ls())  # lookup set
-
-    for container in containers:
-        # Find parent
-        # FIXME (jasperge): re-evaluate this. How would it be possible
-        # to 'nest' assets?  Collections can have several parents, for
-        # now assume it has only 1 parent
-        parent = [
-            coll for coll in bpy.data.collections if container in coll.children
-        ]
-        for node in parent:
-            if node in all_containers:
-                container["parent"] = node
-                break
-
-        log.debug("Container: %s", container)
-
-        yield container
-
-
 def publish():
     """Shorthand to publish from within host."""
 


### PR DESCRIPTION
## Changelog Description
Remove `update_hierarchy` function which is causing crashes in scene inventory tool.

## Additional info
The function can change view of scene inventory hierarchy in Scene manager when user use cherry-pick on set of containers. But the implementation does crashes with `unhashable type: dict` (code: `all_containers = set(ls())`). The code probably never worked.

## Testing notes:
1. Open blender.
2. Make sure you have something loaded in.
3. Open scene manager.
4. Right click on loaded container and trigger `Cherry-pick` action.
5. It should cherry pick it and the view should show only cherry picked containers (before it crashed).