### PR TITLE
Nuke: loaders' containers updating as nodes

### DIFF
--- a/openpype/hosts/nuke/api/pipeline.py
+++ b/openpype/hosts/nuke/api/pipeline.py
@@ -478,8 +478,6 @@ def parse_container(node):
     """
     data = read_avalon_data(node)
 
-    # (TODO) Remove key validation when `ls` has re-implemented.
-    #
     # If not all required data return the empty container
     required = ["schema", "id", "name",
                 "namespace", "loader", "representation"]
@@ -487,7 +485,10 @@ def parse_container(node):
         return
 
     # Store the node's name
-    data["objectName"] = node["name"].value()
+    data.update({
+        "objectName": node.fullName(),
+        "node": node,
+    })
 
     return data
 

--- a/openpype/hosts/nuke/api/plugin.py
+++ b/openpype/hosts/nuke/api/plugin.py
@@ -537,6 +537,7 @@ class NukeLoader(LoaderPlugin):
             node.addKnob(knob)
 
     def clear_members(self, parent_node):
+        parent_class = parent_node.Class()
         members = self.get_members(parent_node)
 
         dependent_nodes = None
@@ -549,6 +550,8 @@ class NukeLoader(LoaderPlugin):
             break
 
         for member in members:
+            if member.Class() == parent_class:
+                continue
             self.log.info("removing node: `{}".format(member.name()))
             nuke.delete(member)
 

--- a/openpype/hosts/nuke/plugins/load/load_backdrop.py
+++ b/openpype/hosts/nuke/plugins/load/load_backdrop.py
@@ -64,8 +64,7 @@ class LoadBackdropNodes(load.LoaderPlugin):
 
         data_imprint = {
             "version": vname,
-            "colorspaceInput": colorspace,
-            "objectName": object_name
+            "colorspaceInput": colorspace
         }
 
         for k in add_keys:
@@ -194,7 +193,7 @@ class LoadBackdropNodes(load.LoaderPlugin):
         version_doc = get_version_by_id(project_name, representation["parent"])
 
         # get corresponding node
-        GN = nuke.toNode(container['objectName'])
+        GN = container["node"]
 
         file = get_representation_path(representation).replace("\\", "/")
 
@@ -207,10 +206,11 @@ class LoadBackdropNodes(load.LoaderPlugin):
 
         add_keys = ["source", "author", "fps"]
 
-        data_imprint = {"representation": str(representation["_id"]),
-                        "version": vname,
-                        "colorspaceInput": colorspace,
-                        "objectName": object_name}
+        data_imprint = {
+            "representation": str(representation["_id"]),
+            "version": vname,
+            "colorspaceInput": colorspace,
+        }
 
         for k in add_keys:
             data_imprint.update({k: version_data[k]})
@@ -252,6 +252,6 @@ class LoadBackdropNodes(load.LoaderPlugin):
         self.update(container, representation)
 
     def remove(self, container):
-        node = nuke.toNode(container['objectName'])
+        node = container["node"]
         with viewer_update_and_undo_stop():
             nuke.delete(node)

--- a/openpype/hosts/nuke/plugins/load/load_camera_abc.py
+++ b/openpype/hosts/nuke/plugins/load/load_camera_abc.py
@@ -48,10 +48,11 @@ class AlembicCameraLoader(load.LoaderPlugin):
         # add additional metadata from the version to imprint to Avalon knob
         add_keys = ["source", "author", "fps"]
 
-        data_imprint = {"frameStart": first,
-                        "frameEnd": last,
-                        "version": vname,
-                        "objectName": object_name}
+        data_imprint = {
+            "frameStart": first,
+            "frameEnd": last,
+            "version": vname,
+        }
 
         for k in add_keys:
             data_imprint.update({k: version_data[k]})
@@ -111,7 +112,7 @@ class AlembicCameraLoader(load.LoaderPlugin):
         project_name = get_current_project_name()
         version_doc = get_version_by_id(project_name, representation["parent"])
 
-        object_name = container['objectName']
+        object_name = container["node"]
 
         # get main variables
         version_data = version_doc.get("data", {})
@@ -124,11 +125,12 @@ class AlembicCameraLoader(load.LoaderPlugin):
         # add additional metadata from the version to imprint to Avalon knob
         add_keys = ["source", "author", "fps"]
 
-        data_imprint = {"representation": str(representation["_id"]),
-                        "frameStart": first,
-                        "frameEnd": last,
-                        "version": vname,
-                        "objectName": object_name}
+        data_imprint = {
+            "representation": str(representation["_id"]),
+            "frameStart": first,
+            "frameEnd": last,
+            "version": vname
+        }
 
         for k in add_keys:
             data_imprint.update({k: version_data[k]})
@@ -194,6 +196,6 @@ class AlembicCameraLoader(load.LoaderPlugin):
         self.update(container, representation)
 
     def remove(self, container):
-        node = nuke.toNode(container['objectName'])
+        node = container["node"]
         with viewer_update_and_undo_stop():
             nuke.delete(node)

--- a/openpype/hosts/nuke/plugins/load/load_clip.py
+++ b/openpype/hosts/nuke/plugins/load/load_clip.py
@@ -299,9 +299,6 @@ class LoadClip(plugin.NukeLoader):
                 "Representation id `{}` is failing to load".format(repre_id))
             return
 
-        read_name = self._get_node_name(representation)
-
-        read_node["name"].setValue(read_name)
         read_node["file"].setValue(filepath)
 
         # to avoid multiple undo steps for rest of process

--- a/openpype/hosts/nuke/plugins/load/load_clip.py
+++ b/openpype/hosts/nuke/plugins/load/load_clip.py
@@ -189,8 +189,6 @@ class LoadClip(plugin.NukeLoader):
                         value_ = value_.replace("\\", "/")
                     data_imprint[key] = value_
 
-            data_imprint["objectName"] = read_name
-
             if add_retime and version_data.get("retime", None):
                 data_imprint["addRetime"] = True
 
@@ -254,7 +252,7 @@ class LoadClip(plugin.NukeLoader):
 
         is_sequence = len(representation["files"]) > 1
 
-        read_node = nuke.toNode(container['objectName'])
+        read_node = container["node"]
 
         if is_sequence:
             representation = self._representation_with_hash_in_frame(
@@ -353,7 +351,7 @@ class LoadClip(plugin.NukeLoader):
         self.set_as_member(read_node)
 
     def remove(self, container):
-        read_node = nuke.toNode(container['objectName'])
+        read_node = container["node"]
         assert read_node.Class() == "Read", "Must be Read"
 
         with viewer_update_and_undo_stop():

--- a/openpype/hosts/nuke/plugins/load/load_effects.py
+++ b/openpype/hosts/nuke/plugins/load/load_effects.py
@@ -62,11 +62,12 @@ class LoadEffects(load.LoaderPlugin):
         add_keys = ["frameStart", "frameEnd", "handleStart", "handleEnd",
                     "source", "author", "fps"]
 
-        data_imprint = {"frameStart": first,
-                        "frameEnd": last,
-                        "version": vname,
-                        "colorspaceInput": colorspace,
-                        "objectName": object_name}
+        data_imprint = {
+            "frameStart": first,
+            "frameEnd": last,
+            "version": vname,
+            "colorspaceInput": colorspace,
+        }
 
         for k in add_keys:
             data_imprint.update({k: version_data[k]})
@@ -159,7 +160,7 @@ class LoadEffects(load.LoaderPlugin):
         version_doc = get_version_by_id(project_name, representation["parent"])
 
         # get corresponding node
-        GN = nuke.toNode(container['objectName'])
+        GN = container["node"]
 
         file = get_representation_path(representation).replace("\\", "/")
         name = container['name']
@@ -175,12 +176,13 @@ class LoadEffects(load.LoaderPlugin):
         add_keys = ["frameStart", "frameEnd", "handleStart", "handleEnd",
                     "source", "author", "fps"]
 
-        data_imprint = {"representation": str(representation["_id"]),
-                        "frameStart": first,
-                        "frameEnd": last,
-                        "version": vname,
-                        "colorspaceInput": colorspace,
-                        "objectName": object_name}
+        data_imprint = {
+            "representation": str(representation["_id"]),
+            "frameStart": first,
+            "frameEnd": last,
+            "version": vname,
+            "colorspaceInput": colorspace
+        }
 
         for k in add_keys:
             data_imprint.update({k: version_data[k]})
@@ -212,7 +214,7 @@ class LoadEffects(load.LoaderPlugin):
             pre_node = nuke.createNode("Input")
             pre_node["name"].setValue("rgb")
 
-            for ef_name, ef_val in nodes_order.items():
+            for _, ef_val in nodes_order.items():
                 node = nuke.createNode(ef_val["class"])
                 for k, v in ef_val["node"].items():
                     if k in self.ignore_attr:
@@ -346,6 +348,6 @@ class LoadEffects(load.LoaderPlugin):
         self.update(container, representation)
 
     def remove(self, container):
-        node = nuke.toNode(container['objectName'])
+        node = container["node"]
         with viewer_update_and_undo_stop():
             nuke.delete(node)

--- a/openpype/hosts/nuke/plugins/load/load_effects_ip.py
+++ b/openpype/hosts/nuke/plugins/load/load_effects_ip.py
@@ -63,11 +63,12 @@ class LoadEffectsInputProcess(load.LoaderPlugin):
         add_keys = ["frameStart", "frameEnd", "handleStart", "handleEnd",
                     "source", "author", "fps"]
 
-        data_imprint = {"frameStart": first,
-                        "frameEnd": last,
-                        "version": vname,
-                        "colorspaceInput": colorspace,
-                        "objectName": object_name}
+        data_imprint = {
+            "frameStart": first,
+            "frameEnd": last,
+            "version": vname,
+            "colorspaceInput": colorspace,
+        }
 
         for k in add_keys:
             data_imprint.update({k: version_data[k]})
@@ -98,7 +99,7 @@ class LoadEffectsInputProcess(load.LoaderPlugin):
             pre_node = nuke.createNode("Input")
             pre_node["name"].setValue("rgb")
 
-            for ef_name, ef_val in nodes_order.items():
+            for _, ef_val in nodes_order.items():
                 node = nuke.createNode(ef_val["class"])
                 for k, v in ef_val["node"].items():
                     if k in self.ignore_attr:
@@ -164,28 +165,26 @@ class LoadEffectsInputProcess(load.LoaderPlugin):
         version_doc = get_version_by_id(project_name, representation["parent"])
 
         # get corresponding node
-        GN = nuke.toNode(container['objectName'])
+        GN = container["node"]
 
         file = get_representation_path(representation).replace("\\", "/")
-        name = container['name']
         version_data = version_doc.get("data", {})
         vname = version_doc.get("name", None)
         first = version_data.get("frameStart", None)
         last = version_data.get("frameEnd", None)
         workfile_first_frame = int(nuke.root()["first_frame"].getValue())
-        namespace = container['namespace']
         colorspace = version_data.get("colorspace", None)
-        object_name = "{}_{}".format(name, namespace)
 
         add_keys = ["frameStart", "frameEnd", "handleStart", "handleEnd",
                     "source", "author", "fps"]
 
-        data_imprint = {"representation": str(representation["_id"]),
-                        "frameStart": first,
-                        "frameEnd": last,
-                        "version": vname,
-                        "colorspaceInput": colorspace,
-                        "objectName": object_name}
+        data_imprint = {
+            "representation": str(representation["_id"]),
+            "frameStart": first,
+            "frameEnd": last,
+            "version": vname,
+            "colorspaceInput": colorspace,
+        }
 
         for k in add_keys:
             data_imprint.update({k: version_data[k]})
@@ -217,7 +216,7 @@ class LoadEffectsInputProcess(load.LoaderPlugin):
             pre_node = nuke.createNode("Input")
             pre_node["name"].setValue("rgb")
 
-            for ef_name, ef_val in nodes_order.items():
+            for _, ef_val in nodes_order.items():
                 node = nuke.createNode(ef_val["class"])
                 for k, v in ef_val["node"].items():
                     if k in self.ignore_attr:
@@ -250,11 +249,6 @@ class LoadEffectsInputProcess(load.LoaderPlugin):
             # create output node
             output = nuke.createNode("Output")
             output.setInput(0, pre_node)
-
-        # # try to place it under Viewer1
-        # if not self.connect_active_viewer(GN):
-        #     nuke.delete(GN)
-        #     return
 
         # get all versions in list
         last_version_doc = get_last_version_by_subset_id(
@@ -365,6 +359,6 @@ class LoadEffectsInputProcess(load.LoaderPlugin):
         self.update(container, representation)
 
     def remove(self, container):
-        node = nuke.toNode(container['objectName'])
+        node = container["node"]
         with viewer_update_and_undo_stop():
             nuke.delete(node)

--- a/openpype/hosts/nuke/plugins/load/load_gizmo.py
+++ b/openpype/hosts/nuke/plugins/load/load_gizmo.py
@@ -64,11 +64,12 @@ class LoadGizmo(load.LoaderPlugin):
         add_keys = ["frameStart", "frameEnd", "handleStart", "handleEnd",
                     "source", "author", "fps"]
 
-        data_imprint = {"frameStart": first,
-                        "frameEnd": last,
-                        "version": vname,
-                        "colorspaceInput": colorspace,
-                        "objectName": object_name}
+        data_imprint = {
+            "frameStart": first,
+            "frameEnd": last,
+            "version": vname,
+            "colorspaceInput": colorspace
+        }
 
         for k in add_keys:
             data_imprint.update({k: version_data[k]})
@@ -111,7 +112,7 @@ class LoadGizmo(load.LoaderPlugin):
         version_doc = get_version_by_id(project_name, representation["parent"])
 
         # get corresponding node
-        group_node = nuke.toNode(container['objectName'])
+        group_node = container["node"]
 
         file = get_representation_path(representation).replace("\\", "/")
         name = container['name']
@@ -126,12 +127,13 @@ class LoadGizmo(load.LoaderPlugin):
         add_keys = ["frameStart", "frameEnd", "handleStart", "handleEnd",
                     "source", "author", "fps"]
 
-        data_imprint = {"representation": str(representation["_id"]),
-                        "frameStart": first,
-                        "frameEnd": last,
-                        "version": vname,
-                        "colorspaceInput": colorspace,
-                        "objectName": object_name}
+        data_imprint = {
+            "representation": str(representation["_id"]),
+            "frameStart": first,
+            "frameEnd": last,
+            "version": vname,
+            "colorspaceInput": colorspace
+        }
 
         for k in add_keys:
             data_imprint.update({k: version_data[k]})
@@ -175,6 +177,6 @@ class LoadGizmo(load.LoaderPlugin):
         self.update(container, representation)
 
     def remove(self, container):
-        node = nuke.toNode(container['objectName'])
+        node = container["node"]
         with viewer_update_and_undo_stop():
             nuke.delete(node)

--- a/openpype/hosts/nuke/plugins/load/load_gizmo_ip.py
+++ b/openpype/hosts/nuke/plugins/load/load_gizmo_ip.py
@@ -66,11 +66,12 @@ class LoadGizmoInputProcess(load.LoaderPlugin):
         add_keys = ["frameStart", "frameEnd", "handleStart", "handleEnd",
                     "source", "author", "fps"]
 
-        data_imprint = {"frameStart": first,
-                        "frameEnd": last,
-                        "version": vname,
-                        "colorspaceInput": colorspace,
-                        "objectName": object_name}
+        data_imprint = {
+            "frameStart": first,
+            "frameEnd": last,
+            "version": vname,
+            "colorspaceInput": colorspace
+        }
 
         for k in add_keys:
             data_imprint.update({k: version_data[k]})
@@ -118,7 +119,7 @@ class LoadGizmoInputProcess(load.LoaderPlugin):
         version_doc = get_version_by_id(project_name, representation["parent"])
 
         # get corresponding node
-        group_node = nuke.toNode(container['objectName'])
+        group_node = container["node"]
 
         file = get_representation_path(representation).replace("\\", "/")
         name = container['name']
@@ -133,12 +134,13 @@ class LoadGizmoInputProcess(load.LoaderPlugin):
         add_keys = ["frameStart", "frameEnd", "handleStart", "handleEnd",
                     "source", "author", "fps"]
 
-        data_imprint = {"representation": str(representation["_id"]),
-                        "frameStart": first,
-                        "frameEnd": last,
-                        "version": vname,
-                        "colorspaceInput": colorspace,
-                        "objectName": object_name}
+        data_imprint = {
+            "representation": str(representation["_id"]),
+            "frameStart": first,
+            "frameEnd": last,
+            "version": vname,
+            "colorspaceInput": colorspace
+        }
 
         for k in add_keys:
             data_imprint.update({k: version_data[k]})
@@ -256,6 +258,6 @@ class LoadGizmoInputProcess(load.LoaderPlugin):
         self.update(container, representation)
 
     def remove(self, container):
-        node = nuke.toNode(container['objectName'])
+        node = container["node"]
         with viewer_update_and_undo_stop():
             nuke.delete(node)

--- a/openpype/hosts/nuke/plugins/load/load_image.py
+++ b/openpype/hosts/nuke/plugins/load/load_image.py
@@ -146,8 +146,6 @@ class LoadImage(load.LoaderPlugin):
                     data_imprint.update(
                         {k: context["version"]['data'].get(k, str(None))})
 
-            data_imprint.update({"objectName": read_name})
-
             r["tile_color"].setValue(int("0x4ecd25ff", 16))
 
             return containerise(r,
@@ -168,7 +166,7 @@ class LoadImage(load.LoaderPlugin):
         inputs:
 
         """
