### PR TITLE
Ftrack: Events are not processed if project is not available in OpenPype

### DIFF
--- a/openpype/modules/ftrack/event_handlers_server/event_next_task_update.py
+++ b/openpype/modules/ftrack/event_handlers_server/event_next_task_update.py
@@ -1,4 +1,6 @@
 import collections
+
+from openpype.client import get_project
 from openpype_modules.ftrack.lib import BaseEvent
 
 
@@ -99,6 +101,10 @@ class NextTaskUpdate(BaseEvent):
         project_name = self.get_project_name_from_event(
             session, event, project_id
         )
+        if get_project(project_name) is None:
+            self.log.debug("Project not found in OpenPype. Skipping")
+            return
+
         # Load settings
         project_settings = self.get_project_settings_from_event(
             event, project_name

--- a/openpype/modules/ftrack/event_handlers_server/event_push_frame_values_to_task.py
+++ b/openpype/modules/ftrack/event_handlers_server/event_push_frame_values_to_task.py
@@ -3,6 +3,8 @@ import copy
 from typing import Any
 
 import ftrack_api
+
+from openpype.client import get_project
 from openpype_modules.ftrack.lib import (
     BaseEvent,
     query_custom_attributes,
@@ -139,6 +141,10 @@ class PushHierValuesToNonHierEvent(BaseEvent):
         project_name: str = self.get_project_name_from_event(
             session, event, project_id
         )
+        if get_project(project_name) is None:
+            self.log.debug("Project not found in OpenPype. Skipping")
+            return set(), set()
+
         # Load settings
         project_settings: dict[str, Any] = (
             self.get_project_settings_from_event(event, project_name)

--- a/openpype/modules/ftrack/event_handlers_server/event_task_to_parent_status.py
+++ b/openpype/modules/ftrack/event_handlers_server/event_task_to_parent_status.py
@@ -1,4 +1,6 @@
 import collections
+
+from openpype.client import get_project
 from openpype_modules.ftrack.lib import BaseEvent
 
 
@@ -60,6 +62,10 @@ class TaskStatusToParent(BaseEvent):
         project_name = self.get_project_name_from_event(
             session, event, project_id
         )
+        if get_project(project_name) is None:
+            self.log.debug("Project not found in OpenPype. Skipping")
+            return
+
         # Load settings
         project_settings = self.get_project_settings_from_event(
             event, project_name

--- a/openpype/modules/ftrack/event_handlers_server/event_task_to_version_status.py
+++ b/openpype/modules/ftrack/event_handlers_server/event_task_to_version_status.py
@@ -1,4 +1,6 @@
 import collections
+
+from openpype.client import get_project
 from openpype_modules.ftrack.lib import BaseEvent
 
 
@@ -102,6 +104,10 @@ class TaskToVersionStatus(BaseEvent):
         project_name = self.get_project_name_from_event(
             session, event, project_id
         )
+        if get_project(project_name) is None:
+            self.log.debug("Project not found in OpenPype. Skipping")
+            return
+
         # Load settings
         project_settings = self.get_project_settings_from_event(
             event, project_name

--- a/openpype/modules/ftrack/event_handlers_server/event_thumbnail_updates.py
+++ b/openpype/modules/ftrack/event_handlers_server/event_thumbnail_updates.py
@@ -1,4 +1,6 @@
 import collections
+
+from openpype.client import get_project
 from openpype_modules.ftrack.lib import BaseEvent
 
 
@@ -22,6 +24,10 @@ class ThumbnailEvents(BaseEvent):
         project_name = self.get_project_name_from_event(
             session, event, project_id
         )
+        if get_project(project_name) is None:
+            self.log.debug("Project not found in OpenPype. Skipping")
+            return
+
         # Load settings
         project_settings = self.get_project_settings_from_event(
             event, project_name

--- a/openpype/modules/ftrack/event_handlers_server/event_version_to_task_statuses.py
+++ b/openpype/modules/ftrack/event_handlers_server/event_version_to_task_statuses.py
@@ -1,3 +1,4 @@
+from openpype.client import get_project
 from openpype_modules.ftrack.lib import BaseEvent
 
 
@@ -50,6 +51,10 @@ class VersionToTaskStatus(BaseEvent):
         project_name = self.get_project_name_from_event(
             session, event, project_id
         )
+        if get_project(project_name) is None:
+            self.log.debug("Project not found in OpenPype. Skipping")
+            return
+
         # Load settings
         project_settings = self.get_project_settings_from_event(
             event, project_name


### PR DESCRIPTION
## Changelog Description
Events that happened on project which is not in OpenPype is not processed.

## Additional info
We should not run automations on ftrack projects which are not synced to OpenPype.

## Testing notes:
Ftrack project which is not synchronized to OpenPype should not trigger any event handlers.
- sync of hierarchical <> non hierarchical attributes
- task to version / version to task status propagation
- thumbnails updates
- first version status
- next task status