### PR TITLE
Houdini: USD Render actually use Render Products from Render Settings

### DIFF
--- a/openpype/hosts/houdini/api/plugin.py
+++ b/openpype/hosts/houdini/api/plugin.py
@@ -182,8 +182,9 @@ class HoudiniCreator(NewCreator, HoudiniCreatorBase):
             if node_type is None:
                 node_type = "geometry"
 
+            parent = pre_create_data.get("parent", "/out")
             instance_node = self.create_instance_node(
-                subset_name, "/out", node_type)
+                subset_name, parent, node_type)
 
             self.customize_node_look(instance_node)
 

--- a/openpype/hosts/houdini/api/usd.py
+++ b/openpype/hosts/houdini/api/usd.py
@@ -189,7 +189,7 @@ def get_usd_rop_loppath(node):
     if node_type == "usd":
         return node.parm("loppath").evalAsNode()
 
-    elif node_type in {"usd_rop", "usdrender_rop"}:
+    elif node_type in {"usd_rop", "usdrender_rop", "usdrender"}:
         # Inside Solaris e.g. /stage (not in ROP context)
         # When incoming connection is present it takes it directly
         inputs = node.inputs()

--- a/openpype/hosts/houdini/plugins/create/create_usdrender.py
+++ b/openpype/hosts/houdini/plugins/create/create_usdrender.py
@@ -14,8 +14,6 @@ class CreateUSDRender(plugin.HoudiniCreator):
     def create(self, subset_name, instance_data, pre_create_data):
         import hou  # noqa
 
-        instance_data["parent"] = hou.node("/stage")
-
         # Remove the active, we are checking the bypass flag of the nodes
         instance_data.pop("active", None)
         instance_data.update({"node_type": "usdrender"})
@@ -26,8 +24,6 @@ class CreateUSDRender(plugin.HoudiniCreator):
             pre_create_data)  # type: CreatedInstance
 
         instance_node = hou.node(instance.get("instance_node"))
-
-
         parms = {
             # Render frame range
             "trange": 1

--- a/openpype/hosts/houdini/plugins/publish/collect_render_products.py
+++ b/openpype/hosts/houdini/plugins/publish/collect_render_products.py
@@ -117,5 +117,6 @@ class CollectRenderProducts(pyblish.api.InstancePlugin):
 
             files.append(filename)
 
-            # TODO: Report the product's prim path?
-            self.log.info("Collected %s name: %s" % (product, filename))
+            self.log.info(
+                "Collected '%s' name: %s", str(prim.GetPath()), filename
+            )

--- a/openpype/hosts/houdini/plugins/publish/collect_render_products.py
+++ b/openpype/hosts/houdini/plugins/publish/collect_render_products.py
@@ -86,6 +86,12 @@ class CollectRenderProducts(pyblish.api.InstancePlugin):
                         input_node.cook(force=True)
 
         stage = node.stage()
+
+        # Houdini docs state about the `rendersettings` parm:
+        #  If this is blank, the node looks for default render settings
+        #  on the root prim. If the root prim has no render settings,
+        #  the node will use default settings.
+        # TODO: Allow empty value to fallback to defaults
         render_settings_prim_path = rop_node.evalParm("rendersettings")
         render_settings_prim = stage.GetPrimAtPath(render_settings_prim_path)
         if not render_settings_prim:

--- a/openpype/hosts/houdini/plugins/publish/collect_render_products.py
+++ b/openpype/hosts/houdini/plugins/publish/collect_render_products.py
@@ -42,7 +42,8 @@ class CollectRenderProducts(pyblish.api.InstancePlugin):
         #  If this is blank, the node looks for default render settings
         #  on the root prim. If the root prim has no render settings,
         #  the node will use default settings.
-        # TODO: Allow empty value to fallback to defaults
+        # Also see:
+        #  https://github.com/sideeffects/HoudiniUsdBridge/blob/cab7aae818fc582db2890d640b8468f7fbf4865c/src/houdini/lib/H_USD/HUSD/XUSD_RenderSettings.C#L1005-L1033  # noqa
         render_settings_prim_path = rop_node.evalParm("rendersettings")
         if render_settings_prim_path:
             render_settings_prim = stage.GetPrimAtPath(


### PR DESCRIPTION
## Changelog Description

The Collect Render Products logic previously traversed the full USD stage to find all render products, but a Render may not use all Render Products but will only render those defined by the Render Settings - as such, we should be retrieving them from the used Render Settings in the render.

## Additional notes

Came up on Discord [here](https://discord.com/channels/517362899170230292/517382145552154634/1176080300288245840)

More details about USD Rendering:

- [USD Render Schema: Concepts](https://openusd.org/dev/api/usd_render_page_front.html)
- [Houdini USD Render ROP](https://www.sidefx.com/docs/houdini/nodes/out/usdrender.html)

According to [this documentation on `UsdRenderSettingsBase`](https://openusd.org/dev/api/class_usd_render_settings_base.html) it should be possible to also set Render Settings on RenderProduct prims - but how that would work in practice I'm not sure. They state:
> Abstract base class that defines render settings that can be specified on either a RenderSettings prim or a RenderProduct prim.

## Testing notes:

1. Submit USD renders (via _usdrender_ instance!)
2. Render Products should be collected and submitted only for those render products that are in the render settings


Note that the Karma ROP publish instance is **different** from this one since it doesn't use the USD data to collect the expected outputs but instead parses the Karma ROP parms itself. Eventually it'd mean less code duplication if that logic could _also_ adopt reading it from the USD data. But this PR will not touch that.