### PR TITLE
Ayon General: traypublisher editorial check of hierarchy in wrong data 

### DIFF
--- a/openpype/plugins/publish/collect_resources_path.py
+++ b/openpype/plugins/publish/collect_resources_path.py
@@ -82,7 +82,7 @@ class CollectResourcesPath(pyblish.api.InstancePlugin):
         # Add fill keys for editorial publishing creating new entity
         # TODO handle in editorial plugin
         if instance.data.get("newAssetPublishing"):
-            if "hierarchy" not in instance.data:
+            if "hierarchy" not in template_data:
                 template_data["hierarchy"] = instance.data["hierarchy"]
 
             if "asset" not in template_data:


### PR DESCRIPTION
## Changelog Description
Editorial publishing is fixed and work as expected.

## Additional info
- checking in wrong data

## Testing notes:
1. start with this step
2. follow this step
