### PR TITLE
Traypublisher: editorial preserve clip case sensitivity

### DIFF
--- a/openpype/hosts/traypublisher/plugins/create/create_editorial.py
+++ b/openpype/hosts/traypublisher/plugins/create/create_editorial.py
@@ -663,7 +663,7 @@ or updating already created. Publishing will create OTIO file.
         variant_name = instance_data["variant"]
 
         # basic unique asset name
-        clip_name = os.path.splitext(otio_clip.name)[0].lower()
+        clip_name = os.path.splitext(otio_clip.name)[0]
         project_doc = get_project(self.project_name)
 
         shot_name, shot_metadata = self._shot_metadata_solver.generate_data(


### PR DESCRIPTION
## Changelog Description
Keep EDL clip name inheritance with case sensitivity. 

## Additional info
The code change updates the way the clip name is extracted from the OTIO file. The ".lower()" method has been removed to preserve case sensitivity.
