### PR TITLE
Bug: fix AYON settings for Maya workspace

### DIFF
--- a/openpype/settings/defaults/project_settings/maya.json
+++ b/openpype/settings/defaults/project_settings/maya.json
@@ -436,7 +436,7 @@
             "viewTransform": "sRGB gamma"
         }
     },
-    "mel_workspace": "workspace -fr \"shaders\" \"renderData/shaders\";\nworkspace -fr \"images\" \"renders/maya\";\nworkspace -fr \"particles\" \"particles\";\nworkspace -fr \"mayaAscii\" \"\";\nworkspace -fr \"mayaBinary\" \"\";\nworkspace -fr \"scene\" \"\";\nworkspace -fr \"alembicCache\" \"cache/alembic\";\nworkspace -fr \"renderData\" \"renderData\";\nworkspace -fr \"sourceImages\" \"sourceimages\";\nworkspace -fr \"fileCache\" \"cache/nCache\";\n",
+    "mel_workspace": "workspace -fr \"shaders\" \"renderData/shaders\";\nworkspace -fr \"images\" \"renders/maya\";\nworkspace -fr \"particles\" \"particles\";\nworkspace -fr \"mayaAscii\" \"\";\nworkspace -fr \"mayaBinary\" \"\";\nworkspace -fr \"scene\" \"\";\nworkspace -fr \"alembicCache\" \"cache/alembic\";\nworkspace -fr \"renderData\" \"renderData\";\nworkspace -fr \"sourceImages\" \"sourceimages\";\nworkspace -fr \"fileCache\" \"cache/nCache\";\nworkspace -fr \"autoSave\" \"autosave\";",
     "ext_mapping": {
         "model": "ma",
         "mayaAscii": "ma",

--- a/server_addon/maya/server/settings/main.py
+++ b/server_addon/maya/server/settings/main.py
@@ -97,7 +97,7 @@ DEFAULT_MEL_WORKSPACE_SETTINGS = "\n".join((
     'workspace -fr "renderData" "renderData";',
     'workspace -fr "sourceImages" "sourceimages";',
     'workspace -fr "fileCache" "cache/nCache";',
-    'workspace -fr "autoSave" "autosave"',
+    'workspace -fr "autoSave" "autosave";',
     '',
 ))
 


### PR DESCRIPTION
## Changelog Description
This is changing bug in default AYON setting for Maya workspace, where missing semicolumn caused workspace not being set. This is also syncing default workspace settings to OpenPype

## Testing notes:
1. start Maya on new asset
3. workspace values should be set correcty