-        node = nuke.toNode(container["objectName"])
+        node = container["node"]
         frame_number = node["first"].value()
 
         assert node.Class() == "Read", "Must be Read"
@@ -237,7 +235,7 @@ class LoadImage(load.LoaderPlugin):
         self.log.info("updated to version: {}".format(version_doc.get("name")))
 
     def remove(self, container):
-        node = nuke.toNode(container['objectName'])
+        node = container["node"]
         assert node.Class() == "Read", "Must be Read"
 
         with viewer_update_and_undo_stop():

--- a/openpype/hosts/nuke/plugins/load/load_model.py
+++ b/openpype/hosts/nuke/plugins/load/load_model.py
@@ -46,10 +46,11 @@ class AlembicModelLoader(load.LoaderPlugin):
         # add additional metadata from the version to imprint to Avalon knob
         add_keys = ["source", "author", "fps"]
 
-        data_imprint = {"frameStart": first,
-                        "frameEnd": last,
-                        "version": vname,
-                        "objectName": object_name}
+        data_imprint = {
+            "frameStart": first,
+            "frameEnd": last,
+            "version": vname
+        }
 
         for k in add_keys:
             data_imprint.update({k: version_data[k]})
@@ -114,9 +115,9 @@ class AlembicModelLoader(load.LoaderPlugin):
         # Get version from io
         project_name = get_current_project_name()
         version_doc = get_version_by_id(project_name, representation["parent"])
