### PR TITLE
Fusion: Validate frame range optional

### DIFF
--- a/openpype/hosts/fusion/plugins/publish/validate_instance_frame_range.py
+++ b/openpype/hosts/fusion/plugins/publish/validate_instance_frame_range.py
@@ -1,15 +1,20 @@
 import pyblish.api
 
-from openpype.pipeline import PublishValidationError
+from openpype.pipeline import (
+    PublishValidationError,
+    OptionalPyblishPluginMixin
+)
 
-
-class ValidateInstanceFrameRange(pyblish.api.InstancePlugin):
+class ValidateInstanceFrameRange(pyblish.api.InstancePlugin,
+                                 OptionalPyblishPluginMixin):
     """Validate instance frame range is within comp's global render range."""
 
     order = pyblish.api.ValidatorOrder
-    label = "Validate Filename Has Extension"
+    label = "Validate Frame Range"
     families = ["render"]
     hosts = ["fusion"]
+
+    optional = True
 
     def process(self, instance):
 

--- a/openpype/hosts/fusion/plugins/publish/validate_instance_frame_range.py
+++ b/openpype/hosts/fusion/plugins/publish/validate_instance_frame_range.py
@@ -17,6 +17,8 @@ class ValidateInstanceFrameRange(pyblish.api.InstancePlugin,
     optional = True
 
     def process(self, instance):
+        if not self.is_active(instance.data):
+            return
 
         context = instance.context
         global_start = context.data["compFrameStart"]

--- a/openpype/hosts/fusion/plugins/publish/validate_instance_frame_range.py
+++ b/openpype/hosts/fusion/plugins/publish/validate_instance_frame_range.py
@@ -5,6 +5,7 @@ from openpype.pipeline import (
     OptionalPyblishPluginMixin
 )
 
+
 class ValidateInstanceFrameRange(pyblish.api.InstancePlugin,
                                  OptionalPyblishPluginMixin):
     """Validate instance frame range is within comp's global render range."""

--- a/openpype/settings/defaults/project_settings/fusion.json
+++ b/openpype/settings/defaults/project_settings/fusion.json
@@ -33,6 +33,11 @@
             "enabled": true,
             "optional": true,
             "active": true
+        },
+        "ValidateInstanceFrameRange": {
+            "enabled": true,
+            "optional": true,
+            "active": true
         }
     }
 }

--- a/openpype/settings/defaults/project_settings/fusion.json
+++ b/openpype/settings/defaults/project_settings/fusion.json
@@ -38,6 +38,11 @@
             "enabled": true,
             "optional": true,
             "active": true
+        },
+        "ValidateBackgroundDepth": {
+            "enabled": true,
+            "optional": true,
+            "active": true
         }
     }
 }

--- a/openpype/settings/entities/schemas/projects_schema/schema_project_fusion.json
+++ b/openpype/settings/entities/schemas/projects_schema/schema_project_fusion.json
@@ -100,6 +100,16 @@
                             "label": "Validate Saver Resolution"
                         }
                     ]
+                },
+                {
+                    "type": "schema_template",
+                    "name": "template_publish_plugin",
+                    "template_data": [
+                        {
+                            "key": "ValidateInstanceFrameRange",
+                            "label": "Validate Frame Range"
+                        }
+                    ]
                 }
             ]
         }

--- a/openpype/settings/entities/schemas/projects_schema/schema_project_fusion.json
+++ b/openpype/settings/entities/schemas/projects_schema/schema_project_fusion.json
@@ -110,6 +110,16 @@
                             "label": "Validate Frame Range"
                         }
                     ]
+                },
+                {
+                    "type": "schema_template",
+                    "name": "template_publish_plugin",
+                    "template_data": [
+                        {
+                            "key": "ValidateBackgroundDepth",
+                            "label": "Validate Background Depth 32 bit"
+                        }
+                    ]
                 }
             ]
         }

--- a/server_addon/fusion/server/settings.py
+++ b/server_addon/fusion/server/settings.py
@@ -48,6 +48,25 @@ class CreatPluginsModel(BaseSettingsModel):
     )
 
 
+class BasicValidateModel(BaseSettingsModel):
+    enabled: bool = Field(title="Enabled")
+    optional: bool = Field(title="Optional")
+    active: bool = Field(title="Active")
+
+
+class PublishPluginsModel(BaseSettingsModel):
+    ValidateSaverResolution: BasicValidateModel = Field(
+        default_factory=BasicValidateModel,
+        title="Validate Saver Resolution",
+        section="Validators")
+    ValidateInstanceFrameRange: BasicValidateModel = Field(
+        default_factory=BasicValidateModel,
+        title="Validate Frame Range")
+    ValidateBackgroundDepth: BasicValidateModel = Field(
+        default_factory=BasicValidateModel,
+        title="Validate Background Depth 32 bit")
+
+
 class FusionSettings(BaseSettingsModel):
     imageio: FusionImageIOModel = Field(
         default_factory=FusionImageIOModel,
@@ -60,6 +79,10 @@ class FusionSettings(BaseSettingsModel):
     create: CreatPluginsModel = Field(
         default_factory=CreatPluginsModel,
         title="Creator plugins"
+    )
+    publish: PublishPluginsModel = Field(
+        default_factory=PublishPluginsModel,
+        title="Publish Plugins",
     )
 
 
@@ -90,6 +113,23 @@ DEFAULT_VALUES = {
                 "reviewable",
                 "farm_rendering"
             ]
+        }
+    },
+    "publish": {
+        "ValidateSaverResolution": {
+            "enabled": true,
+            "optional": true,
+            "active": true
+        },
+        "ValidateInstanceFrameRange": {
+            "enabled": true,
+            "optional": true,
+            "active": true
+        },
+        "ValidateBackgroundDepth": {
+            "enabled": true,
+            "optional": true,
+            "active": true
         }
     }
 }

--- a/server_addon/fusion/server/settings.py
+++ b/server_addon/fusion/server/settings.py
@@ -117,19 +117,19 @@ DEFAULT_VALUES = {
     },
     "publish": {
         "ValidateSaverResolution": {
-            "enabled": true,
-            "optional": true,
-            "active": true
+            "enabled": True,
+            "optional": True,
+            "active": True
         },
         "ValidateInstanceFrameRange": {
-            "enabled": true,
-            "optional": true,
-            "active": true
+            "enabled": True,
+            "optional": True,
+            "active": True
         },
         "ValidateBackgroundDepth": {
-            "enabled": true,
-            "optional": true,
-            "active": true
+            "enabled": True,
+            "optional": True,
+            "active": True
         }
     }
 }


### PR DESCRIPTION
## Changelog Description
Validation of frame range was required, this forbids artist to override it when they know what they are doing (only single frame should be rendered, subrange for fixes etc.)

This adds possibility to configure it in Settings and for artist.

## Additional info
Added missed another validator

## Testing notes:
1. play with settings in `project_settings/fusion/publish`
<img width="167" alt="AnyDesk_14BpI6b4e4" src="https://github.com/ynput/OpenPype/assets/4457962/c961ad05-0e5d-486c-be77-d3e06e4afb27">

3. disable `Validate Frame Range` in publish and try to modify frame range (in `global time slider`)

