### PR TITLE
Max: Add families with frame range extractions back to the frame range validator

### DIFF
--- a/openpype/hosts/max/plugins/publish/validate_frame_range.py
+++ b/openpype/hosts/max/plugins/publish/validate_frame_range.py
@@ -27,7 +27,9 @@ class ValidateFrameRange(pyblish.api.InstancePlugin,
 
     label = "Validate Frame Range"
     order = ValidateContentsOrder
-    families = ["maxrender"]
+    families = ["camera", "maxrender",
+                "pointcache", "pointcloud",
+                "review", "redshiftproxy"]
     hosts = ["max"]
     optional = True
     actions = [RepairAction]


### PR DESCRIPTION
## Changelog Description
In 3dsMax, there are some instances which exports the files in frame range but not being added to the optional frame range validator. In this PR, these instances would have the optional frame range validators to allow users to check if frame range aligns with the context data from DB.
The following families have been added to have optional frame range validator:
- camera
- maxrender
- pointcache
- pointcloud
- review
- redshiftproxy

## Additional info
N/A

## Testing notes:
1. Create Instance with the families mentioned above
2. Enable the validator
3. Publish
4. If the frame range doesn't match with the context data from DB, the publishing process won't pass the validator
