### PR TITLE
Attribute Defs: Hide multivalue widget in Number by default

### DIFF
--- a/openpype/tools/attribute_defs/widgets.py
+++ b/openpype/tools/attribute_defs/widgets.py
@@ -298,6 +298,7 @@ class NumberAttrWidget(_BaseAttrDefWidget):
         input_widget.installEventFilter(self)
 
         multisel_widget = ClickableLineEdit("< Multiselection >", self)
+        multisel_widget.setVisible(False)
 
         input_widget.valueChanged.connect(self._on_value_change)
         multisel_widget.clicked.connect(self._on_multi_click)


### PR DESCRIPTION
## Changelog Description
Fixed default look of `NumberAttrWidget` by hiding its multiselection widget.

## Screenshot
![image](https://github.com/ynput/OpenPype/assets/43494761/eb1ba600-e1d2-40e1-90a2-39e3fe504e38)
