### PR TITLE
Deadline: correct webservice couldn't be selected in Ayon

### DIFF
--- a/openpype/modules/deadline/plugins/publish/collect_default_deadline_server.py
+++ b/openpype/modules/deadline/plugins/publish/collect_default_deadline_server.py
@@ -32,22 +32,29 @@ class CollectDefaultDeadlineServer(pyblish.api.ContextPlugin):
 
         # get default deadline webservice url from deadline module
         self.log.debug(deadline_module.deadline_urls)
-        context.data["defaultDeadline"] = deadline_module.deadline_urls["default"]  # noqa: E501
+        default_deadline_webservice = deadline_module.deadline_urls["default"]
 
         context.data["deadlinePassMongoUrl"] = self.pass_mongo_url
 
         deadline_servers = (context.data
                             ["project_settings"]
                             ["deadline"]
-                            ["deadline_servers"])
-        if deadline_servers:
+                            .get("deadline_servers"))
+        if deadline_servers:  # legacy OP
             deadline_server_name = deadline_servers[0]
+        else:
+            #new Ayon
+            deadline_server_name = (context.data
+                                    ["project_settings"]
+                                    ["deadline"]
+                                    .get("deadline_server"))
+
+        deadline_webservice = None
+        if deadline_server_name:
             deadline_webservice = deadline_module.deadline_urls.get(
                 deadline_server_name)
-            if deadline_webservice:
-                context.data["defaultDeadline"] = deadline_webservice
-                self.log.debug("Overriding from project settings with {}".format(  # noqa: E501
-                    deadline_webservice))
 
-        context.data["defaultDeadline"] = \
-            context.data["defaultDeadline"].strip().rstrip("/")
+        deadline_webservice = (deadline_webservice or
+                               default_deadline_webservice)
+
+        context.data["defaultDeadline"] = deadline_webservice.strip().rstrip("/")  #noqa

--- a/server_addon/deadline/server/settings/main.py
+++ b/server_addon/deadline/server/settings/main.py
@@ -14,15 +14,35 @@ class ServerListSubmodel(BaseSettingsModel):
     value: str = Field(title="Value")
 
 
+async def defined_deadline_ws_name_enum_resolver(
+    addon: "BaseServerAddon",
+    settings_variant: str = "production",
+    project_name: str | None = None,
+) -> list[str]:
+    """Provides list of names of configured Deadline webservice urls."""
+    if addon is None:
+        return []
+
+    settings =  await addon.get_studio_settings(variant=settings_variant)
+
+    ws_urls = []
+    for deadline_url_item in settings.deadline_urls:
+        ws_urls.append(deadline_url_item.name)
+
+    return ws_urls
+
+
 class DeadlineSettings(BaseSettingsModel):
     deadline_urls: list[ServerListSubmodel] = Field(
         default_factory=list,
         title="System Deadline Webservice URLs",
         scope=["studio"],
     )
-    deadline_servers: list[str] = Field(
-        title="Project deadline servers",
+    deadline_server: str = Field(
+        title="Project deadline server",
         section="---",
+        scope=["project"],
+        enum_resolver=defined_deadline_ws_name_enum_resolver
     )
     publish: PublishPluginsModel = Field(
         default_factory=PublishPluginsModel,
@@ -42,7 +62,6 @@ DEFAULT_VALUES = {
             "value": "http://127.0.0.1:8082"
         }
     ],
-    # TODO: this needs to be dynamic from "deadline_urls"
-    "deadline_servers": [],
+    "deadline_server": "default",
     "publish": DEFAULT_DEADLINE_PLUGINS_SETTINGS
 }

--- a/server_addon/deadline/server/settings/publish_plugins.py
+++ b/server_addon/deadline/server/settings/publish_plugins.py
@@ -3,12 +3,6 @@ from pydantic import Field, validator
 from ayon_server.settings import BaseSettingsModel, ensure_unique_names
 
 
-class CollectDefaultDeadlineServerModel(BaseSettingsModel):
-    """Settings for event handlers running in ftrack service."""
-
-    pass_mongo_url: bool = Field(title="Pass Mongo url to job")
-
-
 class CollectDeadlinePoolsModel(BaseSettingsModel):
     """Settings Deadline default pools."""
 
@@ -286,12 +280,6 @@ class ProcessSubmittedJobOnFarmModel(BaseSettingsModel):
 
 
 class PublishPluginsModel(BaseSettingsModel):
-    CollectDefaultDeadlineServer: CollectDefaultDeadlineServerModel = Field(
-        default_factory=CollectDefaultDeadlineServerModel,
-        title="Default Deadline Webservice")
-    CollectDefaultDeadlineServer: CollectDefaultDeadlineServerModel = Field(
-        default_factory=CollectDefaultDeadlineServerModel,
-        title="Default Deadline Webservice")
     CollectDeadlinePools: CollectDeadlinePoolsModel = Field(
         default_factory=CollectDeadlinePoolsModel,
         title="Default Pools")
@@ -332,9 +320,6 @@ class PublishPluginsModel(BaseSettingsModel):
 
 
 DEFAULT_DEADLINE_PLUGINS_SETTINGS = {
-    "CollectDefaultDeadlineServer": {
-        "pass_mongo_url": True
-    },
     "CollectDeadlinePools": {
         "primary_pool": "",
         "secondary_pool": ""


### PR DESCRIPTION
## Changelog Description
Changed the Setting model to mimic more OP approach as it needs to live together for time being.

## Additional info
Cleaned up unnecessary settings for passing MongoDB.

## Testing notes:
1. re-create new Deadline addon with `server_addon/create_server_addon.py` and install it to Ayon
2. double check that `Default` value is selected in `ayon+settings://deadline/deadline_server`
![image](https://github.com/ynput/OpenPype/assets/4457962/eb2c9363-f718-4f80-b7e5-b5603f783c78)
3.publish something via DL in Ayon
4.publish something via DL in OP

