### PR TITLE
Enhancement/expose workfile artist note

### DIFF
--- a/openpype/pipeline/workfile/__init__.py
+++ b/openpype/pipeline/workfile/__init__.py
@@ -14,10 +14,10 @@ from .path_resolving import (
 )
 
 from .build_workfile import BuildWorkfile
-from .artist_note import (
+from .workfile_doc import (
     get_workfile_doc,
     create_workfile_doc,
-    set_workfile_note,
+    set_workfile_data,
 )
 
 
@@ -39,5 +39,5 @@ __all__ = (
 
     "get_workfile_doc",
     "create_workfile_doc",
-    "set_workfile_note",
+    "set_workfile_data",
 )

--- a/openpype/pipeline/workfile/__init__.py
+++ b/openpype/pipeline/workfile/__init__.py
@@ -14,6 +14,11 @@ from .path_resolving import (
 )
 
 from .build_workfile import BuildWorkfile
+from .artist_note import (
+    get_workfile_doc,
+    create_workfile_doc,
+    set_workfile_note,
+)
 
 
 __all__ = (
@@ -31,4 +36,8 @@ __all__ = (
     "create_workdir_extra_folders",
 
     "BuildWorkfile",
+
+    "get_workfile_doc",
+    "create_workfile_doc",
+    "set_workfile_note",
 )

--- a/openpype/pipeline/workfile/artist_note.py
+++ b/openpype/pipeline/workfile/artist_note.py
@@ -11,7 +11,14 @@ from openpype.client.operations import (
 
 
 def get_workfile_doc(project_name, asset_id, task_name, filepath):
-    """Return workfile document from database, if it exists."""
+    """Return workfile document from database, if it exists.
+
+    Args:
+        project_name (str): Project name.
+        asset_id (ObjectID): Asset ID.
+        task_name (str): Task name.
+        filepath (str): Workfile filepath.
+    """
     filename = os.path.basename(filepath)
     return get_workfile_info(project_name, asset_id, task_name, filename)
 
@@ -20,6 +27,12 @@ def create_workfile_doc(project_name, asset_id, task_name, filepath):
     """Create workfile document in database.
 
     If it already exists. the existing document is returned.
+
+    Args:
+        project_name (str): Project name.
+        asset_id (ObjectID): Asset ID.
+        task_name (str): Task name.
+        filepath (str): Workfile filepath.
     """
     workdir, filename = os.path.split(filepath)
     workfile_doc = get_workfile_info(
@@ -45,12 +58,21 @@ def create_workfile_doc(project_name, asset_id, task_name, filepath):
     session.create_entity(project_name, "workfile", workfile_doc)
     session.commit()
 
+    return workfile_doc
+
 
 def set_workfile_note(project_name, asset_id, task_name, filepath, note):
     """Update the artist note for a workfile.
 
     If the workfile document does not exist in the database yet
     it will be created.
+
+    Args:
+        project_name (str): Project name.
+        asset_id (ObjectID): Asset ID.
+        task_name (str): Task name.
+        filepath (str): Workfile filepath.
+        note (str): Artist note content.
     """
     # This does not create the document if it already exists.
     workfile_doc = create_workfile_doc(

--- a/openpype/pipeline/workfile/artist_note.py
+++ b/openpype/pipeline/workfile/artist_note.py
@@ -83,7 +83,7 @@ def set_workfile_note(project_name, asset_id, task_name, filepath, note):
         return
 
     new_workfile_doc = copy.deepcopy(workfile_doc)
-    new_workfile_doc.setdefault("data", {})["notes"] = note
+    new_workfile_doc.setdefault("data", {})["note"] = note
     update_data = prepare_workfile_info_update_data(
         workfile_doc, new_workfile_doc
     )

--- a/openpype/pipeline/workfile/workfile_doc.py
+++ b/openpype/pipeline/workfile/workfile_doc.py
@@ -83,7 +83,7 @@ def set_workfile_data(project_name, asset_id, task_name, filepath, data):
         return
 
     new_workfile_doc = copy.deepcopy(workfile_doc)
-    new_workfile_doc["data"] = data
+    new_workfile_doc.setdefault("data", {}).update(data)
     update_data = prepare_workfile_info_update_data(
         workfile_doc, new_workfile_doc
     )

--- a/openpype/pipeline/workfile/workfile_doc.py
+++ b/openpype/pipeline/workfile/workfile_doc.py
@@ -61,8 +61,8 @@ def create_workfile_doc(project_name, asset_id, task_name, filepath):
     return workfile_doc
 
 
-def set_workfile_note(project_name, asset_id, task_name, filepath, note):
-    """Update the artist note for a workfile.
+def set_workfile_data(project_name, asset_id, task_name, filepath, data):
+    """Update workfile data.
 
     If the workfile document does not exist in the database yet
     it will be created.
@@ -72,18 +72,18 @@ def set_workfile_note(project_name, asset_id, task_name, filepath, note):
         asset_id (ObjectID): Asset ID.
         task_name (str): Task name.
         filepath (str): Workfile filepath.
-        note (str): Artist note content.
+        data (dict): Workfile data content.
     """
     # This does not create the document if it already exists.
     workfile_doc = create_workfile_doc(
         project_name, asset_id, task_name, filepath
     )
-    if workfile_doc.get("data", {}).get("note") == note:
+    if workfile_doc.get("data") == data:
         # Nothing to update
         return
 
     new_workfile_doc = copy.deepcopy(workfile_doc)
-    new_workfile_doc.setdefault("data", {})["note"] = note
+    new_workfile_doc["data"] = data
     update_data = prepare_workfile_info_update_data(
         workfile_doc, new_workfile_doc
     )

--- a/openpype/tools/workfiles/window.py
+++ b/openpype/tools/workfiles/window.py
@@ -20,7 +20,7 @@ from openpype.pipeline import (
     get_current_task_name,
 )
 from openpype.pipeline import legacy_io
-from openpype.pipeline.workfile import set_workfile_note
+from openpype.pipeline.workfile import set_workfile_data
 from openpype.tools.utils.assets_widget import SingleSelectAssetsWidget
 from openpype.tools.utils.tasks_widget import TasksWidget
 
@@ -342,12 +342,12 @@ class Window(QtWidgets.QWidget):
 
     def on_side_panel_save(self):
         """Save artist note when save button is pressed."""
-        set_workfile_note(
+        set_workfile_data(
             self.project_name,
             self.assets_widget.get_selected_asset_id(),
             self.tasks_widget.get_selected_task_name(),
             self.files_widget._get_selected_filepath(),
-            self.side_panel._note_input.toPlainText(),
+            {"note": self.side_panel._note_input.toPlainText()},
         )
 
     def _get_current_workfile_doc(self, filepath=None):


### PR DESCRIPTION
## Changelog Description
Exposing workfile ~~artist note~~ data so it can be easily be set programmatically, without having to interact directly with the UI. This can be use, for instance to set workfile artist note.

## Additional info
Related to issue #5719.
Requested in PR #5660.

## Testing notes:
- Open any workfile.
- Open workfile Qt menu.
- Set artist note and save it.