### PR TITLE
Chore: New session schema

### DIFF
--- a/openpype/pipeline/context_tools.py
+++ b/openpype/pipeline/context_tools.py
@@ -43,7 +43,7 @@ from . import (
 
 _is_installed = False
 _process_id = None
-_registered_root = {"_": ""}
+_registered_root = {"_": {}}
 _registered_host = {"_": None}
 # Keep modules manager (and it's modules) in memory
 # - that gives option to register modules' callbacks
@@ -85,10 +85,7 @@ def register_root(path):
 
 def registered_root():
     """Return currently registered root"""
-    root = _registered_root["_"]
-    if root:
-        return root
-    return {}
+    return _registered_root["_"]
 
 
 def install_host(host):

--- a/openpype/pipeline/context_tools.py
+++ b/openpype/pipeline/context_tools.py
@@ -88,11 +88,7 @@ def registered_root():
     root = _registered_root["_"]
     if root:
         return root
-
-    root = legacy_io.Session.get("AVALON_PROJECTS")
-    if root:
-        return os.path.normpath(root)
-    return ""
+    return {}
 
 
 def install_host(host):

--- a/openpype/pipeline/context_tools.py
+++ b/openpype/pipeline/context_tools.py
@@ -84,7 +84,21 @@ def register_root(path):
 
 
 def registered_root():
-    """Return currently registered root"""
+    """Return registered roots from current project anatomy.
+
+    Consider this does return roots only for current project and current
+        platforms, only if host was installer using 'install_host'.
+
+    Deprecated:
+        Please use project 'Anatomy' to get roots. This function is still used
+            at current core functions of load logic, but that will change
+            in future and this function will be removed eventually. Using this
+            function at new places can cause problems in the future.
+
+    Returns:
+        dict[str, str]: Root paths.
+    """
+
     return _registered_root["_"]
 
 

--- a/openpype/pipeline/legacy_io.py
+++ b/openpype/pipeline/legacy_io.py
@@ -30,7 +30,7 @@ def install():
 
     session = session_data_from_environment(context_keys=True)
 
-    session["schema"] = "openpype:session-3.0"
+    session["schema"] = "openpype:session-4.0"
     try:
         schema.validate(session)
     except schema.ValidationError as e:

--- a/openpype/pipeline/mongodb.py
+++ b/openpype/pipeline/mongodb.py
@@ -62,8 +62,6 @@ def auto_reconnect(func):
 
 
 SESSION_CONTEXT_KEYS = (
-    # Root directory of projects on disk
-    "AVALON_PROJECTS",
     # Name of current Project
     "AVALON_PROJECT",
     # Name of current Asset

--- a/openpype/pipeline/schema/session-4.0.json
+++ b/openpype/pipeline/schema/session-4.0.json
@@ -1,0 +1,81 @@
+{
+    "$schema": "http://json-schema.org/draft-04/schema#",
+
+    "title": "openpype:session-3.0",
+    "description": "The Avalon environment",
+
+    "type": "object",
+
+    "additionalProperties": true,
+
+    "required": [
+        "AVALON_PROJECT",
+        "AVALON_ASSET"
+    ],
+
+    "properties": {
+        "AVALON_PROJECTS": {
+            "description": "Absolute path to root of project directories",
+            "type": "string",
+            "example": "/nas/projects"
+        },
+        "AVALON_PROJECT": {
+            "description": "Name of project",
+            "type": "string",
+            "pattern": "^\\w*$",
+            "example": "Hulk"
+        },
+        "AVALON_ASSET": {
+            "description": "Name of asset",
+            "type": "string",
+            "pattern": "^\\w*$",
+            "example": "Bruce"
+        },
+        "AVALON_TASK": {
+            "description": "Name of task",
+            "type": "string",
+            "pattern": "^\\w*$",
+            "example": "modeling"
+        },
+        "AVALON_APP": {
+            "description": "Name of host",
+            "type": "string",
+            "pattern": "^\\w*$",
+            "example": "maya2016"
+        },
+        "AVALON_DB": {
+            "description": "Name of database",
+            "type": "string",
+            "pattern": "^\\w*$",
+            "example": "avalon",
+            "default": "avalon"
+        },
+        "AVALON_LABEL": {
+            "description": "Nice name of Avalon, used in e.g. graphical user interfaces",
+            "type": "string",
+            "example": "Mindbender",
+            "default": "Avalon"
+        },
+        "AVALON_TIMEOUT": {
+            "description": "Wherever there is a need for a timeout, this is the default value.",
+            "type": "string",
+            "pattern": "^[0-9]*$",
+            "default": "1000",
+            "example": "1000"
+        },
+        "AVALON_INSTANCE_ID": {
+            "description": "Unique identifier for instances in a working file",
+            "type": "string",
+            "pattern": "^[\\w.]*$",
+            "default": "avalon.instance",
+            "example": "avalon.instance"
+        },
+        "AVALON_CONTAINER_ID": {
+            "description": "Unique identifier for a loaded representation in a working file",
+            "type": "string",
+            "pattern": "^[\\w.]*$",
+            "default": "avalon.container",
+            "example": "avalon.container"
+        }
+    }
+}

--- a/openpype/pipeline/schema/session-4.0.json
+++ b/openpype/pipeline/schema/session-4.0.json
@@ -28,7 +28,7 @@
         "AVALON_ASSET": {
             "description": "Name of asset",
             "type": "string",
-            "pattern": "^\\w*$",
+            "pattern": "^[\\/\\w]*$",
             "example": "Bruce"
         },
         "AVALON_TASK": {

--- a/openpype/pipeline/schema/session-4.0.json
+++ b/openpype/pipeline/schema/session-4.0.json
@@ -14,11 +14,6 @@
     ],
 
     "properties": {
-        "AVALON_PROJECTS": {
-            "description": "Absolute path to root of project directories",
-            "type": "string",
-            "example": "/nas/projects"
-        },
         "AVALON_PROJECT": {
             "description": "Name of project",
             "type": "string",
@@ -62,20 +57,6 @@
             "pattern": "^[0-9]*$",
             "default": "1000",
             "example": "1000"
-        },
-        "AVALON_INSTANCE_ID": {
-            "description": "Unique identifier for instances in a working file",
-            "type": "string",
-            "pattern": "^[\\w.]*$",
-            "default": "avalon.instance",
-            "example": "avalon.instance"
-        },
-        "AVALON_CONTAINER_ID": {
-            "description": "Unique identifier for a loaded representation in a working file",
-            "type": "string",
-            "pattern": "^[\\w.]*$",
-            "default": "avalon.container",
-            "example": "avalon.container"
         }
     }
 }

--- a/openpype/pipeline/schema/session-4.0.json
+++ b/openpype/pipeline/schema/session-4.0.json
@@ -35,7 +35,7 @@
             "description": "Name of host",
             "type": "string",
             "pattern": "^\\w*$",
-            "example": "maya2016"
+            "example": "maya"
         },
         "AVALON_DB": {
             "description": "Name of database",
@@ -47,7 +47,7 @@
         "AVALON_LABEL": {
             "description": "Nice name of Avalon, used in e.g. graphical user interfaces",
             "type": "string",
-            "example": "Mindbender",
+            "example": "MyLabel",
             "default": "Avalon"
         },
         "AVALON_TIMEOUT": {

--- a/openpype/pipeline/schema/session-4.0.json
+++ b/openpype/pipeline/schema/session-4.0.json
@@ -9,8 +9,7 @@
     "additionalProperties": true,
 
     "required": [
-        "AVALON_PROJECT",
-        "AVALON_ASSET"
+        "AVALON_PROJECT"
     ],
 
     "properties": {

--- a/openpype/pipeline/schema/session-4.0.json
+++ b/openpype/pipeline/schema/session-4.0.json
@@ -1,7 +1,7 @@
 {
     "$schema": "http://json-schema.org/draft-04/schema#",
 
-    "title": "openpype:session-3.0",
+    "title": "openpype:session-4.0",
     "description": "The Avalon environment",
 
     "type": "object",


### PR DESCRIPTION
## Changelog Description
Added new session schema required for https://github.com/ynput/OpenPype/pull/5817.

## Additional info
Now `AVALON_ASSET` may contain forward slash which is requirement for folder path.
With new schema it is possible to do small cleanup.
- Environment `AVALON_PROJECTS` is not used anymore thus can be removed.
- Similar with `AVALON_INSTANCE_ID` and `AVALON_CONTAINER_ID`, I don't know if were actually used in past.
- Removed `AVALON_ASSET` from required keys, so `AVALON_PROJECT` is only requirement to create context session in `legacy_io`.

## Testing notes:
Validate the schema changes.
