### PR TITLE
Harmony: Fix local rendering

### DIFF
--- a/openpype/hosts/harmony/api/TB_sceneOpened.js
+++ b/openpype/hosts/harmony/api/TB_sceneOpened.js
@@ -13,7 +13,7 @@ var LD_OPENHARMONY_PATH = System.getenv('LIB_OPENHARMONY_PATH');
 LD_OPENHARMONY_PATH = LD_OPENHARMONY_PATH + '/openHarmony.js';
 LD_OPENHARMONY_PATH = LD_OPENHARMONY_PATH.replace(/\\/g, "/");
 include(LD_OPENHARMONY_PATH);
-this.__proto__['$'] = $;
+//this.__proto__['$'] = $;
 
 function Client() {
     var self = this;

--- a/openpype/hosts/harmony/plugins/publish/extract_render.py
+++ b/openpype/hosts/harmony/plugins/publish/extract_render.py
@@ -59,8 +59,8 @@ class ExtractRender(pyblish.api.InstancePlugin):
 
         args = [application_path, "-batch",
                 "-frames", str(frame_start), str(frame_end),
-                "-scene", scene_path]
-        self.log.info(f"running [ {application_path} {' '.join(args)}")
+                scene_path]
+        self.log.info(f"running: {' '.join(args)}")
         proc = subprocess.Popen(
             args,
             stdout=subprocess.PIPE,


### PR DESCRIPTION
## Changelog Description
Local rendering was throwing warning about license, but didn't fail per se. It just didn't produce anything.


## Testing notes:
1. create `Render` instance to be rendered locally
2. it should finish successfully
