### PR TITLE
Webpublisher: removal of usage of no_of_frames in error message

### DIFF
--- a/openpype/hosts/webpublisher/plugins/publish/collect_published_files.py
+++ b/openpype/hosts/webpublisher/plugins/publish/collect_published_files.py
@@ -156,8 +156,7 @@ class CollectPublishedFiles(pyblish.api.ContextPlugin):
                             self.log.debug("frameEnd:: {}".format(
                                 instance.data["frameEnd"]))
                     except Exception:
-                        self.log.warning("Unable to count frames "
-                                         "duration {}".format(no_of_frames))
+                        self.log.warning("Unable to count frames duration.")
 
             instance.data["handleStart"] = asset_doc["data"]["handleStart"]
             instance.data["handleEnd"] = asset_doc["data"]["handleEnd"]


### PR DESCRIPTION
## Changelog Description
If it throws exception, `no_of_frames` value  wont be available, so it doesn't make sense to log it.

## Additional info
This approach is used to limit need to decide if published file is image or video-like. Hopefully exception is fast enough and would be still necessary for rare cases of weird video-likes files.

## Testing notes:
1. setup in WP Settings family 'pointcache' and appropriate non video-like extension (could be .zip)
2. publish file with that extension, it shouldn't fail in `CollectPublishedFiles`
