### PR TITLE
Maya: Repair task in instance in context.

### DIFF
--- a/openpype/hosts/maya/plugins/publish/validate_instance_in_context.py
+++ b/openpype/hosts/maya/plugins/publish/validate_instance_in_context.py
@@ -16,15 +16,16 @@ from maya import cmds
 
 class ValidateInstanceInContext(pyblish.api.InstancePlugin,
                                 OptionalPyblishPluginMixin):
-    """Validator to check if instance asset match context asset.
+    """Validator to check if instance asset match context asset and task.
 
     When working in per-shot style you always publish data in context of
-    current asset (shot). This validator checks if this is so. It is optional
-    so it can be disabled when needed.
+    current asset (shot) and task. This validator checks if this is so. It is
+    optional so it can be disabled when needed.
 
     Action on this validator will select invalid instances in Outliner.
     """
 
+    # Depends on CollectContextEntities
     order = ValidateContentsOrder
     label = "Instance in same Context"
     optional = True
@@ -69,6 +70,11 @@ class ValidateInstanceInContext(pyblish.api.InstancePlugin,
         cmds.setAttr(
             "{}.asset".format(instance_node),
             context_asset,
+            type="string"
+        )
+        cmds.setAttr(
+            "{}.task".format(instance_node),
+            instance.context.data["task"],
             type="string"
         )
 

--- a/openpype/hosts/maya/plugins/publish/validate_instance_in_context.py
+++ b/openpype/hosts/maya/plugins/publish/validate_instance_in_context.py
@@ -38,25 +38,42 @@ class ValidateInstanceInContext(pyblish.api.InstancePlugin,
         if not self.is_active(instance.data):
             return
 
+
+        message = (
+            "Instance '{}' publishes to a different {} than current context: "
+            "{}. Current context: {}"
+        )
+        description = (
+            "## Publishing to a different asset or task\n"
+            "There are publish instances present which are publishing into a "
+            "different asset or task than your current context.\n\n"
+            "Usually this is not what you want but there can be cases where "
+            "you might want to publish into another asset or shot. If that's "
+            "the case you can disable the validation on the instance to "
+            "ignore it."
+        )
+
+        # Validate asset context.
         asset = instance.data.get("asset")
         context_asset = self.get_context_asset(instance)
-        if asset != context_asset:
+        if asset != instance.context.data["assetEntity"]["name"]:
             raise PublishValidationError(
-                message=(
-                    "Instance '{}' publishes to different asset than current "
-                    "context: {}. Current context: {}".format(
-                        instance.name, asset, context_asset
-                    )
+                message=message.format(
+                    instance.name, "asset", asset, context_asset
                 ),
-                description=(
-                    "## Publishing to a different asset\n"
-                    "There are publish instances present which are publishing "
-                    "into a different asset than your current context.\n\n"
-                    "Usually this is not what you want but there can be cases "
-                    "where you might want to publish into another asset or "
-                    "shot. If that's the case you can disable the validation "
-                    "on the instance to ignore it."
-                )
+                description=description
+            )
+
+        # Validate task context.
+        if instance.context.data["task"] != instance.data["task"]:
+            raise PublishValidationError(
+                message=message.format(
+                    instance.name,
+                    "task",
+                    instance.data["task"],
+                    instance.context.data["task"]
+                ),
+                description=description
             )
 
     @classmethod

--- a/openpype/hosts/maya/plugins/publish/validate_instance_in_context.py
+++ b/openpype/hosts/maya/plugins/publish/validate_instance_in_context.py
@@ -38,7 +38,6 @@ class ValidateInstanceInContext(pyblish.api.InstancePlugin,
         if not self.is_active(instance.data):
             return
 
-
         message = (
             "Instance '{}' publishes to a different {} than current context: "
             "{}. Current context: {}"


### PR DESCRIPTION
## Changelog Description
When repairing the instance in context, only the asset gets repaired, but this can lead to a confusing situation where the publisher blocks validation and publishing due to the task being invalid.

![instance_in_context_task](https://github.com/ynput/OpenPype/assets/1860085/bc6a5b36-dfe8-4715-a658-21c6ea6c2bef)

## Testing notes:
1. Open a workfile with existing instances and save to a different context.
2. Publish the instances and repair the `instance in context` validation.
