### PR TITLE
AYON: Bug fix for loading Mesh as new project not working

### DIFF
--- a/openpype/hosts/substancepainter/api/lib.py
+++ b/openpype/hosts/substancepainter/api/lib.py
@@ -588,6 +588,7 @@ def prompt_new_file_with_mesh(mesh_filepath):
         # the file
         while not file_dialog.selectedFiles():
             app.processEvents(QtCore.QEventLoop.ExcludeUserInputEvents, 1000)
+            continue
         print(f"Selected: {file_dialog.selectedFiles()}")
 
         # Set it again now we know the path is refreshed - without this


### PR DESCRIPTION
## Changelog Description
Substance Painter in AYON can't load mesh for creating a new project

## Additional info
For tech: Welcome for any code feedback on resolving indefinite loop for loading the mesh

## Testing notes:
1. Launch Substance Painter via launcher
2. Load Mesh from loader
3. It should be being loaded as expected
