### PR TITLE
AYON tools: Fix refresh thread

### DIFF
--- a/openpype/tools/ayon_utils/widgets/utils.py
+++ b/openpype/tools/ayon_utils/widgets/utils.py
@@ -15,6 +15,7 @@ class RefreshThread(QtCore.QThread):
         self._callback = partial(func, *args, **kwargs)
         self._exception = None
         self._result = None
+        self.finished.connect(self._on_finish_callback)
 
     @property
     def id(self):
@@ -29,10 +30,12 @@ class RefreshThread(QtCore.QThread):
             self._result = self._callback()
         except Exception as exc:
             self._exception = exc
-        self.refresh_finished.emit(self.id)
 
     def get_result(self):
         return self._result
+
+    def _on_finish_callback(self):
+        self.refresh_finished.emit(self.id)
 
 
 class _IconsCache:


### PR DESCRIPTION
## Changelog Description
Trigger 'refresh_finished' signal out of 'run' method.

## Additional info
Because the signal was triggered at the `run` method the signal callback should not remove the thread from memory (which usually happened). That lead to unexpected crashes especially in projects widget. Modified the thread to trigger signal on `finished` signal of `QThread` where we're 100% sure the object can be cleaned up.

From QThread deconstructor comment
```
Destroys the QThread.

    Note that deleting a QThread object will not stop the execution
    of the thread it manages. Deleting a running QThread (i.e.
    isFinished() returns \c false) will result in a program
    crash. Wait for the finished() signal before deleting the
    QThread.
```

## Testing notes:
1. Press refresh in launcher tool rapidly
2. It should not cause crash because of QThread
