### PR TITLE
Photoshop: fix layer publish thumbnail missing in loader

### DIFF
--- a/openpype/hosts/photoshop/plugins/publish/extract_review.py
+++ b/openpype/hosts/photoshop/plugins/publish/extract_review.py
@@ -224,7 +224,7 @@ class ExtractReview(publish.Extractor):
             "stagingDir": staging_dir,
             "tags": ["thumbnail", "delete"]
         })
-        instance.data["thumbnailPath"] = thumbnail_path  # for Ayon integration
+        instance.data["thumbnailPath"] = thumbnail_path
 
     def _check_and_resize(self, processed_img_names, source_files_pattern,
                           staging_dir):

--- a/openpype/hosts/photoshop/plugins/publish/extract_review.py
+++ b/openpype/hosts/photoshop/plugins/publish/extract_review.py
@@ -224,6 +224,7 @@ class ExtractReview(publish.Extractor):
             "stagingDir": staging_dir,
             "tags": ["thumbnail", "delete"]
         })
+        instance.data["thumbnailPath"] = thumbnail_path  # for Ayon integration
 
     def _check_and_resize(self, processed_img_names, source_files_pattern,
                           staging_dir):

--- a/openpype/plugins/publish/integrate_thumbnail_ayon.py
+++ b/openpype/plugins/publish/integrate_thumbnail_ayon.py
@@ -13,7 +13,6 @@
     - instance.data["thumbnailPath"]
     - representation with 'thumbnail' name in 'published_representations'
     - context.data["thumbnailPath"]
-    
 
     Notes:
         Issue with 'thumbnail' representation is that we most likely don't

--- a/openpype/plugins/publish/integrate_thumbnail_ayon.py
+++ b/openpype/plugins/publish/integrate_thumbnail_ayon.py
@@ -5,7 +5,7 @@
     pull into a scene.
 
     This one is used only as image describing content of published item and
-    shows up only in Loader or Server UI in right column section.
+        shows up only in Loader or WebUI.
 
     Possible sources of thumbnail paths (OR):
     - context.data.get("thumbnailPath")

--- a/openpype/plugins/publish/integrate_thumbnail_ayon.py
+++ b/openpype/plugins/publish/integrate_thumbnail_ayon.py
@@ -15,9 +15,11 @@
     - context.data["thumbnailPath"]
     
 
-    (issue with last option is that we most likely don't want to integrate
-    thumbnail, eg. store it DB. Integrated representation would be polluting
-    Loaader (and DB) and its use is likely minimal.)
+    Notes:
+        Issue with 'thumbnail' representation is that we most likely don't
+            want to integrate it as representation. Integrated representation
+            is polluting Loader and database without real usage. That's why
+            they usually have 'delete' tag to skip the integration.
 
 """
 

--- a/openpype/plugins/publish/integrate_thumbnail_ayon.py
+++ b/openpype/plugins/publish/integrate_thumbnail_ayon.py
@@ -5,7 +5,19 @@
     pull into a scene.
 
     This one is used only as image describing content of published item and
-    shows up only in Loader in right column section.
+    shows up only in Loader or Server UI in right column section.
+
+    Possible sources of thumbnail paths (OR):
+    - context.data.get("thumbnailPath")
+    (instance must have "published_representations")
+    - instance.data.get("thumbnailSource")
+    - instance.data.get("thumbnailPath")
+    - representation with 'thumbnail' name from "published_representations"
+
+    (issue with last option is that we most likely don't want to integrate
+    thumbnail, eg. store it DB. Integrated representation would be polluting
+    Loaader (and DB) and its use is likely minimal.)
+
 """
 
 import os

--- a/openpype/plugins/publish/integrate_thumbnail_ayon.py
+++ b/openpype/plugins/publish/integrate_thumbnail_ayon.py
@@ -7,12 +7,13 @@
     This one is used only as image describing content of published item and
         shows up only in Loader or WebUI.
 
-    Possible sources of thumbnail paths (OR):
-    - context.data.get("thumbnailPath")
-    (instance must have "published_representations")
-    - instance.data.get("thumbnailSource")
-    - instance.data.get("thumbnailPath")
-    - representation with 'thumbnail' name from "published_representations"
+    Instance must have 'published_representations' to
+        be able to integrate thumbnail.
+    Possible sources of thumbnail paths:
+    - instance.data["thumbnailPath"]
+    - representation with 'thumbnail' name in 'published_representations'
+    - context.data["thumbnailPath"]
+    
 
     (issue with last option is that we most likely don't want to integrate
     thumbnail, eg. store it DB. Integrated representation would be polluting


### PR DESCRIPTION
## Changelog Description
Thumbnails from any products (either `review` nor separate layer instances) weren't stored in Ayon.
This resulted in not showing them in Loader and Server UI. After this PR thumbnails should be shown in the Loader and on the Server (`http://YOUR_AYON_HOSTNAME:5000/projects/YOUR_PROJECT/browser`).

## Additional info
Tis PR explicitly sets path to thumbnail on the instance (as there might be only one thumbnail per instance, imho) bypassing issue that representation with 'name' == 'thumbnail' is by default set to not be integrated.

## Testing notes:
1. publish workfile in PS with default `review` instance
2. publish workfile in PS with separate `image` instances which have `Review` toggle set to True 
![image](https://github.com/ynput/OpenPype/assets/4457962/79d4a5c2-980f-4dbf-979a-d881e2834821)
3. Check right column in the Loader and Server UI 

