### PR TITLE
Chore: Removed unused variable from `AbstractCollectRender`

### DIFF
--- a/openpype/pipeline/publish/abstract_collect_render.py
+++ b/openpype/pipeline/publish/abstract_collect_render.py
@@ -11,7 +11,6 @@ import six
 
 import pyblish.api
 
-from openpype.pipeline import legacy_io
 from .publish_plugins import AbstractMetaContextPlugin
 
 
@@ -31,7 +30,7 @@ class RenderInstance(object):
     label = attr.ib()  # label to show in GUI
     subset = attr.ib()  # subset name
     task = attr.ib()  # task name
-    asset = attr.ib()  # asset name (AVALON_ASSET)
+    asset = attr.ib()  # asset name
     attachTo = attr.ib()  # subset name to attach render to
     setMembers = attr.ib()  # list of nodes/members producing render output
     publish = attr.ib()  # bool, True to publish instance
@@ -129,7 +128,6 @@ class AbstractCollectRender(pyblish.api.ContextPlugin):
         """Constructor."""
         super(AbstractCollectRender, self).__init__(*args, **kwargs)
         self._file_path = None
-        self._asset = legacy_io.Session["AVALON_ASSET"]
         self._context = None
 
     def process(self, context):


### PR DESCRIPTION
## Changelog Description
Removed unused `_asset` variable from `RenderInstance`.

## Additional info
I didn't find any usage of the variable anywhere, and because it was using `legacy_io` it looked like a good candidate to be removed. As far as I know each instance should have the the asset so it should not be really used anywhere.

## Testing notes:
1. Validate the variable is not used
