### PR TITLE
Maya: Render Settings cleanup remove global `RENDER_ATTRS`

### DIFF
--- a/openpype/hosts/maya/api/lib.py
+++ b/openpype/hosts/maya/api/lib.py
@@ -62,19 +62,6 @@ SHAPE_ATTRS = {"castsShadows",
                "doubleSided",
                "opposite"}
 
-RENDER_ATTRS = {"vray": {
-    "node": "vraySettings",
-    "prefix": "fileNamePrefix",
-    "padding": "fileNamePadding",
-    "ext": "imageFormatStr"
-},
-    "default": {
-    "node": "defaultRenderGlobals",
-    "prefix": "imageFilePrefix",
-    "padding": "extensionPadding"
-}
-}
-
 
 DEFAULT_MATRIX = [1.0, 0.0, 0.0, 0.0,
                   0.0, 1.0, 0.0, 0.0,

--- a/openpype/hosts/maya/api/lib_rendersettings.py
+++ b/openpype/hosts/maya/api/lib_rendersettings.py
@@ -35,6 +35,14 @@ class RenderSettings(object):
     def get_image_prefix_attr(cls, renderer):
         return cls._image_prefix_nodes[renderer]
 
+    @staticmethod
+    def get_padding_attr(renderer):
+        """Return attribute for renderer that defines frame padding amount"""
+        if renderer == "vray":
+            return "vraySettings.fileNamePadding"
+        else:
+            return "defaultRenderGlobals.extensionPadding"
+
     def __init__(self, project_settings=None):
         if not project_settings:
             project_settings = get_project_settings(

--- a/openpype/hosts/maya/plugins/publish/validate_rendersettings.py
+++ b/openpype/hosts/maya/plugins/publish/validate_rendersettings.py
@@ -12,6 +12,7 @@ from openpype.pipeline.publish import (
     PublishValidationError,
 )
 from openpype.hosts.maya.api import lib
+from openpype.hosts.maya.api.lib_rendersettings import RenderSettings
 
 
 def convert_to_int_or_float(string_value):
@@ -129,13 +130,13 @@ class ValidateRenderSettings(pyblish.api.InstancePlugin):
         layer = instance.data['renderlayer']
         cameras = instance.data.get("cameras", [])
 
-        # Get the node attributes for current renderer
-        attrs = lib.RENDER_ATTRS.get(renderer, lib.RENDER_ATTRS['default'])
         # Prefix attribute can return None when a value was never set
         prefix = lib.get_attr_in_layer(cls.ImagePrefixes[renderer],
                                        layer=layer) or ""
-        padding = lib.get_attr_in_layer("{node}.{padding}".format(**attrs),
-                                        layer=layer)
+        padding = lib.get_attr_in_layer(
+            attr=RenderSettings.get_padding_attr(renderer),
+            layer=layer
+        )
 
         anim_override = lib.get_attr_in_layer("defaultRenderGlobals.animation",
                                               layer=layer)
@@ -372,8 +373,6 @@ class ValidateRenderSettings(pyblish.api.InstancePlugin):
                 lib.set_attribute(data["attribute"], data["values"][0], node)
 
         with lib.renderlayer(layer_node):
-            default = lib.RENDER_ATTRS['default']
-            render_attrs = lib.RENDER_ATTRS.get(renderer, default)
 
             # Repair animation must be enabled
             cmds.setAttr("defaultRenderGlobals.animation", True)
@@ -391,15 +390,13 @@ class ValidateRenderSettings(pyblish.api.InstancePlugin):
                         default_prefix = default_prefix.replace(variant, "")
 
             if renderer != "renderman":
-                node = render_attrs["node"]
-                prefix_attr = render_attrs["prefix"]
-
+                prefix_attr = RenderSettings.get_image_prefix_attr(renderer)
                 fname_prefix = default_prefix
                 cmds.setAttr("{}.{}".format(node, prefix_attr),
                              fname_prefix, type="string")
 
                 # Repair padding
-                padding_attr = render_attrs["padding"]
+                padding_attr = RenderSettings.get_padding_attr(renderer)
                 cmds.setAttr("{}.{}".format(node, padding_attr),
                              cls.DEFAULT_PADDING)
             else:

--- a/openpype/modules/muster/plugins/publish/submit_maya_muster.py
+++ b/openpype/modules/muster/plugins/publish/submit_maya_muster.py
@@ -10,6 +10,7 @@ from maya import cmds
 import pyblish.api
 from openpype.lib import requests_post
 from openpype.hosts.maya.api import lib
+from openpype.hosts.maya.api.lib_rendersettings import RenderSettings
 from openpype.pipeline import legacy_io
 from openpype.settings import get_system_settings
 
@@ -68,10 +69,8 @@ def get_renderer_variables(renderlayer=None):
     """
 
     renderer = lib.get_renderer(renderlayer or lib.get_current_renderlayer())
-    render_attrs = lib.RENDER_ATTRS.get(renderer, lib.RENDER_ATTRS["default"])
 
-    padding = cmds.getAttr("{}.{}".format(render_attrs["node"],
-                                          render_attrs["padding"]))
+    padding = cmds.getAttr(RenderSettings.get_padding_attr(renderer))
 
     filename_0 = cmds.renderSettings(fullPath=True, firstImageName=True)[0]
 


### PR DESCRIPTION
## Changelog Description

Remove global `lib.RENDER_ATTRS` and implement a `RenderSettings.get_padding_attr(renderer)` method instead.

## Additional info

Allows more re-use of the functionality and has a simpler entry point to use it.

- Partial cleanup extracted from #3880

## Testing notes:

1. Submitting renders should still work
