### PR TITLE
Blender: Better name of 'asset_name' function

### DIFF
--- a/openpype/hosts/blender/api/plugin.py
+++ b/openpype/hosts/blender/api/plugin.py
@@ -28,7 +28,7 @@ from .lib import imprint
 VALID_EXTENSIONS = [".blend", ".json", ".abc", ".fbx"]
 
 
-def asset_name(
+def prepare_scene_name(
     asset: str, subset: str, namespace: Optional[str] = None
 ) -> str:
     """Return a consistent name for an asset."""
@@ -225,7 +225,7 @@ class BaseCreator(Creator):
             bpy.context.scene.collection.children.link(instances)
 
         # Create asset group
-        name = asset_name(instance_data["asset"], subset_name)
+        name = prepare_scene_name(instance_data["asset"], subset_name)
         if self.create_as_asset_group:
             # Create instance as empty
             instance_node = bpy.data.objects.new(name=name, object_data=None)
@@ -298,7 +298,7 @@ class BaseCreator(Creator):
                     "subset" in changes.changed_keys
                     or "asset" in changes.changed_keys
             ):
-                name = asset_name(asset=data["asset"], subset=data["subset"])
+                name = prepare_scene_name(asset=data["asset"], subset=data["subset"])
                 node.name = name
 
             imprint(node, data)
@@ -454,7 +454,7 @@ class AssetLoader(LoaderPlugin):
             asset, subset
         )
         namespace = namespace or f"{asset}_{unique_number}"
-        name = name or asset_name(
+        name = name or prepare_scene_name(
             asset, subset, unique_number
         )
 
@@ -483,7 +483,7 @@ class AssetLoader(LoaderPlugin):
 
         # asset = context["asset"]["name"]
         # subset = context["subset"]["name"]
-        # instance_name = asset_name(asset, subset, unique_number) + '_CON'
+        # instance_name = prepare_scene_name(asset, subset, unique_number) + '_CON'
 
         # return self._get_instance_collection(instance_name, nodes)
 

--- a/openpype/hosts/blender/api/plugin.py
+++ b/openpype/hosts/blender/api/plugin.py
@@ -298,7 +298,9 @@ class BaseCreator(Creator):
                     "subset" in changes.changed_keys
                     or "asset" in changes.changed_keys
             ):
-                name = prepare_scene_name(asset=data["asset"], subset=data["subset"])
+                name = prepare_scene_name(
+                    asset=data["asset"], subset=data["subset"]
+                )
                 node.name = name
 
             imprint(node, data)
@@ -483,7 +485,9 @@ class AssetLoader(LoaderPlugin):
 
         # asset = context["asset"]["name"]
         # subset = context["subset"]["name"]
-        # instance_name = prepare_scene_name(asset, subset, unique_number) + '_CON'
+        # instance_name = prepare_scene_name(
+        #     asset, subset, unique_number
+        # ) + '_CON'
 
         # return self._get_instance_collection(instance_name, nodes)
 

--- a/openpype/hosts/blender/plugins/create/create_action.py
+++ b/openpype/hosts/blender/plugins/create/create_action.py
@@ -22,7 +22,7 @@ class CreateAction(plugin.BaseCreator):
         )
 
         # Get instance name
-        name = plugin.asset_name(instance_data["asset"], subset_name)
+        name = plugin.prepare_scene_name(instance_data["asset"], subset_name)
 
         if pre_create_data.get("use_selection"):
             for obj in lib.get_selection():

--- a/openpype/hosts/blender/plugins/load/import_workfile.py
+++ b/openpype/hosts/blender/plugins/load/import_workfile.py
@@ -7,7 +7,7 @@ def append_workfile(context, fname, do_import):
     asset = context['asset']['name']
     subset = context['subset']['name']
 
-    group_name = plugin.asset_name(asset, subset)
+    group_name = plugin.prepare_scene_name(asset, subset)
 
     # We need to preserve the original names of the scenes, otherwise,
     # if there are duplicate names in the current workfile, the imported

--- a/openpype/hosts/blender/plugins/load/load_abc.py
+++ b/openpype/hosts/blender/plugins/load/load_abc.py
@@ -137,9 +137,9 @@ class CacheModelLoader(plugin.AssetLoader):
         asset = context["asset"]["name"]
         subset = context["subset"]["name"]
 
-        asset_name = plugin.asset_name(asset, subset)
+        asset_name = plugin.prepare_scene_name(asset, subset)
         unique_number = plugin.get_unique_number(asset, subset)
