### PR TITLE
Enhancement: Tweak logging for Nuke for artist facing reports

### DIFF
--- a/openpype/hosts/nuke/plugins/publish/collect_backdrop.py
+++ b/openpype/hosts/nuke/plugins/publish/collect_backdrop.py
@@ -57,4 +57,4 @@ class CollectBackdrops(pyblish.api.InstancePlugin):
         if version:
             instance.data['version'] = version
 
-        self.log.info("Backdrop instance collected: `{}`".format(instance))
+        self.log.debug("Backdrop instance collected: `{}`".format(instance))

--- a/openpype/hosts/nuke/plugins/publish/collect_context_data.py
+++ b/openpype/hosts/nuke/plugins/publish/collect_context_data.py
@@ -64,4 +64,4 @@ class CollectContextData(pyblish.api.ContextPlugin):
         context.data["scriptData"] = script_data
         context.data.update(script_data)
 
-        self.log.info('Context from Nuke script collected')
+        self.log.debug('Context from Nuke script collected')

--- a/openpype/hosts/nuke/plugins/publish/collect_gizmo.py
+++ b/openpype/hosts/nuke/plugins/publish/collect_gizmo.py
@@ -43,4 +43,4 @@ class CollectGizmo(pyblish.api.InstancePlugin):
             "frameStart": first_frame,
             "frameEnd": last_frame
         })
-        self.log.info("Gizmo instance collected: `{}`".format(instance))
+        self.log.debug("Gizmo instance collected: `{}`".format(instance))

--- a/openpype/hosts/nuke/plugins/publish/collect_model.py
+++ b/openpype/hosts/nuke/plugins/publish/collect_model.py
@@ -43,4 +43,4 @@ class CollectModel(pyblish.api.InstancePlugin):
             "frameStart": first_frame,
             "frameEnd": last_frame
         })
-        self.log.info("Model instance collected: `{}`".format(instance))
+        self.log.debug("Model instance collected: `{}`".format(instance))

--- a/openpype/hosts/nuke/plugins/publish/collect_slate_node.py
+++ b/openpype/hosts/nuke/plugins/publish/collect_slate_node.py
@@ -39,7 +39,7 @@ class CollectSlate(pyblish.api.InstancePlugin):
                 instance.data["slateNode"] = slate_node
                 instance.data["slate"] = True
                 instance.data["families"].append("slate")
-                self.log.info(
+                self.log.debug(
                     "Slate node is in node graph: `{}`".format(slate.name()))
                 self.log.debug(
                     "__ instance.data: `{}`".format(instance.data))

--- a/openpype/hosts/nuke/plugins/publish/collect_workfile.py
+++ b/openpype/hosts/nuke/plugins/publish/collect_workfile.py
@@ -37,4 +37,6 @@ class CollectWorkfile(pyblish.api.InstancePlugin):
         # adding basic script data
         instance.data.update(script_data)
 
-        self.log.info("Collect script version")
+        self.log.debug(
+            "Collected current script version: {}".format(current_file)
+        )

--- a/openpype/hosts/nuke/plugins/publish/extract_backdrop.py
+++ b/openpype/hosts/nuke/plugins/publish/extract_backdrop.py
@@ -56,8 +56,6 @@ class ExtractBackdropNode(publish.Extractor):
             # connect output node
             for n, output in connections_out.items():
                 opn = nuke.createNode("Output")
-                self.log.info(n.name())
-                self.log.info(output.name())
                 output.setInput(
                     next((i for i, d in enumerate(output.dependencies())
                           if d.name() in n.name()), 0), opn)
@@ -102,5 +100,5 @@ class ExtractBackdropNode(publish.Extractor):
         }
         instance.data["representations"].append(representation)
 
