### PR TITLE
Bug: fix key in application json

### DIFF
--- a/server_addon/applications/server/applications.json
+++ b/server_addon/applications/server/applications.json
@@ -69,7 +69,7 @@
                 }
             ]
         },
-        "maya": {
+        "mayapy": {
             "enabled": true,
             "label": "Maya",
             "icon": "{}/app_icons/maya.png",


### PR DESCRIPTION
## Changelog Description
In PR #5705 `maya` was wrongly used instead of `mayapy`, breaking AYON defaults in AYON Application Addon.

## Testing notes:
Unchanged defaults in Application Addon in AYON should show correct maya executables
