### PR TITLE
Houdini/AYON: Missing ifdFile as instance data blocks the deadline submission

### DIFF
--- a/openpype/modules/deadline/plugins/publish/submit_houdini_render_deadline.py
+++ b/openpype/modules/deadline/plugins/publish/submit_houdini_render_deadline.py
@@ -248,16 +248,16 @@ class HoudiniSubmitDeadline(
             family = instance.data.get("family")
             if family == "arnold_rop":
                 plugin_info = ArnoldRenderDeadlinePluginInfo(
-                    InputFile=instance.data["ifdFile"]
+                    InputFile=instance.data.get("ifdFile", "")
                 )
             elif family == "mantra_rop":
                 plugin_info = MantraRenderDeadlinePluginInfo(
-                    SceneFile=instance.data["ifdFile"],
+                    SceneFile=instance.data.get("ifdFile", ""),
                     Version=hou_major_minor,
                 )
             elif family == "vray_rop":
                 plugin_info = VrayRenderPluginInfo(
-                    InputFilename=instance.data["ifdFile"],
+                    InputFilename=instance.data.get("ifdFile", ""),
                 )
             else:
                 self.log.error(


### PR DESCRIPTION
## Changelog Description
When the ifdFile is not being collected, it will error out and blocks houdini deadline submission.
![image](https://github.com/ynput/OpenPype/assets/64118225/b2421a2d-defd-4476-8478-ad0a5ee0d053)

## Additional info
n/a

## Testing notes:
1. Create any render ROP in Houdini
2. Publish
3. It should be published successfully.
