### PR TITLE
Chore/houdini update startup log

### DIFF
--- a/openpype/hosts/houdini/startup/MainMenuCommon.xml
+++ b/openpype/hosts/houdini/startup/MainMenuCommon.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <mainMenu>
     <menuBar>
-        <subMenu id="openpype_menu">
+        <subMenu id="ayon_menu">
             <labelExpression><![CDATA[
 import os
 return os.environ.get("AVALON_LABEL") or "AYON"

--- a/openpype/hosts/houdini/startup/python2.7libs/pythonrc.py
+++ b/openpype/hosts/houdini/startup/python2.7libs/pythonrc.py
@@ -1,11 +1,13 @@
 # -*- coding: utf-8 -*-
-"""OpenPype startup script."""
+"""AYON startup script."""
 from openpype.pipeline import install_host
 from openpype.hosts.houdini.api import HoudiniHost
+import os
 
 
 def main():
-    print("Installing OpenPype ...")
+    print("Installing {} ...".format(
+        os.environ.get("AVALON_LABEL") or "AYON"))
     install_host(HoudiniHost())
 
 

--- a/openpype/hosts/houdini/startup/python3.10libs/pythonrc.py
+++ b/openpype/hosts/houdini/startup/python3.10libs/pythonrc.py
@@ -1,11 +1,13 @@
 # -*- coding: utf-8 -*-
-"""OpenPype startup script."""
+"""AYON startup script."""
 from openpype.pipeline import install_host
 from openpype.hosts.houdini.api import HoudiniHost
+import os
 
 
 def main():
-    print("Installing OpenPype ...")
+    print("Installing {} ...".format(
+        os.environ.get("AVALON_LABEL") or "AYON"))
     install_host(HoudiniHost())
 
 

--- a/openpype/hosts/houdini/startup/python3.7libs/pythonrc.py
+++ b/openpype/hosts/houdini/startup/python3.7libs/pythonrc.py
@@ -1,11 +1,13 @@
 # -*- coding: utf-8 -*-
-"""OpenPype startup script."""
+"""AYON startup script."""
 from openpype.pipeline import install_host
 from openpype.hosts.houdini.api import HoudiniHost
+import os
 
 
 def main():
-    print("Installing OpenPype ...")
+    print("Installing {} ...".format(
+        os.environ.get("AVALON_LABEL") or "AYON"))
     install_host(HoudiniHost())
 
 

--- a/openpype/hosts/houdini/startup/python3.9libs/pythonrc.py
+++ b/openpype/hosts/houdini/startup/python3.9libs/pythonrc.py
@@ -1,11 +1,13 @@
 # -*- coding: utf-8 -*-
-"""OpenPype startup script."""
+"""AYON startup script."""
 from openpype.pipeline import install_host
 from openpype.hosts.houdini.api import HoudiniHost
+import os
 
 
 def main():
-    print("Installing OpenPype ...")
+    print("Installing {} ...".format(
+        os.environ.get("AVALON_LABEL") or "AYON"))
     install_host(HoudiniHost())
 
 


### PR DESCRIPTION
## Changelog Description
print `Installing AYON ...` on startup when launching houdini from launcher in ayon mode.
also update submenu to `ayon_menu` instead of `openpype_menu`

![image](https://github.com/ynput/OpenPype/assets/20871534/f1f0b54a-8da9-4f6e-a59f-ff74083b8298)

## Testing notes:
1. everything should work as usual in houdini.  
