### PR TITLE
Fusion: added missing OPENPYPE_VERSION

### DIFF
--- a/openpype/modules/deadline/plugins/publish/submit_fusion_deadline.py
+++ b/openpype/modules/deadline/plugins/publish/submit_fusion_deadline.py
@@ -13,7 +13,8 @@ from openpype.pipeline.publish import (
 )
 from openpype.lib import (
     BoolDef,
-    NumberDef
+    NumberDef,
+    is_running_from_build
 )
 
 
@@ -230,6 +231,11 @@ class FusionSubmitDeadline(
             "OPENPYPE_LOG_NO_COLORS",
             "IS_TEST"
         ]
+
+        # Add OpenPype version if we are running from build.
+        if is_running_from_build():
+            keys.append("OPENPYPE_VERSION")
+
         environment = dict({key: os.environ[key] for key in keys
                             if key in os.environ}, **legacy_io.Session)
 


### PR DESCRIPTION
## Changelog Description
Fusion submission to Deadline was missing OPENPYPE_VERSION env var when submitting from build (not source code directly). This missing env var might break rendering on DL if path to OP executable (openpype_console.exe) is not set explicitly and might cause an issue when different versions of OP are deployed.

This PR adds this environment variable.


## Testing notes:
1. build OP
2. start publish from build and Fusion
3. check that render job `Environments` contain OPENPYPE_VERSION
4. remove explicit path to `openpype_console.exe` (and keep only dir there?)
5. try to republish again
