### PR TITLE
Maya: Add Label to MayaUSDReferenceLoader

### DIFF
--- a/openpype/hosts/maya/plugins/load/load_reference.py
+++ b/openpype/hosts/maya/plugins/load/load_reference.py
@@ -265,6 +265,7 @@ class ReferenceLoader(openpype.hosts.maya.api.plugin.ReferenceLoader):
 class MayaUSDReferenceLoader(ReferenceLoader):
     """Reference USD file to native Maya nodes using MayaUSDImport reference"""
 
+    label = "Reference Maya USD"
     families = ["usd"]
     representations = ["usd"]
     extensions = {"usd", "usda", "usdc"}


### PR DESCRIPTION
## Changelog Description
As the create placeholder dialog displays the two distinct loaders with the same name, this PR is to distinguish Maya USD Reference Loaders from the loaders of which inherited from. 
See the screenshot below:
![image](https://github.com/ynput/OpenPype/assets/64118225/254bb1ba-ebc9-410f-93a2-759214db071f)
 
## Additional info
n/a
## Testing notes:
1. Launch Maya via launcher
2. Go to Template Builder -> Create Placeholder
3. It should show loaders with different names as expected
