### PR TITLE
Blender: Fix loading of blend layouts

### DIFF
--- a/openpype/hosts/blender/plugins/load/load_blend.py
+++ b/openpype/hosts/blender/plugins/load/load_blend.py
@@ -32,7 +32,7 @@ class BlendLoader(plugin.AssetLoader):
         empties = [obj for obj in objects if obj.type == 'EMPTY']
 
         for empty in empties:
-            if empty.get(AVALON_PROPERTY):
+            if empty.get(AVALON_PROPERTY) and empty.parent is None:
                 return empty
 
         return None
@@ -90,6 +90,7 @@ class BlendLoader(plugin.AssetLoader):
                 members.append(data)
 
         container = self._get_asset_container(data_to.objects)
+        print(container)
         assert container, "No asset group found"
 
         container.name = group_name
@@ -100,7 +101,10 @@ class BlendLoader(plugin.AssetLoader):
 
         # Link all the container children to the collection
         for obj in container.children_recursive:
+            print(obj)
             bpy.context.scene.collection.objects.link(obj)
+
+        print("")
 
         # Remove the library from the blend file
         library = bpy.data.libraries.get(bpy.path.basename(libpath))


### PR DESCRIPTION
## Changelog Description
Fix a problem with loading blend layouts.

## Additional info
There was a missing condition when loading blend layout to find the asset group in the published blend file. For this reason, the wrong object was picked up as the asset group, and the rest of the layout wasn't loaded properly.

## Testing notes:
1. Publish a layout that includes loaded assets.
2. Load it, it should be loaded properly.