### PR TITLE
AYON: Loader tool bugs hunt

### DIFF
--- a/openpype/tools/ayon_loader/control.py
+++ b/openpype/tools/ayon_loader/control.py
@@ -1,4 +1,5 @@
 import logging
+import uuid
 
 import ayon_api
 
@@ -314,8 +315,15 @@ class LoaderController(BackendLoaderController, FrontendLoaderController):
                 containers = self._host.get_containers()
             else:
                 containers = self._host.ls()
-            repre_ids = {c.get("representation") for c in containers}
-            repre_ids.discard(None)
+            repre_ids = set()
+            for container in containers:
+                repre_id = container.get("representation")
+                try:
+                    uuid.UUID(repre_id)
+                    repre_ids.add(repre_id)
+                except ValueError:
+                    pass
+
             product_ids = self._products_model.get_product_ids_by_repre_ids(
                 project_name, repre_ids
             )

--- a/openpype/tools/ayon_loader/control.py
+++ b/openpype/tools/ayon_loader/control.py
@@ -318,6 +318,12 @@ class LoaderController(BackendLoaderController, FrontendLoaderController):
             repre_ids = set()
             for container in containers:
                 repre_id = container.get("representation")
+                # Ignore invalid representation ids.
+                # - invalid representation ids may be available if e.g. is
+                #   opened scene from OpenPype whe 'ObjectId' was used instead
+                #   of 'uuid'.
+                # NOTE: Server call would crash if there is any invalid id.
+                #   That would cause crash we won't get any information.
                 try:
                     uuid.UUID(repre_id)
                     repre_ids.add(repre_id)

--- a/openpype/tools/ayon_loader/models/products.py
+++ b/openpype/tools/ayon_loader/models/products.py
@@ -79,8 +79,8 @@ def product_item_from_entity(
     product_type = product_entity["productType"]
     product_type_item = product_type_items_by_name.get(product_type)
     # NOTE This is needed for cases when products were not created on server
-    #   using api functions. In that case product type item may not available
-    #   and we need to create a default.
+    #   using api functions. In that case product type item may not be
+    #   available and we need to create a default.
     if product_type_item is None:
         product_type_item = create_default_product_type_item(product_type)
         # Cache the item for future use

--- a/openpype/tools/ayon_loader/models/products.py
+++ b/openpype/tools/ayon_loader/models/products.py
@@ -77,7 +77,15 @@ def product_item_from_entity(
     product_attribs = product_entity["attrib"]
     group = product_attribs.get("productGroup")
     product_type = product_entity["productType"]
-    product_type_item = product_type_items_by_name[product_type]
+    product_type_item = product_type_items_by_name.get(product_type)
+    # NOTE This is needed for cases when products were not created on server
+    #   using api functions. In that case product type item may not available
+    #   and we need to create a default.
+    if product_type_item is None:
+        product_type_item = create_default_product_type_item(product_type)
+        # Cache the item for future use
+        product_type_items_by_name[product_type] = product_type_item
+
     product_type_icon = product_type_item.icon
 
     product_icon = {
@@ -115,6 +123,15 @@ def product_type_item_from_data(product_type_data):
     }
     # TODO implement checked logic
     return ProductTypeItem(product_type_data["name"], icon, True)
+
+
+def create_default_product_type_item(product_type):
+    icon = {
+        "type": "awesome-font",
+        "name": "fa.folder",
+        "color": "#0091B2",
+    }
+    return ProductTypeItem(product_type, icon, True)
 
 
 class ProductsModel:


### PR DESCRIPTION
## Changelog Description
Fix issues with invalid representation ids in loaded containers and handle missing product type in server database.

## Additional info
Both issues can happen only under specific conditions, e.g. imported OpenPype project or opened OpenPype scene in AYON mode.

## Testing notes:
1. Open DCC scene from OpenPype in AYON (should have loaded/referenced representations)
2. Open loader tool
3. Loader tool should work as expected