### PR TITLE
Chore: Staging mode determination

### DIFF
--- a/openpype/lib/openpype_version.py
+++ b/openpype/lib/openpype_version.py
@@ -140,7 +140,7 @@ def is_running_staging():
             latest_version = get_latest_version(local=False, remote=True)
         staging_version = latest_version
 
-    if current_version == production_version:
+    if current_version == staging_version:
         return True
 
     return is_staging_enabled()

--- a/openpype/resources/__init__.py
+++ b/openpype/resources/__init__.py
@@ -1,6 +1,6 @@
 import os
 from openpype import AYON_SERVER_ENABLED
-from openpype.lib.openpype_version import is_running_staging
+from openpype.lib.openpype_version import is_staging_enabled
 
 RESOURCES_DIR = os.path.dirname(os.path.abspath(__file__))
 
@@ -59,7 +59,7 @@ def get_openpype_icon_filepath(staging=None):
         return get_resource("icons", "AYON_icon_dev.png")
 
     if staging is None:
-        staging = is_running_staging()
+        staging = is_staging_enabled()
 
     if staging:
         return get_openpype_staging_icon_filepath()
@@ -68,7 +68,7 @@ def get_openpype_icon_filepath(staging=None):
 
 def get_openpype_splash_filepath(staging=None):
     if staging is None:
-        staging = is_running_staging()
+        staging = is_staging_enabled()
 
     if AYON_SERVER_ENABLED:
         if os.getenv("AYON_USE_DEV") == "1":


### PR DESCRIPTION
## Changelog Description
Resources use `is_staging_enabled` function instead of `is_running_staging` to determine if should use staging icon. And fixed comparison bug in `is_running_staging`.

## Additional info
Function `is_staging_enabled` is not meant to be used the way it was used in resources. In resource we care if we're in staging mode, not if we're in version that should be used for staging.

## Testing notes:
1. Determination of staging mode should be much faster
