### PR TITLE
Blender: Fix blend extraction and packed images

### DIFF
--- a/openpype/hosts/blender/plugins/publish/extract_blend.py
+++ b/openpype/hosts/blender/plugins/publish/extract_blend.py
@@ -28,16 +28,22 @@ class ExtractBlend(publish.Extractor):
         for obj in instance:
             data_blocks.add(obj)
             # Pack used images in the blend files.
-            if obj.type == 'MESH':
-                for material_slot in obj.material_slots:
-                    mat = material_slot.material
-                    if mat and mat.use_nodes:
-                        tree = mat.node_tree
-                        if tree.type == 'SHADER':
-                            for node in tree.nodes:
-                                if node.bl_idname == 'ShaderNodeTexImage':
-                                    if node.image:
-                                        node.image.pack()
+            if obj.type != 'MESH':
+                continue
+            for material_slot in obj.material_slots:
+                mat = material_slot.material
+                if not(mat and mat.use_nodes):
+                    continue
+                tree = mat.node_tree
+                if tree.type != 'SHADER':
+                    continue
+                for node in tree.nodes:
+                    if node.bl_idname != 'ShaderNodeTexImage':
+                        continue
+                    # Check if image is not packed already
+                    # and pack it if not.
+                    if node.image and node.image.packed_file is None:
+                        node.image.pack()
 
         bpy.data.libraries.write(filepath, data_blocks)
 


### PR DESCRIPTION
## Changelog Description
Fixed a with blend extractor and packed images.

## Additional info
The extractor was packing all the images in the instance, but it was causing issues if the image was already packed and it wasn't in the saved location anymore, or if the image was saved with a relative path. This PR fixes it by checking if the image was already packed, and pack it only if it isn't.

## Testing notes:
1. Publish a model with a texture.
2. Delete the original texture file.
3. Load the model and create a layout with that model.
4. Try publish the layout, it should succeed.