### PR TITLE
TVPaint: Expect legacy instances in metadata

### DIFF
--- a/openpype/hosts/tvpaint/plugins/publish/collect_render_instances.py
+++ b/openpype/hosts/tvpaint/plugins/publish/collect_render_instances.py
@@ -73,7 +73,7 @@ class CollectRenderInstances(pyblish.api.InstancePlugin):
         render_layer_id = creator_attributes["render_layer_instance_id"]
         for in_data in instance.context.data["workfileInstances"]:
             if (
-                in_data["creator_identifier"] == "render.layer"
+                in_data.get("creator_identifier") == "render.layer"
                 and in_data["instance_id"] == render_layer_id
             ):
                 render_layer_data = in_data


### PR DESCRIPTION
## Changelog Description
Do not expect `"workfileInstances"` constains only new type instance data with `creator_identifier`.

## Testing notes:
1. Open scene with legacy instances in TVPaint
2. Run publishing
3. Publishing should not crash
