### PR TITLE
Nuke: Validate Nuke Write Nodes refactor to use variable `node_value` instead of `value`

### DIFF
--- a/openpype/hosts/nuke/plugins/publish/validate_write_nodes.py
+++ b/openpype/hosts/nuke/plugins/publish/validate_write_nodes.py
@@ -111,7 +111,6 @@ class ValidateNukeWriteNode(
             for value in values:
                 if type(node_value) in (int, float):
                     try:
-
                         if isinstance(value, list):
                             value = color_gui_to_int(value)
                         else:
@@ -130,7 +129,7 @@ class ValidateNukeWriteNode(
                 and key != "file"
                 and key != "tile_color"
             ):
-                check.append([key, value, write_node[key].value()])
+                check.append([key, node_value, write_node[key].value()])
 
         if check:
             self._make_error(check)


### PR DESCRIPTION
## Changelog Description

Nuke: Validate Nuke Write Nodes refactor to use variable `node_value` instead of `value`
The variable `value` only exists as the last variable value in the `for value in values` loop and might not be declared if `values` is an empty iterable.

## Additional info

Mentioned on [discord](https://discord.com/channels/517362899170230292/517382145552154634/1162367040972128256)

## Testing notes:

1. Run Validate write node and make sure it does what it intends to do
