### PR TITLE
Bigfix: Houdini skip frame_range_validator if node has no 'trange' parameter

### DIFF
--- a/openpype/hosts/houdini/plugins/publish/validate_frame_range.py
+++ b/openpype/hosts/houdini/plugins/publish/validate_frame_range.py
@@ -57,15 +57,17 @@ class ValidateFrameRange(pyblish.api.InstancePlugin):
             return
 
         rop_node = hou.node(instance.data["instance_node"])
+        frame_start = instance.data.get("frameStart")
+        frame_end = instance.data.get("frameEnd")
 
-        if rop_node.parm("trange") is None:
+        if not (frame_start or frame_end):
             cls.log.debug(
-                "Skipping Check, Node has no 'trange' parameter: {}"
-                .format(rop_node.path())
+                "Skipping frame range validation for "
+                "instance without frame data: {}".format(rop_node.path())
             )
             return
 
-        if instance.data["frameStart"] > instance.data["frameEnd"]:
+        if frame_start > frame_end:
             cls.log.info(
                 "The ROP node render range is set to "
                 "{0[frameStartHandle]} - {0[frameEndHandle]} "

--- a/openpype/hosts/houdini/plugins/publish/validate_frame_range.py
+++ b/openpype/hosts/houdini/plugins/publish/validate_frame_range.py
@@ -60,7 +60,7 @@ class ValidateFrameRange(pyblish.api.InstancePlugin):
         frame_start = instance.data.get("frameStart")
         frame_end = instance.data.get("frameEnd")
 
-        if not (frame_start or frame_end):
+        if frame_start is None or frame_end is None:
             cls.log.debug(
                 "Skipping frame range validation for "
                 "instance without frame data: {}".format(rop_node.path())

--- a/openpype/hosts/houdini/plugins/publish/validate_frame_range.py
+++ b/openpype/hosts/houdini/plugins/publish/validate_frame_range.py
@@ -57,6 +57,14 @@ class ValidateFrameRange(pyblish.api.InstancePlugin):
             return
 
         rop_node = hou.node(instance.data["instance_node"])
+
+        if rop_node.parm("trange") is None:
+            cls.log.debug(
+                "Skipping Check, Node has no 'trange' parameter: {}"
+                .format(rop_node.path())
+            )
+            return
+
         if instance.data["frameStart"] > instance.data["frameEnd"]:
             cls.log.info(
                 "The ROP node render range is set to "


### PR DESCRIPTION
## Changelog Description
I faced a bug when publishing HDA instance as it has no `trange` parameter. 
As this PR title says : skip  frame_range_validator  if node has no 'trange' parameter

## Testing notes:
1. publish hda from Houdini, publisher shouldn't complain about frame range.

