### PR TITLE
Photoshop: Fix removed unsupported Path

### DIFF
--- a/server_addon/photoshop/server/settings/workfile_builder.py
+++ b/server_addon/photoshop/server/settings/workfile_builder.py
@@ -1,31 +1,18 @@
 from pydantic import Field
-from pathlib import Path
 
-from ayon_server.settings import BaseSettingsModel
-
-
-class PathsTemplate(BaseSettingsModel):
-    windows: Path = Field(
-        '',
-        title="Windows"
-    )
-    darwin: Path = Field(
-        '',
-        title="MacOS"
-    )
-    linux: Path = Field(
-        '',
-        title="Linux"
-    )
+from ayon_server.settings import BaseSettingsModel, MultiplatformPathModel
 
 
 class CustomBuilderTemplate(BaseSettingsModel):
+    _layout = "expanded"
     task_types: list[str] = Field(
         default_factory=list,
         title="Task types",
     )
-    template_path: PathsTemplate = Field(
-        default_factory=PathsTemplate
+
+    template_path: MultiplatformPathModel = Field(
+        default_factory=MultiplatformPathModel,
+        title="Template path"
     )
 
 
@@ -37,5 +24,6 @@ class WorkfileBuilderPlugin(BaseSettingsModel):
     )
 
     custom_templates: list[CustomBuilderTemplate] = Field(
-        default_factory=CustomBuilderTemplate
+        default_factory=CustomBuilderTemplate,
+        title="Template profiles"
     )

--- a/server_addon/photoshop/server/settings/workfile_builder.py
+++ b/server_addon/photoshop/server/settings/workfile_builder.py
@@ -10,7 +10,7 @@ class CustomBuilderTemplate(BaseSettingsModel):
         title="Task types",
     )
 
-    template_path: MultiplatformPathModel = Field(
+    path: MultiplatformPathModel = Field(
         default_factory=MultiplatformPathModel,
         title="Template path"
     )


### PR DESCRIPTION
## Changelog Description
Path is not json serializable by default, it is not necessary, better model reused.


## Additional info
Was causing issues when saving profiles for Workfile builder. `"invalid input for query argument $4: {'workfile_builder': {'create_first_vers... (Type is not JSON serializable: PosixPath)`

## Testing notes:
1. run `server/create_ayon_addons.py` and re-upload `Photoshop` addon OR update `workfile_builder.py` directly in `ayon-docker/addons/photoshop...`
