### PR TITLE
Houdini: Remove `setParms` call since it's responsibility of `self.imprint` to set the values

### DIFF
--- a/openpype/hosts/houdini/api/lib.py
+++ b/openpype/hosts/houdini/api/lib.py
@@ -363,11 +363,10 @@ def imprint(node, data, update=False):
         parm_folder.setParmTemplates(templates)
         parm_group.append(parm_folder)
     else:
+        # Add to parm folder instance, then replace with updated one in group
         for template in templates:
-            parm_group.appendToFolder(parm_folder, template)
-            # this is needed because the pointer to folder
-            # is for some reason lost every call to `appendToFolder()`
-            parm_folder = parm_group.findFolder("Extra")
+            parm_folder.addParmTemplate(template)
+        parm_group.replace(parm_folder.name(), parm_folder)
 
     for parm_template in update_parms:
         parm_group.replace(parm_template.name(), parm_template)

--- a/openpype/hosts/houdini/api/lib.py
+++ b/openpype/hosts/houdini/api/lib.py
@@ -369,15 +369,17 @@ def imprint(node, data, update=False):
             # is for some reason lost every call to `appendToFolder()`
             parm_folder = parm_group.findFolder("Extra")
 
+    for parm_template in update_parms:
+        parm_group.replace(parm_template.name(), parm_template)
+
+        # When replacing a parm with a parm of the same name it preserves its
+        # value if before the replacement the parm was not at the default,
+        # because it has a value override set. Since we're trying to update the
+        # parm by using the new value as `default` we enforce the parm is at
+        # default state
+        node.parm(parm_template.name()).revertToDefaults()
+
     node.setParmTemplateGroup(parm_group)
-
-    # TODO: Updating is done here, by calling probably deprecated functions.
-    #       This needs to be addressed in the future.
-    if not update_parms:
-        return
-
-    for parm in update_parms:
-        node.replaceSpareParmTuple(parm.name(), parm)
 
 
 def lsattr(attr, value=None, root="/"):

--- a/openpype/hosts/houdini/api/lib.py
+++ b/openpype/hosts/houdini/api/lib.py
@@ -339,7 +339,7 @@ def imprint(node, data, update=False):
         if value is None:
             continue
 
-        parm = get_template_from_value(key, value)
+        parm_template = get_template_from_value(key, value)
 
         if key in current_parms:
             if node.evalParm(key) == data[key]:
@@ -348,10 +348,10 @@ def imprint(node, data, update=False):
                 log.debug(f"{key} already exists on {node}")
             else:
                 log.debug(f"replacing {key}")
-                update_parms.append(parm)
+                update_parms.append(parm_template)
             continue
 
-        templates.append(parm)
+        templates.append(parm_template)
 
     parm_group = node.parmTemplateGroup()
     parm_folder = parm_group.findFolder("Extra")

--- a/openpype/hosts/houdini/api/lib.py
+++ b/openpype/hosts/houdini/api/lib.py
@@ -342,7 +342,7 @@ def imprint(node, data, update=False):
         parm_template = get_template_from_value(key, value)
 
         if key in current_parms:
-            if node.evalParm(key) == data[key]:
+            if node.evalParm(key) == value:
                 continue
             if not update:
                 log.debug(f"{key} already exists on {node}")

--- a/openpype/hosts/houdini/api/plugin.py
+++ b/openpype/hosts/houdini/api/plugin.py
@@ -250,14 +250,12 @@ class HoudiniCreator(NewCreator, HoudiniCreatorBase):
                 key: changes[key].new_value
                 for key in changes.changed_keys
             }
-            # Update ParmTemplates
+            # Update parm templates and values
             self.imprint(
                 instance_node,
                 new_values,
                 update=True
             )
-            # Update values
-            instance_node.setParms(new_values)
 
     def imprint(self, node, values, update=False):
         # Never store instance node and instance id since that data comes


### PR DESCRIPTION
## Changelog Description

Revert a recent change made in #5621 due to this [comment](https://github.com/ynput/OpenPype/pull/5621#discussion_r1355611105). However the change is faulty as can be seen [mentioned here](https://github.com/ynput/OpenPype/pull/5698#pullrequestreview-1685448609)

## Additional info

This is how I tested - if I open the publisher and "reset" in the publisher the instances also match the states set in this code, e.g. all on or all off depending on how I ran it.
```python
from openpype.pipeline import registered_host
from openpype.pipeline.create import CreateContext

host = registered_host()
context = CreateContext(host, reset=True)
for instance in context.instances:
    instance.data["active"] = False
context.save_changes()

# Assert all are off - then enable all
context = CreateContext(host, reset=True)
assert all(instance.data["active"] == False for instance in context.instances)
print("All are off")
for instance in context.instances:
    instance.data["active"] = True
context.save_changes()

# Assert all are on
context = CreateContext(host, reset=True)
assert all(instance.data["active"] == True for instance in context.instances)
print("All are on")
print("Success")
```

It **could be** that the original test case that @MustafaJafar tried that failed has an `instance_node` that by chance has an `active` parm of its own and thus can't be a [replaced spare parm](https://github.com/ynput/OpenPype/blob/13159c48890e24734da1390edd87d578aa98f640/openpype/hosts/houdini/api/lib.py#L379-L380) because it is not a spare parm as such `lib.imprint` might fail to update? However, without a clear test case that reproduces the issue it's hard to figure out if that's the issue he was facing. If that is the case it just hints that we **should have** prefixed all Creator related attributes with e.g. `openpype_` or `ayon_` to avoid such clashes.

## Testing notes:

1. Publishing should work as expected
2. Self publishing should also work as expected
