### PR TITLE
Maya: Remove duplicated attributes of MTOA verbosity level 

### DIFF
--- a/openpype/modules/deadline/plugins/publish/submit_maya_deadline.py
+++ b/openpype/modules/deadline/plugins/publish/submit_maya_deadline.py
@@ -97,7 +97,6 @@ class VRayPluginInfo(object):
 @attr.s
 class ArnoldPluginInfo(object):
     ArnoldFile = attr.ib(default=None)
-    ArnoldVerbose = attr.ib(default=2)
 
 
 class MayaSubmitDeadline(abstract_submit_deadline.AbstractSubmitDeadline,
@@ -661,12 +660,9 @@ class MayaSubmitDeadline(abstract_submit_deadline.AbstractSubmitDeadline,
         # Plugin Info
         ass_file, _ = os.path.splitext(data["output_filename_0"])
         ass_filepath = ass_file + ".ass"
-        current_verbosity_level = cmds.getAttr(
-            "defaultArnoldRenderOptions.log_verbosity")
 
         plugin_info = ArnoldPluginInfo(
-            ArnoldFile=ass_filepath,
-            ArnoldVerbose=current_verbosity_level
+            ArnoldFile=ass_filepath
         )
 
         return job_info, attr.asdict(plugin_info)


### PR DESCRIPTION
## Changelog Description
Remove duplicated attributes implementation mentioned in https://github.com/ynput/OpenPype/pull/5931#discussion_r1402175289

## Additional info
n/a

## Testing notes:
1.Go to Openpype Settings -> project_settings/deadline/publish/MayaSubmitDeadline/pluginInfo

2. Add {"ArnoldVerbose": 2}

3. Launch Maya via launcher with your rendering scene

4. Make sure your current renderer is Arnold

5. Publish