### PR TITLE
Blender: Use folder path as unique identifier

### DIFF
--- a/openpype/hosts/blender/plugins/publish/extract_abc.py
+++ b/openpype/hosts/blender/plugins/publish/extract_abc.py
@@ -17,7 +17,10 @@ class ExtractABC(publish.Extractor):
     def process(self, instance):
         # Define extract output file path
         stagingdir = self.staging_dir(instance)
-        filename = f"{instance.name}.abc"
+        asset_name = instance.data["assetEntity"]["name"]
+        subset = instance.data["subset"]
+        instance_name = f"{asset_name}_{subset}"
+        filename = f"{instance_name}.abc"
         filepath = os.path.join(stagingdir, filename)
 
         # Perform extraction
@@ -59,8 +62,8 @@ class ExtractABC(publish.Extractor):
         }
         instance.data["representations"].append(representation)
 
-        self.log.info("Extracted instance '%s' to: %s",
-                      instance.name, representation)
+        self.log.info(
+            f"Extracted instance '{instance_name}' to: {representation}")
 
 
 class ExtractModelABC(ExtractABC):

--- a/openpype/hosts/blender/plugins/publish/extract_abc_animation.py
+++ b/openpype/hosts/blender/plugins/publish/extract_abc_animation.py
@@ -17,7 +17,11 @@ class ExtractAnimationABC(publish.Extractor):
     def process(self, instance):
         # Define extract output file path
         stagingdir = self.staging_dir(instance)
-        filename = f"{instance.name}.abc"
+        asset_name = instance.data["assetEntity"]["name"]
+        subset = instance.data["subset"]
+        instance_name = f"{asset_name}_{subset}"
+        filename = f"{instance_name}.abc"
+
         filepath = os.path.join(stagingdir, filename)
 
         # Perform extraction
@@ -66,5 +70,5 @@ class ExtractAnimationABC(publish.Extractor):
         }
         instance.data["representations"].append(representation)
 
-        self.log.info("Extracted instance '%s' to: %s",
-                      instance.name, representation)
+        self.log.info(
+            f"Extracted instance '{instance_name}' to: {representation}")

--- a/openpype/hosts/blender/plugins/publish/extract_blend.py
+++ b/openpype/hosts/blender/plugins/publish/extract_blend.py
@@ -17,7 +17,10 @@ class ExtractBlend(publish.Extractor):
         # Define extract output file path
 
         stagingdir = self.staging_dir(instance)
-        filename = f"{instance.name}.blend"
+        asset_name = instance.data["assetEntity"]["name"]
+        subset = instance.data["subset"]
+        instance_name = f"{asset_name}_{subset}"
+        filename = f"{instance_name}.blend"
         filepath = os.path.join(stagingdir, filename)
 
         # Perform extraction
@@ -52,5 +55,5 @@ class ExtractBlend(publish.Extractor):
         }
         instance.data["representations"].append(representation)
 
-        self.log.info("Extracted instance '%s' to: %s",
-                      instance.name, representation)
+        self.log.info(
+            f"Extracted instance '{instance_name}' to: {representation}")

--- a/openpype/hosts/blender/plugins/publish/extract_blend_animation.py
+++ b/openpype/hosts/blender/plugins/publish/extract_blend_animation.py
@@ -17,7 +17,10 @@ class ExtractBlendAnimation(publish.Extractor):
         # Define extract output file path
 
         stagingdir = self.staging_dir(instance)
-        filename = f"{instance.name}.blend"
+        asset_name = instance.data["assetEntity"]["name"]
+        subset = instance.data["subset"]
+        instance_name = f"{asset_name}_{subset}"
+        filename = f"{instance_name}.blend"
         filepath = os.path.join(stagingdir, filename)
 
         # Perform extraction
@@ -50,5 +53,5 @@ class ExtractBlendAnimation(publish.Extractor):
         }
         instance.data["representations"].append(representation)
 
-        self.log.info("Extracted instance '%s' to: %s",
-                      instance.name, representation)
+        self.log.info(
+            f"Extracted instance '{instance_name}' to: {representation}")

--- a/openpype/hosts/blender/plugins/publish/extract_camera_abc.py
+++ b/openpype/hosts/blender/plugins/publish/extract_camera_abc.py
@@ -18,7 +18,10 @@ class ExtractCameraABC(publish.Extractor):
     def process(self, instance):
         # Define extract output file path
         stagingdir = self.staging_dir(instance)
-        filename = f"{instance.name}.abc"
+        asset_name = instance.data["assetEntity"]["name"]
+        subset = instance.data["subset"]
+        instance_name = f"{asset_name}_{subset}"
+        filename = f"{instance_name}.abc"
         filepath = os.path.join(stagingdir, filename)
 
         # Perform extraction
@@ -64,5 +67,5 @@ class ExtractCameraABC(publish.Extractor):
         }
         instance.data["representations"].append(representation)
 
-        self.log.info("Extracted instance '%s' to: %s",
-                      instance.name, representation)
+        self.log.info(
+            f"Extracted instance '{instance_name}' to: {representation}")

--- a/openpype/hosts/blender/plugins/publish/extract_camera_fbx.py
+++ b/openpype/hosts/blender/plugins/publish/extract_camera_fbx.py
@@ -17,7 +17,10 @@ class ExtractCamera(publish.Extractor):
     def process(self, instance):
         # Define extract output file path
         stagingdir = self.staging_dir(instance)
