### PR TITLE
Fusion: fix for single frame rendering

### DIFF
--- a/openpype/hosts/fusion/plugins/publish/extract_render_local.py
+++ b/openpype/hosts/fusion/plugins/publish/extract_render_local.py
@@ -146,11 +146,15 @@ class FusionRenderLocal(
 
         staging_dir = os.path.dirname(path)
 
+        files = [os.path.basename(f) for f in expected_files]
+        if len(expected_files) == 1:
+            files = files[0]
+
         repre = {
             "name": ext[1:],
             "ext": ext[1:],
             "frameStart": f"%0{padding}d" % start,
-            "files": [os.path.basename(f) for f in expected_files],
+            "files": files,
             "stagingDir": staging_dir,
         }
 


### PR DESCRIPTION
## Changelog Description
Fixes publishes of single frame of `render` product type.

## Additional info
Files must be string not single element array.

## Testing notes:
1. set timeline to single frame
2. set `Frame range source` 
![image](https://github.com/ynput/OpenPype/assets/4457962/7f081872-55d8-4db2-8507-a43b43fc1b9d)

