### PR TITLE
AYON: Remove 'shotgun_api3' from dependencies

### DIFF
--- a/server_addon/openpype/client/pyproject.toml
+++ b/server_addon/openpype/client/pyproject.toml
@@ -8,7 +8,6 @@ aiohttp_json_rpc = "*" # TVPaint server
 aiohttp-middlewares = "^2.0.0"
 wsrpc_aiohttp = "^3.1.1" # websocket server
 clique = "1.6.*"
-shotgun_api3 = {git = "https://github.com/shotgunsoftware/python-api.git", rev = "v3.3.3"}
 gazu = "^0.9.3"
 google-api-python-client = "^1.12.8" # sync server google support (should be separate?)
 jsonschema = "^2.6.0"


### PR DESCRIPTION
## Changelog Description
Removed `shotgun_api3` dependency from openpype dependencies for AYON launcher. The dependency is already defined in shotgrid addon and change of version causes clashes.
