### PR TITLE
Enhancement: Nuke refactor `SelectInvalidAction`

### DIFF
--- a/openpype/hosts/nuke/api/__init__.py
+++ b/openpype/hosts/nuke/api/__init__.py
@@ -50,7 +50,10 @@ from .utils import (
     get_colorspace_list
 )
 
-from .actions import SelectInvalidAction
+from .actions import (
+    SelectInvalidAction,
+    SelectInstanceNodeAction
+)
 
 __all__ = (
     "file_extensions",
@@ -97,4 +100,5 @@ __all__ = (
     "get_colorspace_list",
 
     "SelectInvalidAction",
+    "SelectInstanceNodeAction"
 )

--- a/openpype/hosts/nuke/api/actions.py
+++ b/openpype/hosts/nuke/api/actions.py
@@ -20,31 +20,58 @@ class SelectInvalidAction(pyblish.api.Action):
 
     def process(self, context, plugin):
 
+        errored_instances = get_errored_instances_from_context(context,
+                                                               plugin=plugin)
+
+        # Get the invalid nodes for the plug-ins
+        self.log.info("Finding invalid nodes..")
+        invalid = set()
+        for instance in errored_instances:
+            invalid_nodes = plugin.get_invalid(instance)
+
+            if invalid_nodes:
+                if isinstance(invalid_nodes, (list, tuple)):
+                    invalid.update(invalid_nodes)
+                else:
+                    self.log.warning("Plug-in returned to be invalid, "
+                                     "but has no selectable nodes.")
+
+        if invalid:
+            self.log.info("Selecting invalid nodes: {}".format(invalid))
+            reset_selection()
+            select_nodes(invalid)
+        else:
+            self.log.info("No invalid nodes found.")
+
+
+class SelectInstanceNodeAction(pyblish.api.Action):
+    """Select instance node for failed plugin."""
+    label = "Select instance node"
+    on = "failed"  # This action is only available on a failed plug-in
+    icon = "mdi.cursor-default-click"
+
+    def process(self, context, plugin):
+
         # Get the errored instances for the plug-in
         errored_instances = get_errored_instances_from_context(
             context, plugin)
 
         # Get the invalid nodes for the plug-ins
-        self.log.info("Finding invalid nodes..")
-        invalid_nodes = set()
+        self.log.info("Finding instance nodes..")
+        nodes = set()
         for instance in errored_instances:
-            invalid = plugin.get_invalid(instance)
-
-            if not invalid:
-                continue
-
-            select_node = instance.data.get("transientData", {}).get("node")
-            if not select_node:
+            instance_node = instance.data.get("transientData", {}).get("node")
+            if not instance_node:
                 raise RuntimeError(
                     "No transientData['node'] found on instance: {}".format(
-                        instance)
+                        instance
+                    )
                 )
+            nodes.add(instance_node)
 
-            invalid_nodes.add(select_node)
-
-        if invalid_nodes:
-            self.log.info("Selecting invalid nodes: {}".format(invalid_nodes))
+        if nodes:
+            self.log.info("Selecting instance nodes: {}".format(nodes))
             reset_selection()
-            select_nodes(list(invalid_nodes))
+            select_nodes(nodes)
         else:
-            self.log.info("No invalid nodes found.")
+            self.log.info("No instance nodes found.")

--- a/openpype/hosts/nuke/api/lib.py
+++ b/openpype/hosts/nuke/api/lib.py
@@ -2833,9 +2833,10 @@ def select_nodes(nodes):
     """Selects all inputted nodes
 
     Arguments:
-        nodes (list): nuke nodes to be selected
+        nodes (Union[list, tuple, set]): nuke nodes to be selected
     """
-    assert isinstance(nodes, (list, tuple)), "nodes has to be list or tuple"
+    assert isinstance(nodes, (list, tuple, set)), \
+        "nodes has to be list, tuple or set"
 
     for node in nodes:
         node["selected"].setValue(True)

--- a/openpype/hosts/nuke/plugins/publish/validate_asset_context.py
+++ b/openpype/hosts/nuke/plugins/publish/validate_asset_context.py
@@ -10,7 +10,7 @@ from openpype.pipeline.publish import (
     PublishXmlValidationError,
     OptionalPyblishPluginMixin
 )
-from openpype.hosts.nuke.api import SelectInvalidAction
+from openpype.hosts.nuke.api import SelectInstanceNodeAction
 
 
 class ValidateCorrectAssetContext(
@@ -30,7 +30,7 @@ class ValidateCorrectAssetContext(
     hosts = ["nuke"]
     actions = [
         RepairAction,
-        SelectInvalidAction
+        SelectInstanceNodeAction
     ]
     optional = True
 


### PR DESCRIPTION
## Changelog Description

Refactor `SelectInvalidAction` to behave like other action for other host, create `SelectInstanceNodeAction` as dedicated action to select the instance node for a failed plugin.

- Note: Selecting Instance Node will still select the instance node even if the user has currently 'fixed' the problem.

## Additional info

Implement comment as per [here](https://github.com/ynput/OpenPype/pull/5749/files#r1358090182)

This also makes sure there's backwards compatibility to before this PR  #5749 for studios that might have used the `SelectInvalidAction` of Nuke host for any validators they had rolled out themselves. (Currently in native OpenPype no nuke validator is currently using it)

## Testing notes:

1. validate asset context - action should still work
2. select invalid action is currently unused so might be hard to test - but at least the design is now like in other hosts
