### PR TITLE
AYON: Use AYON username for user in template data

### DIFF
--- a/openpype/lib/local_settings.py
+++ b/openpype/lib/local_settings.py
@@ -611,6 +611,12 @@ def get_openpype_username():
     settings and last option is to use `getpass.getuser()` which returns
     machine username.
     """
+
+    if AYON_SERVER_ENABLED:
+        import ayon_api
+
+        return ayon_api.get_user()["name"]
+
     username = os.environ.get("OPENPYPE_USERNAME")
     if not username:
         local_settings = get_local_settings()

--- a/openpype/plugins/publish/collect_current_pype_user.py
+++ b/openpype/plugins/publish/collect_current_pype_user.py
@@ -1,4 +1,6 @@
 import pyblish.api
+
+from openpype import AYON_SERVER_ENABLED
 from openpype.lib import get_openpype_username
 
 
@@ -7,7 +9,11 @@ class CollectCurrentUserPype(pyblish.api.ContextPlugin):
 
     # Order must be after default pyblish-base CollectCurrentUser
     order = pyblish.api.CollectorOrder + 0.001
-    label = "Collect Pype User"
+    label = (
+        "Collect AYON User"
+        if AYON_SERVER_ENABLED
+        else "Collect OpenPype User"
+    )
 
     def process(self, context):
         user = get_openpype_username()


### PR DESCRIPTION
## Changelog Description
Use ayon username for template data in AYON mode.

## Testing notes:
1. Use `{user}` in one of anatomy templates
2. Publish
3. The username should be filled in the final path
