### PR TITLE
AYON settings: Use correct label for follow workfile version

### DIFF
--- a/server_addon/core/server/settings/publish_plugins.py
+++ b/server_addon/core/server/settings/publish_plugins.py
@@ -21,7 +21,7 @@ class ValidateBaseModel(BaseSettingsModel):
 class CollectAnatomyInstanceDataModel(BaseSettingsModel):
     _isGroup = True
     follow_workfile_version: bool = Field(
-        True, title="Collect Anatomy Instance Data"
+        True, title="Follow workfile version"
     )
 
 


### PR DESCRIPTION
## Changelog Description
Follow workfile version label was marked as Collect Anatomy Instance Data label.

## Additional info
The location of the setting is questionable, but that is not goal of this PR.
