### PR TITLE
AYON ftrack: Expect 'ayon' group in custom attributes

### DIFF
--- a/openpype/modules/ftrack/lib/custom_attributes.py
+++ b/openpype/modules/ftrack/lib/custom_attributes.py
@@ -66,7 +66,7 @@ def get_openpype_attr(session, split_hierarchical=True, query_keys=None):
         "select {}"
         " from CustomAttributeConfiguration"
         # Kept `pype` for Backwards Compatibility
-        " where group.name in (\"pype\", \"{}\")"
+        " where group.name in (\"pype\", \"ayon\", \"{}\")"
     ).format(", ".join(query_keys), CUST_ATTR_GROUP)
     all_avalon_attr = session.query(cust_attrs_query).all()
     for cust_attr in all_avalon_attr:

--- a/openpype/modules/ftrack/plugins/publish/integrate_hierarchy_ftrack.py
+++ b/openpype/modules/ftrack/plugins/publish/integrate_hierarchy_ftrack.py
@@ -21,7 +21,7 @@ def get_pype_attr(session, split_hierarchical=True):
         "select id, entity_type, object_type_id, is_hierarchical, default"
         " from CustomAttributeConfiguration"
         # Kept `pype` for Backwards Compatibility
-        " where group.name in (\"pype\", \"{}\")"
+        " where group.name in (\"pype\", \"ayon\", \"{}\")"
     ).format(CUST_ATTR_GROUP)
     all_avalon_attr = session.query(cust_attrs_query).all()
     for cust_attr in all_avalon_attr:


### PR DESCRIPTION
## Changelog Description
Expect `ayon` group as one of options to get custom attributes.

## Additional info
This is necessary for testing AYON and OpenPype at the same time in ftrack.
