### PR TITLE
Publisher: Bugfixes and enhancements

### DIFF
--- a/openpype/tools/publisher/control.py
+++ b/openpype/tools/publisher/control.py
@@ -1881,10 +1881,19 @@ class PublisherController(BasePublisherController):
         self._emit_event("plugins.refresh.finished")
 
     def _collect_creator_items(self):
-        return {
-            identifier: CreatorItem.from_creator(creator)
-            for identifier, creator in self._create_context.creators.items()
-        }
+        # TODO add crashed initialization of create plugins to report
+        output = {}
+        for identifier, creator in self._create_context.creators.items():
+            try:
+                output[identifier] = CreatorItem.from_creator(creator)
+            except Exception:
+                self.log.error(
+                    "Failed to create creator item for '%s'",
+                    identifier,
+                    exc_info=True
+                )
+
+        return output
 
     def _reset_instances(self):
         """Reset create instances."""

--- a/openpype/tools/publisher/control.py
+++ b/openpype/tools/publisher/control.py
@@ -1453,7 +1453,7 @@ class BasePublisherController(AbstractPublisherController):
         """
 
         if self._log is None:
-            self._log = logging.getLogget(self.__class__.__name__)
+            self._log = logging.getLogger(self.__class__.__name__)
         return self._log
 
     @property

--- a/openpype/tools/publisher/widgets/overview_widget.py
+++ b/openpype/tools/publisher/widgets/overview_widget.py
@@ -35,7 +35,10 @@ class OverviewWidget(QtWidgets.QFrame):
         # --- Created Subsets/Instances ---
         # Common widget for creation and overview
         subset_views_widget = BorderedLabelWidget(
-            "Subsets to publish", subset_content_widget
+            "{} to publish".format(
+                "Products" if AYON_SERVER_ENABLED else "Subsets"
+            ),
+            subset_content_widget
         )
 
         subset_view_cards = InstanceCardView(controller, subset_views_widget)

--- a/openpype/tools/publisher/widgets/overview_widget.py
+++ b/openpype/tools/publisher/widgets/overview_widget.py
@@ -1,5 +1,7 @@
 from qtpy import QtWidgets, QtCore
 
+from openpype import AYON_SERVER_ENABLED
+
 from .border_label_widget import BorderedLabelWidget
 
 from .card_view_widgets import InstanceCardView

--- a/openpype/tools/publisher/widgets/widgets.py
+++ b/openpype/tools/publisher/widgets/widgets.py
@@ -210,7 +210,9 @@ class CreateBtn(PublishIconBtn):
     def __init__(self, parent=None):
         icon_path = get_icon_path("create")
         super(CreateBtn, self).__init__(icon_path, "Create", parent)
-        self.setToolTip("Create new subset/s")
+        self.setToolTip("Create new {}/s".format(
+            "product" if AYON_SERVER_ENABLED else "subset"
+        ))
         self.setLayoutDirection(QtCore.Qt.RightToLeft)
 
 
@@ -655,7 +657,11 @@ class TasksCombobox(QtWidgets.QComboBox):
         self._proxy_model.set_filter_empty(invalid)
         if invalid:
             self._set_is_valid(False)
-            self.set_text("< One or more subsets require Task selected >")
+            self.set_text(
+                "< One or more {} require Task selected >".format(
+                    "products" if AYON_SERVER_ENABLED else "subsets"
+                )
+            )
         else:
             self.set_text(None)
 


### PR DESCRIPTION
## Changelog Description
Small fixes/enhancements in publisher UI.

## Additional info
Fixed typo in logger creation. One invalid create plugin does not cause that none create plugins are visible. Use products instead of subset in UI.

The invalid create plugin was discovered by having a bug in `get_pre_create_attributes` which caused that UI was useless. By logging of the issue I've discovered that logger creation does not work.

## Testing notes:
- Labels in AYON mode should have `product` instead of `subset`.
- Fake bug in `get_pre_create_attr_defs` of a create plugin > the plugin will not show up in the list but other plugins should appear.