### PR TITLE
Bug: Fix Publisher parent window in Nuke

### DIFF
--- a/openpype/hosts/nuke/api/pipeline.py
+++ b/openpype/hosts/nuke/api/pipeline.py
@@ -260,7 +260,7 @@ def _install_menu():
             "Create...",
             lambda: host_tools.show_publisher(
                 parent=(
-                    main_window if nuke.NUKE_VERSION_RELEASE >= 14 else None
+                    main_window if nuke.NUKE_VERSION_MAJOR >= 14 else None
                 ),
                 tab="create"
             )
@@ -271,7 +271,7 @@ def _install_menu():
             "Publish...",
             lambda: host_tools.show_publisher(
                 parent=(
-                    main_window if nuke.NUKE_VERSION_RELEASE >= 14 else None
+                    main_window if nuke.NUKE_VERSION_MAJOR >= 14 else None
                 ),
                 tab="publish"
             )


### PR DESCRIPTION
## Changelog Description
Fixing issue where publisher parent window wasn't set because wrong use of version constant.

## Testing notes:
1. open Nuke
2. open Publisher
3. create new dialog in Nuke, like "render all write nodes..."

>[!note]
> Related issue: #6016
