### PR TITLE
Houdini: TAB create instances in /obj or /stage directly instead of /out 

### DIFF
--- a/openpype/hosts/houdini/api/plugin.py
+++ b/openpype/hosts/houdini/api/plugin.py
@@ -182,8 +182,9 @@ class HoudiniCreator(NewCreator, HoudiniCreatorBase):
             if node_type is None:
                 node_type = "geometry"
 
+            parent_path = pre_create_data.get("parent", "/out")
             instance_node = self.create_instance_node(
-                subset_name, "/out", node_type)
+                subset_name, parent_path, node_type)
 
             self.customize_node_look(instance_node)
 

--- a/openpype/hosts/houdini/api/plugin.py
+++ b/openpype/hosts/houdini/api/plugin.py
@@ -319,6 +319,13 @@ class HoudiniCreator(NewCreator, HoudiniCreatorBase):
         """
         return [hou.ropNodeTypeCategory()]
 
+    def create_interactive(self, kwargs):
+        """The behavior for an interactive creation from TAB menu."""
+        from openpype.hosts.houdini.api.creator_node_shelves import (
+            default_create_interactive
+        )
+        return default_create_interactive(creator=self, kwargs=kwargs)
+
     def apply_settings(self, project_settings):
         """Method called on initialization of plugin to apply settings."""
 

--- a/openpype/hosts/houdini/plugins/create/create_usd.py
+++ b/openpype/hosts/houdini/plugins/create/create_usd.py
@@ -16,8 +16,23 @@ class CreateUSD(plugin.HoudiniCreator):
 
     def create(self, subset_name, instance_data, pre_create_data):
 
+        # Allow creating the USD node directly in a LOP network as opposed
+        # to an /out network by defining the type based on a `parent` if
+        # it passed along.
+        node_type = "usd"
+        parent = pre_create_data.get("parent")
+        if parent:
+            parent_node = hou.node(parent)
+            if parent_node.childTypeCategory() == hou.lopNodeTypeCategory():
+                node_type = "usd_rop"
+            elif parent_node.childTypeCategory() != hou.ropNodeTypeCategory():
+                raise ValueError(
+                    "Unable to create USD Render instance under parent: "
+                    "{}".format(parent)
+                )
+
         instance_data.pop("active", None)
-        instance_data.update({"node_type": "usd"})
+        instance_data.update({"node_type": node_type})
 
         instance = super(CreateUSD, self).create(
             subset_name,
@@ -50,3 +65,28 @@ class CreateUSD(plugin.HoudiniCreator):
             hou.ropNodeTypeCategory(),
             hou.lopNodeTypeCategory()
         ]
+
+    def create_interactive(self, kwargs):
+        # Allow to create a USD render rop directly in LOP networks natively
+        import stateutils
+        from openpype.hosts.houdini.api.creator_node_shelves import (
+            prompt_variant
+        )
+
+        context = self.create_context
+        pane = stateutils.activePane(kwargs)
+        if isinstance(pane, hou.NetworkEditor):
+            pwd = pane.pwd()
+            if pwd.childTypeCategory() == hou.lopNodeTypeCategory():
+                # Allow to create the ROP node parented under this
+                variant = prompt_variant(creator=self)
+                context.create(
+                    creator_identifier=self.identifier,
+                    variant=variant,
+                    pre_create_data={"use_selection": False,
+                                     "parent": pwd.path()}
+                )
+                return
+
+        # Fall back to default behavior
+        return super(CreateUSD, self).create_interactive(kwargs)

--- a/openpype/hosts/houdini/plugins/create/create_usdrender.py
+++ b/openpype/hosts/houdini/plugins/create/create_usdrender.py
@@ -3,6 +3,8 @@
 from openpype.hosts.houdini.api import plugin
 from openpype.pipeline import CreatedInstance
 
+import hou
+
 
 class CreateUSDRender(plugin.HoudiniCreator):
     """USD Render ROP in /stage"""
@@ -12,13 +14,25 @@ class CreateUSDRender(plugin.HoudiniCreator):
     icon = "magic"
 
     def create(self, subset_name, instance_data, pre_create_data):
-        import hou  # noqa
+
+        # Allow creating the
+        node_type = "usdrender"
+        parent = pre_create_data.get("parent")
+        if parent:
+            parent_node = hou.node(parent)
+            if parent_node.childTypeCategory() == hou.lopNodeTypeCategory():
+                node_type = "usdrender_rop"
+            elif parent_node.childTypeCategory() != hou.ropNodeTypeCategory():
+                raise ValueError(
+                    "Unable to create USD Render instance under parent: "
+                    "{}".format(parent)
+                )
 
         instance_data["parent"] = hou.node("/stage")
 
         # Remove the active, we are checking the bypass flag of the nodes
         instance_data.pop("active", None)
-        instance_data.update({"node_type": "usdrender"})
+        instance_data.update({"node_type": node_type})
 
         instance = super(CreateUSDRender, self).create(
             subset_name,
@@ -39,3 +53,44 @@ class CreateUSDRender(plugin.HoudiniCreator):
         # Lock some Avalon attributes
         to_lock = ["family", "id"]
         self.lock_parameters(instance_node, to_lock)
+
+    def get_network_categories(self):
+        """Return in which network view type this creator should show.
+
+        The node type categories returned here will be used to define where
+        the creator will show up in the TAB search for nodes in Houdini's
+        Network View.
+
+        This can be overridden in inherited classes to define where that
+        particular Creator should be visible in the TAB search.
+
+        Returns:
+            list: List of houdini node type categories
+
+        """
+        return [hou.ropNodeTypeCategory(), hou.lopNodeTypeCategory()]
+
+    def create_interactive(self, kwargs):
+        # Allow to create a USD render rop directly in LOP networks natively
+        import stateutils
+        from openpype.hosts.houdini.api.creator_node_shelves import (
+            prompt_variant
+        )
+
+        context = self.create_context
+        pane = stateutils.activePane(kwargs)
+        if isinstance(pane, hou.NetworkEditor):
+            pwd = pane.pwd()
+            if pwd.childTypeCategory() == hou.lopNodeTypeCategory():
+                # Allow to create the ROP node parented under this
+                variant = prompt_variant(creator=self)
+                context.create(
+                    creator_identifier=self.identifier,
+                    variant=variant,
+                    pre_create_data={"use_selection": False,
+                                     "parent": pwd.path()}
+                )
+                return
+
+        # Fall back to default behavior
+        return super(CreateUSDRender, self).create_interactive(kwargs)

--- a/openpype/hosts/houdini/plugins/create/create_usdrender.py
+++ b/openpype/hosts/houdini/plugins/create/create_usdrender.py
@@ -28,8 +28,6 @@ class CreateUSDRender(plugin.HoudiniCreator):
                     "{}".format(parent)
                 )
 
-        instance_data["parent"] = hou.node("/stage")
-
         # Remove the active, we are checking the bypass flag of the nodes
         instance_data.pop("active", None)
         instance_data.update({"node_type": node_type})


### PR DESCRIPTION
## Changelog Description

Allow Alembic pointcache and USD rop instances to be created in respectively SOP or LOP network directly via TAB menu.

This is just a quick prototype and there's lot of code duplication which we might want to simplify down the line, anyway - it's worth playing around with it to discuss whether this is something we want to support in this manner. (Or discuss whether other implementation for publish instances are actually more native to houdini and thus better anyway.)

## Additional info

Just a prototype showing the possibility.

Basically a Creator can now override the behavior for the interactive creations - e.g. doing something different when created in `/stage` or alike.

## Testing notes:

1. Create pointcache or USD instances via TAB menu
2. Publish