### PR TITLE
UIDefLabel can be unique

### DIFF
--- a/openpype/lib/attribute_definitions.py
+++ b/openpype/lib/attribute_definitions.py
@@ -243,7 +243,7 @@ class UILabelDef(UIDef):
     def __eq__(self, other):
         if not super(UILabelDef, self).__eq__(other):
             return False
-        return self.label == other.label:
+        return self.label == other.label
 
 
 # ---------------------------------------

--- a/openpype/lib/attribute_definitions.py
+++ b/openpype/lib/attribute_definitions.py
@@ -237,8 +237,8 @@ class UISeparatorDef(UIDef):
 class UILabelDef(UIDef):
     type = "label"
 
-    def __init__(self, label):
-        super(UILabelDef, self).__init__(label=label)
+    def __init__(self, label, key=None):
+        super(UILabelDef, self).__init__(label=label, key=key)
 
     def __eq__(self, other):
         if not super(UILabelDef, self).__eq__(other):

--- a/openpype/lib/attribute_definitions.py
+++ b/openpype/lib/attribute_definitions.py
@@ -240,6 +240,11 @@ class UILabelDef(UIDef):
     def __init__(self, label):
         super(UILabelDef, self).__init__(label=label)
 
+    def __eq__(self, other):
+        if not super(UILabelDef, self).__eq__(other):
+            return False
+        return self.label == other.label:
+
 
 # ---------------------------------------
 # Attribute defintioins should hold value


### PR DESCRIPTION
## Changelog Description
`UILabelDef` have implemented comparison and uniqueness.

## Additional info
Label of the attribute definition is considered when comparing the objects and it is possible to define a key of label to be able differentiate between different objects.

## Additional information
I didn't test the `key`, but it should work.

## Testing notes:
1. Use something like this in create plugin
```python
def get_instance_attr_defs(self):
        return [
            UILabelDef("<b>Header 1</b>"),
            BoolDef("Bool1", label="Boolean 1"),
            UILabelDef("<b>Header 2</b>"),
            BoolDef("Bool2", label="Boolean 2"),
        ]
```
2. Open publisher
3. See the labels in attributes list after creation

Resolves https://github.com/ynput/OpenPype/issues/5797
