### PR TITLE
Nuke: Change context label enhancement

### DIFF
--- a/openpype/hosts/nuke/api/lib.py
+++ b/openpype/hosts/nuke/api/lib.py
@@ -120,7 +120,7 @@ def deprecated(new_destination):
 
 class Context:
     main_window = None
-    context_label = None
+    context_action_item = None
     project_name = os.getenv("AVALON_PROJECT")
     # Workfile related code
     workfiles_launched = False

--- a/openpype/hosts/nuke/api/pipeline.py
+++ b/openpype/hosts/nuke/api/pipeline.py
@@ -352,6 +352,8 @@ def _install_menu():
 
 
 def change_context_label():
+    if ASSIST:
+        return
 
     context_action_item = Context.context_action_item
     if context_action_item is None:

--- a/openpype/hosts/nuke/api/pipeline.py
+++ b/openpype/hosts/nuke/api/pipeline.py
@@ -236,9 +236,13 @@ def _install_menu():
 
     if not ASSIST:
         label = get_context_label()
-        Context.context_label = label
-        context_action = menu.addCommand(label)
-        context_action.setEnabled(False)
+        context_action_item = menu.addCommand("Context")
+        context_action_item.setEnabled(False)
+
+        Context.context_action_item = context_action_item
+
+        context_action = context_action_item.action()
+        context_action.setText(label)
 
         # add separator after context label
         menu.addSeparator()
@@ -348,26 +352,19 @@ def _install_menu():
 
 
 def change_context_label():
-    menubar = nuke.menu("Nuke")
-    menu = menubar.findItem(MENU_LABEL)
 
-    label = get_context_label()
+    context_action_item = Context.context_action_item
+    if context_action_item is None:
+        return
+    context_action = context_action_item.action()
 
-    rm_item = [
-        (i, item) for i, item in enumerate(menu.items())
-        if Context.context_label in item.name()
-    ][0]
+    old_label = context_action.text()
+    new_label = get_context_label()
 
-    menu.removeItem(rm_item[1].name())
-
-    context_action = menu.addCommand(
-        label,
-        index=(rm_item[0])
-    )
-    context_action.setEnabled(False)
+    context_action.setText(new_label)
 
     log.info("Task label changed from `{}` to `{}`".format(
-        Context.context_label, label))
+        old_label, new_label))
 
 
 def add_shortcuts_from_presets():


### PR DESCRIPTION
## Changelog Description
Use QAction to change label of context label in Nuke pipeline menu.

## Additional info
This is preparation for https://github.com/ynput/OpenPype/pull/5817 where asset in context will contain slashes, which nuke converts into submenus when `addCommand` is used. That was modified. Returned object from `addCommand` should have `action()` method which returns `QAction` object on which is possible to call `setText` to change the label.

Added skip of change label function if in nuke assist.

## Testing notes:
Test this PR in oldest possible nuke we should support.
1. The context label should be set on launcher.
2. The context label should be changed when context changes via workfiles tool.
