### PR TITLE
Fusion: Allow specifying custom frame range per saver

### DIFF
--- a/openpype/hosts/fusion/plugins/publish/collect_instances.py
+++ b/openpype/hosts/fusion/plugins/publish/collect_instances.py
@@ -57,6 +57,14 @@ class CollectInstanceData(pyblish.api.InstancePlugin):
             start_with_handle = comp_start
             end_with_handle = comp_end
 
+        if frame_range_source == "custom_range":
+            start = int(instance.data["custom_frameStart"])
+            end = int(instance.data["custom_frameEnd"])
+            handle_start = int(instance.data["custom_handleStart"])
+            handle_end = int(instance.data["custom_handleEnd"])
+            start_with_handle = start - handle_start
+            end_with_handle = end + handle_end
+
         # Include start and end render frame in label
         subset = instance.data["subset"]
         label = (

--- a/openpype/hosts/fusion/plugins/publish/validate_instance_frame_range.py
+++ b/openpype/hosts/fusion/plugins/publish/validate_instance_frame_range.py
@@ -7,7 +7,7 @@ class ValidateInstanceFrameRange(pyblish.api.InstancePlugin):
     """Validate instance frame range is within comp's global render range."""
 
     order = pyblish.api.ValidatorOrder
-    label = "Validate Filename Has Extension"
+    label = "Validate Frame Range"
     families = ["render"]
     hosts = ["fusion"]
 


### PR DESCRIPTION
## Changelog Description

Adds a "Custom Frame Range" option which uses the frame ranges specified in the publisher instead so you can set a custom frame range per saver.

## Additional info

Unfortunately due to the new publisher's current design we can not hide the frame range attributes when they are irrelevant (e.g. when NOT set to "render custom frame range") so they will also be visible even when unused.

## Testing notes:

1. Launch Fusion
2. Render a mixed range of frames for different instances
