### PR TITLE
Nuke: Add Nuke 11.0 as default setting

### DIFF
--- a/openpype/settings/defaults/system_settings/applications.json
+++ b/openpype/settings/defaults/system_settings/applications.json
@@ -344,13 +344,30 @@
                 },
                 "environment": {}
             },
+            "11-0": {
+                "use_python_2": true,
+                "executables": {
+                    "windows": [
+                        "C:\\Program Files\\Nuke11.0v4\\Nuke11.0.exe"
+                    ],
+                    "darwin": [],
+                    "linux": []
+                },
+                "arguments": {
+                    "windows": [],
+                    "darwin": [],
+                    "linux": []
+                },
+                "environment": {}
+            },
             "__dynamic_keys_labels__": {
                 "13-2": "13.2",
                 "13-0": "13.0",
                 "12-2": "12.2",
                 "12-0": "12.0",
                 "11-3": "11.3",
-                "11-2": "11.2"
+                "11-2": "11.2",
+                "11-0": "11.0"
             }
         }
     },


### PR DESCRIPTION
## Changelog Description
Found I needed Nuke 11.0 in the default settings to help with unit testing.

## Testing notes:
1. Only install Nuke 11.0v4 on the machine.
2. Run testing suite.
