### PR TITLE
AYON: Skip kitsu module when creating ayon addons

### DIFF
--- a/openpype/modules/base.py
+++ b/openpype/modules/base.py
@@ -66,6 +66,7 @@ IGNORED_FILENAMES_IN_AYON = {
     "shotgrid",
     "sync_server",
     "slack",
+    "kitsu",
 }
 
 

--- a/server_addon/create_ayon_addons.py
+++ b/server_addon/create_ayon_addons.py
@@ -205,7 +205,8 @@ def create_openpype_package(
         "shotgrid",
         "sync_server",
         "example_addons",
-        "slack"
+        "slack",
+        "kitsu",
     ]
     # Subdirs that won't be added to output zip file
     ignored_subpaths = [


### PR DESCRIPTION
## Changelog Description
Create AYON packages is skipping kitsu module in creation of modules/addons and kitsu module is not loaded from modules on start. The addon already has it's repository https://github.com/ynput/ayon-kitsu.