### PR TITLE
General: Use manual thumbnail if present when publishing

### DIFF
--- a/openpype/hosts/blender/plugins/publish/extract_thumbnail.py
+++ b/openpype/hosts/blender/plugins/publish/extract_thumbnail.py
@@ -26,6 +26,10 @@ class ExtractThumbnail(publish.Extractor):
     def process(self, instance):
         self.log.debug("Extracting capture..")
 
+        if instance.data.get("thumbnailSource"):
+            self.log.debug("Thumbnail source found, skipping...")
+            return
+
         stagingdir = self.staging_dir(instance)
         asset_name = instance.data["assetEntity"]["name"]
         subset = instance.data["subset"]

--- a/openpype/plugins/publish/integrate_thumbnail_ayon.py
+++ b/openpype/plugins/publish/integrate_thumbnail_ayon.py
@@ -92,8 +92,10 @@ class IntegrateThumbnailsAYON(pyblish.api.ContextPlugin):
                 continue
 
             # Find thumbnail path on instance
-            thumbnail_path = self._get_instance_thumbnail_path(
-                published_repres)
+            thumbnail_source = instance.data.get("thumbnailSource")
+            thumbnail_path = (thumbnail_source or
+                              self._get_instance_thumbnail_path(
+                                  published_repres))
             if thumbnail_path:
                 self.log.debug((
                     "Found thumbnail path for instance \"{}\"."


### PR DESCRIPTION
## Changelog Description
Use manual thumbnail added to the publisher instead of using it from published representation.

## Testing notes:
1. Add a thumbnail to any instance.
2. Add a review instance as well (just to check if it actually works. If there is a manual thumbnail, it should use that).
3. Try to publish it.
4. The thumbnail for that published instance should the the one manually added.