-        group_name = plugin.asset_name(asset, subset, unique_number)
+        group_name = plugin.prepare_scene_name(asset, subset, unique_number)
         namespace = namespace or f"{asset}_{unique_number}"
 
         containers = bpy.data.collections.get(AVALON_CONTAINERS)

--- a/openpype/hosts/blender/plugins/load/load_action.py
+++ b/openpype/hosts/blender/plugins/load/load_action.py
@@ -7,7 +7,7 @@ from typing import Dict, List, Optional
 
 import bpy
 from openpype.pipeline import get_representation_path
-import openpype.hosts.blender.api.plugin
+from openpype.hosts.blender.api import plugin
 from openpype.hosts.blender.api.pipeline import (
     containerise_existing,
     AVALON_PROPERTY,
@@ -16,7 +16,7 @@ from openpype.hosts.blender.api.pipeline import (
 logger = logging.getLogger("openpype").getChild("blender").getChild("load_action")
 
 
-class BlendActionLoader(openpype.hosts.blender.api.plugin.AssetLoader):
+class BlendActionLoader(plugin.AssetLoader):
     """Load action from a .blend file.
 
     Warning:
@@ -46,8 +46,8 @@ class BlendActionLoader(openpype.hosts.blender.api.plugin.AssetLoader):
         libpath = self.filepath_from_context(context)
         asset = context["asset"]["name"]
         subset = context["subset"]["name"]
-        lib_container = openpype.hosts.blender.api.plugin.asset_name(asset, subset)
-        container_name = openpype.hosts.blender.api.plugin.asset_name(
+        lib_container = plugin.prepare_scene_name(asset, subset)
+        container_name = plugin.prepare_scene_name(
             asset, subset, namespace
         )
 
@@ -152,7 +152,7 @@ class BlendActionLoader(openpype.hosts.blender.api.plugin.AssetLoader):
         assert libpath.is_file(), (
             f"The file doesn't exist: {libpath}"
         )
-        assert extension in openpype.hosts.blender.api.plugin.VALID_EXTENSIONS, (
+        assert extension in plugin.VALID_EXTENSIONS, (
             f"Unsupported file: {libpath}"
         )
 

--- a/openpype/hosts/blender/plugins/load/load_audio.py
+++ b/openpype/hosts/blender/plugins/load/load_audio.py
@@ -42,9 +42,9 @@ class AudioLoader(plugin.AssetLoader):
         asset = context["asset"]["name"]
         subset = context["subset"]["name"]
 
-        asset_name = plugin.asset_name(asset, subset)
+        asset_name = plugin.prepare_scene_name(asset, subset)
         unique_number = plugin.get_unique_number(asset, subset)
-        group_name = plugin.asset_name(asset, subset, unique_number)
+        group_name = plugin.prepare_scene_name(asset, subset, unique_number)
         namespace = namespace or f"{asset}_{unique_number}"
 
         avalon_container = bpy.data.collections.get(AVALON_CONTAINERS)

--- a/openpype/hosts/blender/plugins/load/load_blend.py
+++ b/openpype/hosts/blender/plugins/load/load_blend.py
@@ -133,9 +133,9 @@ class BlendLoader(plugin.AssetLoader):
 
         representation = str(context["representation"]["_id"])
 
-        asset_name = plugin.asset_name(asset, subset)
+        asset_name = plugin.prepare_scene_name(asset, subset)
         unique_number = plugin.get_unique_number(asset, subset)
-        group_name = plugin.asset_name(asset, subset, unique_number)
+        group_name = plugin.prepare_scene_name(asset, subset, unique_number)
         namespace = namespace or f"{asset}_{unique_number}"
 
         avalon_container = bpy.data.collections.get(AVALON_CONTAINERS)

--- a/openpype/hosts/blender/plugins/load/load_blendscene.py
+++ b/openpype/hosts/blender/plugins/load/load_blendscene.py
@@ -85,9 +85,9 @@ class BlendSceneLoader(plugin.AssetLoader):
         except ValueError:
             family = "model"
 
-        asset_name = plugin.asset_name(asset, subset)
+        asset_name = plugin.prepare_scene_name(asset, subset)
         unique_number = plugin.get_unique_number(asset, subset)
-        group_name = plugin.asset_name(asset, subset, unique_number)
+        group_name = plugin.prepare_scene_name(asset, subset, unique_number)
         namespace = namespace or f"{asset}_{unique_number}"
 
         avalon_container = bpy.data.collections.get(AVALON_CONTAINERS)

--- a/openpype/hosts/blender/plugins/load/load_camera_abc.py
+++ b/openpype/hosts/blender/plugins/load/load_camera_abc.py
@@ -87,9 +87,9 @@ class AbcCameraLoader(plugin.AssetLoader):
         asset = context["asset"]["name"]
         subset = context["subset"]["name"]
 
-        asset_name = plugin.asset_name(asset, subset)
+        asset_name = plugin.prepare_scene_name(asset, subset)
         unique_number = plugin.get_unique_number(asset, subset)
-        group_name = plugin.asset_name(asset, subset, unique_number)
+        group_name = plugin.prepare_scene_name(asset, subset, unique_number)
         namespace = namespace or f"{asset}_{unique_number}"
 
         avalon_container = bpy.data.collections.get(AVALON_CONTAINERS)

--- a/openpype/hosts/blender/plugins/load/load_camera_fbx.py
+++ b/openpype/hosts/blender/plugins/load/load_camera_fbx.py
@@ -90,9 +90,9 @@ class FbxCameraLoader(plugin.AssetLoader):
         asset = context["asset"]["name"]
         subset = context["subset"]["name"]
 
-        asset_name = plugin.asset_name(asset, subset)
+        asset_name = plugin.prepare_scene_name(asset, subset)
         unique_number = plugin.get_unique_number(asset, subset)
-        group_name = plugin.asset_name(asset, subset, unique_number)
+        group_name = plugin.prepare_scene_name(asset, subset, unique_number)
         namespace = namespace or f"{asset}_{unique_number}"
 
         avalon_container = bpy.data.collections.get(AVALON_CONTAINERS)

--- a/openpype/hosts/blender/plugins/load/load_fbx.py
+++ b/openpype/hosts/blender/plugins/load/load_fbx.py
@@ -134,9 +134,9 @@ class FbxModelLoader(plugin.AssetLoader):
         asset = context["asset"]["name"]
         subset = context["subset"]["name"]
 
-        asset_name = plugin.asset_name(asset, subset)
+        asset_name = plugin.prepare_scene_name(asset, subset)
         unique_number = plugin.get_unique_number(asset, subset)
-        group_name = plugin.asset_name(asset, subset, unique_number)
+        group_name = plugin.prepare_scene_name(asset, subset, unique_number)
         namespace = namespace or f"{asset}_{unique_number}"
 
         avalon_container = bpy.data.collections.get(AVALON_CONTAINERS)

--- a/openpype/hosts/blender/plugins/load/load_layout_json.py
+++ b/openpype/hosts/blender/plugins/load/load_layout_json.py
@@ -149,9 +149,9 @@ class JsonLayoutLoader(plugin.AssetLoader):
         asset = context["asset"]["name"]
         subset = context["subset"]["name"]
 
-        asset_name = plugin.asset_name(asset, subset)
+        asset_name = plugin.prepare_scene_name(asset, subset)
         unique_number = plugin.get_unique_number(asset, subset)
-        group_name = plugin.asset_name(asset, subset, unique_number)
+        group_name = plugin.prepare_scene_name(asset, subset, unique_number)
         namespace = namespace or f"{asset}_{unique_number}"
 
         avalon_container = bpy.data.collections.get(AVALON_CONTAINERS)

--- a/openpype/hosts/blender/plugins/load/load_look.py
+++ b/openpype/hosts/blender/plugins/load/load_look.py
@@ -96,14 +96,14 @@ class BlendLookLoader(plugin.AssetLoader):
         asset = context["asset"]["name"]
         subset = context["subset"]["name"]
 
-        lib_container = plugin.asset_name(
+        lib_container = plugin.prepare_scene_name(
             asset, subset
         )
         unique_number = plugin.get_unique_number(
             asset, subset
         )
         namespace = namespace or f"{asset}_{unique_number}"
-        container_name = plugin.asset_name(
+        container_name = plugin.prepare_scene_name(
             asset, subset, unique_number
         )
 


### PR DESCRIPTION
## Changelog Description
Renamed function `asset_name` to `prepare_scene_name`.

## Additional info
The name `asset_name` is not very good decision for a function name. It does not tell what the function does and the name canot be used as variable where the function is used. I've hit an issue when I wanted to use variable `asset_name`.

## Testing notes:
1. All loaders and creators should work as before this PR.