### PR TITLE
'NumberAttrWidget' shows 'Multiselection' label on multiselection

### DIFF
--- a/openpype/tools/attribute_defs/widgets.py
+++ b/openpype/tools/attribute_defs/widgets.py
@@ -20,7 +20,6 @@ from openpype.tools.utils import (
     FocusSpinBox,
     FocusDoubleSpinBox,
     MultiSelectionComboBox,
-    ClickableFrame,
 )
 from openpype.widgets.nice_checkbox import NiceCheckbox
 

--- a/openpype/tools/attribute_defs/widgets.py
+++ b/openpype/tools/attribute_defs/widgets.py
@@ -347,7 +347,9 @@ class NumberAttrWidget(_BaseAttrDefWidget):
             value = self.attr_def.default
         else:
             value = self._last_multivalue
+        self._input_widget.blockSignals(True)
         self._input_widget.setValue(value)
+        self._input_widget.blockSignals(False)
         if not change_focus:
             return
         # Change focus to input field and move cursor to the end


### PR DESCRIPTION
## Changelog Description
Attribute definition widget 'NumberAttrWidget' shows `< Multiselection >`  label on multiselection.

## Additional info
I've tried multiple different approaches and after few fails when overriding `paintEvent`, changing `QLineEdit` in spinboxes and some others, I found out the easiest is to show different QLineEdit which is clickable.

## Testing notes:
1. Create 2 instances with number inputs
2. Change value of first to different value from second instance
3. Select both
4. Label `< Multiselection >` should show and if you click on it it should show one of the values there

Resolves https://github.com/ynput/OpenPype/issues/5790