-        self.log.info("Extracted instance '{}' to: {}".format(
+        self.log.debug("Extracted instance '{}' to: {}".format(
             instance.name, path))

--- a/openpype/hosts/nuke/plugins/publish/extract_camera.py
+++ b/openpype/hosts/nuke/plugins/publish/extract_camera.py
@@ -36,11 +36,11 @@ class ExtractCamera(publish.Extractor):
         step = 1
         output_range = str(nuke.FrameRange(first_frame, last_frame, step))
 
-        self.log.info("instance.data: `{}`".format(
+        self.log.debug("instance.data: `{}`".format(
             pformat(instance.data)))
 
         rm_nodes = []
-        self.log.info("Crating additional nodes")
+        self.log.debug("Creating additional nodes for 3D Camera Extractor")
         subset = instance.data["subset"]
         staging_dir = self.staging_dir(instance)
 
@@ -84,8 +84,6 @@ class ExtractCamera(publish.Extractor):
             for n in rm_nodes:
                 nuke.delete(n)
 
-            self.log.info(file_path)
-
         # create representation data
         if "representations" not in instance.data:
             instance.data["representations"] = []
@@ -112,7 +110,7 @@ class ExtractCamera(publish.Extractor):
             "frameEndHandle": last_frame,
         })
 
-        self.log.info("Extracted instance '{0}' to: {1}".format(
+        self.log.debug("Extracted instance '{0}' to: {1}".format(
             instance.name, file_path))
 
 

--- a/openpype/hosts/nuke/plugins/publish/extract_camera.py
+++ b/openpype/hosts/nuke/plugins/publish/extract_camera.py
@@ -36,8 +36,6 @@ class ExtractCamera(publish.Extractor):
         step = 1
         output_range = str(nuke.FrameRange(first_frame, last_frame, step))
 
-        self.log.debug("instance.data: `{}`".format(
-            pformat(instance.data)))
 
         rm_nodes = []
         self.log.debug("Creating additional nodes for 3D Camera Extractor")

--- a/openpype/hosts/nuke/plugins/publish/extract_camera.py
+++ b/openpype/hosts/nuke/plugins/publish/extract_camera.py
@@ -36,7 +36,6 @@ class ExtractCamera(publish.Extractor):
         step = 1
         output_range = str(nuke.FrameRange(first_frame, last_frame, step))
 
-
         rm_nodes = []
         self.log.debug("Creating additional nodes for 3D Camera Extractor")
         subset = instance.data["subset"]

--- a/openpype/hosts/nuke/plugins/publish/extract_gizmo.py
+++ b/openpype/hosts/nuke/plugins/publish/extract_gizmo.py
@@ -85,8 +85,5 @@ class ExtractGizmo(publish.Extractor):
         }
         instance.data["representations"].append(representation)
 
-        self.log.info("Extracted instance '{}' to: {}".format(
+        self.log.debug("Extracted instance '{}' to: {}".format(
             instance.name, path))
-
-        self.log.info("Data {}".format(
-            instance.data))

--- a/openpype/hosts/nuke/plugins/publish/extract_model.py
+++ b/openpype/hosts/nuke/plugins/publish/extract_model.py
@@ -33,13 +33,13 @@ class ExtractModel(publish.Extractor):
         first_frame = int(nuke.root()["first_frame"].getValue())
         last_frame = int(nuke.root()["last_frame"].getValue())
 
-        self.log.info("instance.data: `{}`".format(
+        self.log.debug("instance.data: `{}`".format(
             pformat(instance.data)))
 
         rm_nodes = []
         model_node = instance.data["transientData"]["node"]
 
-        self.log.info("Crating additional nodes")
+        self.log.debug("Creating additional nodes for Extract Model")
         subset = instance.data["subset"]
         staging_dir = self.staging_dir(instance)
 
@@ -76,7 +76,7 @@ class ExtractModel(publish.Extractor):
             for n in rm_nodes:
                 nuke.delete(n)
 
-            self.log.info(file_path)
+            self.log.debug("Filepath: {}".format(file_path))
 
         # create representation data
         if "representations" not in instance.data:
@@ -104,5 +104,5 @@ class ExtractModel(publish.Extractor):
             "frameEndHandle": last_frame,
         })
 
-        self.log.info("Extracted instance '{0}' to: {1}".format(
+        self.log.debug("Extracted instance '{0}' to: {1}".format(
             instance.name, file_path))

--- a/openpype/hosts/nuke/plugins/publish/extract_ouput_node.py
+++ b/openpype/hosts/nuke/plugins/publish/extract_ouput_node.py
@@ -27,7 +27,7 @@ class CreateOutputNode(pyblish.api.ContextPlugin):
 
             if active_node:
                 active_node = active_node.pop()
-                self.log.info(active_node)
+                self.log.debug("Active node: {}".format(active_node))
                 active_node['selected'].setValue(True)
 
             # select only instance render node

--- a/openpype/hosts/nuke/plugins/publish/extract_render_local.py
+++ b/openpype/hosts/nuke/plugins/publish/extract_render_local.py
@@ -119,7 +119,7 @@ class NukeRenderLocal(publish.Extractor,
 
         instance.data["representations"].append(repre)
 
-        self.log.info("Extracted instance '{0}' to: {1}".format(
+        self.log.debug("Extracted instance '{0}' to: {1}".format(
             instance.name,
             out_dir
         ))
@@ -143,7 +143,7 @@ class NukeRenderLocal(publish.Extractor,
         instance.data["families"] = families
 
         collections, remainder = clique.assemble(filenames)
-        self.log.info('collections: {}'.format(str(collections)))
+        self.log.debug('collections: {}'.format(str(collections)))
 
         if collections:
             collection = collections[0]

--- a/openpype/hosts/nuke/plugins/publish/extract_review_data_lut.py
+++ b/openpype/hosts/nuke/plugins/publish/extract_review_data_lut.py
@@ -20,7 +20,7 @@ class ExtractReviewDataLut(publish.Extractor):
     hosts = ["nuke"]
 
     def process(self, instance):
-        self.log.info("Creating staging dir...")
+        self.log.debug("Creating staging dir...")
         if "representations" in instance.data:
             staging_dir = instance.data[
                 "representations"][0]["stagingDir"].replace("\\", "/")
@@ -33,7 +33,7 @@ class ExtractReviewDataLut(publish.Extractor):
             staging_dir = os.path.normpath(os.path.dirname(render_path))
             instance.data["stagingDir"] = staging_dir
 
-        self.log.info(
+        self.log.debug(
             "StagingDir `{0}`...".format(instance.data["stagingDir"]))
 
         # generate data

--- a/openpype/hosts/nuke/plugins/publish/extract_review_intermediates.py
+++ b/openpype/hosts/nuke/plugins/publish/extract_review_intermediates.py
@@ -52,7 +52,7 @@ class ExtractReviewIntermediates(publish.Extractor):
 
         task_type = instance.context.data["taskType"]
         subset = instance.data["subset"]
-        self.log.info("Creating staging dir...")
+        self.log.debug("Creating staging dir...")
 
         if "representations" not in instance.data:
             instance.data["representations"] = []
@@ -62,10 +62,10 @@ class ExtractReviewIntermediates(publish.Extractor):
 
         instance.data["stagingDir"] = staging_dir
 
-        self.log.info(
+        self.log.debug(
             "StagingDir `{0}`...".format(instance.data["stagingDir"]))
 
-        self.log.info(self.outputs)
+        self.log.debug("Outputs: {}".format(self.outputs))
 
         # generate data
         with maintained_selection():
@@ -104,9 +104,10 @@ class ExtractReviewIntermediates(publish.Extractor):
                         re.search(s, subset) for s in f_subsets):
                     continue
 
-                self.log.info(
+                self.log.debug(
                     "Baking output `{}` with settings: {}".format(
-                        o_name, o_data))
+                        o_name, o_data)
+                )
 
                 # check if settings have more then one preset
                 # so we dont need to add outputName to representation
@@ -155,10 +156,10 @@ class ExtractReviewIntermediates(publish.Extractor):
             instance.data["useSequenceForReview"] = False
         else:
             instance.data["families"].remove("review")
-            self.log.info((
+            self.log.debug(
                 "Removing `review` from families. "
                 "Not available baking profile."
-            ))
+            )
             self.log.debug(instance.data["families"])
 
         self.log.debug(

--- a/openpype/hosts/nuke/plugins/publish/extract_script_save.py
+++ b/openpype/hosts/nuke/plugins/publish/extract_script_save.py
@@ -3,13 +3,12 @@ import pyblish.api
 
 
 class ExtractScriptSave(pyblish.api.Extractor):
-    """
-    """
+    """Save current Nuke workfile script"""
     label = 'Script Save'
     order = pyblish.api.Extractor.order - 0.1
     hosts = ['nuke']
 
     def process(self, instance):
 
-        self.log.info('saving script')
+        self.log.debug('Saving current script')
         nuke.scriptSave()

--- a/openpype/hosts/nuke/plugins/publish/extract_slate_frame.py
+++ b/openpype/hosts/nuke/plugins/publish/extract_slate_frame.py
@@ -48,7 +48,7 @@ class ExtractSlateFrame(publish.Extractor):
 
             if instance.data.get("bakePresets"):
                 for o_name, o_data in instance.data["bakePresets"].items():
-                    self.log.info("_ o_name: {}, o_data: {}".format(
+                    self.log.debug("_ o_name: {}, o_data: {}".format(
                         o_name, pformat(o_data)))
                     self.render_slate(
                         instance,
@@ -65,14 +65,14 @@ class ExtractSlateFrame(publish.Extractor):
 
     def _create_staging_dir(self, instance):
 
-        self.log.info("Creating staging dir...")
+        self.log.debug("Creating staging dir...")
 
         staging_dir = os.path.normpath(
             os.path.dirname(instance.data["path"]))
 
         instance.data["stagingDir"] = staging_dir
 
-        self.log.info(
+        self.log.debug(
             "StagingDir `{0}`...".format(instance.data["stagingDir"]))
 
     def _check_frames_exists(self, instance):
@@ -275,10 +275,10 @@ class ExtractSlateFrame(publish.Extractor):
                 break
 
         if not matching_repre:
-            self.log.info((
-                "Matching reresentaion was not found."
+            self.log.info(
+                "Matching reresentation was not found."
                 " Representation files were not filled with slate."
-            ))
+            )
             return
 
         # Add frame to matching representation files
@@ -345,7 +345,7 @@ class ExtractSlateFrame(publish.Extractor):
 
             try:
                 node[key].setValue(value)
-                self.log.info("Change key \"{}\" to value \"{}\"".format(
+                self.log.debug("Change key \"{}\" to value \"{}\"".format(
                     key, value
                 ))
             except NameError:

--- a/openpype/hosts/nuke/plugins/publish/extract_thumbnail.py
+++ b/openpype/hosts/nuke/plugins/publish/extract_thumbnail.py
@@ -69,7 +69,7 @@ class ExtractThumbnail(publish.Extractor):
             "bake_viewer_input_process"]
 
         node = instance.data["transientData"]["node"]  # group node
-        self.log.info("Creating staging dir...")
+        self.log.debug("Creating staging dir...")
 
         if "representations" not in instance.data:
             instance.data["representations"] = []
@@ -79,7 +79,7 @@ class ExtractThumbnail(publish.Extractor):
 
         instance.data["stagingDir"] = staging_dir
 
-        self.log.info(
+        self.log.debug(
             "StagingDir `{0}`...".format(instance.data["stagingDir"]))
 
         temporary_nodes = []

--- a/openpype/hosts/nuke/plugins/publish/validate_backdrop.py
+++ b/openpype/hosts/nuke/plugins/publish/validate_backdrop.py
@@ -43,8 +43,8 @@ class SelectCenterInNodeGraph(pyblish.api.Action):
                 all_xC.append(xC)
                 all_yC.append(yC)
 
-        self.log.info("all_xC: `{}`".format(all_xC))
-        self.log.info("all_yC: `{}`".format(all_yC))
+        self.log.debug("all_xC: `{}`".format(all_xC))
+        self.log.debug("all_yC: `{}`".format(all_yC))
 
         # zoom to nodes in node graph
         nuke.zoom(2, [min(all_xC), min(all_yC)])

--- a/openpype/hosts/nuke/plugins/publish/validate_output_resolution.py
+++ b/openpype/hosts/nuke/plugins/publish/validate_output_resolution.py
@@ -104,9 +104,9 @@ class ValidateOutputResolution(
                     _rfn["resize"].setValue(0)
                     _rfn["black_outside"].setValue(1)
 
-                cls.log.info("I am adding reformat node")
+                cls.log.info("Adding reformat node")
 
         if cls.resolution_msg == invalid:
             reformat = cls.get_reformat(instance)
             reformat["format"].setValue(nuke.root()["format"].value())
-            cls.log.info("I am fixing reformat to root.format")
+            cls.log.info("Fixing reformat to root.format")

--- a/openpype/hosts/nuke/plugins/publish/validate_rendered_frames.py
+++ b/openpype/hosts/nuke/plugins/publish/validate_rendered_frames.py
@@ -76,8 +76,8 @@ class ValidateRenderedFrames(pyblish.api.InstancePlugin):
                 return
 
             collections, remainder = clique.assemble(repre["files"])
-            self.log.info("collections: {}".format(str(collections)))
-            self.log.info("remainder: {}".format(str(remainder)))
+            self.log.debug("collections: {}".format(str(collections)))
+            self.log.debug("remainder: {}".format(str(remainder)))
 
             collection = collections[0]
 
@@ -103,15 +103,15 @@ class ValidateRenderedFrames(pyblish.api.InstancePlugin):
             coll_start = min(collection.indexes)
             coll_end = max(collection.indexes)
 
-            self.log.info("frame_length: {}".format(frame_length))
-            self.log.info("collected_frames_len: {}".format(
+            self.log.debug("frame_length: {}".format(frame_length))
+            self.log.debug("collected_frames_len: {}".format(
                 collected_frames_len))
-            self.log.info("f_start_h-f_end_h: {}-{}".format(
+            self.log.debug("f_start_h-f_end_h: {}-{}".format(
                 f_start_h, f_end_h))
-            self.log.info(
+            self.log.debug(
                 "coll_start-coll_end: {}-{}".format(coll_start, coll_end))
 
-            self.log.info(
+            self.log.debug(
                 "len(collection.indexes): {}".format(collected_frames_len)
             )
 

--- a/openpype/hosts/nuke/plugins/publish/validate_write_nodes.py
+++ b/openpype/hosts/nuke/plugins/publish/validate_write_nodes.py
@@ -39,7 +39,7 @@ class RepairNukeWriteNodeAction(pyblish.api.Action):
 
             set_node_knobs_from_settings(write_node, correct_data["knobs"])
 
-            self.log.info("Node attributes were fixed")
+            self.log.debug("Node attributes were fixed")
 
 
 class ValidateNukeWriteNode(


### PR DESCRIPTION
## Changelog Description

Tweak logs that are not artist-facing to debug level + in some cases clarify what the logged value is.

## Additional info

Note that I don't use Nuke, so someone else would need to test how well the reports now end up in Nuke.

## Testing notes:

1. Publish lots of different stuff from Nuke, like models, renders, cameras, etc.

The Publish Reports should not contain technical logs - but should be limited only to information an artist cares about after a publish.