### PR TITLE
AYON tools: Handle empty icon definition

### DIFF
--- a/openpype/tools/ayon_utils/widgets/utils.py
+++ b/openpype/tools/ayon_utils/widgets/utils.py
@@ -54,6 +54,8 @@ class _IconsCache:
 
     @classmethod
     def get_icon(cls, icon_def):
+        if not icon_def:
+            return None
         icon_type = icon_def["type"]
         cache_key = cls._get_cache_key(icon_def)
         cache = cls._cache.get(cache_key)


### PR DESCRIPTION
## Changelog Description
Ignore if passed icon definition is `None`.

## Additional info
This caused crashes if e.g. loader plugin does not have defined icon definition.

## Testing notes:
1. Loader plugins should be visible on loader tools (specifically AE and PS)
