### PR TITLE
Publisher: Instance context changes confirm works

### DIFF
--- a/openpype/tools/publisher/widgets/widgets.py
+++ b/openpype/tools/publisher/widgets/widgets.py
@@ -579,6 +579,10 @@ class AssetsField(BaseClickableFrame):
         """Change to asset names set with last `set_selected_items` call."""
         self.set_selected_items(self._origin_value)
 
+    def confirm_value(self):
+        self._origin_value = copy.deepcopy(self._selected_items)
+        self._has_value_changed = False
+
 
 class TasksComboboxProxy(QtCore.QSortFilterProxyModel):
     def __init__(self, *args, **kwargs):
@@ -785,6 +789,18 @@ class TasksCombobox(QtWidgets.QComboBox):
 
         self._set_is_valid(is_valid)
 
+    def confirm_value(self):
+        new_task_name = self._selected_items[0]
+        origin_value = copy.deepcopy(self._origin_value)
+        new_origin_value = [
+            (asset_name, new_task_name)
+            for (asset_name, task_name) in origin_value
+        ]
+
+        self._origin_value = new_origin_value
+        self._origin_selection = copy.deepcopy(self._selected_items)
+        self._has_value_changed = False
+
     def set_selected_items(self, asset_task_combinations=None):
         """Set items for selected instances.
 
@@ -918,6 +934,10 @@ class VariantInputWidget(PlaceholderLineEdit):
     def set_multiselection_text(self, text):
         """Change text of multiselection."""
         self._multiselection_text = text
+
+    def confirm_value(self):
+        self._origin_value = copy.deepcopy(self._current_value)
+        self._has_value_changed = False
 
     def _set_is_valid(self, valid):
         if valid == self._is_valid:
@@ -1209,6 +1229,15 @@ class GlobalAttrsWidget(QtWidgets.QWidget):
 
         self._set_btns_enabled(False)
         self._set_btns_visible(invalid_tasks)
+
+        if variant_value is not None:
+            self.variant_input.confirm_value()
+
+        if asset_name is not None:
+            self.asset_value_widget.confirm_value()
+
+        if task_name is not None:
+            self.task_value_widget.confirm_value()
 
         self.instance_context_changed.emit()
 

--- a/openpype/tools/publisher/widgets/widgets.py
+++ b/openpype/tools/publisher/widgets/widgets.py
@@ -1127,6 +1127,7 @@ class GlobalAttrsWidget(QtWidgets.QWidget):
         btns_layout = QtWidgets.QHBoxLayout()
         btns_layout.setContentsMargins(0, 0, 0, 0)
         btns_layout.addStretch(1)
+        btns_layout.setSpacing(5)
         btns_layout.addWidget(submit_btn)
         btns_layout.addWidget(cancel_btn)
 

--- a/openpype/tools/publisher/widgets/widgets.py
+++ b/openpype/tools/publisher/widgets/widgets.py
@@ -789,15 +789,12 @@ class TasksCombobox(QtWidgets.QComboBox):
 
         self._set_is_valid(is_valid)
 
-    def confirm_value(self):
+    def confirm_value(self, asset_names):
         new_task_name = self._selected_items[0]
-        origin_value = copy.deepcopy(self._origin_value)
-        new_origin_value = [
+        self._origin_value = [
             (asset_name, new_task_name)
-            for (asset_name, task_name) in origin_value
+            for asset_name in asset_names
         ]
-
-        self._origin_value = new_origin_value
         self._origin_selection = copy.deepcopy(self._selected_items)
         self._has_value_changed = False
 
@@ -1180,6 +1177,7 @@ class GlobalAttrsWidget(QtWidgets.QWidget):
 
         subset_names = set()
         invalid_tasks = False
+        asset_names = []
         for instance in self._current_instances:
             new_variant_value = instance.get("variant")
             new_asset_name = instance.get("asset")
@@ -1193,6 +1191,7 @@ class GlobalAttrsWidget(QtWidgets.QWidget):
             if task_name is not None:
                 new_task_name = task_name
 
+            asset_names.append(new_asset_name)
             try:
                 new_subset_name = self._controller.get_subset_name(
                     instance.creator_identifier,
@@ -1237,7 +1236,7 @@ class GlobalAttrsWidget(QtWidgets.QWidget):
             self.asset_value_widget.confirm_value()
 
         if task_name is not None:
-            self.task_value_widget.confirm_value()
+            self.task_value_widget.confirm_value(asset_names)
 
         self.instance_context_changed.emit()
 


### PR DESCRIPTION
## Changelog Description
Confirmation of context changes in publisher on existing instances does not cause glitches.

## Additional info
The glitches are happening only if a context is changed from A to B, and back to A.

### Steps to reproduce bug
- open publisher
- select existing instance (in my case has variant: `Main` asset: `Alpaca_01` and task: `animation`)
- change asset (in my case asset: `Buddy_01`)
- hit Confirm
- change asset back to origin asset (in my case asset `Alpaca_01`)
- now, the confirm button is not visible

The same happens when variant or task is changed, or with combination of them.

## Testing notes:
1. Go throught steps to reproduce > play with it a little
2. Try to change other values and hit Confirm/Cancel
3. All changes/confirms/cancels should do what is expected to happen