-        object_name = container['objectName']
+
         # get corresponding node
-        model_node = nuke.toNode(object_name)
+        model_node = container["node"]
 
         # get main variables
         version_data = version_doc.get("data", {})
@@ -129,11 +130,12 @@ class AlembicModelLoader(load.LoaderPlugin):
         # add additional metadata from the version to imprint to Avalon knob
         add_keys = ["source", "author", "fps"]
 
-        data_imprint = {"representation": str(representation["_id"]),
-                        "frameStart": first,
-                        "frameEnd": last,
-                        "version": vname,
-                        "objectName": object_name}
+        data_imprint = {
+            "representation": str(representation["_id"]),
+            "frameStart": first,
+            "frameEnd": last,
+            "version": vname
+        }
 
         for k in add_keys:
             data_imprint.update({k: version_data[k]})
@@ -142,7 +144,6 @@ class AlembicModelLoader(load.LoaderPlugin):
         file = get_representation_path(representation).replace("\\", "/")
 
         with maintained_selection():
-            model_node = nuke.toNode(object_name)
             model_node['selected'].setValue(True)
 
             # collect input output dependencies
@@ -163,8 +164,10 @@ class AlembicModelLoader(load.LoaderPlugin):
             ypos = model_node.ypos()
             nuke.nodeCopy("%clipboard%")
             nuke.delete(model_node)
