### PR TITLE
Publisher: Center publisher window on first show

### DIFF
--- a/openpype/tools/publisher/window.py
+++ b/openpype/tools/publisher/window.py
@@ -15,6 +15,7 @@ from openpype.tools.utils import (
     MessageOverlayObject,
     PixmapLabel,
 )
+from openpype.tools.utils.lib import center_window
 
 from .constants import ResetKeySequence
 from .publish_report_viewer import PublishReportViewerWidget
@@ -529,6 +530,7 @@ class PublisherWindow(QtWidgets.QDialog):
     def _on_first_show(self):
         self.resize(self.default_width, self.default_height)
         self.setStyleSheet(style.load_stylesheet())
+        center_window(self)
         self._reset_on_show = self._reset_on_first_show
 
     def _on_show_timer(self):


### PR DESCRIPTION
## Changelog Description
Move publisher window to center of a screen on first show.

## Additional info
The publisher window is a little bit offset on show which cause that all actionable buttons may be out of screen. Centering the window should help to change it.

## Testing notes:
1. Open Publisher in DCCs of your choice
2. It would be goot to try this out in all Qt based DCCs to check for possible glitches > maya, nuke, houdini
