### PR TITLE
Houdini: Remove on instance toggled callback

### DIFF
--- a/openpype/hosts/houdini/api/pipeline.py
+++ b/openpype/hosts/houdini/api/pipeline.py
@@ -3,7 +3,6 @@
 import os
 import sys
 import logging
-import contextlib
 
 import hou  # noqa
 
@@ -65,10 +64,6 @@ class HoudiniHost(HostBase, IWorkfileHost, ILoadHost, IPublishHost):
         register_event_callback("save", on_save)
         register_event_callback("open", on_open)
         register_event_callback("new", on_new)
-
-        pyblish.api.register_callback(
-            "instanceToggled", on_pyblish_instance_toggled
-        )
 
         self._has_been_setup = True
         # add houdini vendor packages
@@ -406,54 +401,3 @@ def _set_context_settings():
 
     lib.reset_framerange()
     lib.update_houdini_vars_context()
-
-
-def on_pyblish_instance_toggled(instance, new_value, old_value):
-    """Toggle saver tool passthrough states on instance toggles."""
-    @contextlib.contextmanager
-    def main_take(no_update=True):
-        """Enter root take during context"""
-        original_take = hou.takes.currentTake()
-        original_update_mode = hou.updateModeSetting()
-        root = hou.takes.rootTake()
-        has_changed = False
-        try:
-            if original_take != root:
-                has_changed = True
-                if no_update:
-                    hou.setUpdateMode(hou.updateMode.Manual)
-                hou.takes.setCurrentTake(root)
-                yield
-        finally:
-            if has_changed:
-                if no_update:
-                    hou.setUpdateMode(original_update_mode)
-                hou.takes.setCurrentTake(original_take)
-
-    if not instance.data.get("_allowToggleBypass", True):
-        return
-
-    nodes = instance[:]
-    if not nodes:
-        return
-
-    # Assume instance node is first node
-    instance_node = nodes[0]
-
-    if not hasattr(instance_node, "isBypassed"):
-        # Likely not a node that can actually be bypassed
-        log.debug("Can't bypass node: %s", instance_node.path())
-        return
-
-    if instance_node.isBypassed() != (not old_value):
-        print("%s old bypass state didn't match old instance state, "
-              "updating anyway.." % instance_node.path())
-
-    try:
-        # Go into the main take, because when in another take changing
-        # the bypass state of a note cannot be done due to it being locked
-        # by default.
-        with main_take(no_update=True):
-            instance_node.bypass(not new_value)
-    except hou.PermissionError as exc:
-        log.warning("%s - %s", instance_node.path(), exc)

--- a/openpype/hosts/houdini/plugins/publish/collect_instances_usd_layered.py
+++ b/openpype/hosts/houdini/plugins/publish/collect_instances_usd_layered.py
@@ -122,10 +122,6 @@ class CollectInstancesUsdLayered(pyblish.api.ContextPlugin):
                 instance.data.update(save_data)
                 instance.data["usdLayer"] = layer
 
-                # Don't allow the Pyblish `instanceToggled` we have installed
-                # to set this node to bypass.
-                instance.data["_allowToggleBypass"] = False
-
                 instances.append(instance)
 
         # Store the collected ROP node dependencies


### PR DESCRIPTION
## Changelog Description

Remove on instance toggled callback which isn't relevant to the new publisher

## Additional info

As far as I know this does nothing in the new publisher.

## Testing notes:

1. Use publisher
2. Toggling instances should still work as intended
