### PR TITLE
Chore: Remove unused `instanceToggled` callbacks

### DIFF
--- a/openpype/hosts/aftereffects/api/pipeline.py
+++ b/openpype/hosts/aftereffects/api/pipeline.py
@@ -74,11 +74,6 @@ class AfterEffectsHost(HostBase, IWorkfileHost, ILoadHost, IPublishHost):
 
         register_loader_plugin_path(LOAD_PATH)
         register_creator_plugin_path(CREATE_PATH)
-        log.info(PUBLISH_PATH)
-
-        pyblish.api.register_callback(
-            "instanceToggled", on_pyblish_instance_toggled
-        )
 
         register_event_callback("application.launched", application_launch)
 
@@ -184,11 +179,6 @@ class AfterEffectsHost(HostBase, IWorkfileHost, ILoadHost, IPublishHost):
 def application_launch():
     """Triggered after start of app"""
     check_inventory()
-
-
-def on_pyblish_instance_toggled(instance, old_value, new_value):
-    """Toggle layer visibility on instance toggles."""
-    instance[0].Visible = new_value
 
 
 def ls():

--- a/openpype/hosts/nuke/api/pipeline.py
+++ b/openpype/hosts/nuke/api/pipeline.py
@@ -129,9 +129,6 @@ class NukeHost(
         register_event_callback("workio.open_file", check_inventory_versions)
         register_event_callback("taskChanged", change_context_label)
 
-        pyblish.api.register_callback(
-            "instanceToggled", on_pyblish_instance_toggled)
-
         _install_menu()
 
         # add script menu
@@ -400,25 +397,6 @@ def add_shortcuts_from_presets():
                 menuitem.setShortcut(shortcut_str)
             except (AttributeError, KeyError) as e:
                 log.error(e)
-
-
-def on_pyblish_instance_toggled(instance, old_value, new_value):
-    """Toggle node passthrough states on instance toggles."""
-
-    log.info("instance toggle: {}, old_value: {}, new_value:{} ".format(
-        instance, old_value, new_value))
-
-    # Whether instances should be passthrough based on new value
-
-    with viewer_update_and_undo_stop():
-        n = instance[0]
-        try:
-            n["publish"].value()
-        except ValueError:
-            n = add_publish_knob(n)
-            log.info(" `Publish` knob was added to write node..")
-
-        n["publish"].setValue(new_value)
 
 
 def containerise(node,

--- a/openpype/hosts/photoshop/api/pipeline.py
+++ b/openpype/hosts/photoshop/api/pipeline.py
@@ -48,11 +48,6 @@ class PhotoshopHost(HostBase, IWorkfileHost, ILoadHost, IPublishHost):
         pyblish.api.register_plugin_path(PUBLISH_PATH)
         register_loader_plugin_path(LOAD_PATH)
         register_creator_plugin_path(CREATE_PATH)
-        log.info(PUBLISH_PATH)
-
-        pyblish.api.register_callback(
-            "instanceToggled", on_pyblish_instance_toggled
-        )
 
         register_event_callback("application.launched", on_application_launch)
 
@@ -175,11 +170,6 @@ def check_inventory():
 
 def on_application_launch():
     check_inventory()
-
-
-def on_pyblish_instance_toggled(instance, old_value, new_value):
-    """Toggle layer visibility on instance toggles."""
-    instance[0].Visible = new_value
 
 
 def ls():

--- a/openpype/hosts/tvpaint/api/pipeline.py
+++ b/openpype/hosts/tvpaint/api/pipeline.py
@@ -84,10 +84,6 @@ class TVPaintHost(HostBase, IWorkfileHost, ILoadHost, IPublishHost):
         register_loader_plugin_path(load_dir)
         register_creator_plugin_path(create_dir)
 
-        registered_callbacks = (
-            pyblish.api.registered_callbacks().get("instanceToggled") or []
-        )
-
         register_event_callback("application.launched", self.initial_launch)
         register_event_callback("application.exit", self.application_exit)
 


### PR DESCRIPTION
## Changelog Description

The `instanceToggled` callbacks should be irrelevant for new publisher.

## Additional info

Similar to PR #5860 but for [other hosts than Houdini as described here](https://github.com/ynput/OpenPype/pull/5860#issuecomment-1791728692).

## Testing notes:

1. Publishing from these hosts should still work

- [x] After Effects
- [x] Photoshop
- [x] Nuke
- [x] TVPaint