### PR TITLE
Photoshop: fix Collect Color Coded settings

### DIFF
--- a/server_addon/photoshop/server/settings/publish_plugins.py
+++ b/server_addon/photoshop/server/settings/publish_plugins.py
@@ -29,7 +29,7 @@ class ColorCodeMappings(BaseSettingsModel):
     )
 
     layer_name_regex: list[str] = Field(
-        "",
+        default_factory=list,
         title="Layer name regex"
     )
 

--- a/server_addon/photoshop/server/version.py
+++ b/server_addon/photoshop/server/version.py
@@ -1,3 +1,3 @@
 # -*- coding: utf-8 -*-
 """Package declaring addon version."""
-__version__ = "0.1.0"
+__version__ = "0.1.1"


### PR DESCRIPTION
## Changelog Description
Fix for wrong default value for `Collect Color Coded Instances` Settings

## Additional info
Paragraphs of text giving context of additional technical information or code examples.

## Testing notes:
1. build new Photoshop addon zip via `server_addons/create_package.py`
2. install it to Ayon server
3. try to set `ayon+settings://photoshop/publish/CollectColorCodedInstances`
<img width="659" alt="chrome_NZrfuIw7Tf" src="https://github.com/ynput/OpenPype/assets/4457962/781e582f-0c5d-4f11-9646-b4368dd80468">

