### PR TITLE
Python console widget: Save registry fix

### DIFF
--- a/openpype/modules/python_console_interpreter/window/widgets.py
+++ b/openpype/modules/python_console_interpreter/window/widgets.py
@@ -415,7 +415,7 @@ class PythonInterpreterWidget(QtWidgets.QWidget):
         self._first_show = True
         self._splitter_size_ratio = None
         self._allow_save_registry = allow_save_registry
-        self._should_save_registry = False
+        self._registry_saved = True
 
         self._init_from_registry()
 
@@ -460,9 +460,10 @@ class PythonInterpreterWidget(QtWidgets.QWidget):
 
     def save_registry(self):
         # Window was not showed
-        if not self._allow_save_registry or not self._should_save_registry:
+        if not self._allow_save_registry or self._registry_saved:
             return
 
+        self._registry_saved = True
         setting_registry = PythonInterpreterRegistry()
 
         setting_registry.set_item("width", self.width())
@@ -656,8 +657,8 @@ class PythonInterpreterWidget(QtWidgets.QWidget):
 
     def showEvent(self, event):
         self._line_check_timer.start()
+        self._registry_saved = False
         super(PythonInterpreterWidget, self).showEvent(event)
-        self._should_save_registry = True
         # First show setup
         if self._first_show:
             self._first_show = False
@@ -683,6 +684,5 @@ class PythonInterpreterWidget(QtWidgets.QWidget):
 
     def closeEvent(self, event):
         self.save_registry()
-        self._should_save_registry = False
         super(PythonInterpreterWidget, self).closeEvent(event)
         self._line_check_timer.stop()

--- a/openpype/modules/python_console_interpreter/window/widgets.py
+++ b/openpype/modules/python_console_interpreter/window/widgets.py
@@ -354,7 +354,7 @@ class PythonInterpreterWidget(QtWidgets.QWidget):
     default_width = 1000
     default_height = 600
 
-    def __init__(self, parent=None):
+    def __init__(self, allow_save_registry=True, parent=None):
         super(PythonInterpreterWidget, self).__init__(parent)
 
         self.setWindowTitle("{} Console".format(
@@ -414,6 +414,8 @@ class PythonInterpreterWidget(QtWidgets.QWidget):
 
         self._first_show = True
         self._splitter_size_ratio = None
+        self._allow_save_registry = allow_save_registry
+        self._should_save_registry = False
 
         self._init_from_registry()
 
@@ -457,6 +459,10 @@ class PythonInterpreterWidget(QtWidgets.QWidget):
             pass
 
     def save_registry(self):
+        # Window was not showed
+        if not self._allow_save_registry or not self._should_save_registry:
+            return
+
         setting_registry = PythonInterpreterRegistry()
 
         setting_registry.set_item("width", self.width())
@@ -651,6 +657,7 @@ class PythonInterpreterWidget(QtWidgets.QWidget):
     def showEvent(self, event):
         self._line_check_timer.start()
         super(PythonInterpreterWidget, self).showEvent(event)
+        self._should_save_registry = True
         # First show setup
         if self._first_show:
             self._first_show = False
@@ -676,5 +683,6 @@ class PythonInterpreterWidget(QtWidgets.QWidget):
 
     def closeEvent(self, event):
         self.save_registry()
+        self._should_save_registry = False
         super(PythonInterpreterWidget, self).closeEvent(event)
         self._line_check_timer.stop()


### PR DESCRIPTION
## Changelog Description
Do not save registry until there is something to save.

## Additional info
The addon logic tries to store last save registry even if console is not showed up at all, which may lead to confusing scenarios when `None` is stored as ideal width and height etc.
