### PR TITLE
AYON Chore: Do not use thumbnailSource for thumbnail integration

### DIFF
--- a/openpype/plugins/publish/integrate_thumbnail_ayon.py
+++ b/openpype/plugins/publish/integrate_thumbnail_ayon.py
@@ -92,11 +92,8 @@ class IntegrateThumbnailsAYON(pyblish.api.ContextPlugin):
                 continue
 
             # Find thumbnail path on instance
-            thumbnail_source = instance.data.get("thumbnailSource")
-            thumbnail_path = instance.data.get("thumbnailPath")
             thumbnail_path = (
-                thumbnail_source
-                or thumbnail_path
+                instance.data.get("thumbnailPath")
                 or self._get_instance_thumbnail_path(published_repres)
             )
             if thumbnail_path:


### PR DESCRIPTION
## Changelog Description
Do not use `thumbnailSource` for thumbnail integration.

## Additional info
The value of `"thumbnailSource"` is what should be used as source for `"thumbnailPath"`, so it can be .exr, .mp4 etc. all of them are invalid for thumbnail. It looks like it was accidentaly used instead of thumbnailPath and nobody noticed...

### OpenPype Note
I found out the logic how to determine what should be used as thumbnail is different in AYON and OpenPype integrator. Looks like the logic in OpenPype is quite old.

### Steps to replicate issues
- Open traypublisher
- Select render
- Pass as source file mp4 and use the same mp4 for review
- Publish
- Integrate thumbnail will probably crash because mp4 is invalid file for thumbnail

## Testing notes:
1. Thumbnail publishing should work as expected
