### PR TITLE
AYON: Fix TrayPublisher editorial settings

### DIFF
--- a/openpype/settings/ayon_settings.py
+++ b/openpype/settings/ayon_settings.py
@@ -1021,10 +1021,14 @@ def _convert_traypublisher_project_settings(ayon_settings, output):
         item["family"] = item.pop("product_type")
 
     shot_add_tasks = ayon_editorial_simple["shot_add_tasks"]
+
+    # TODO: backward compatibility and remove in future
     if isinstance(shot_add_tasks, dict):
         shot_add_tasks = []
+
+    # aggregate shot_add_tasks items
     new_shot_add_tasks = {
-        item["name"]: item["task_type"]
+        item["name"]: {"type": item["task_type"]}
         for item in shot_add_tasks
     }
     ayon_editorial_simple["shot_add_tasks"] = new_shot_add_tasks

--- a/server_addon/traypublisher/server/settings/editorial_creators.py
+++ b/server_addon/traypublisher/server/settings/editorial_creators.py
@@ -5,19 +5,17 @@ from ayon_server.settings import BaseSettingsModel, task_types_enum
 
 class ClipNameTokenizerItem(BaseSettingsModel):
     _layout = "expanded"
-    # TODO was 'dict-modifiable', is list of dicts now, must be fixed in code
-    name: str = Field("#TODO", title="Tokenizer name")
+    name: str = Field("", title="Tokenizer name")
     regex: str = Field("", title="Tokenizer regex")
 
 
 class ShotAddTasksItem(BaseSettingsModel):
     _layout = "expanded"
-    # TODO was 'dict-modifiable', is list of dicts now, must be fixed in code
     name: str = Field('', title="Key")
-    task_type: list[str] = Field(
+    task_type: str = Field(
         title="Task type",
-        default_factory=list,
-        enum_resolver=task_types_enum)
+        enum_resolver=task_types_enum
+    )
 
 
 class ShotRenameSubmodel(BaseSettingsModel):
@@ -54,7 +52,7 @@ class TokenToParentConvertorItem(BaseSettingsModel):
     )
 
 
-class ShotHierchySubmodel(BaseSettingsModel):
+class ShotHierarchySubmodel(BaseSettingsModel):
     enabled: bool = True
     parents_path: str = Field(
         "",
@@ -102,9 +100,9 @@ class EditorialSimpleCreatorPlugin(BaseSettingsModel):
         title="Shot Rename",
         default_factory=ShotRenameSubmodel
     )
-    shot_hierarchy: ShotHierchySubmodel = Field(
+    shot_hierarchy: ShotHierarchySubmodel = Field(
         title="Shot Hierarchy",
-        default_factory=ShotHierchySubmodel
+        default_factory=ShotHierarchySubmodel
     )
     shot_add_tasks: list[ShotAddTasksItem] = Field(
         title="Add tasks to shot",

--- a/server_addon/traypublisher/server/version.py
+++ b/server_addon/traypublisher/server/version.py
@@ -1,3 +1,3 @@
 # -*- coding: utf-8 -*-
 """Package declaring addon version."""
-__version__ = "0.1.2"
+__version__ = "0.1.3"


### PR DESCRIPTION
## Changelog Description
Fixing Traypublisher settings for adding task in simple editorial.

## Additional info
- changing task settings conversion 
- changing settings value from list to string
- fixing some typos

## Testing notes:
1. Add some tasks here `ayon+settings://traypublisher/editorial_creators/editorial_simple/shot_add_tasks`
2. use Simple Editorial testing file in Tray publisher and create instances.
3. If they were created then all works as it should
