### PR TITLE
AYON 3dsMax settings: 'ValidateAttributes' settings converte only if available

### DIFF
--- a/openpype/settings/ayon_settings.py
+++ b/openpype/settings/ayon_settings.py
@@ -641,13 +641,14 @@ def _convert_3dsmax_project_settings(ayon_settings, output):
         ayon_max["PointCloud"]["attribute"] = new_point_cloud_attribute
     # --- Publish (START) ---
     ayon_publish = ayon_max["publish"]
-    try:
-        attributes = json.loads(
-            ayon_publish["ValidateAttributes"]["attributes"]
-        )
-    except ValueError:
-        attributes = {}
-    ayon_publish["ValidateAttributes"]["attributes"] = attributes
+    if "ValidateAttributes" in ayon_publish:
+        try:
+            attributes = json.loads(
+                ayon_publish["ValidateAttributes"]["attributes"]
+            )
+        except ValueError:
+            attributes = {}
+        ayon_publish["ValidateAttributes"]["attributes"] = attributes
 
     output["max"] = ayon_max
 


### PR DESCRIPTION
## Changelog Description
Convert `ValidateAttributes` settings only if are available in AYON settings.

## Additional info
The settings were added in one of latest PRs and the conversion is expecting the value to be there which breaks when older version of 3dsMax addon is used.

## Testing notes:
1. Use 3dsMax addon v1.0.0
2. Use this branch for openpype addon
3. Launch of AYON should not cause crashes when settings are received
