### PR TITLE
[DRAFT] Fix deadline webserver collection in Ayon

### DIFF
--- a/openpype/modules/deadline/plugins/publish/collect_default_deadline_server.py
+++ b/openpype/modules/deadline/plugins/publish/collect_default_deadline_server.py
@@ -41,9 +41,12 @@ class CollectDefaultDeadlineServer(pyblish.api.ContextPlugin):
                             ["deadline"]
                             ["deadline_servers"])
         if deadline_servers:
-            deadline_server_name = deadline_servers[0]
-            deadline_webservice = deadline_module.deadline_urls.get(
-                deadline_server_name)
+            # This is wrong but either the Ayon settings schema is wrong or
+            # this logic needs to change
+            deadline_webservice = deadline_servers[0]
+            # deadline_server_name = deadline_servers[0]
+            # deadline_webservice = deadline_module.deadline_urls.get(
+            #     deadline_server_name)
             if deadline_webservice:
                 context.data["defaultDeadline"] = deadline_webservice
                 self.log.debug("Overriding from project settings with {}".format(  # noqa: E501


### PR DESCRIPTION
## Changelog Description
The Deadline servers setting in Ayon is no longer a dictionary and so when collecting the webserver it was not picking up the right one as it couldn't find the one named "default". Either the Ayon Deadline settings need to change or the logic behind the Deadline addon needs to change. This snippet no longer makes sense:

```
        deadline_url = deadline_settings.get("DEADLINE_REST_URL")
        if deadline_url:
            self.deadline_urls = {"default": deadline_url}
        else:
            self.deadline_urls = deadline_settings.get("deadline_urls")  # noqa: E501
```

## Testing notes:
1. Set a deadline web server on the settings and try to submit a Nuke job to the farm
