### PR TITLE
Chore: Do not use template data as source for context

### DIFF
--- a/openpype/hosts/photoshop/plugins/publish/collect_auto_image.py
+++ b/openpype/hosts/photoshop/plugins/publish/collect_auto_image.py
@@ -22,9 +22,9 @@ class CollectAutoImage(pyblish.api.ContextPlugin):
                 self.log.debug("Auto image instance found, won't create new")
                 return
 
-        project_name = context.data["anatomyData"]["project"]["name"]
+        project_name = context.data["projectName"]
         proj_settings = context.data["project_settings"]
-        task_name = context.data["anatomyData"]["task"]["name"]
+        task_name = context.data["task"]
         host_name = context.data["hostName"]
         asset_doc = context.data["assetEntity"]
         asset_name = asset_doc["name"]

--- a/openpype/hosts/photoshop/plugins/publish/collect_auto_review.py
+++ b/openpype/hosts/photoshop/plugins/publish/collect_auto_review.py
@@ -60,9 +60,9 @@ class CollectAutoReview(pyblish.api.ContextPlugin):
         variant = (context.data.get("variant") or
                    auto_creator["default_variant"])
 
-        project_name = context.data["anatomyData"]["project"]["name"]
+        project_name = context.data["projectName"]
         proj_settings = context.data["project_settings"]
-        task_name = context.data["anatomyData"]["task"]["name"]
+        task_name = context.data["task"]
         host_name = context.data["hostName"]
         asset_doc = context.data["assetEntity"]
         asset_name = asset_doc["name"]

--- a/openpype/hosts/photoshop/plugins/publish/collect_auto_workfile.py
+++ b/openpype/hosts/photoshop/plugins/publish/collect_auto_workfile.py
@@ -51,7 +51,7 @@ class CollectAutoWorkfile(pyblish.api.ContextPlugin):
                     self.log.debug("Workfile instance disabled")
                     return
 
-        project_name = context.data["anatomyData"]["project"]["name"]
+        project_name = context.data["projectName"]
         proj_settings = context.data["project_settings"]
         auto_creator = proj_settings.get(
             "photoshop", {}).get(
@@ -66,7 +66,7 @@ class CollectAutoWorkfile(pyblish.api.ContextPlugin):
         variant = (context.data.get("variant") or
                    auto_creator["default_variant"])
 
-        task_name = context.data["anatomyData"]["task"]["name"]
+        task_name = context.data["task"]
         host_name = context.data["hostName"]
         asset_doc = context.data["assetEntity"]
         asset_name = asset_doc["name"]

--- a/openpype/modules/deadline/plugins/publish/submit_publish_job.py
+++ b/openpype/modules/deadline/plugins/publish/submit_publish_job.py
@@ -708,6 +708,7 @@ class ProcessSubmittedJobOnFarm(pyblish.api.InstancePlugin,
         """
 
         project_name = context.data["projectName"]
+        host_name = context.data["hostName"]
         if not version:
             version = get_last_version_by_subset_name(
                 project_name,
@@ -719,7 +720,7 @@ class ProcessSubmittedJobOnFarm(pyblish.api.InstancePlugin,
             else:
                 version = get_versioning_start(
                     project_name,
-                    template_data["app"],
+                    host_name,
                     task_name=template_data["task"]["name"],
                     task_type=template_data["task"]["type"],
                     family="render",

--- a/openpype/modules/slack/plugins/publish/collect_slack_family.py
+++ b/openpype/modules/slack/plugins/publish/collect_slack_family.py
@@ -38,7 +38,7 @@ class CollectSlackFamilies(pyblish.api.InstancePlugin,
             "families": family,
             "tasks": task_data.get("name"),
             "task_types": task_data.get("type"),
-            "hosts": instance.data["anatomyData"]["app"],
+            "hosts": instance.context.data["hostName"],
             "subsets": instance.data["subset"]
         }
         profile = filter_profiles(self.profiles, key_values,


### PR DESCRIPTION
## Changelog Description
Use available information on context to receive context data instead of using `"anatomyData"` during publishing.

## Additional info
Most of the data are available on context and it is not necessary to use data dedicated for template formatting to receive them, especially host name.

## Testing notes:
Nothing should change.
