### PR TITLE
Testing: Fix is_test_failed

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -85,3 +85,11 @@ def pytest_runtest_makereport(item, call):
     # be "setup", "call", "teardown"
 
     setattr(item, "rep_" + rep.when, rep)
+
+    # In the event of module scoped fixtures, also mark failure in module.
+    module = item
+    while module is not None and not isinstance(module, pytest.Module):
+        module = module.parent
+    if module is not None:
+        if rep.when == 'call' and (rep.failed or rep.skipped):
+            setattr(module, "module_test_failure", True)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -92,4 +92,4 @@ def pytest_runtest_makereport(item, call):
         module = module.parent
     if module is not None:
         if rep.when == 'call' and (rep.failed or rep.skipped):
-            setattr(module, "module_test_failure", True)
+            module.module_test_failure = True

--- a/tests/lib/testing_classes.py
+++ b/tests/lib/testing_classes.py
@@ -218,11 +218,7 @@ class ModuleUnitTest(BaseTest):
         yield mongo_client[self.TEST_OPENPYPE_NAME]["settings"]
 
     def is_test_failed(self, request):
-        # if request.node doesn't have rep_call, something failed
-        try:
-            return request.node.rep_call.failed
-        except AttributeError:
-            return True
+        return getattr(request.node, "module_test_failure", False)
 
 
 class PublishTest(ModuleUnitTest):


### PR DESCRIPTION
## Changelog Description
[`is_test_failed`](https://github.com/ynput/OpenPype/blob/develop/tests/lib/testing_classes.py#L220) is used (exclusively) on module fixtures to determine whether the tests have failed or not. This determines whether to run tear down code like cleaning up the database and temporary files.

But in the module scope `request.node.rep_call` is not available, which results in `is_test_failed` always returning `True`, and no tear down code get executed.

The solution was taken from; https://github.com/pytest-dev/pytest/issues/5090

## Testing notes:
```
openpype_console runtests
```
