### PR TITLE
TrayPublisher: adding back `asset_doc` variable

### DIFF
--- a/openpype/hosts/traypublisher/plugins/publish/validate_frame_ranges.py
+++ b/openpype/hosts/traypublisher/plugins/publish/validate_frame_ranges.py
@@ -41,6 +41,7 @@ class ValidateFrameRange(OptionalPyblishPluginMixin,
                 for pattern in self.skip_timelines_check)):
             self.log.info("Skipping for {} task".format(instance.data["task"]))
 
+        asset_doc = instance.data["assetEntity"]
         asset_data = asset_doc["data"]
         frame_start = asset_data["frameStart"]
         frame_end = asset_data["frameEnd"]


### PR DESCRIPTION
## Changelog Description
Returning variable which had been removed accidentally in previous PR.

## Testing notes:
1. in trapublisher publish `plate` family
2.  Validator for Frame ranges should not fail critically.
