### PR TITLE
Maya: Bug fix load image for texturesetMain

### DIFF
--- a/openpype/hosts/maya/plugins/load/load_image.py
+++ b/openpype/hosts/maya/plugins/load/load_image.py
@@ -286,7 +286,7 @@ class FileNodeLoader(load.LoaderPlugin):
 
         path = get_representation_path_from_context(context)
         colorspace = get_imageio_colorspace_from_filepath(
-            path=path,
+            filepath=path,
             host_name=host_name,
             project_name=project_name,
             config_data=config_data,


### PR DESCRIPTION
## Changelog Description
Bug fix load image with file node for texturesetMain

## Additional info
n/a

## Testing notes:
1. Launch Maya via Launcher
2. AYON -> Load
3. Load file node (Image)
4. The textures should be loaded with the file node created in hypershade 
