### PR TITLE
Publish report tool: Fix PySide6

### DIFF
--- a/openpype/tools/publisher/publish_report_viewer/window.py
+++ b/openpype/tools/publisher/publish_report_viewer/window.py
@@ -329,7 +329,9 @@ class LoadedFilesView(QtWidgets.QTreeView):
     def __init__(self, *args, **kwargs):
         super(LoadedFilesView, self).__init__(*args, **kwargs)
         self.setEditTriggers(
-            self.EditKeyPressed | self.SelectedClicked | self.DoubleClicked
+            QtWidgets.QAbstractItemView.EditKeyPressed
+            | QtWidgets.QAbstractItemView.SelectedClicked
+            | QtWidgets.QAbstractItemView.DoubleClicked
         )
         self.setIndentation(0)
         self.setAlternatingRowColors(True)
@@ -366,7 +368,7 @@ class LoadedFilesView(QtWidgets.QTreeView):
 
     def _on_rows_inserted(self):
         header = self.header()
-        header.resizeSections(header.ResizeToContents)
+        header.resizeSections(QtWidgets.QHeaderView.ResizeToContents)
         self._update_remove_btn()
 
     def resizeEvent(self, event):
@@ -377,7 +379,7 @@ class LoadedFilesView(QtWidgets.QTreeView):
         super(LoadedFilesView, self).showEvent(event)
         self._model.refresh()
         header = self.header()
-        header.resizeSections(header.ResizeToContents)
+        header.resizeSections(QtWidgets.QHeaderView.ResizeToContents)
         self._update_remove_btn()
 
     def _on_selection_change(self):


### PR DESCRIPTION
## Changelog Description
Use constants from classes instead of objects.

## Additional info
Using constances from objects is not supported in PySide6.

## Testing notes:
1. Use Publish report viewer tool with PySide6 e.g. on MacOs (run `./openpype_console publish-report-viewer`)