### PR TITLE
Chore: PySide6 tree view style

### DIFF
--- a/openpype/style/style.css
+++ b/openpype/style/style.css
@@ -512,52 +512,58 @@ QAbstractItemView::item:selected:hover {
 }
 
 /* Row colors (alternate colors) are from left - right */
-QAbstractItemView:branch {
-    background: transparent;
+QTreeView::branch {
+    background: {color:bg-view};
+}
+QTreeView::branch:hover {
+    background: {color:bg-view};
+}
+QTreeView::branch:selected {
+    background: {color:bg-view};
 }
 
 QAbstractItemView::branch:open:has-children:!has-siblings,
 QAbstractItemView::branch:open:has-children:has-siblings {
     border-image: none;
     image: url(:/openpype/images/branch_open.png);
-    background: transparent;
+    background: {color:bg-view};
 }
 QAbstractItemView::branch:open:has-children:!has-siblings:hover,
 QAbstractItemView::branch:open:has-children:has-siblings:hover {
     border-image: none;
     image: url(:/openpype/images/branch_open_on.png);
-    background: transparent;
+    background: {color:bg-view};
 }
 
 QAbstractItemView::branch:has-children:!has-siblings:closed,
 QAbstractItemView::branch:closed:has-children:has-siblings {
     border-image: none;
     image: url(:/openpype/images/branch_closed.png);
-    background: transparent;
+    background: {color:bg-view};
 }
 QAbstractItemView::branch:has-children:!has-siblings:closed:hover,
 QAbstractItemView::branch:closed:has-children:has-siblings:hover {
     border-image: none;
     image: url(:/openpype/images/branch_closed_on.png);
-    background: transparent;
+    background: {color:bg-view};
 }
 
 QAbstractItemView::branch:has-siblings:!adjoins-item {
     border-image: none;
     image: url(:/openpype/images/transparent.png);
-    background: transparent;
+    background: {color:bg-view};
 }
 
 QAbstractItemView::branch:has-siblings:adjoins-item {
     border-image: none;
     image: url(:/openpype/images/transparent.png);
-    background: transparent;
+    background: {color:bg-view};
 }
 
 QAbstractItemView::branch:!has-children:!has-siblings:adjoins-item {
     border-image: none;
     image: url(:/openpype/images/transparent.png);
-    background: transparent;
+    background: {color:bg-view};
 }
 
 CompleterView {


### PR DESCRIPTION
## Changelog Description
Define solid color for background of branch in QTreeView.

## Additional info
PySide6 draws some backgroup from item's background under branch (not exactly sure why/where from), so transparent background under branch reveals the color. Only solution I found was to set solid color of background color over that part.

## Screenshots
Left:   Before this PR.
Right: With this PR.
![image](https://github.com/ynput/OpenPype/assets/43494761/390c92d0-6f2f-4716-acc4-e32c8f1a7d1b)

## Testing notes:
I'm not aware of a view where is used different background color, that could potentially cause issues.
1. Make sure you're using PySide6 (is automatically used on MacOs)
2. Try out UIs with PySide6

### How to install PySide6 to OpenPype
1. Go to `./vendor/python/`.
2. Remove `PySide2` and `shiboken2`.
3. Modify `./pyproject.toml`. Replace windows/linux qtbinding with PySide6
```
[openpype.qtbinding.windows]
package = "PySide6"
version = "6.4.3"
```
4. Run `./tools/fetch_thirdparty_libs.ps1`