### PR TITLE
Blender: Fix missing Grease Pencils in review

### DIFF
--- a/openpype/hosts/blender/plugins/publish/collect_review.py
+++ b/openpype/hosts/blender/plugins/publish/collect_review.py
@@ -31,11 +31,12 @@ class CollectReview(pyblish.api.InstancePlugin):
 
         focal_length = cameras[0].data.lens
 
-        # get isolate objects list from meshes instance members .
+        # get isolate objects list from meshes instance members.
+        types = {"MESH", "GPENCIL"}
         isolate_objects = [
             obj
             for obj in instance
-            if isinstance(obj, bpy.types.Object) and obj.type == "MESH"
+            if isinstance(obj, bpy.types.Object) and obj.type in types
         ]
 
         if not instance.data.get("remove"):


### PR DESCRIPTION
## Changelog Description
Fix Grease Pencil missing in review when isolating objects.

## Additional info
When isolating objects for review, the grease pencils objects were excluded. This was supposed to be solved in #5812, but it was missing the case of isolating objects.

## Testing notes:
1. Try creating a review and add an object that include grease pencil to the instance (they must be linked to the review instance collection).
2. Publish the review. The Grease Pencil should be visible.