### PR TITLE
AYON make sure the AYON menu bar in 3dsMax is named AYON when AYON launches

### DIFF
--- a/openpype/hosts/max/api/menu.py
+++ b/openpype/hosts/max/api/menu.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
-"""3dsmax menu definition of OpenPype."""
+"""3dsmax menu definition of OpenPype/AYON."""
+import os
 from qtpy import QtWidgets, QtCore
 from pymxs import runtime as rt
 
@@ -8,7 +9,7 @@ from openpype.hosts.max.api import lib
 
 
 class OpenPypeMenu(object):
-    """Object representing OpenPype menu.
+    """Object representing OpenPype/AYON menu.
 
     This is using "hack" to inject itself before "Help" menu of 3dsmax.
     For some reason `postLoadingMenus` event doesn't fire, and main menu
@@ -50,17 +51,17 @@ class OpenPypeMenu(object):
         return list(self.main_widget.findChildren(QtWidgets.QMenuBar))[0]
 
     def get_or_create_openpype_menu(
-            self, name: str = "&OpenPype",
+            self, name: str = "&Openpype",
             before: str = "&Help") -> QtWidgets.QAction:
-        """Create OpenPype menu.
+        """Create AYON menu.
 
         Args:
-            name (str, Optional): OpenPypep menu name.
+            name (str, Optional): Openpype/AYON menu name.
             before (str, Optional): Name of the 3dsmax main menu item to
-                add OpenPype menu before.
+                add Openpype/AYON menu before.
 
         Returns:
-            QtWidgets.QAction: OpenPype menu action.
+            QtWidgets.QAction: Openpype/AYON menu action.
 
         """
         if self.menu is not None:
@@ -77,15 +78,15 @@ class OpenPypeMenu(object):
 
             if before in item.title():
                 help_action = item.menuAction()
-
-        op_menu = QtWidgets.QMenu("&OpenPype")
+        tab_menu_label = os.environ.get("AVALON_LABEL") or "AYON"
+        op_menu = QtWidgets.QMenu("&{}".format(tab_menu_label))
         menu_bar.insertMenu(help_action, op_menu)
 
         self.menu = op_menu
         return op_menu
 
     def build_openpype_menu(self) -> QtWidgets.QAction:
-        """Build items in OpenPype menu."""
+        """Build items in AYON menu."""
         openpype_menu = self.get_or_create_openpype_menu()
         load_action = QtWidgets.QAction("Load...", openpype_menu)
         load_action.triggered.connect(self.load_callback)


### PR DESCRIPTION
## Changelog Description
Renaming the menu bar in 3dsMax for AYON
## Additional info
n/a

## Testing notes:
1. Create New Openpype package with server addon
2. Install the new Openpype package as a new bundle in AYON server
3. Set your new bundle as production
4. Remove your old openpype  in `C:\Users\{YOUR USERNAME}\AppData\Local\ynput\ayon\addons`
5. Launch 3dsMax via AYON
6. You find the menu bar named AYON in Max
![image](https://github.com/ynput/OpenPype/assets/64118225/90732296-0420-483b-b9f9-f52a4e6ea0d0)
