### PR TITLE
General: thumbnail extractor as last extractor

### DIFF
--- a/openpype/plugins/publish/extract_thumbnail.py
+++ b/openpype/plugins/publish/extract_thumbnail.py
@@ -17,7 +17,7 @@ class ExtractThumbnail(pyblish.api.InstancePlugin):
     """Create jpg thumbnail from sequence using ffmpeg"""
 
     label = "Extract Thumbnail"
-    order = pyblish.api.ExtractorOrder
+    order = pyblish.api.ExtractorOrder + 0.49
     families = [
         "imagesequence", "render", "render2d", "prerender",
         "source", "clip", "take", "online", "image"


### PR DESCRIPTION
## Changelog Description
Fixing issue with the order of the `ExtractOIIOTranscode` and `ExtractThumbnail` plugins. The problem was that the `ExtractThumbnail` plugin was processed before the `ExtractOIIOTranscode` plugin. As a result, the `ExtractThumbnail` plugin did not inherit the `review` tag into the representation data. This caused the `ExtractThumbnail` plugin to fail in processing and creating thumbnails.

## Testing notes:
1. We need to test mainly Maya, Houdini and ideally local and farm publishing
2. Test it with ExtractOIIOTrancode multiple presets. Here is an example 
![image](https://github.com/ynput/OpenPype/assets/40640033/98d92367-3f5f-40a8-846a-b17d8601e2a7)
3. In combination with Ftrack it should create two AssetVersions and each with own Thumbnail.

