### PR TITLE
Update houdini license validator

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -35,6 +35,7 @@ body:
       label: Version
       description: What version are you running? Look to OpenPype Tray
       options:
+        - 3.17.6-nightly.1
         - 3.17.5
         - 3.17.5-nightly.3
         - 3.17.5-nightly.2
@@ -134,7 +135,6 @@ body:
         - 3.15.1
         - 3.15.1-nightly.6
         - 3.15.1-nightly.5
-        - 3.15.1-nightly.4
     validations:
       required: true
   - type: dropdown

--- a/openpype/hosts/houdini/plugins/publish/validate_houdini_license_category.py
+++ b/openpype/hosts/houdini/plugins/publish/validate_houdini_license_category.py
@@ -30,7 +30,8 @@ class ValidateHoudiniNotApprenticeLicense(pyblish.api.InstancePlugin):
             # Find which family was matched with the plug-in
             families = {instance.data["family"]}
             families.update(instance.data.get("families", []))
-            families = " ".join(families).title()
+            disallowed_families = families.intersection(self.families)
+            families = " ".join(sorted(disallowed_families)).title()
 
             raise PublishValidationError(
                 "{} publishing requires a non apprentice license."

--- a/openpype/hosts/houdini/plugins/publish/validate_houdini_license_category.py
+++ b/openpype/hosts/houdini/plugins/publish/validate_houdini_license_category.py
@@ -7,13 +7,16 @@ import hou
 class ValidateHoudiniNotApprenticeLicense(pyblish.api.InstancePlugin):
     """Validate the Houdini instance runs a non Apprentice license.
 
-    When extracting USD files from an apprentice Houdini license,
-    the resulting files will get "scrambled" with a license protection
-    and get a special .usdnc suffix.
+    USD ROPs:
+        When extracting USD files from an apprentice Houdini license,
+        the resulting files will get "scrambled" with a license protection
+        and get a special .usdnc suffix.
 
-    This currently breaks the Subset/representation pipeline so we disallow
-    any publish with apprentice license.
+        This currently breaks the Subset/representation pipeline so we disallow
+        any publish with apprentice license.
 
+    Alembic ROPs:
+        Houdini Apprentice does not export Alembic.
     """
 
     order = pyblish.api.ValidatorOrder

--- a/openpype/hosts/houdini/plugins/publish/validate_houdini_license_category.py
+++ b/openpype/hosts/houdini/plugins/publish/validate_houdini_license_category.py
@@ -3,30 +3,29 @@ import pyblish.api
 from openpype.pipeline import PublishValidationError
 
 
-class ValidateHoudiniCommercialLicense(pyblish.api.InstancePlugin):
-    """Validate the Houdini instance runs a Commercial license.
+class ValidateHoudiniNotApprenticeLicense(pyblish.api.InstancePlugin):
+    """Validate the Houdini instance runs a non Apprentice license.
 
-    When extracting USD files from a non-commercial Houdini license, even with
-    Houdini Indie license, the resulting files will get "scrambled" with
-    a license protection and get a special .usdnc or .usdlc suffix.
+    When extracting USD files from an apprentice Houdini license,
+    the resulting files will get "scrambled" with a license protection
+    and get a special .usdnc or .usdlc suffix.
 
     This currently breaks the Subset/representation pipeline so we disallow
-    any publish with those licenses. Only the commercial license is valid.
+    any publish with apprentice license.
 
     """
 
     order = pyblish.api.ValidatorOrder
     families = ["usd"]
     hosts = ["houdini"]
-    label = "Houdini Commercial License"
+    label = "Houdini Apprentice License"
 
     def process(self, instance):
 
         import hou
 
-        license = hou.licenseCategory()
-        if license != hou.licenseCategoryType.Commercial:
+        if hou.isApprentice():
             raise PublishValidationError(
-                ("USD Publishing requires a full Commercial "
-                 "license. You are on: {}").format(license),
+                ("USD Publishing requires a non apprentice "
+                 "license."),
                 title=self.label)

--- a/openpype/hosts/houdini/plugins/publish/validate_houdini_license_category.py
+++ b/openpype/hosts/houdini/plugins/publish/validate_houdini_license_category.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 import pyblish.api
 from openpype.pipeline import PublishValidationError
+import hou
 
 
 class ValidateHoudiniNotApprenticeLicense(pyblish.api.InstancePlugin):
@@ -16,16 +17,18 @@ class ValidateHoudiniNotApprenticeLicense(pyblish.api.InstancePlugin):
     """
 
     order = pyblish.api.ValidatorOrder
-    families = ["usd"]
+    families = ["usd", "abc"]
     hosts = ["houdini"]
     label = "Houdini Apprentice License"
 
     def process(self, instance):
 
-        import hou
+        if hou.isApprentice() or 1:
+            families = [instance.data["family"]]
+            families += instance.data.get("families", [])
+            families = " ".join(families).title()
 
-        if hou.isApprentice():
             raise PublishValidationError(
-                ("USD Publishing requires a non apprentice "
-                 "license."),
+                "{} Publishing requires a non apprentice license."
+                .format(families),
                 title=self.label)

--- a/openpype/hosts/houdini/plugins/publish/validate_houdini_license_category.py
+++ b/openpype/hosts/houdini/plugins/publish/validate_houdini_license_category.py
@@ -23,7 +23,7 @@ class ValidateHoudiniNotApprenticeLicense(pyblish.api.InstancePlugin):
 
     def process(self, instance):
 
-        if hou.isApprentice() or 1:
+        if hou.isApprentice():
             families = [instance.data["family"]]
             families += instance.data.get("families", [])
             families = " ".join(families).title()

--- a/openpype/hosts/houdini/plugins/publish/validate_houdini_license_category.py
+++ b/openpype/hosts/houdini/plugins/publish/validate_houdini_license_category.py
@@ -27,11 +27,12 @@ class ValidateHoudiniNotApprenticeLicense(pyblish.api.InstancePlugin):
     def process(self, instance):
 
         if hou.isApprentice():
-            families = [instance.data["family"]]
-            families += instance.data.get("families", [])
+            # Find which family was matched with the plug-in
+            families = {instance.data["family"]}
+            families.update(instance.data.get("families", []))
             families = " ".join(families).title()
 
             raise PublishValidationError(
-                "{} Publishing requires a non apprentice license."
+                "{} publishing requires a non apprentice license."
                 .format(families),
                 title=self.label)


### PR DESCRIPTION
## Changelog Description
As reported in this [community comment](https://community.ynput.io/t/ayon-monthly-beginners-topic-november-23/967/9)
Houdini USD publishing is only restricted in Houdini apprentice. 


## Testing notes:
1. publish USD from an apprentice Houdini license won't work in OP or Ayon.
