### PR TITLE
Fix the Wrong key words for tycache workfile template settings in AYON

### DIFF
--- a/server_addon/core/server/settings/tools.py
+++ b/server_addon/core/server/settings/tools.py
@@ -489,7 +489,7 @@ DEFAULT_TOOLS_VALUES = {
                 "template_name": "publish_online"
             },
             {
-                "families": [
+                "product_types": [
                     "tycache"
                 ],
                 "hosts": [


### PR DESCRIPTION
## Changelog Description
Fix the wrong key words for the tycache workfile template settings in AYON
(i.e. Instead of families, product_types should be used)
## Additional info
n/a

## Testing notes:
1. Build the server-addon with this branch
2. Update the addon to your ayon server
3. Update your ayon bundle
4. Launch AYON(If you have the app data built, please delete the old addon build)
5. Publish anything.
