### PR TITLE
Publisher: Selection change by enabled checkbox on instance update attributes

### DIFF
--- a/openpype/tools/publisher/widgets/card_view_widgets.py
+++ b/openpype/tools/publisher/widgets/card_view_widgets.py
@@ -797,6 +797,7 @@ class InstanceCardView(AbstractInstanceView):
                     widget.set_active(value)
         else:
             self._select_item_clear(instance_id, group_name, instance_widget)
+            self.selection_changed.emit()
         self.active_changed.emit()
 
     def _on_widget_selection(self, instance_id, group_name, selection_type):


### PR DESCRIPTION
## Changelog Description
Change of instance by clicking on enabled checkbox will actually update attributes on right side to match the selection.

## Additional info
Trigger 'selection_changed' signal to propagate selection change.

## Testing notes:
1. Open publisher
2. Create 2 instances
3. Change any visible attribute on one of the instances so there are visible change when changing their selection
4. Select only one if the instances
5. Click on enabled checkbox of the second instance
6. It should change the state, the instance should be selected and the attributes on right side should be related to selected instance

Resolves https://github.com/ynput/OpenPype/issues/5789