### PR TITLE
Nuke: fixing UNC support for OCIO path

### DIFF
--- a/openpype/hosts/nuke/api/lib.py
+++ b/openpype/hosts/nuke/api/lib.py
@@ -2222,7 +2222,6 @@ Reopening Nuke should synchronize these paths and resolve any discrepancies.
         """
         # replace path with env var if possible
         ocio_path = self._replace_ocio_path_with_env_var(config_data)
-        ocio_path = ocio_path.replace("\\", "/")
 
         log.info("Setting OCIO config path to: `{}`".format(
             ocio_path))
@@ -2303,7 +2302,7 @@ Reopening Nuke should synchronize these paths and resolve any discrepancies.
             if env_path in path:
                 # with regsub we make sure path format of slashes is correct
                 resub_expr = (
-                    "[regsub -all {{\\\\}} [getenv {}] \"/\"]").format(env_var)
+                    "[regsub -all {{\\}} [getenv {}] \"/\"]").format(env_var)
 
                 new_path = path.replace(
                     env_path, resub_expr

--- a/openpype/hosts/nuke/api/lib.py
+++ b/openpype/hosts/nuke/api/lib.py
@@ -2302,7 +2302,7 @@ Reopening Nuke should synchronize these paths and resolve any discrepancies.
             if env_path in path:
                 # with regsub we make sure path format of slashes is correct
                 resub_expr = (
-                    "[regsub -all {{\\}} [getenv {}] \"/\"]").format(env_var)
+                    "[regsub -all {{\\\\}} [getenv {}] \"/\"]").format(env_var)
 
                 new_path = path.replace(
                     env_path, resub_expr


### PR DESCRIPTION
## Changelog Description
UNC paths were broken on windows for custom OCIO path and this is solving the issue with removed double slash at start of path 

## Testing notes:
1. add UNC path to second anatomy root ("resources") >> on windows just go to folder properties and switch to `share` tab. Then copy past the unc path to the Anatomy windows field. My looks like this 
![image](https://github.com/ynput/OpenPype/assets/40640033/c99319b4-a59e-4d5a-b6dc-eebc7cf01594)
2. add new ocio path to first position on a project `project_settings/global/imageio/ocio_config` and use `{root[resources]}` as part of path >> my looks like this
![image](https://github.com/ynput/OpenPype/assets/40640033/ccaa15b2-695d-4333-985a-b79c07a7ad0c)

3. save and open Nuke. All should work as expected and the ocio path should be added to the nuke workfile properties looking like this > 
![image](https://github.com/ynput/OpenPype/assets/40640033/71f5383c-68e3-4c50-a616-f48d4c8490d2)

4. No warning message about `using previouse ocio config...`

