### PR TITLE
TimersManager: Use available data to get context info

### DIFF
--- a/openpype/modules/timers_manager/plugins/publish/start_timer.py
+++ b/openpype/modules/timers_manager/plugins/publish/start_timer.py
@@ -6,8 +6,6 @@ Requires:
 
 import pyblish.api
 
-from openpype.pipeline import legacy_io
-
 
 class StartTimer(pyblish.api.ContextPlugin):
     label = "Start Timer"
@@ -25,9 +23,9 @@ class StartTimer(pyblish.api.ContextPlugin):
             self.log.debug("Publish is not affecting running timers.")
             return
 
-        project_name = legacy_io.active_project()
-        asset_name = legacy_io.Session.get("AVALON_ASSET")
-        task_name = legacy_io.Session.get("AVALON_TASK")
+        project_name = context.data["projectName"]
+        asset_name = context.data.get("asset")
+        task_name = context.data.get("task")
         if not project_name or not asset_name or not task_name:
             self.log.info((
                 "Current context does not contain all"


### PR DESCRIPTION
## Changelog Description
Get context information from pyblish context data instead of using `legacy_io`.

## Testing notes:
I didn't know we have the plugin, so I'm not sure?
1. Change `"disregard_publishing"` in timers manager settings to `True` and make sure Timers manager is enabled
2. Have enabled module that handles timer (e.g. ftrack)
3. Start a DCC -> that should start a timer
4. Start publishing -> That should stop timer at the beginning and start the timer again once finished