### PR TITLE
Fix registering launcher actions from OpenPypeModules

### DIFF
--- a/openpype/modules/launcher_action.py
+++ b/openpype/modules/launcher_action.py
@@ -40,7 +40,7 @@ class LauncherAction(OpenPypeModule, ITrayAction):
         actions_paths = self.manager.collect_plugin_paths()["actions"]
         for path in actions_paths:
             if path and os.path.exists(path):
-                register_launcher_action_path(actions_dir)
+                register_launcher_action_path(path)
 
         paths_str = os.environ.get("AVALON_ACTIONS") or ""
         if paths_str:


### PR DESCRIPTION
## Changelog Description

Fix typo `actions_dir` -> `path` to fix register launcher actions fromm OpenPypeModule

## Additional info

[Issue reported on discord](https://discord.com/channels/517362899170230292/517382145552154634/1168917035355471953)

## Testing notes:
1. Register launcher action from a module with `IPluginPaths` interface in `get_plugin_paths` returning `"actions"` key.
2. Actions should be visible in launcher.

Example registering:
```python
import os

from openpype.modules import OpenPypeAddOn
from openpype.modules.interfaces import IPluginPaths


class MyModule(OpenPypeAddOn, IPluginPaths):
    name = "my_module"

    def get_plugin_paths(self):
        """Implementation of IPluginPaths to get plugin paths."""
        current_dir = os.path.dirname(os.path.abspath(__file__))

        return {
            "actions": [os.path.join(current_dir, "launcher_actions")]
        }
```

Or see [here](https://github.com/BigRoy/OpenPype/blob/colorbleed/openpype/modules/colorbleed/__init__.py#L15).