+
+            # paste the node back and set the position
             nuke.nodePaste("%clipboard%")
-            model_node = nuke.toNode(object_name)
+            model_node = nuke.selectedNode()
             model_node.setXYpos(xpos, ypos)
 
             # link to original input nodes

--- a/openpype/hosts/nuke/plugins/load/load_ociolook.py
+++ b/openpype/hosts/nuke/plugins/load/load_ociolook.py
@@ -55,7 +55,7 @@ class LoadOcioLookNodes(load.LoaderPlugin):
         """
         namespace = namespace or context['asset']['name']
         suffix = secrets.token_hex(nbytes=4)
-        object_name = "{}_{}_{}".format(
+        node_name = "{}_{}_{}".format(
             name, namespace, suffix)
 
         # getting file path
@@ -64,7 +64,9 @@ class LoadOcioLookNodes(load.LoaderPlugin):
         json_f = self._load_json_data(filepath)
 
         group_node = self._create_group_node(
-            object_name, filepath, json_f["data"])
+            filepath, json_f["data"])
+        # renaming group node
+        group_node["name"].setValue(node_name)
 
         self._node_version_color(context["version"], group_node)
 
@@ -76,17 +78,14 @@ class LoadOcioLookNodes(load.LoaderPlugin):
             name=name,
             namespace=namespace,
             context=context,
-            loader=self.__class__.__name__,
-            data={
-                "objectName": object_name,
-            }
+            loader=self.__class__.__name__
         )
 
     def _create_group_node(
         self,
-        object_name,
         filepath,
-        data
+        data,
+        group_node=None
     ):
         """Creates group node with all the nodes inside.
 
