### PR TITLE
Chore: Create plugin auto-apply settings

### DIFF
--- a/openpype/hosts/maya/api/plugin.py
+++ b/openpype/hosts/maya/api/plugin.py
@@ -271,7 +271,7 @@ class MayaCreatorBase(object):
 @six.add_metaclass(ABCMeta)
 class MayaCreator(NewCreator, MayaCreatorBase):
 
-    settings_name = None
+    settings_category = "maya"
 
     def create(self, subset_name, instance_data, pre_create_data):
 
@@ -317,24 +317,6 @@ class MayaCreator(NewCreator, MayaCreatorBase):
                     default=True)
         ]
 
-    def apply_settings(self, project_settings):
-        """Method called on initialization of plugin to apply settings."""
-
-        settings_name = self.settings_name
-        if settings_name is None:
-            settings_name = self.__class__.__name__
-
-        settings = project_settings["maya"]["create"]
-        settings = settings.get(settings_name)
-        if settings is None:
-            self.log.debug(
-                "No settings found for {}".format(self.__class__.__name__)
-            )
-            return
-
-        for key, value in settings.items():
-            setattr(self, key, value)
-
 
 class MayaAutoCreator(AutoCreator, MayaCreatorBase):
     """Automatically triggered creator for Maya.
@@ -342,6 +324,8 @@ class MayaAutoCreator(AutoCreator, MayaCreatorBase):
     The plugin is not visible in UI, and 'create' method does not expect
         any arguments.
     """
+
+    settings_category = "maya"
 
     def collect_instances(self):
         return self._default_collect_instances()
@@ -359,6 +343,8 @@ class MayaHiddenCreator(HiddenCreator, MayaCreatorBase):
     The plugin is not visible in UI, and it does not have strictly defined
         arguments for 'create' method.
     """
+
+    settings_category = "maya"
 
     def create(self, *args, **kwargs):
         return MayaCreator.create(self, *args, **kwargs)

--- a/openpype/pipeline/create/creator_plugins.py
+++ b/openpype/pipeline/create/creator_plugins.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 import copy
 import collections
 
@@ -264,6 +265,35 @@ class BaseCreator:
 
     def apply_settings(self, project_settings):
         """Method called on initialization of plugin to apply settings.
+
+        Default implementation tries to auto-apply settings values if are
+            in expected hierarchy.
+
+        Data hierarchy to auto-apply settings:
+            ├─ {self.settings_category}                 - Root key in settings
+            │ └─ "create"                               - Hardcoded key
+            │   └─ {self.settings_name} | {class name}  - Name of plugin
+            │     ├─ ... attribute values...            - Attribute/value pair
+
+        It is mandatory to define 'settings_category' attribute. Attribute
+        'settings_name' is optional and class name is used if is not defined.
+
+        Example data:
+            ProjectSettings {
+                "maya": {                    # self.settings_category
+                    "create": {              # Hardcoded key
+                        "CreateAnimation": { # self.settings_name / class name
+                            "enabled": True, # --- Attributes to set ---
+                            "optional": True,#
+                            "active": True,  #
+                            "fps": 25,       # -------------------------
+                        },
+                        ...
+                    },
+                    ...
+                },
+                ...
+            }
 
         Args:
             project_settings (dict[str, Any]): Project settings.

--- a/openpype/pipeline/create/creator_plugins.py
+++ b/openpype/pipeline/create/creator_plugins.py
@@ -318,7 +318,7 @@ class BaseCreator:
             # - those may be potential dangerous typos in settings
             if not hasattr(self, key):
                 self.log.debug((
-                    "Applying settings to unknown attribute '{}' on '{}."
+                    "Applying settings to unknown attribute '{}' on '{}'."
                 ).format(
                     key, cls_name
                 ))


### PR DESCRIPTION
## Changelog Description
Create plugins can auto-apply settings.

## Additional info
I was convinced that this should be default behavior like in other plugins. It is mandatory to set `settings_category` to be able to make auto-apply to work, category is root key in project settings. There looks for `"create"` key (hardcoded) where is looking for key `settings_name`, a class name is used instead of `settings_name` is not filled. The logic implemented in maya was removed.

## Testing notes:
1. Settings of Maya create plugins should be auto-applied
