### PR TITLE
Chore: Limit current context template data function

### DIFF
--- a/openpype/hosts/houdini/api/lib.py
+++ b/openpype/hosts/houdini/api/lib.py
@@ -11,20 +11,21 @@ import json
 import six
 
 from openpype.lib import StringTemplate
-from openpype.client import get_asset_by_name
+from openpype.client import get_project, get_asset_by_name
 from openpype.settings import get_current_project_settings
 from openpype.pipeline import (
+    Anatomy,
     get_current_project_name,
     get_current_asset_name,
-    registered_host
+    registered_host,
+    get_current_context,
+    get_current_host_name,
 )
-from openpype.pipeline.context_tools import (
-    get_current_context_template_data,
-    get_current_project_asset
-)
+from openpype.pipeline.create import CreateContext
+from openpype.pipeline.template_data import get_template_data
+from openpype.pipeline.context_tools import get_current_project_asset
 from openpype.widgets import popup
 from openpype.tools.utils.host_tools import get_tool_by_name
-from openpype.pipeline.create import CreateContext
 
 import hou
 
@@ -804,6 +805,45 @@ def get_camera_from_container(container):
     return cameras[0]
 
 
+def get_current_context_template_data_with_asset_data():
+    """
+    TODOs:
+        Support both 'assetData' and 'folderData' in future.
+    """
+
+    context = get_current_context()
+    project_name = context["project_name"]
+    asset_name = context["asset_name"]
+    task_name = context["task_name"]
+    host_name = get_current_host_name()
+
+    anatomy = Anatomy(project_name)
+    project_doc = get_project(project_name)
+    asset_doc = get_asset_by_name(project_name, asset_name)
+
+    # get context specific vars
+    asset_data = asset_doc["data"]
+
+    # compute `frameStartHandle` and `frameEndHandle`
+    frame_start = asset_data.get("frameStart")
+    frame_end = asset_data.get("frameEnd")
+    handle_start = asset_data.get("handleStart")
+    handle_end = asset_data.get("handleEnd")
+    if frame_start is not None and handle_start is not None:
+        asset_data["frameStartHandle"] = frame_start - handle_start
+
+    if frame_end is not None and handle_end is not None:
+        asset_data["frameEndHandle"] = frame_end + handle_end
+
+    template_data = get_template_data(
+        project_doc, asset_doc, task_name, host_name
+    )
+    template_data["root"] = anatomy.roots
+    template_data["assetData"] = asset_data
+
+    return template_data
+
+
 def get_context_var_changes():
     """get context var changes."""
 
@@ -823,7 +863,7 @@ def get_context_var_changes():
         return houdini_vars_to_update
 
     # Get Template data
-    template_data = get_current_context_template_data()
+    template_data = get_current_context_template_data_with_asset_data()
 
     # Set Houdini Vars
     for item in houdini_vars:

--- a/openpype/hosts/houdini/api/shelves.py
+++ b/openpype/hosts/houdini/api/shelves.py
@@ -7,9 +7,10 @@ from openpype.settings import get_project_settings
 from openpype.pipeline import get_current_project_name
 
 from openpype.lib import StringTemplate
-from openpype.pipeline.context_tools import get_current_context_template_data
 
 import hou
+
+from .lib import get_current_context_template_data_with_asset_data
 
 log = logging.getLogger("openpype.hosts.houdini.shelves")
 
@@ -30,7 +31,7 @@ def generate_shelves():
         return
 
     # Get Template data
-    template_data = get_current_context_template_data()
+    template_data = get_current_context_template_data_with_asset_data()
 
     for shelf_set_config in shelves_set_config:
         shelf_set_filepath = shelf_set_config.get('shelf_set_source_path')

--- a/openpype/pipeline/context_tools.py
+++ b/openpype/pipeline/context_tools.py
@@ -25,10 +25,7 @@ from openpype.tests.lib import is_in_tests
 
 from .publish.lib import filter_pyblish_plugins
 from .anatomy import Anatomy
-from .template_data import (
-    get_template_data_with_names,
-    get_template_data
-)
+from .template_data import get_template_data_with_names
 from .workfile import (
     get_workfile_template_key,
     get_custom_workfile_template_by_string_context,
@@ -483,6 +480,27 @@ def get_template_data_from_session(session=None, system_settings=None):
     )
 
 
+def get_current_context_template_data(system_settings=None):
+    """Prepare template data for current context.
+
+    Args:
+        system_settings (Optional[Dict[str, Any]]): Prepared system settings.
+
+    Returns:
+        Dict[str, Any] Template data for current context.
+    """
+
+    context = get_current_context()
+    project_name = context["project_name"]
+    asset_name = context["asset_name"]
+    task_name = context["task_name"]
+    host_name = get_current_host_name()
+
+    return get_template_data_with_names(
+        project_name, asset_name, task_name, host_name, system_settings
+    )
+
+
 def get_workdir_from_session(session=None, template_key=None):
     """Template data for template fill from session keys.
 
@@ -661,70 +679,3 @@ def get_process_id():
     if _process_id is None:
         _process_id = str(uuid.uuid4())
     return _process_id
-
-
-def get_current_context_template_data():
-    """Template data for template fill from current context
-
-    Returns:
-        Dict[str, Any] of the following tokens and their values
-        Supported Tokens:
-            - Regular Tokens
-                - app
-                - user
-                - asset
-                - parent
-                - hierarchy
-                - folder[name]
-                - root[work, ...]
-                - studio[code, name]
-                - project[code, name]
-                - task[type, name, short]
-
-            - Context Specific Tokens
-                - assetData[frameStart]
-                - assetData[frameEnd]
-                - assetData[handleStart]
-                - assetData[handleEnd]
-                - assetData[frameStartHandle]
-                - assetData[frameEndHandle]
-                - assetData[resolutionHeight]
-                - assetData[resolutionWidth]
-
-    """
-
-    # pre-prepare get_template_data args
-    current_context = get_current_context()
-    project_name = current_context["project_name"]
-    asset_name = current_context["asset_name"]
-    anatomy = Anatomy(project_name)
-
-    # prepare get_template_data args
-    project_doc = get_project(project_name)
-    asset_doc = get_asset_by_name(project_name, asset_name)
-    task_name = current_context["task_name"]
-    host_name = get_current_host_name()
-
-    # get regular template data
-    template_data = get_template_data(
-        project_doc, asset_doc, task_name, host_name
-    )
-
-    template_data["root"] = anatomy.roots
-
-    # get context specific vars
-    asset_data = asset_doc["data"].copy()
-
-    # compute `frameStartHandle` and `frameEndHandle`
-    if "frameStart" in asset_data and "handleStart" in asset_data:
-        asset_data["frameStartHandle"] = \
-            asset_data["frameStart"] - asset_data["handleStart"]
-
-    if "frameEnd" in asset_data and "handleEnd" in asset_data:
-        asset_data["frameEndHandle"] = \
-            asset_data["frameEnd"] + asset_data["handleEnd"]
-
-    # add assetData
-    template_data["assetData"] = asset_data
-
-    return template_data


### PR DESCRIPTION
## Changelog Description
Current implementation of `get_current_context_template_data` does return the same values as base template data function `get_template_data`.

## Additional info
The previous implementation added few more data that are different from the base, which makes the function "unique" > hard to maintain, especially now with AYON compatibility. Implemented the same functionality in houdini to not break current usage. We can think about adding some of the functionality in the base function, but in separated PR.

## Testing notes:
1. Houdini context change should still update environment variables and shelves correctly.