### PR TITLE
Chore AYON: AYON addon class

### DIFF
--- a/openpype/modules/__init__.py
+++ b/openpype/modules/__init__.py
@@ -10,6 +10,7 @@ from .interfaces import (
 )
 
 from .base import (
+    AYONAddon,
     OpenPypeModule,
     OpenPypeAddOn,
 
@@ -35,6 +36,7 @@ __all__ = (
     "ISettingsChangeListener",
     "IHostAddon",
 
+    "AYONAddon",
     "OpenPypeModule",
     "OpenPypeAddOn",
 

--- a/openpype/modules/base.py
+++ b/openpype/modules/base.py
@@ -919,7 +919,7 @@ class ModulesManager:
         for modules_item in module_classes:
             is_openpype_module = issubclass(modules_item, OpenPypeModule)
             settings = (
-                system_settings if is_openpype_module else ayon_settings
+                modules_settings if is_openpype_module else ayon_settings
             )
             name = modules_item.__name__
             try:

--- a/openpype/modules/base.py
+++ b/openpype/modules/base.py
@@ -806,6 +806,8 @@ class ModulesManager:
 
     # Helper attributes for report
     _report_total_key = "Total"
+    _system_settings = None
+    _ayon_settings = None
 
     def __init__(self, system_settings=None, ayon_settings=None):
         self.log = logging.getLogger(self.__class__.__name__)
@@ -864,7 +866,11 @@ class ModulesManager:
 
         import openpype_modules
 
-        self.log.debug("*** Pype modules initialization.")
+        self.log.debug("*** {} initialization.".format(
+            "AYON addons"
+            if AYON_SERVER_ENABLED
+            else "OpenPype modules"
+        ))
         # Prepare settings for modules
         system_settings = self._system_settings
         if system_settings is None:

--- a/openpype/modules/base.py
+++ b/openpype/modules/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-"""Base class for Pype Modules."""
+"""Base class for AYON addons."""
 import copy
 import os
 import sys
@@ -11,6 +11,7 @@ import platform
 import threading
 import collections
 import traceback
+
 from uuid import uuid4
 from abc import ABCMeta, abstractmethod
 
@@ -29,9 +30,12 @@ from openpype.settings import (
 
 from openpype.settings.lib import (
     get_studio_system_settings_overrides,
-    load_json_file
+    load_json_file,
 )
-from openpype.settings.ayon_settings import is_dev_mode_enabled
+from openpype.settings.ayon_settings import (
+    is_dev_mode_enabled,
+    get_ayon_settings,
+)
 
 from openpype.lib import (
     Logger,
@@ -47,11 +51,11 @@ from .interfaces import (
     ITrayService
 )
 
-# Files that will be always ignored on modules import
+# Files that will be always ignored on addons import
 IGNORED_FILENAMES = (
     "__pycache__",
 )
-# Files ignored on modules import from "./openpype/modules"
+# Files ignored on addons import from "./openpype/modules"
 IGNORED_DEFAULT_FILENAMES = (
     "__init__.py",
     "base.py",
@@ -59,8 +63,8 @@ IGNORED_DEFAULT_FILENAMES = (
     "example_addons",
     "default_modules",
 )
-# Modules that won't be loaded in AYON mode from "./openpype/modules"
-# - the same modules are ignored in "./server_addon/create_ayon_addons.py"
+# Addons that won't be loaded in AYON mode from "./openpype/modules"
+# - the same addons are ignored in "./server_addon/create_ayon_addons.py"
 IGNORED_FILENAMES_IN_AYON = {
     "ftrack",
     "shotgrid",
@@ -466,7 +470,7 @@ def _load_ayon_addons(openpype_modules, modules_key, log):
                     attr = getattr(mod, attr_name)
                     if (
                         inspect.isclass(attr)
-                        and issubclass(attr, OpenPypeModule)
+                        and issubclass(attr, AYONAddon)
                     ):
                         imported_modules.append(mod)
                         break
@@ -633,25 +637,21 @@ def _load_modules():
 
 
 @six.add_metaclass(ABCMeta)
-class OpenPypeModule:
-    """Base class of pype module.
+class AYONAddon(object):
+    """Base class of AYON addon.
 
     Attributes:
-        id (UUID): Module's id.
-        enabled (bool): Is module enabled.
-        name (str): Module name.
-        manager (ModulesManager): Manager that created the module.
+        id (UUID): Addon object id.
+        enabled (bool): Is addon enabled.
+        name (str): Addon name.
+
+    Args:
+        manager (ModulesManager): Manager object who discovered addon.
+        settings (dict[str, Any]): AYON settings.
     """
 
-    # Disable by default
-    enabled = False
+    enabled = True
     _id = None
-
-    @property
-    @abstractmethod
-    def name(self):
-        """Module's name."""
-        pass
 
     def __init__(self, manager, settings):
         self.manager = manager
@@ -662,22 +662,45 @@ class OpenPypeModule:
 
     @property
     def id(self):
+        """Random id of addon object.
+
+        Returns:
+            str: Object id.
+        """
+
         if self._id is None:
             self._id = uuid4()
         return self._id
 
+    @property
     @abstractmethod
-    def initialize(self, module_settings):
-        """Initialization of module attributes.
+    def name(self):
+        """Addon name.
 
-        It is not recommended to override __init__ that's why specific method
-        was implemented.
+        Returns:
+            str: Addon name.
         """
 
         pass
 
-    def connect_with_modules(self, enabled_modules):
-        """Connect with other enabled modules."""
+    def initialize(self, settings):
+        """Initialization of module attributes.
+
+        It is not recommended to override __init__ that's why specific method
+        was implemented.
+
+        Args:
+            settings (dict[str, Any]): Settings.
+        """
+
+        pass
+
+    def connect_with_modules(self, enabled_addons):
+        """Connect with other enabled addons.
+
+        Args:
+            enabled_addons (list[AYONAddon]): Addons that are enabled.
+        """
 
         pass
 
@@ -685,6 +708,9 @@ class OpenPypeModule:
         """Get global environments values of module.
 
         Environment variables that can be get only from system settings.
+
+        Returns:
+            dict[str, str]: Environment variables.
         """
 
         return {}
@@ -697,7 +723,7 @@ class OpenPypeModule:
 
         Args:
             application (Application): Application that is launched.
-            env (dict): Current environment variables.
+            env (dict[str, str]): Current environment variables.
         """
 
         pass
@@ -713,7 +739,8 @@ class OpenPypeModule:
         to receive from 'host' object.
 
         Args:
-            host (ModuleType): Access to installed/registered host object.
+            host (Union[ModuleType, HostBase]): Access to installed/registered
+                host object.
             host_name (str): Name of host.
             project_name (str): Project name which is main part of host
                 context.
@@ -727,47 +754,64 @@ class OpenPypeModule:
         The best practise is to create click group for whole module which is
         used to separate commands.
 
-        class MyPlugin(OpenPypeModule):
-            ...
-            def cli(self, module_click_group):
-                module_click_group.add_command(cli_main)
+        Example:
+            class MyPlugin(AYONAddon):
+                ...
+                def cli(self, module_click_group):
+                    module_click_group.add_command(cli_main)
 
 
-        @click.group(<module name>, help="<Any help shown in cmd>")
-        def cli_main():
-            pass
+            @click.group(<module name>, help="<Any help shown in cmd>")
+            def cli_main():
+                pass
 
-        @cli_main.command()
-        def mycommand():
-            print("my_command")
+            @cli_main.command()
+            def mycommand():
+                print("my_command")
+
+        Args:
+            module_click_group (click.Group): Group to which can be added
+                commands.
         """
 
         pass
+
+
+class OpenPypeModule(AYONAddon):
+    """Base class of OpenPype module.
+
+    Instead of 'AYONAddon' are passed in module settings.
+
+    Args:
+        manager (ModulesManager): Manager object who discovered addon.
+        settings (dict[str, Any]): OpenPype settings.
+    """
+
+    # Disable by default
+    enabled = False
 
 
 class OpenPypeAddOn(OpenPypeModule):
     # Enable Addon by default
     enabled = True
 
-    def initialize(self, module_settings):
-        """Initialization is not be required for most of addons."""
-        pass
-
 
 class ModulesManager:
     """Manager of Pype modules helps to load and prepare them to work.
 
     Args:
-        modules_settings(dict): To be able create module manager with specified
-            data. For settings changes callbacks and testing purposes.
+        system_settings (Optional[dict[str, Any]]): OpenPype system settings.
+        ayon_settings (Optional[dict[str, Any]]): AYON studio settings.
     """
+
     # Helper attributes for report
     _report_total_key = "Total"
 
-    def __init__(self, _system_settings=None):
+    def __init__(self, system_settings=None, ayon_settings=None):
         self.log = logging.getLogger(self.__class__.__name__)
 
-        self._system_settings = _system_settings
+        self._system_settings = system_settings
+        self._ayon_settings = ayon_settings
 
         self.modules = []
         self.modules_by_id = {}
@@ -789,8 +833,9 @@ class ModulesManager:
             default (Any): Default output if module is not available.
 
         Returns:
-            Union[OpenPypeModule, None]: Module found by name or None.
+            Union[AYONAddon, None]: Module found by name or None.
         """
+
         return self.modules_by_name.get(module_name, default)
 
     def get_enabled_module(self, module_name, default=None):
@@ -804,7 +849,7 @@ class ModulesManager:
                 not enabled.
 
         Returns:
-            Union[OpenPypeModule, None]: Enabled module found by name or None.
+            Union[AYONAddon, None]: Enabled module found by name or None.
         """
 
         module = self.get(module_name)
@@ -821,9 +866,14 @@ class ModulesManager:
 
         self.log.debug("*** Pype modules initialization.")
         # Prepare settings for modules
-        system_settings = getattr(self, "_system_settings", None)
+        system_settings = self._system_settings
         if system_settings is None:
             system_settings = get_system_settings()
+
+        ayon_settings = self._ayon_settings
+        if AYON_SERVER_ENABLED and ayon_settings is None:
+            ayon_settings = get_ayon_settings()
+
         modules_settings = system_settings["modules"]
 
         report = {}
@@ -836,12 +886,13 @@ class ModulesManager:
             for name in dir(module):
                 modules_item = getattr(module, name, None)
                 # Filter globals that are not classes which inherit from
-                #   OpenPypeModule
+                #   AYONAddon
                 if (
                     not inspect.isclass(modules_item)
+                    or modules_item is AYONAddon
                     or modules_item is OpenPypeModule
                     or modules_item is OpenPypeAddOn
-                    or not issubclass(modules_item, OpenPypeModule)
+                    or not issubclass(modules_item, AYONAddon)
                 ):
                     continue
 
@@ -866,10 +917,14 @@ class ModulesManager:
                 module_classes.append(modules_item)
 
         for modules_item in module_classes:
+            is_openpype_module = issubclass(modules_item, OpenPypeModule)
+            settings = (
+                system_settings if is_openpype_module else ayon_settings
+            )
+            name = modules_item.__name__
             try:
-                name = modules_item.__name__
                 # Try initialize module
-                module = modules_item(self, modules_settings)
+                module = modules_item(self, settings)
                 # Store initialized object
                 self.modules.append(module)
                 self.modules_by_id[module.id] = module
@@ -924,8 +979,9 @@ class ModulesManager:
         """Enabled modules initialized by the manager.
 
         Returns:
-            list: Initialized and enabled modules.
+            list[AYONAddon]: Initialized and enabled modules.
         """
+
         return [
             module
             for module in self.modules
@@ -1108,7 +1164,7 @@ class ModulesManager:
             host_name (str): Host name for which is found host module.
 
         Returns:
-            OpenPypeModule: Found host module by name.
+            AYONAddon: Found host module by name.
             None: There was not found module inheriting IHostAddon which has
                 host name set to passed 'host_name'.
         """
@@ -1129,12 +1185,11 @@ class ModulesManager:
                 inheriting 'IHostAddon'.
         """
 
-        host_names = {
+        return {
             module.host_name
             for module in self.get_enabled_modules()
             if isinstance(module, IHostAddon)
         }
-        return host_names
 
     def print_report(self):
         """Print out report of time spent on modules initialization parts.
@@ -1290,6 +1345,10 @@ class TrayModulesManager(ModulesManager):
         callback can be defined with `doubleclick_callback` attribute.
 
         Missing feature how to define default callback.
+
+        Args:
+            addon (AYONAddon): Addon object.
+            callback (FunctionType): Function callback.
         """
         callback_name = "_".join([module.name, callback.__name__])
         if callback_name not in self.doubleclick_callbacks:
@@ -1310,11 +1369,17 @@ class TrayModulesManager(ModulesManager):
         self.tray_menu(tray_menu)
 
     def get_enabled_tray_modules(self):
-        output = []
-        for module in self.modules:
-            if module.enabled and isinstance(module, ITrayModule):
-                output.append(module)
-        return output
+        """Enabled tray modules.
+
+        Returns:
+            list[AYONAddon]: Enabled addons that inherit from tray interface.
+        """
+
+        return [
+            module
+            for module in self.modules
+            if module.enabled and isinstance(module, ITrayModule)
+        ]
 
     def restart_tray(self):
         if self.tray_manager:

--- a/openpype/settings/ayon_settings.py
+++ b/openpype/settings/ayon_settings.py
@@ -1591,3 +1591,18 @@ def get_ayon_system_settings(default_values):
     return convert_system_settings(
         ayon_settings, default_values, addon_versions
     )
+
+
+def get_ayon_settings(project_name=None):
+    """AYON studio settings.
+
+    Raw AYON settings values.
+
+    Args:
+        project_name (Optional[str]): Project name.
+
+    Returns:
+        dict[str, Any]: AYON settings.
+    """
+
+    return _AyonSettingsCache.get_value_by_project(project_name)


### PR DESCRIPTION
## Changelog Description
Introduced base class for AYON addon in openpype modules discovery logic.

## Additional info
The reason to add this class is to be able to pass in original AYON settings instead of settings converted for OpenPype. That is hitting issues in addons that were already moved from the openpype repository which have to receive their settings in other way.

## Testing notes:
Examine the code. OpenPype modules discovery should work as always did.