### PR TITLE
Blender: Fix tools handling in AYON mode

### DIFF
--- a/openpype/hosts/blender/api/ops.py
+++ b/openpype/hosts/blender/api/ops.py
@@ -284,6 +284,8 @@ class LaunchLoader(LaunchQtApp):
     _tool_name = "loader"
 
     def before_window_show(self):
+        if AYON_SERVER_ENABLED:
+            return
         self._window.set_context(
             {"asset": get_current_asset_name()},
             refresh=True
@@ -309,6 +311,8 @@ class LaunchManager(LaunchQtApp):
     _tool_name = "sceneinventory"
 
     def before_window_show(self):
+        if AYON_SERVER_ENABLED:
+            return
         self._window.refresh()
 
 
@@ -320,6 +324,8 @@ class LaunchLibrary(LaunchQtApp):
     _tool_name = "libraryloader"
 
     def before_window_show(self):
+        if AYON_SERVER_ENABLED:
+            return
         self._window.refresh()
 
 
@@ -340,6 +346,8 @@ class LaunchWorkFiles(LaunchQtApp):
         return result
 
     def before_window_show(self):
+        if AYON_SERVER_ENABLED:
+            return
         self._window.root = str(Path(
             os.environ.get("AVALON_WORKDIR", ""),
             os.environ.get("AVALON_SCENEDIR", ""),


### PR DESCRIPTION
## Changelog Description
Skip logic in `before_window_show` in blender when in AYON mode. Most of the stuff called there happes on show automatically.

## Testing notes:
1. Run AYON with openpype addon from this PR
2. Launch blender
3. Try to use tools (workfiles, sceneinventory, loader) in blender
4. They shoud work
