### PR TITLE
Testing: Do not persist data by default in Maya/Deadline.

### DIFF
--- a/tests/integration/hosts/maya/test_deadline_publish_in_maya.py
+++ b/tests/integration/hosts/maya/test_deadline_publish_in_maya.py
@@ -21,7 +21,7 @@ class TestDeadlinePublishInMaya(MayaDeadlinePublishTestClass):
         {OPENPYPE_ROOT}/.venv/Scripts/python.exe {OPENPYPE_ROOT}/start.py runtests ../tests/integration/hosts/maya  # noqa: E501
 
     """
-    PERSIST = True
+    PERSIST = False
 
     TEST_FILES = [
         ("test_deadline_publish_in_maya", "", "")


### PR DESCRIPTION
## Changelog Description
This is similar to the Maya publishing test.

## Testing notes:
```
openpype_console runtests C:\Users\tokejepsen\OpenPype\tests\integration\hosts\maya\test_deadline_publish_in_maya.py --mongo_url "mongodb://localhost:2707/"
```
Verify that the temporary folders gets cleaned up.
