### PR TITLE
Reference USD file as maya native geometry

### DIFF
--- a/openpype/hosts/maya/api/plugin.py
+++ b/openpype/hosts/maya/api/plugin.py
@@ -771,7 +771,8 @@ class ReferenceLoader(Loader):
             "ma": "mayaAscii",
             "mb": "mayaBinary",
             "abc": "Alembic",
-            "fbx": "FBX"
+            "fbx": "FBX",
+            "usd": "USD Import"
         }.get(representation["name"])
 
         assert file_type, "Unsupported representation: %s" % representation

--- a/openpype/hosts/maya/plugins/load/load_reference.py
+++ b/openpype/hosts/maya/plugins/load/load_reference.py
@@ -1,7 +1,9 @@
 import os
 import difflib
 import contextlib
+
 from maya import cmds
+import qargparse
 
 from openpype.settings import get_project_settings
 import openpype.hosts.maya.api.plugin
@@ -128,6 +130,12 @@ class ReferenceLoader(openpype.hosts.maya.api.plugin.ReferenceLoader):
         if not attach_to_root:
             group_name = namespace
 
+        kwargs = {}
+        if "file_options" in options:
+            kwargs["options"] = options["file_options"]
+        if "file_type" in options:
+            kwargs["type"] = options["file_type"]
+
         path = self.filepath_from_context(context)
         with maintained_selection():
             cmds.loadPlugin("AbcImport.mll", quiet=True)
@@ -139,7 +147,8 @@ class ReferenceLoader(openpype.hosts.maya.api.plugin.ReferenceLoader):
                               reference=True,
                               returnNewNodes=True,
                               groupReference=attach_to_root,
-                              groupName=group_name)
+                              groupName=group_name,
+                              **kwargs)
 
             shapes = cmds.ls(nodes, shapes=True, long=True)
 
@@ -251,3 +260,92 @@ class ReferenceLoader(openpype.hosts.maya.api.plugin.ReferenceLoader):
         else:
             self.log.warning("This version of Maya does not support locking of"
                              " transforms of cameras.")
+
+
+class MayaUSDReferenceLoader(ReferenceLoader):
+    """Reference USD file to native Maya nodes using MayaUSDImport reference"""
+
+    families = ["usd"]
+    representations = ["usd"]
+    extensions = {"usd", "usda", "usdc"}
+
+    options = ReferenceLoader.options + [
+        qargparse.Boolean(
+            "readAnimData",
+            label="Load anim data",
+            default=True,
+            help="Load animation data from USD file"
+        ),
+        qargparse.Boolean(
+            "useAsAnimationCache",
+            label="Use as animation cache",
+            default=True,
+            help=(
+                "Imports geometry prims with time-sampled point data using a "
+                "point-based deformer that references the imported "
+                "USD file.\n"
+                "This provides better import and playback performance when "
+                "importing time-sampled geometry from USD, and should "
+                "reduce the weight of the resulting Maya scene."
+            )
+        ),
+        qargparse.Boolean(
+            "importInstances",
+            label="Import instances",
+            default=True,
+            help=(
+                "Import USD instanced geometries as Maya instanced shapes. "
+                "Will flatten the scene otherwise."
+            )
+        ),
+        qargparse.String(
+            "primPath",
+            label="Prim Path",
+            default="/",
+            help=(
+                "Name of the USD scope where traversing will begin.\n"
+                "The prim at the specified primPath (including the prim) will "
+                "be imported.\n"
+                "Specifying the pseudo-root (/) means you want "
+                "to import everything in the file.\n"
+                "If the passed prim path is empty, it will first try to "
+                "import the defaultPrim for the rootLayer if it exists.\n"
+                "Otherwise, it will behave as if the pseudo-root was passed "
+                "in."
+            )
+        )
+    ]
+
+    file_type = "USD Import"
+
+    def process_reference(self, context, name, namespace, options):
+        cmds.loadPlugin("mayaUsdPlugin", quiet=True)
+
+        def bool_option(key, default):
+            # Shorthand for getting optional boolean file option from options
+            value = int(bool(options.get(key, default)))
+            return "{}={}".format(key, value)
+
+        def string_option(key, default):
+            # Shorthand for getting optional string file option from options
+            value = str(options.get(key, default))
+            return "{}={}".format(key, value)
+
+        options["file_options"] = ";".join([
+            string_option("primPath", default="/"),
+            bool_option("importInstances", default=True),
+            bool_option("useAsAnimationCache", default=True),
+            bool_option("readAnimData", default=True),
+            # TODO: Expose more parameters
+            # "preferredMaterial=none",
+            # "importRelativeTextures=Automatic",
+            # "useCustomFrameRange=0",
+            # "startTime=0",
+            # "endTime=0",
+            # "importUSDZTextures=0"
+        ])
+        options["file_type"] = self.file_type
+
+        return super(MayaUSDReferenceLoader, self).process_reference(
+            context, name, namespace, options
+        )


### PR DESCRIPTION
## Changelog Description

Add MayaUsdReferenceLoader to reference USD as Maya native geometry using `mayaUSDImport` file translator.

## Additional info

This allows referencing a USD file similar to referencing Alembic files as native maya geometry.
Unlike Alembic it can actually load the loaded geometry as instances. (However not yet as Instancer, see known issues)

This uses the `mayaUsdPlugin` that comes with recent maya versions and is open-source available [here](https://github.com/Autodesk/maya-usd) where they also provide releases, e.g. 0.25 instead of 0.23.1 that comes by default with Maya 2024.1

It is possible to define Custom Python chasers that run during the file load and thus should be able to be produce nodes as if part of the reference itself. This could allow even 'referencing' custom USD data into Maya native nodes or data that you can manage yourself. E.g. see [here](https://github.com/Autodesk/maya-usd/discussions/1909).

You can customize how the data is loaded, e.g. you can enable/disable loading animation using a live connection (somewhat like `AlembicNode` used to do) or by flattening anim data into a series of blendshapes (which is what happens when `useAsAnimationCache` is disabled)

All [`mayaUSDImport`](https://github.com/Autodesk/maya-usd/blob/dev/lib/mayaUsd/commands/Readme.md#mayausdimportcommand) flags should be able to be passed along as "options" to the maya `cmds.file` command for referencing. The current Loader already exposes some options currently for some flags.

### Known Issues

There are some known Maya USD issues:
- [You can't import USD Point Instancer](https://github.com/Autodesk/maya-usd/issues/3391)  (yet?)
- [User properties are not imported with `mayaUSDImport`](https://github.com/Autodesk/maya-usd/issues/3395) and thus e.g. `cbId` attributes are not loaded.
    - If we were to export `cbId` as `primvar:cbId` instead of `userProperties:cbId` it does import it however, see [issue](https://github.com/Autodesk/maya-usd/issues/3395#issuecomment-1766192003).
- [~~Exporting a cube from maya and importing it again shows different normals on the cube~~](https://github.com/Autodesk/maya-usd/issues/3396)?
    - This actually seems to be by design, exporting as "Catmull Clark" subdivision scheme omits normals. Exporting as "None (Polygonal Mesh)" exports the normals, but then doesn't include creases. See [linked issue](https://github.com/Autodesk/maya-usd/issues/3396).

## Testing notes:

1. Open Maya
2. Reference USD files
