### PR TITLE
AYON: Scene inventory tool without site sync

### DIFF
--- a/openpype/tools/ayon_sceneinventory/models/site_sync.py
+++ b/openpype/tools/ayon_sceneinventory/models/site_sync.py
@@ -40,9 +40,9 @@ class SiteSyncModel:
             dict[str, str]: Path by provider name.
         """
 
-        site_sync = self._get_sync_server_module()
-        if site_sync is None:
+        if not self.is_sync_server_enabled():
             return {}
+        site_sync = self._get_sync_server_module()
         return site_sync.get_site_icons()
 
     def get_sites_information(self):


### PR DESCRIPTION
## Changelog Description
Skip 'get_site_icons' if site sync addon is disabled.

## Additional info
It did not validate if the addon was disabled.
