### PR TITLE
Bugfix Houdini refactor `get_output_parameter` 

### DIFF
--- a/openpype/hosts/houdini/api/lib.py
+++ b/openpype/hosts/houdini/api/lib.py
@@ -121,62 +121,6 @@ def get_id_required_nodes():
     return list(nodes)
 
 
-def get_export_parameter(node):
-    """Return the export output parameter of the given node
-
-    Example:
-        root = hou.node("/obj")
-        my_alembic_node = root.createNode("alembic")
-        get_output_parameter(my_alembic_node)
-        # Result: "output"
-
-    Args:
-        node(hou.Node): node instance
-
-    Returns:
-        hou.Parm
-
-    """
-    node_type = node.type().description()
-
-    # Ensures the proper Take is selected for each ROP to retrieve the correct
-    # ifd
-    try:
-        rop_take = hou.takes.findTake(node.parm("take").eval())
-        if rop_take is not None:
-            hou.takes.setCurrentTake(rop_take)
-    except AttributeError:
-        # hou object doesn't always have the 'takes' attribute
-        pass
-
-    if node_type == "Mantra" and node.parm("soho_outputmode").eval():
-        return node.parm("soho_diskfile")
-    elif node_type == "Alfred":
-        return node.parm("alf_diskfile")
-    elif (node_type == "RenderMan" or node_type == "RenderMan RIS"):
-        pre_ris22 = node.parm("rib_outputmode") and \
-            node.parm("rib_outputmode").eval()
-        ris22 = node.parm("diskfile") and node.parm("diskfile").eval()
-        if pre_ris22 or ris22:
-            return node.parm("soho_diskfile")
-    elif node_type == "Redshift" and node.parm("RS_archive_enable").eval():
-        return node.parm("RS_archive_file")
-    elif node_type == "Wedge" and node.parm("driver").eval():
-        return get_export_parameter(node.node(node.parm("driver").eval()))
-    elif node_type == "Arnold":
-        return node.parm("ar_ass_file")
-    elif node_type == "Alembic" and node.parm("use_sop_path").eval():
-        return node.parm("sop_path")
-    elif node_type == "Shotgun Mantra" and node.parm("soho_outputmode").eval():
-        return node.parm("sgtk_soho_diskfile")
-    elif node_type == "Shotgun Alembic" and node.parm("use_sop_path").eval():
-        return node.parm("sop_path")
-    elif node.type().nameWithCategory() == "Driver/vray_renderer":
-        return node.parm("render_export_filepath")
-
-    raise TypeError("Node type '%s' not supported" % node_type)
-
-
 def get_output_parameter(node):
     """Return the render output parameter of the given node
 
@@ -184,7 +128,7 @@ def get_output_parameter(node):
         root = hou.node("/obj")
         my_alembic_node = root.createNode("alembic")
         get_output_parameter(my_alembic_node)
-        # Result: "output"
+        # Result: "filename"
 
     Args:
         node(hou.Node): node instance
@@ -192,33 +136,47 @@ def get_output_parameter(node):
     Returns:
         hou.Parm
 
+    Note 1:
+        I'm using node.type().name() to get on par with the creators,
+        Because the return value of `node.type().name()` is the same string value used in creators
+        e.g. instance_data.update({"node_type": "alembic"})
+
+    Note 2:
+        Rop nodes in different network categories have the same output parameter.
+        So, I took that into consideration as a hint for future development.
+
     """
-    node_type = node.type().description()
-    category = node.type().category().name()
+
+    node_type = node.type().name()
 
     # Figure out which type of node is being rendered
-    if node_type == "Geometry" or node_type == "Filmbox FBX" or \
-            (node_type == "ROP Output Driver" and category == "Sop"):
-        return node.parm("sopoutput")
-    elif node_type == "Composite":
-        return node.parm("copoutput")
-    elif node_type == "opengl":
-        return node.parm("picture")
-    elif node_type == "arnold":
-        if node.evalParm("ar_ass_export_enable"):
+    if node_type == "alembic" or node_type == "rop_alembic":
+        return node.parm("filename")
+    elif  node_type == "arnold":
+        if node_type.evalParm("ar_ass_export_enable"):
             return node.parm("ar_ass_file")
-    elif node_type == "Redshift_Proxy_Output":
-        return node.parm("RS_archive_file")
-    elif node_type == "ifd":
+        else:
+            return node.parm("ar_picture")
+    elif node_type == "geometry" or node_type == "rop_geometry" or node_type == "filmboxfbx" or node_type == "rop_fbx" :
+        return node.parm("sopoutput")
+    elif node_type == "comp":
+        return node.parm("copoutput")
+    elif node_type == "karma" or node_type == "opengl":
+        return node.parm("picture")
+    elif node_type == "ifd":  # Matnra
         if node.evalParm("soho_outputmode"):
             return node.parm("soho_diskfile")
-    elif node_type == "Octane":
-        return node.parm("HO_img_fileName")
-    elif node_type == "Fetch":
-        inner_node = node.node(node.parm("source").eval())
-        if inner_node:
-            return get_output_parameter(inner_node)
-    elif node.type().nameWithCategory() == "Driver/vray_renderer":
+        else:
+            return node.parm("vm_picture")
+    elif node_type == "Redshift_Proxy_Output":
+        return node.parm("RS_archive_file")
+    elif node_type == "Redshift_ROP":
+        return node.parm("RS_outputFileNamePrefix")
+    elif node_type == "usd" or node_type == "usd_rop" or node_type == "usdexport":
+        return node.parm("lopoutput")
+    elif node_type == "usdrender" or node_type == "usdrender_rop":
+        return node.parm("outputimage")
+    elif node_type == "vray_renderer":
         return node.parm("SettingsOutput_img_file_path")
 
     raise TypeError("Node type '%s' not supported" % node_type)


### PR DESCRIPTION
## Changelog Description
This PR is a follow up PR to https://github.com/ynput/OpenPype/pull/5420 

This PR returns `get_output_parameter` to what it's used to be check it here in the latest tag https://github.com/ynput/OpenPype/blob/d834c59f6c8d5beb73de406a4d81cc8045d5d152/openpype/hosts/houdini/api/lib.py#L124

## Testing notes:
1. open houdini
2. submit different product types, they should work
    > Karma doesn't work and that issue should be addressed in another PR!
