### PR TITLE
AYON loader: Fix SubsetLoader functionality

### DIFF
--- a/openpype/tools/ayon_loader/models/actions.py
+++ b/openpype/tools/ayon_loader/models/actions.py
@@ -447,11 +447,12 @@ class LoaderActionsModel:
         project_doc["code"] = project_doc["data"]["code"]
 
         for version_doc in version_docs:
+            version_id = version_doc["_id"]
             product_id = version_doc["parent"]
             product_doc = product_docs_by_id[product_id]
             folder_id = product_doc["parent"]
             folder_doc = folder_docs_by_id[folder_id]
-            version_context_by_id[product_id] = {
+            version_context_by_id[version_id] = {
                 "project": project_doc,
                 "asset": folder_doc,
                 "subset": product_doc,


### PR DESCRIPTION
## Changelog Description
Fix SubsetLoader plugin processing in AYON loader tool.

## Additional info
Version contexts supposed to be stored by their id, but were stored by product id which lead to invalid contexts on load.

## Testing notes:
1. Open loader in tray
2. Use on of SubsetLoader actions (e.g. Calculate old versions)
3. The action should work as expected (in case of Calulcate old versions the size should not be `0.0 b`)
