### PR TITLE
Photoshop: fix creation of .mov

### DIFF
--- a/openpype/hosts/photoshop/plugins/publish/extract_review.py
+++ b/openpype/hosts/photoshop/plugins/publish/extract_review.py
@@ -170,8 +170,7 @@ class ExtractReview(publish.Extractor):
         # Generate mov.
         mov_path = os.path.join(staging_dir, "review.mov")
         self.log.info(f"Generate mov review: {mov_path}")
-        args = [
-            ffmpeg_path,
+        args = ffmpeg_path + [
             "-y",
             "-i", source_files_pattern,
             "-vf", "pad=ceil(iw/2)*2:ceil(ih/2)*2",


### PR DESCRIPTION
## Changelog Description
Generation of .mov file with 1 frame per published layer was failing.




## Testing notes:
1. set `ayon+settings://photoshop/publish/ExtractReview?project=demo_Commercial` `Make an image sequence instead of flatten image`
2. 
![image](https://github.com/ynput/OpenPype/assets/4457962/7cfa627c-1c1b-4490-9433-52653685fc90)

3. publish workfile with multiple `image` instances
4. it shouldn't fail