@@ -94,9 +93,9 @@ class LoadOcioLookNodes(load.LoaderPlugin):
         in between - in case those are needed.
 
         Arguments:
-            object_name (str): name of the group node
             filepath (str): path to json file
             data (dict): data from json file
+            group_node (Optional[nuke.Node]): group node or None
 
         Returns:
             nuke.Node: group node with all the nodes inside
@@ -117,7 +116,6 @@ class LoadOcioLookNodes(load.LoaderPlugin):
 
         input_node = None
         output_node = None
-        group_node = nuke.toNode(object_name)
         if group_node:
             # remove all nodes between Input and Output nodes
             for node in group_node.nodes():
@@ -130,7 +128,6 @@ class LoadOcioLookNodes(load.LoaderPlugin):
         else:
             group_node = nuke.createNode(
                 "Group",
-                "name {}_1".format(object_name),
                 inpanel=False
             )
 
@@ -227,16 +224,16 @@ class LoadOcioLookNodes(load.LoaderPlugin):
         project_name = get_current_project_name()
         version_doc = get_version_by_id(project_name, representation["parent"])
 
-        object_name = container['objectName']
+        group_node = container["node"]
 
         filepath = get_representation_path(representation)
 
         json_f = self._load_json_data(filepath)
 
         group_node = self._create_group_node(
-            object_name,
             filepath,
-            json_f["data"]
+            json_f["data"],
+            group_node
         )
 
         self._node_version_color(version_doc, group_node)

