### PR TITLE
AYON: Initialize connection with all information

### DIFF
--- a/openpype/client/__init__.py
+++ b/openpype/client/__init__.py
@@ -1,6 +1,7 @@
 from .mongo import (
     OpenPypeMongoConnection,
 )
+from .server.utils import get_ayon_server_api_connection
 
 from .entities import (
     get_projects,
@@ -58,6 +59,8 @@ from .operations import (
 
 __all__ = (
     "OpenPypeMongoConnection",
+
+    "get_ayon_server_api_connection",
 
     "get_projects",
     "get_project",

--- a/openpype/client/server/entities.py
+++ b/openpype/client/server/entities.py
@@ -1,9 +1,8 @@
 import collections
 
-from ayon_api import get_server_api_connection
-
 from openpype.client.mongo.operations import CURRENT_THUMBNAIL_SCHEMA
 
+from .utils import get_ayon_server_api_connection
 from .openpype_comp import get_folders_with_tasks
 from .conversion_utils import (
     project_fields_v3_to_v4,
@@ -37,7 +36,7 @@ def get_projects(active=True, inactive=False, library=None, fields=None):
     elif inactive:
         active = False
 
-    con = get_server_api_connection()
+    con = get_ayon_server_api_connection()
     fields = project_fields_v3_to_v4(fields, con)
     for project in con.get_projects(active, library, fields=fields):
         yield convert_v4_project_to_v3(project)
@@ -45,7 +44,7 @@ def get_projects(active=True, inactive=False, library=None, fields=None):
 
 def get_project(project_name, active=True, inactive=False, fields=None):
     # Skip if both are disabled
-    con = get_server_api_connection()
+    con = get_ayon_server_api_connection()
     fields = project_fields_v3_to_v4(fields, con)
     return convert_v4_project_to_v3(
         con.get_project(project_name, fields=fields)
@@ -66,7 +65,7 @@ def _get_subsets(
     fields=None
 ):
     # Convert fields and add minimum required fields
-    con = get_server_api_connection()
+    con = get_ayon_server_api_connection()
     fields = subset_fields_v3_to_v4(fields, con)
     if fields is not None:
         for key in (
@@ -102,7 +101,7 @@ def _get_versions(
     active=None,
     fields=None
 ):
-    con = get_server_api_connection()
+    con = get_ayon_server_api_connection()
 
     fields = version_fields_v3_to_v4(fields, con)
 
@@ -198,7 +197,7 @@ def get_assets(
     if archived:
         active = None
 
-    con = get_server_api_connection()
+    con = get_ayon_server_api_connection()
     fields = folder_fields_v3_to_v4(fields, con)
     kwargs = dict(
         folder_ids=asset_ids,
@@ -236,7 +235,7 @@ def get_archived_assets(
 
 
 def get_asset_ids_with_subsets(project_name, asset_ids=None):
-    con = get_server_api_connection()
+    con = get_ayon_server_api_connection()
     return con.get_folder_ids_with_products(project_name, asset_ids)
 
 
@@ -282,7 +281,7 @@ def get_subsets(
 
 
 def get_subset_families(project_name, subset_ids=None):
-    con = get_server_api_connection()
+    con = get_ayon_server_api_connection()
     return con.get_product_type_names(project_name, subset_ids)
 
 
@@ -430,7 +429,7 @@ def get_output_link_versions(project_name, version_id, fields=None):
     if not version_id:
         return []
 
-    con = get_server_api_connection()
+    con = get_ayon_server_api_connection()
     version_links = con.get_version_links(
         project_name, version_id, link_direction="out")
 
@@ -446,7 +445,7 @@ def get_output_link_versions(project_name, version_id, fields=None):
 
 
 def version_is_latest(project_name, version_id):
-    con = get_server_api_connection()
+    con = get_ayon_server_api_connection()
     return con.version_is_latest(project_name, version_id)
 
 
@@ -501,7 +500,7 @@ def get_representations(
     else:
         active = None
 
-    con = get_server_api_connection()
+    con = get_ayon_server_api_connection()
     fields = representation_fields_v3_to_v4(fields, con)
     if fields and active is not None:
         fields.add("active")
@@ -535,7 +534,7 @@ def get_representations_parents(project_name, representations):
         repre["_id"]
         for repre in representations
     }
-    con = get_server_api_connection()
+    con = get_ayon_server_api_connection()
     parents_by_repre_id = con.get_representations_parents(project_name,
                                                           repre_ids)
     folder_ids = set()
@@ -677,7 +676,7 @@ def get_workfile_info(
     if not asset_id or not task_name or not filename:
         return None
 
-    con = get_server_api_connection()
+    con = get_ayon_server_api_connection()
     task = con.get_task_by_name(
         project_name, asset_id, task_name, fields=["id", "name", "folderId"]
     )

--- a/openpype/client/server/entity_links.py
+++ b/openpype/client/server/entity_links.py
@@ -1,6 +1,4 @@
-import ayon_api
-from ayon_api import get_folder_links, get_versions_links
-
+from .utils import get_ayon_server_api_connection
 from .entities import get_assets, get_representation_by_id
 
 
@@ -28,7 +26,8 @@ def get_linked_asset_ids(project_name, asset_doc=None, asset_id=None):
     if not asset_id:
         asset_id = asset_doc["_id"]
 
-    links = get_folder_links(project_name, asset_id, link_direction="in")
+    con = get_ayon_server_api_connection()
+    links = con.get_folder_links(project_name, asset_id, link_direction="in")
     return [
         link["entityId"]
         for link in links
@@ -115,6 +114,7 @@ def get_linked_representation_id(
     if link_type:
         link_types = [link_type]
 
+    con = get_ayon_server_api_connection()
     # Store already found version ids to avoid recursion, and also to store
     #   output -> Don't forget to remove 'version_id' at the end!!!
     linked_version_ids = {version_id}
@@ -124,7 +124,7 @@ def get_linked_representation_id(
         if not versions_to_check:
             break
 
-        links = get_versions_links(
+        links = con.get_versions_links(
             project_name,
             versions_to_check,
             link_types=link_types,
@@ -145,8 +145,8 @@ def get_linked_representation_id(
     linked_version_ids.remove(version_id)
     if not linked_version_ids:
         return []
-
-    representations = ayon_api.get_representations(
+    con = get_ayon_server_api_connection()
+    representations = con.get_representations(
         project_name,
         version_ids=linked_version_ids,
         fields=["id"])

--- a/openpype/client/server/operations.py
+++ b/openpype/client/server/operations.py
@@ -5,7 +5,6 @@ import uuid
 import datetime
 
 from bson.objectid import ObjectId
-from ayon_api import get_server_api_connection
 
 from openpype.client.operations_base import (
     REMOVED_VALUE,
@@ -41,7 +40,7 @@ from .conversion_utils import (
     convert_update_representation_to_v4,
     convert_update_workfile_info_to_v4,
 )
-from .utils import create_entity_id
+from .utils import create_entity_id, get_ayon_server_api_connection
 
 
 def _create_or_convert_to_id(entity_id=None):
@@ -680,7 +679,7 @@ class OperationsSession(BaseOperationsSession):
     def __init__(self, con=None, *args, **kwargs):
         super(OperationsSession, self).__init__(*args, **kwargs)
         if con is None:
-            con = get_server_api_connection()
+            con = get_ayon_server_api_connection()
         self._con = con
         self._project_cache = {}
         self._nested_operations = collections.defaultdict(list)
@@ -858,7 +857,7 @@ def create_project(
     """
 
     if con is None:
-        con = get_server_api_connection()
+        con = get_ayon_server_api_connection()
 
     return con.create_project(
         project_name,
@@ -870,12 +869,12 @@ def create_project(
 
 def delete_project(project_name, con=None):
     if con is None:
-        con = get_server_api_connection()
+        con = get_ayon_server_api_connection()
 
     return con.delete_project(project_name)
 
 
 def create_thumbnail(project_name, src_filepath, thumbnail_id=None, con=None):
     if con is None:
-        con = get_server_api_connection()
+        con = get_ayon_server_api_connection()
     return con.create_thumbnail(project_name, src_filepath, thumbnail_id)

--- a/openpype/client/server/utils.py
+++ b/openpype/client/server/utils.py
@@ -1,6 +1,31 @@
+import os
 import uuid
 
+import ayon_api
+
 from openpype.client.operations_base import REMOVED_VALUE
+
+
+class _GlobalCache:
+    initialized = False
+
+
+def get_ayon_server_api_connection():
+    if _GlobalCache.initialized:
+        con = ayon_api.get_server_api_connection()
+    else:
+        from openpype.lib.local_settings import get_local_site_id
+
+        _GlobalCache.initialized = True
+        site_id = get_local_site_id()
+        version = os.getenv("AYON_VERSION")
+        if ayon_api.is_connection_created():
+            con = ayon_api.get_server_api_connection()
+            con.set_site_id(site_id)
+            con.set_client_version(version)
+        else:
+            con = ayon_api.create_connection(site_id, version)
+    return con
 
 
 def create_entity_id():

--- a/openpype/lib/local_settings.py
+++ b/openpype/lib/local_settings.py
@@ -36,6 +36,7 @@ from openpype.settings import (
 )
 
 from openpype.client.mongo import validate_mongo_connection
+from openpype.client import get_ayon_server_api_connection
 
 _PLACEHOLDER = object()
 
@@ -613,9 +614,8 @@ def get_openpype_username():
     """
 
     if AYON_SERVER_ENABLED:
-        import ayon_api
-
-        return ayon_api.get_user()["name"]
+        con = get_ayon_server_api_connection()
+        return con.get_user()["name"]
 
     username = os.environ.get("OPENPYPE_USERNAME")
     if not username:

--- a/openpype/modules/base.py
+++ b/openpype/modules/base.py
@@ -16,9 +16,9 @@ from abc import ABCMeta, abstractmethod
 
 import six
 import appdirs
-import ayon_api
 
 from openpype import AYON_SERVER_ENABLED
+from openpype.client import get_ayon_server_api_connection
 from openpype.settings import (
     get_system_settings,
     SYSTEM_SETTINGS_KEY,
@@ -319,8 +319,11 @@ def load_modules(force=False):
 
 
 def _get_ayon_bundle_data():
+    con = get_ayon_server_api_connection()
+    bundles = con.get_bundles()["bundles"]
+
     bundle_name = os.getenv("AYON_BUNDLE_NAME")
-    bundles = ayon_api.get_bundles()["bundles"]
+
     return next(
         (
             bundle
@@ -345,7 +348,8 @@ def _get_ayon_addons_information(bundle_info):
 
     output = []
     bundle_addons = bundle_info["addons"]
-    addons = ayon_api.get_addons_info()["addons"]
+    con = get_ayon_server_api_connection()
+    addons = con.get_addons_info()["addons"]
     for addon in addons:
         name = addon["name"]
         versions = addon.get("versions")

--- a/openpype/pipeline/anatomy.py
+++ b/openpype/pipeline/anatomy.py
@@ -5,7 +5,6 @@ import platform
 import collections
 import numbers
 
-import ayon_api
 import six
 import time
 
@@ -16,7 +15,7 @@ from openpype.settings.lib import (
 from openpype.settings.constants import (
     DEFAULT_PROJECT_KEY
 )
-from openpype.client import get_project
+from openpype.client import get_project, get_ayon_server_api_connection
 from openpype.lib import Logger, get_local_site_id
 from openpype.lib.path_templates import (
     TemplateUnsolved,
@@ -479,7 +478,8 @@ class Anatomy(BaseAnatomy):
         if AYON_SERVER_ENABLED:
             if not project_name:
                 return
-            return ayon_api.get_project_roots_for_site(
+            con = get_ayon_server_api_connection()
+            return con.get_project_roots_for_site(
                 project_name, get_local_site_id()
             )
 

--- a/openpype/pipeline/context_tools.py
+++ b/openpype/pipeline/context_tools.py
@@ -11,12 +11,14 @@ import pyblish.api
 from pyblish.lib import MessageHandler
 
 import openpype
+from openpype import AYON_SERVER_ENABLED
 from openpype.host import HostBase
 from openpype.client import (
     get_project,
     get_asset_by_id,
     get_asset_by_name,
     version_is_latest,
+    get_ayon_server_api_connection,
 )
 from openpype.lib.events import emit_event
 from openpype.modules import load_modules, ModulesManager
@@ -104,6 +106,10 @@ def install_host(host):
     global _is_installed
 
     _is_installed = True
+
+    # Make sure global AYON connection has set site id and version
+    if AYON_SERVER_ENABLED:
+        get_ayon_server_api_connection()
 
     legacy_io.install()
     modules_manager = _get_modules_manager()

--- a/openpype/pipeline/thumbnail.py
+++ b/openpype/pipeline/thumbnail.py
@@ -4,7 +4,7 @@ import logging
 
 from openpype import AYON_SERVER_ENABLED
 from openpype.lib import Logger
-from openpype.client import get_project
+from openpype.client import get_project, get_ayon_server_api_connection
 from . import legacy_io
 from .anatomy import Anatomy
 from .plugin_discover import (
@@ -153,8 +153,6 @@ class ServerThumbnailResolver(ThumbnailResolver):
         if not entity_type or not entity_id:
             return None
 
-        import ayon_api
-
         project_name = self.dbcon.active_project()
         thumbnail_id = thumbnail_entity["_id"]
 
@@ -169,7 +167,7 @@ class ServerThumbnailResolver(ThumbnailResolver):
         # NOTE Use 'get_server_api_connection' because public function
         #   'get_thumbnail_by_id' does not return output of 'ServerAPI'
         #   method.
-        con = ayon_api.get_server_api_connection()
+        con = get_ayon_server_api_connection()
         if hasattr(con, "get_thumbnail_by_id"):
             result = con.get_thumbnail_by_id(thumbnail_id)
             if result.is_valid:

--- a/openpype/settings/ayon_settings.py
+++ b/openpype/settings/ayon_settings.py
@@ -1497,7 +1497,8 @@ class _AyonSettingsCache:
             if cls._use_bundles():
                 value = ayon_api.get_addons_settings(
                     bundle_name=cls._get_bundle_name(),
-                    project_name=project_name
+                    project_name=project_name,
+                    variant=cls._get_variant()
                 )
             else:
                 value = ayon_api.get_addons_settings(project_name)

--- a/openpype/settings/ayon_settings.py
+++ b/openpype/settings/ayon_settings.py
@@ -1467,6 +1467,10 @@ class _AyonSettingsCache:
 
             # Cache variant
             _AyonSettingsCache.variant = variant
+
+            # Set the variant to global ayon api connection
+            con = get_ayon_server_api_connection()
+            con.set_default_settings_variant(variant)
         return _AyonSettingsCache.variant
 
     @classmethod

--- a/openpype/settings/ayon_settings.py
+++ b/openpype/settings/ayon_settings.py
@@ -20,7 +20,8 @@ import copy
 import time
 
 import six
-import ayon_api
+
+from openpype.client import get_ayon_server_api_connection
 
 
 def _convert_color(color_value):
@@ -1445,7 +1446,8 @@ class _AyonSettingsCache:
     @classmethod
     def _use_bundles(cls):
         if _AyonSettingsCache.use_bundles is None:
-            major, minor, _, _, _ = ayon_api.get_server_version_tuple()
+            con = get_ayon_server_api_connection()
+            major, minor, _, _, _ = con.get_server_version_tuple()
             use_bundles = True
             if (major, minor) < (0, 3):
                 use_bundles = False
@@ -1462,6 +1464,8 @@ class _AyonSettingsCache:
                 variant = cls._get_dev_mode_settings_variant()
             elif is_staging_enabled():
                 variant = "staging"
+
+            # Cache variant
             _AyonSettingsCache.variant = variant
         return _AyonSettingsCache.variant
 
@@ -1477,8 +1481,9 @@ class _AyonSettingsCache:
             str: Name of settings variant.
         """
 
-        bundles = ayon_api.get_bundles()
-        user = ayon_api.get_user()
+        con = get_ayon_server_api_connection()
+        bundles = con.get_bundles()
+        user = con.get_user()
         username = user["name"]
         for bundle in bundles["bundles"]:
             if (
@@ -1494,21 +1499,23 @@ class _AyonSettingsCache:
     def get_value_by_project(cls, project_name):
         cache_item = _AyonSettingsCache.cache_by_project_name[project_name]
         if cache_item.is_outdated:
+            con = get_ayon_server_api_connection()
             if cls._use_bundles():
-                value = ayon_api.get_addons_settings(
+                value = con.get_addons_settings(
                     bundle_name=cls._get_bundle_name(),
                     project_name=project_name,
                     variant=cls._get_variant()
                 )
             else:
-                value = ayon_api.get_addons_settings(project_name)
+                value = con.get_addons_settings(project_name)
             cache_item.update_value(value)
         return cache_item.get_value()
 
     @classmethod
     def _get_addon_versions_from_bundle(cls):
+        con = get_ayon_server_api_connection()
         expected_bundle = cls._get_bundle_name()
-        bundles = ayon_api.get_bundles()["bundles"]
+        bundles = con.get_bundles()["bundles"]
         bundle = next(
             (
                 bundle
@@ -1528,8 +1535,11 @@ class _AyonSettingsCache:
             if cls._use_bundles():
                 addons = cls._get_addon_versions_from_bundle()
             else:
-                settings_data = ayon_api.get_addons_settings(
-                    only_values=False, variant=cls._get_variant())
+                con = get_ayon_server_api_connection()
+                settings_data = con.get_addons_settings(
+                    only_values=False,
+                    variant=cls._get_variant()
+                )
                 addons = settings_data["versions"]
             cache_item.update_value(addons)
 


### PR DESCRIPTION
## Changelog Description
Create global AYON api connection with all informations all the time.

## Additional info
Global ayon connection was initialized only in ayon-launcher process, but in DCCs missing or wrong information was used. That lead to unknown site id in DCCs or wrong settings variant being used. A function `get_ayon_server_api_connection` was implemented to be used instead of `ayon_api` directly. The function initialize the global connection with site id and ayon launcher version. Then ayon settings module in `openpype.settings` uses correct variant and also set default settings variant in global connection.

## Testing notes:
1. Settings should be taken from dev settings (or staging settings) inside DCCs and should use correct site id
2. OpenPype should not break at any point
