### PR TITLE
Maya: don't call `cmds.ogs()` in headless mode

### DIFF
--- a/openpype/hosts/maya/api/lib.py
+++ b/openpype/hosts/maya/api/lib.py
@@ -146,15 +146,17 @@ def suspended_refresh(suspend=True):
 
     cmds.ogs(pause=True) is a toggle so we cant pass False.
     """
-    original_state = None
-    if not IS_HEADLESS:
-        original_state = cmds.ogs(query=True, pause=True)
+    if IS_HEADLESS:
+        yield
+        return
+
+    original_state = cmds.ogs(query=True, pause=True)
     try:
-        if suspend and not original_state and not IS_HEADLESS:
+        if suspend and not original_state:
             cmds.ogs(pause=True)
         yield
     finally:
-        if suspend and not original_state and not IS_HEADLESS:
+        if suspend and not original_state:
             cmds.ogs(pause=True)
 
 

--- a/openpype/hosts/maya/api/lib.py
+++ b/openpype/hosts/maya/api/lib.py
@@ -146,13 +146,15 @@ def suspended_refresh(suspend=True):
 
     cmds.ogs(pause=True) is a toggle so we cant pass False.
     """
-    original_state = cmds.ogs(query=True, pause=True)
+    original_state = None
+    if not IS_HEADLESS:
+        original_state = cmds.ogs(query=True, pause=True)
     try:
-        if suspend and not original_state:
+        if suspend and not original_state and not IS_HEADLESS:
             cmds.ogs(pause=True)
         yield
     finally:
-        if suspend and not original_state:
+        if suspend and not original_state and not IS_HEADLESS:
             cmds.ogs(pause=True)
 
 


### PR DESCRIPTION
## Changelog Description
`cmds.ogs()` is a call that will crash if Maya is running in headless mode (mayabatch, mayapy). This is handling that case.

## Additional info
This command is used only in `suspended_refresh` context manager, but that one is used on many places. This is fixing it perhaps in a little dirty way directly inside that context manager to lower impact on other code.

## Testing notes:
This is hard to test - current workflows in UI based Maya should work the same, like publishing pointcaches. But publishing them from mayapy or mayabatch shouldn't crash.