-        filename = f"{instance.name}.fbx"
+        asset_name = instance.data["assetEntity"]["name"]
+        subset = instance.data["subset"]
+        instance_name = f"{asset_name}_{subset}"
+        filename = f"{instance_name}.fbx"
         filepath = os.path.join(stagingdir, filename)
 
         # Perform extraction
@@ -73,5 +76,5 @@ class ExtractCamera(publish.Extractor):
         }
         instance.data["representations"].append(representation)
 
-        self.log.info("Extracted instance '%s' to: %s",
-                      instance.name, representation)
+        self.log.info(
+            f"Extracted instance '{instance_name}' to: {representation}")

--- a/openpype/hosts/blender/plugins/publish/extract_fbx.py
+++ b/openpype/hosts/blender/plugins/publish/extract_fbx.py
@@ -18,7 +18,10 @@ class ExtractFBX(publish.Extractor):
     def process(self, instance):
         # Define extract output file path
         stagingdir = self.staging_dir(instance)
-        filename = f"{instance.name}.fbx"
+        asset_name = instance.data["assetEntity"]["name"]
+        subset = instance.data["subset"]
+        instance_name = f"{asset_name}_{subset}"
+        filename = f"{instance_name}.fbx"
         filepath = os.path.join(stagingdir, filename)
 
         # Perform extraction
@@ -84,5 +87,5 @@ class ExtractFBX(publish.Extractor):
         }
         instance.data["representations"].append(representation)
 
-        self.log.info("Extracted instance '%s' to: %s",
-                      instance.name, representation)
+        self.log.info(
+            f"Extracted instance '{instance_name}' to: {representation}")

--- a/openpype/hosts/blender/plugins/publish/extract_fbx_animation.py
+++ b/openpype/hosts/blender/plugins/publish/extract_fbx_animation.py
@@ -86,7 +86,10 @@ class ExtractAnimationFBX(publish.Extractor):
 
         asset_group.select_set(True)
         armature.select_set(True)
-        fbx_filename = f"{instance.name}_{armature.name}.fbx"
+        asset_name = instance.data["assetEntity"]["name"]
+        subset = instance.data["subset"]
+        instance_name = f"{asset_name}_{subset}"
+        fbx_filename = f"{instance_name}_{armature.name}.fbx"
         filepath = os.path.join(stagingdir, fbx_filename)
 
         override = plugin.create_blender_context(
@@ -119,7 +122,7 @@ class ExtractAnimationFBX(publish.Extractor):
                 pair[1].user_clear()
                 bpy.data.actions.remove(pair[1])
 
-        json_filename = f"{instance.name}.json"
+        json_filename = f"{instance_name}.json"
         json_path = os.path.join(stagingdir, json_filename)
 
         json_dict = {
@@ -158,5 +161,5 @@ class ExtractAnimationFBX(publish.Extractor):
         instance.data["representations"].append(fbx_representation)
         instance.data["representations"].append(json_representation)
 
-        self.log.info("Extracted instance '{}' to: {}".format(
-                      instance.name, fbx_representation))
+        self.log.info(
+            f"Extracted instance '{instance_name}' to: {fbx_representation}")

--- a/openpype/hosts/blender/plugins/publish/extract_layout.py
+++ b/openpype/hosts/blender/plugins/publish/extract_layout.py
@@ -212,7 +212,11 @@ class ExtractLayout(publish.Extractor):
 
             json_data.append(json_element)
 
-        json_filename = "{}.json".format(instance.name)
+        asset_name = instance.data["assetEntity"]["name"]
+        subset = instance.data["subset"]
+        instance_name = f"{asset_name}_{subset}"
+        json_filename = f"{instance_name}.json"
+
         json_path = os.path.join(stagingdir, json_filename)
 
         with open(json_path, "w+") as file:
@@ -245,5 +249,5 @@ class ExtractLayout(publish.Extractor):
             }
             instance.data["representations"].append(fbx_representation)
 
-        self.log.info("Extracted instance '%s' to: %s",
-                      instance.name, json_representation)
+        self.log.info(
+            f"Extracted instance '{instance_name}' to: {json_representation}")

--- a/openpype/hosts/blender/plugins/publish/extract_playblast.py
+++ b/openpype/hosts/blender/plugins/publish/extract_playblast.py
@@ -50,7 +50,10 @@ class ExtractPlayblast(publish.Extractor):
 
         # get output path
         stagingdir = self.staging_dir(instance)
-        filename = instance.name
+        asset_name = instance.data["assetEntity"]["name"]
+        subset = instance.data["subset"]
+        filename = f"{asset_name}_{subset}"
+
         path = os.path.join(stagingdir, filename)
 
         self.log.debug(f"Outputting images to {path}")

--- a/openpype/hosts/blender/plugins/publish/extract_thumbnail.py
+++ b/openpype/hosts/blender/plugins/publish/extract_thumbnail.py
@@ -27,7 +27,10 @@ class ExtractThumbnail(publish.Extractor):
         self.log.debug("Extracting capture..")
 
         stagingdir = self.staging_dir(instance)
-        filename = instance.name
+        asset_name = instance.data["assetEntity"]["name"]
+        subset = instance.data["subset"]
+        filename = f"{asset_name}_{subset}"
+
         path = os.path.join(stagingdir, filename)
 
         self.log.debug(f"Outputting images to {path}")


### PR DESCRIPTION
## Changelog Description
Changed how extractors name the output files to be able to use folder paths as unique identifier.

## Testing notes:
1. Follow steps in #5817 to setup project.
2. Test that creators and extractor works correctly.