### PR TITLE
Revert `extractenvironments` behaviour

### DIFF
--- a/openpype/pype_commands.py
+++ b/openpype/pype_commands.py
@@ -185,8 +185,7 @@ class PypeCommands:
                 task,
                 app,
                 env_group=env_group,
-                launch_type=LaunchTypes.farm_render,
-                env={}
+                launch_type=LaunchTypes.farm_render
             )
         else:
             env = os.environ.copy()


### PR DESCRIPTION
## Changelog Description
This is returning original behaviour of `extractenvironments` command from before #5958 so we restore functionality.

## Additional info
That behaviour is wrong, but currently we don't have any other solution. 

## Testing notes:
Submitted render jobs on farm should start normally (maya/houdini)

> [!WARNING]
This will break #5958 because RoyalRender has 2000 unicode char limit on environments passed to the job