### PR TITLE
AYON: Bug fix on Create Review in Maya

### DIFF
--- a/openpype/hosts/maya/plugins/create/create_review.py
+++ b/openpype/hosts/maya/plugins/create/create_review.py
@@ -84,10 +84,10 @@ class CreateReview(plugin.MayaCreator):
 
             if "Viewport Options" in preset:
                 mapping.update({
-                    "imagePlane":preset["Viewport Options"]["imagePlane"]})
+                    "imagePlane": preset["Viewport Options"]["imagePlane"]})
             elif "ViewportOptions" in preset:
                 mapping.update({
-                    "imagePlane":preset["ViewportOptions"]["imagePlane"]})
+                    "imagePlane": preset["ViewportOptions"]["imagePlane"]})
 
             for key, value in mapping.items():
                 creator_attribute_defs_by_key[key].default = value

--- a/openpype/hosts/maya/plugins/create/create_review.py
+++ b/openpype/hosts/maya/plugins/create/create_review.py
@@ -79,9 +79,16 @@ class CreateReview(plugin.MayaCreator):
                 "review_width": preset["Resolution"]["width"],
                 "review_height": preset["Resolution"]["height"],
                 "isolate": preset["Generic"]["isolate_view"],
-                "imagePlane": preset["Viewport Options"]["imagePlane"],
                 "panZoom": preset["Generic"]["pan_zoom"]
             }
+
+            if "Viewport Options" in preset:
+                mapping.update({
+                    "imagePlane":preset["Viewport Options"]["imagePlane"]})
+            elif "ViewportOptions" in preset:
+                mapping.update({
+                    "imagePlane":preset["ViewportOptions"]["imagePlane"]})
+
             for key, value in mapping.items():
                 creator_attribute_defs_by_key[key].default = value
 


### PR DESCRIPTION
## Changelog Description
This PR is to fix the error is found in Create Review due to the different compatibilities of the current playblast setting from the deprecated one.
## Additional info
["Viewport Options"] in preset will still support after the PR merged but will remove after users migrating all deprecated settings to the current ones

## Testing notes:
1. Build server addon with the code 
2. Install addon with the latest Openpype addon
3. Turn off Image Plane setting in playblast settings for the testing purpose
4. Launch Maya via launcher with the latest update of Openpype in AYON
5. Create Review
6. It is not errored out anymore
