### PR TITLE
Workfiles tool AYON: Fix double click of workfile

### DIFF
--- a/openpype/tools/ayon_workfiles/widgets/files_widget_workarea.py
+++ b/openpype/tools/ayon_workfiles/widgets/files_widget_workarea.py
@@ -334,7 +334,7 @@ class WorkAreaFilesWidget(QtWidgets.QWidget):
 
     def _on_mouse_double_click(self, event):
         if event.button() == QtCore.Qt.LeftButton:
-            self.save_as_requested.emit()
+            self.open_current_requested.emit()
 
     def _on_context_menu(self, point):
         index = self._view.indexAt(point)


### PR DESCRIPTION
## Changelog Description
Fix double click on workfiles in workfiles tool to open the file.

## Additional info
Use `open_current_requested` signal instead of missing `save_as_requested`.

## Testing notes:
1. Open AYON with this PR in openpype addon
2. Launch a DCC
3. Open workfiles tool
4. Double click on a workfile
5. That should open the workfile