### PR TITLE
Show slightly different info in AYON mode

### DIFF
--- a/openpype/tools/tray/pype_info_widget.py
+++ b/openpype/tools/tray/pype_info_widget.py
@@ -6,6 +6,7 @@ import ayon_api
 from qtpy import QtCore, QtGui, QtWidgets
 
 from openpype import style
+import openpype.version
 from openpype import resources
 from openpype import AYON_SERVER_ENABLED
 from openpype.settings.lib import get_local_settings
@@ -512,6 +513,18 @@ class PypeInfoSubWidget(QtWidgets.QWidget):
                 QtWidgets.QLabel(label), row, 0, 1, 1
             )
             value_label = QtWidgets.QLabel(value)
+            value_label.setTextInteractionFlags(
+                QtCore.Qt.TextSelectableByMouse
+            )
+            info_layout.addWidget(
+                value_label, row, 1, 1, 1
+            )
+        if AYON_SERVER_ENABLED:
+            row = info_layout.rowCount()
+            info_layout.addWidget(
+                QtWidgets.QLabel("OpenPype Addon:"), row, 0, 1, 1
+            )
+            value_label = QtWidgets.QLabel(openpype.version.__version__)
             value_label.setTextInteractionFlags(
                 QtCore.Qt.TextSelectableByMouse
             )

--- a/openpype/tools/tray/pype_tray.py
+++ b/openpype/tools/tray/pype_tray.py
@@ -599,7 +599,10 @@ class TrayManager:
         subversion = os.environ.get("OPENPYPE_SUBVERSION")
         client_name = os.environ.get("OPENPYPE_CLIENT")
 
-        version_string = openpype.version.__version__
+        if AYON_SERVER_ENABLED:
+            version_string = os.getenv("AYON_VERSION", "AYON Info")
+        else:
+            version_string = openpype.version.__version__
         if subversion:
             version_string += " ({})".format(subversion)
 


### PR DESCRIPTION
## Changelog Description
This PR changes what is shown in Tray menu in AYON mode. Previously, it showed version of OpenPype that is very confusing in AYON mode. So this now shows AYON version instead. When clicked, it will opene AYON info window, where OpenPype version is now added, for debugging purposes.

## Additional info
![image](https://github.com/ynput/OpenPype/assets/33513211/75ea1282-6bf3-414e-b9a0-96eb62a92e40)
![image](https://github.com/ynput/OpenPype/assets/33513211/d083805d-73a1-4cfd-b214-673e3030753e)