--- a/openpype/hosts/nuke/plugins/load/load_script_precomp.py
+++ b/openpype/hosts/nuke/plugins/load/load_script_precomp.py
@@ -46,8 +46,6 @@ class LinkAsGroup(load.LoaderPlugin):
         file = self.filepath_from_context(context).replace("\\", "/")
         self.log.info("file: {}\n".format(file))
 
-        precomp_name = context["representation"]["context"]["subset"]
-
         self.log.info("versionData: {}\n".format(context["version"]["data"]))
 
         # add additional metadata from the version to imprint to Avalon knob
@@ -62,7 +60,6 @@ class LinkAsGroup(load.LoaderPlugin):
         }
         for k in add_keys:
             data_imprint.update({k: context["version"]['data'][k]})
-        data_imprint.update({"objectName": precomp_name})
 
         # group context is set to precomp, so back up one level.
         nuke.endGroup()
@@ -118,7 +115,7 @@ class LinkAsGroup(load.LoaderPlugin):
         inputs:
 
         """
-        node = nuke.toNode(container['objectName'])
+        node = container["node"]
 
         root = get_representation_path(representation).replace("\\", "/")
 
@@ -159,6 +156,6 @@ class LinkAsGroup(load.LoaderPlugin):
         self.log.info("updated to version: {}".format(version_doc.get("name")))
 
     def remove(self, container):
-        node = nuke.toNode(container['objectName'])
+        node = container["node"]
         with viewer_update_and_undo_stop():
             nuke.delete(node)


### PR DESCRIPTION
## Changelog Description
Nuke loaded containers are updating correctly even they have been duplicating of originally loaded nodes. This had previously been removed duplicated nodes.

## Additional info
- containers are now having `node` key
- container `objectName` is now full path so there is not mistake in nested nodes with the same name
- all loaders had to be updated to access `node` rather then `objectName`

## Testing notes:
1. Nuke leaders' needs to be tested with Loading of all possible product types and also updating to newer versions. 
2. Ideally, test to duplicate node in the graph and update them too.
