### PR TITLE
Editorial & chore: Stop using pathlib2

### DIFF
--- a/openpype/scripts/ocio_wrapper.py
+++ b/openpype/scripts/ocio_wrapper.py
@@ -21,7 +21,7 @@ Providing functionality:
 
 import click
 import json
-from pathlib2 import Path
+from pathlib import Path
 import PyOpenColorIO as ocio
 
 

--- a/server_addon/openpype/client/pyproject.toml
+++ b/server_addon/openpype/client/pyproject.toml
@@ -13,7 +13,6 @@ google-api-python-client = "^1.12.8" # sync server google support (should be sep
 jsonschema = "^2.6.0"
 pymongo = "^3.11.2"
 log4mongo = "^1.7"
-pathlib2= "^2.3.5" # deadline submit publish job only (single place, maybe not needed?)
 pyblish-base = "^1.8.11"
 pynput = "^1.7.2" # Timers manager - TODO replace
 "Qt.py" = "^1.3.3"


### PR DESCRIPTION
## Changelog Description
Do not use `pathlib2` which is Python 2 backport for `pathlib` module in python 3.

## Additional info
Removed only usage in ocio wrapper which 100% will always run in python 3 (and contains python 3 syntax). Removed the dependency from openpype addon.

## Testing notes:
Don't know when is `ocio_warpper.py` used, but should still work with `pathlib`.
