### PR TITLE
Nuke: Adding missing settings for Nuke workfiles

### DIFF
--- a/openpype/hosts/nuke/api/lib.py
+++ b/openpype/hosts/nuke/api/lib.py
@@ -2110,7 +2110,7 @@ class WorkfileSettings(object):
             # skip empty values
             if not value_:
                 continue
-            if self._root_node[knob].value() not in value_:
+            if self._root_node[knob].value() != value_:
                 self._root_node[knob].setValue(str(value_))
                 log.debug("nuke.root()['{}'] changed to: {}".format(
                     knob, value_))

--- a/openpype/settings/defaults/project_settings/nuke.json
+++ b/openpype/settings/defaults/project_settings/nuke.json
@@ -28,7 +28,11 @@
             "colorManagement": "Nuke",
             "OCIO_config": "nuke-default",
             "workingSpaceLUT": "linear",
-            "monitorLut": "sRGB"
+            "monitorLut": "sRGB",
+            "int8Lut": "sRGB",
+            "int16Lut": "sRGB",
+            "logLut": "Cineon",
+            "floatLut": "linear"
         },
         "nodes": {
             "requiredNodes": [

--- a/openpype/settings/entities/schemas/projects_schema/schemas/schema_nuke_imageio.json
+++ b/openpype/settings/entities/schemas/projects_schema/schemas/schema_nuke_imageio.json
@@ -106,6 +106,26 @@
                             "type": "text",
                             "key": "monitorLut",
                             "label": "monitor"
+                        },
+                        {
+                            "type": "text",
+                            "key": "int8Lut",
+                            "label": "8-bit files"
+                        },
+                        {
+                            "type": "text",
+                            "key": "int16Lut",
+                            "label": "16-bit files"
+                        },
+                        {
+                            "type": "text",
+                            "key": "logLut",
+                            "label": "log files"
+                        },
+                        {
+                            "type": "text",
+                            "key": "floatLut",
+                            "label": "float files"
                         }
                     ]
                 }


### PR DESCRIPTION
## Changelog Description
Missing workfile settings from deprecated.

Also stricter checking of the knob values for changing the value.

## Testing notes:
1. Change new settings at `project_settings/nuke/imageio/workfile`
2. Validate launching and/or setting colorspace within Nuke.
