### PR TITLE
Refactor code to skip instance creation for new assets

### DIFF
--- a/openpype/plugins/publish/collect_resources_path.py
+++ b/openpype/plugins/publish/collect_resources_path.py
@@ -68,11 +68,6 @@ class CollectResourcesPath(pyblish.api.InstancePlugin):
                 ]
 
     def process(self, instance):
-        # editorial would fail since they might not be in database yet
-        new_asset_publishing = instance.data.get("newAssetPublishing")
-        if new_asset_publishing:
-            self.log.debug("Instance is creating new asset. Skipping.")
-            return
 
         anatomy = instance.context.data["anatomy"]
 

--- a/openpype/plugins/publish/extract_otio_audio_tracks.py
+++ b/openpype/plugins/publish/extract_otio_audio_tracks.py
@@ -319,6 +319,7 @@ class ExtractOtioAudioTracks(pyblish.api.ContextPlugin):
         Returns:
             str: temp fpath
         """
+        name = name.replace("/", "_")
         return os.path.normpath(
             tempfile.mktemp(
                 prefix="pyblish_tmp_{}_".format(name),


### PR DESCRIPTION
## Changelog Description
Publishing effects from hiero during editorial publish is working as expected again.

## Additional info
- Removed the check for `newAssetPublishing` in `CollectResourcesPath.process()`
- This change allows instances to be processed even if they are creating new assets

## Testing notes Ayon:
1. Publish hiero timeline with softeffects
2. all publishes should be successfull