### PR TITLE
Maya: Create Review, fixing typo

### DIFF
--- a/openpype/hosts/maya/plugins/create/create_review.py
+++ b/openpype/hosts/maya/plugins/create/create_review.py
@@ -79,7 +79,7 @@ class CreateReview(plugin.MayaCreator):
                 "review_width": preset["Resolution"]["width"],
                 "review_height": preset["Resolution"]["height"],
                 "isolate": preset["Generic"]["isolate_view"],
-                "imagePlane": preset["Viewport Options"]["imagePlane"],
+                "imagePlane": preset["ViewportOptions"]["imagePlane"],
                 "panZoom": preset["Generic"]["pan_zoom"]
             }
             for key, value in mapping.items():


### PR DESCRIPTION
## Changelog Description
This is simple fix for `Create Review`:

```
Traceback (most recent call last):
  File "C:\Users\annat\Documents\Projects\Ayon\OpenPype\openpype\pipeline\create\context.py", line 2059, in _create_with_unified_error
    result = creator.create(*args, **kwargs)
  File "C:\Users\annat\Documents\Projects\Ayon\OpenPype\openpype\hosts\maya\plugins\create\create_review.py", line 82, in create
    "imagePlane": preset["Viewport Options"]["imagePlane"],
KeyError: 'Viewport Options'
```

## Testing notes:
1. start Maya
2. create Review
3. all should work as expected
