### PR TITLE
Maya: Small Tweaks on Validator for Look Default Shader Connection for Maya 2024

### DIFF
--- a/openpype/hosts/maya/plugins/publish/validate_look_default_shaders_connections.py
+++ b/openpype/hosts/maya/plugins/publish/validate_look_default_shaders_connections.py
@@ -46,8 +46,9 @@ class ValidateLookDefaultShadersConnections(pyblish.api.InstancePlugin):
         # Process as usual
         invalid = list()
         if int(cmds.about(version=True)) >= 2024:
-            self.log.debug("IntialShadingGroup no longer connected to the default shader"
-                           " in Maya 2024. Skipping Look Default Shader Connections..")
+            self.log.debug("IntialShadingGroup no longer "
+                           "connected to the default shader in Maya 2024"
+                           "Skipping Look Default Shader Connections..")
             return
         for plug, input_node in self.DEFAULTS:
             inputs = cmds.listConnections(plug,

--- a/openpype/hosts/maya/plugins/publish/validate_look_default_shaders_connections.py
+++ b/openpype/hosts/maya/plugins/publish/validate_look_default_shaders_connections.py
@@ -3,65 +3,76 @@ from maya import cmds
 import pyblish.api
 from openpype.pipeline.publish import (
     ValidateContentsOrder,
+    RepairContextAction,
     PublishValidationError
 )
 
 
-class ValidateLookDefaultShadersConnections(pyblish.api.InstancePlugin):
+class ValidateLookDefaultShadersConnections(pyblish.api.ContextPlugin):
     """Validate default shaders in the scene have their default connections.
 
-    For example the lambert1 could potentially be disconnected from the
-    initialShadingGroup. As such it's not lambert1 that will be identified
-    as the default shader which can have unpredictable results.
+    For example the standardSurface1 or lambert1 (maya 2023 and before) could
+    potentially be disconnected from the initialShadingGroup. As such it's not
+    lambert1 that will be identified as the default shader which can have
+    unpredictable results.
 
     To fix the default connections need to be made again. See the logs for
     more details on which connections are missing.
 
     """
 
-    order = ValidateContentsOrder
+    order = pyblish.api.ValidatorOrder - 0.4999
     families = ['look']
     hosts = ['maya']
     label = 'Look Default Shader Connections'
+    actions = [RepairContextAction]
 
     # The default connections to check
-    DEFAULTS = [("initialShadingGroup.surfaceShader", "lambert1"),
-                ("initialParticleSE.surfaceShader", "lambert1"),
-                ("initialParticleSE.volumeShader", "particleCloud1")
-                ]
+    DEFAULTS = {
+        "initialShadingGroup.surfaceShader": ["standardSurface1.outColor",
+                                              "lambert1.outColor"],
+        "initialParticleSE.surfaceShader": ["standardSurface1.outColor",
+                                            "lambert1.outColor"],
+        "initialParticleSE.volumeShader": ["particleCloud1.outColor"]
+    }
 
-    def process(self, instance):
+    def process(self, context):
 
-        # Ensure check is run only once. We don't use ContextPlugin because
-        # of a bug where the ContextPlugin will always be visible. Even when
-        # the family is not present in an instance.
-        key = "__validate_look_default_shaders_connections_checked"
-        context = instance.context
-        is_run = context.data.get(key, False)
-        if is_run:
-            return
-        else:
-            context.data[key] = True
+        if self.get_invalid():
+            raise PublishValidationError(
+                "Default shaders in your scene do not have their "
+                "default shader connections. Please repair them to continue."
+            )
+
+    @classmethod
+    def get_invalid(cls):
 
         # Process as usual
         invalid = list()
-        if int(cmds.about(version=True)) >= 2024:
-            self.log.debug("IntialShadingGroup no longer "
-                           "connected to the default shader in Maya 2024"
-                           "Skipping Look Default Shader Connections..")
-            return
-        for plug, input_node in self.DEFAULTS:
+        for plug, valid_inputs in cls.DEFAULTS.items():
             inputs = cmds.listConnections(plug,
                                           source=True,
-                                          destination=False) or None
-
-            if not inputs or inputs[0] != input_node:
-                self.log.error("{0} is not connected to {1}. "
-                               "This can result in unexpected behavior. "
-                               "Please reconnect to continue.".format(
-                                plug,
-                                input_node))
+                                          destination=False,
+                                          plugs=True) or None
+            if not inputs or inputs[0] not in valid_inputs:
+                cls.log.error(
+                    "{0} is not connected to {1}. This can result in "
+                    "unexpected behavior. Please reconnect to continue."
+                    "".format(plug, " or ".join(valid_inputs))
+                )
                 invalid.append(plug)
 
-        if invalid:
-            raise PublishValidationError("Invalid connections.")
+        return invalid
+
+    @classmethod
+    def repair(cls, context):
+        invalid = cls.get_invalid()
+        for plug in invalid:
+            valid_inputs = cls.DEFAULTS[plug]
+            for valid_input in valid_inputs:
+                if cmds.objExists(valid_input):
+                    cls.log.info(
+                        "Connecting {} -> {}".format(valid_input, plug)
+                    )
+                    cmds.connectAttr(valid_input, plug, force=True)
+                    break

--- a/openpype/hosts/maya/plugins/publish/validate_look_default_shaders_connections.py
+++ b/openpype/hosts/maya/plugins/publish/validate_look_default_shaders_connections.py
@@ -45,6 +45,10 @@ class ValidateLookDefaultShadersConnections(pyblish.api.InstancePlugin):
 
         # Process as usual
         invalid = list()
+        if int(cmds.about(version=True)) >= 2024:
+            self.log.debug("IntialShadingGroup no longer connected to the default shader"
+                           " in Maya 2024. Skipping Look Default Shader Connections..")
+            return
         for plug, input_node in self.DEFAULTS:
             inputs = cmds.listConnections(plug,
                                           source=True,


### PR DESCRIPTION
## Changelog Description
Resolve https://github.com/ynput/OpenPype/issues/5269

## Additional info
Please test Maya 2024 and any version elder than Maya 2024

## Testing notes:
1. Create Look with or without tx options.
2. Publish
3. It should run smoothly 