### PR TITLE
Change ASCII art in the Console based on the server mode

### DIFF
--- a/openpype/modules/python_console_interpreter/window/widgets.py
+++ b/openpype/modules/python_console_interpreter/window/widgets.py
@@ -13,6 +13,7 @@ from openpype.style import load_stylesheet
 from openpype.lib import JSONSettingRegistry
 
 
+
 openpype_art = """
              . .   ..     .    ..
         _oOOP3OPP3Op_. .
@@ -28,6 +29,18 @@ openpype_art = """
          ~P3.OPPPO3OP~ . ..  .
            .  ' '. .  .. . . . ..  .
 
+"""
+
+ayon_art = r"""
+
+                    ▄██▄
+         ▄███▄ ▀██▄ ▀██▀ ▄██▀ ▄██▀▀▀██▄    ▀███▄      █▄
+        ▄▄ ▀██▄  ▀██▄  ▄██▀ ██▀      ▀██▄  ▄  ▀██▄    ███
+       ▄██▀  ██▄   ▀ ▄▄ ▀  ██         ▄██  ███  ▀██▄  ███
+      ▄██▀    ▀██▄   ██    ▀██▄      ▄██▀  ███    ▀██ ▀█▀
+     ▄██▀      ▀██▄  ▀█      ▀██▄▄▄▄██▀    █▀      ▀██▄
+
+     ·  · - =[ by YNPUT ]:[ http://ayon.ynput.io ]= - ·  ·
 
 """
 
@@ -42,8 +55,12 @@ class PythonInterpreterRegistry(JSONSettingRegistry):
     """
 
     def __init__(self):
-        self.vendor = "pypeclub"
-        self.product = "openpype"
+        if AYON_SERVER_ENABLED:
+            self.vendor = "ynput"
+            self.product = "ayon"
+        else:
+            self.vendor = "pypeclub"
+            self.product = "openpype"
         name = "python_interpreter_tool"
         path = appdirs.user_data_dir(self.product, self.vendor)
         super(PythonInterpreterRegistry, self).__init__(name, path)
@@ -390,7 +407,10 @@ class PythonInterpreterWidget(QtWidgets.QWidget):
         self._tab_widget = tab_widget
         self._line_check_timer = line_check_timer
 
-        self._append_lines([openpype_art])
+        if AYON_SERVER_ENABLED:
+            self._append_lines([ayon_art])
+        else:
+            self._append_lines([openpype_art])
 
         self._first_show = True
         self._splitter_size_ratio = None


### PR DESCRIPTION
## Changelog Description
This changes ASCII art in the console based on the AYON/OpenPype mode

## Testing notes:
1. Run console in Openpype - you should see perfect OP art
2. Run console in AYON:

```

                    ▄██▄
         ▄███▄ ▀██▄ ▀██▀ ▄██▀ ▄██▀▀▀██▄    ▀███▄      █▄
        ▄▄ ▀██▄  ▀██▄  ▄██▀ ██▀      ▀██▄  ▄  ▀██▄    ███
       ▄██▀  ██▄   ▀ ▄▄ ▀  ██         ▄██  ███  ▀██▄  ███
      ▄██▀    ▀██▄   ██    ▀██▄      ▄██▀  ███    ▀██ ▀█▀
     ▄██▀      ▀██▄  ▀█      ▀██▄▄▄▄██▀    █▀      ▀██▄

     ·  · - =[ by YNPUT ]:[ http://ayon.ynput.io ]= - ·  ·


```
