### PR TITLE
AYON: Handle staging templates category

### DIFF
--- a/openpype/client/server/conversion_utils.py
+++ b/openpype/client/server/conversion_utils.py
@@ -138,16 +138,22 @@ def _template_replacements_to_v3(template):
     )
 
 
-def _convert_template_item(template):
-    # Others won't have 'directory'
-    if "directory" not in template:
-        return
-    folder = _template_replacements_to_v3(template.pop("directory"))
-    template["folder"] = folder
-    template["file"] = _template_replacements_to_v3(template["file"])
-    template["path"] = "/".join(
-        (folder, template["file"])
-    )
+def _convert_template_item(template_item):
+    for key, value in tuple(template_item.items()):
+        template_item[key] = _template_replacements_to_v3(value)
+
+    # Change 'directory' to 'folder'
+    if "directory" in template_item:
+        template_item["folder"] = template_item.pop("directory")
+
+    if (
+        "path" not in template_item
+        and "file" in template_item
+        and "folder" in template_item
+    ):
+        template_item["path"] = "/".join(
+            (template_item["folder"], template_item["file"])
+        )
 
 
 def _fill_template_category(templates, cat_templates, cat_key):

--- a/openpype/client/server/conversion_utils.py
+++ b/openpype/client/server/conversion_utils.py
@@ -218,10 +218,27 @@ def convert_v4_project_to_v3(project):
             _convert_template_item(template)
             new_others_templates[name] = template
 
+        staging_templates = templates.pop("staging_dir", None)
+        # Key 'staging_directories' is legacy key that changed
+        #   to 'staging_dir'
+        _legacy_staging_templates = templates.pop("staging_directories", None)
+        if staging_templates is None:
+            staging_templates = _legacy_staging_templates
+
+        if staging_templates is None:
+            staging_templates = {}
+
+        # Prefix all staging template names with 'staging_' prefix
+        #   and add them to 'others'
+        for name, template in staging_templates.items():
+            _convert_template_item(template)
+            new_name = "staging_{}".format(name)
+            new_others_templates[new_name] = template
+
         for key in (
             "work",
             "publish",
-            "hero"
+            "hero",
         ):
             cat_templates = templates.pop(key)
             _fill_template_category(templates, cat_templates, key)


### PR DESCRIPTION
## Changelog Description
Staging anatomy templates category is handled during project templates conversion. The keys are stored into `others` with `"staging_"` prefix.

## Testing notes:
1. Create staging template and fill directory in project anatomy (e.g. name `renders`)
2. Use the template in `ayon+settings://core/tools/publish/custom_staging_dir_profiles`
   - use `staging_` prefix for the name (e.g. `staging_renders`)
3. The template should be used for custom staging