### PR TITLE
Testing: app_group flag

### DIFF
--- a/openpype/cli.py
+++ b/openpype/cli.py
@@ -282,6 +282,9 @@ def run(script):
               "--app_variant",
               help="Provide specific app variant for test, empty for latest",
               default=None)
+@click.option("--app_group",
+              help="Provide specific app group for test, empty for default",
+              default=None)
 @click.option("-t",
               "--timeout",
               help="Provide specific timeout value for test case",
@@ -294,11 +297,11 @@ def run(script):
               help="MongoDB for testing.",
               default=None)
 def runtests(folder, mark, pyargs, test_data_folder, persist, app_variant,
-             timeout, setup_only, mongo_url):
+             timeout, setup_only, mongo_url, app_group):
     """Run all automatic tests after proper initialization via start.py"""
     PypeCommands().run_tests(folder, mark, pyargs, test_data_folder,
                              persist, app_variant, timeout, setup_only,
-                             mongo_url)
+                             mongo_url, app_group)
 
 
 @main.command(help="DEPRECATED - run sync server")

--- a/openpype/pype_commands.py
+++ b/openpype/pype_commands.py
@@ -214,7 +214,7 @@ class PypeCommands:
 
     def run_tests(self, folder, mark, pyargs,
                   test_data_folder, persist, app_variant, timeout, setup_only,
-                  mongo_url):
+                  mongo_url, app_group):
         """
             Runs tests from 'folder'
 
@@ -259,6 +259,9 @@ class PypeCommands:
 
         if persist:
             args.extend(["--persist", persist])
+
+        if app_group:
+            args.extend(["--app_group", app_group])
 
         if app_variant:
             args.extend(["--app_variant", app_variant])

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -15,6 +15,11 @@ def pytest_addoption(parser):
     )
 
     parser.addoption(
+        "--app_group", action="store", default=None,
+        help="Keep empty to use default application or explicit"
+    )
+
+    parser.addoption(
         "--app_variant", action="store", default=None,
         help="Keep empty to locate latest installed variant or explicit"
     )
@@ -43,6 +48,11 @@ def test_data_folder(request):
 @pytest.fixture(scope="module")
 def persist(request):
     return request.config.getoption("--persist")
+
+
+@pytest.fixture(scope="module")
+def app_group(request):
+    return request.config.getoption("--app_group")
 
 
 @pytest.fixture(scope="module")

--- a/tests/lib/testing_classes.py
+++ b/tests/lib/testing_classes.py
@@ -248,19 +248,22 @@ class PublishTest(ModuleUnitTest):
     SETUP_ONLY = False
 
     @pytest.fixture(scope="module")
-    def app_name(self, app_variant):
+    def app_name(self, app_variant, app_group):
         """Returns calculated value for ApplicationManager. Eg.(nuke/12-2)"""
         from openpype.lib import ApplicationManager
         app_variant = app_variant or self.APP_VARIANT
+        app_group = app_group or self.APP_GROUP
 
         application_manager = ApplicationManager()
         if not app_variant:
             variant = (
                 application_manager.find_latest_available_variant_for_group(
-                    self.APP_GROUP))
+                    app_group
+                )
+            )
             app_variant = variant.name
 
-        yield "{}/{}".format(self.APP_GROUP, app_variant)
+        yield "{}/{}".format(app_group, app_variant)
 
     @pytest.fixture(scope="module")
     def app_args(self, download_test_data):


### PR DESCRIPTION
## Changelog Description
`app_group` command flag. This is for changing which flavour of the host to launch. In the case of Maya, you can launch Maya and MayaPy, but it can be used for the Nuke family as well.

Split from #5644

## Testing notes:
```
.\openpype_console.bat runtests C:\Users\tokejepsen\OpenPype\tests\integration\hosts\maya\test_publish_in_maya.py --app_group mayapy --mongo_url "mongodb://localhost:2707/"
```
This will fail the testing but should launch MayaPy. We'll resolve issues with testing with MayaPy in a different PR when we make MayaPy the default for testing in Maya.
