### PR TITLE
Ftrack: update asset names for multiple reviewable items

### DIFF
--- a/openpype/modules/ftrack/plugins/publish/integrate_ftrack_instances.py
+++ b/openpype/modules/ftrack/plugins/publish/integrate_ftrack_instances.py
@@ -352,9 +352,9 @@ class IntegrateFtrackInstance(pyblish.api.InstancePlugin):
 
             # add extended name if any
             if (
-                not self.keep_first_subset_name_for_review
+                multiple_reviewable
+                and not self.keep_first_subset_name_for_review
                 and extended_asset_name
-                and multiple_reviewable
             ):
                 other_item["asset_data"]["name"] = extended_asset_name
 

--- a/openpype/modules/ftrack/plugins/publish/integrate_ftrack_instances.py
+++ b/openpype/modules/ftrack/plugins/publish/integrate_ftrack_instances.py
@@ -354,6 +354,7 @@ class IntegrateFtrackInstance(pyblish.api.InstancePlugin):
             if (
                 not self.keep_first_subset_name_for_review
                 and extended_asset_name
+                and multiple_reviewable
             ):
                 other_item["asset_data"]["name"] = extended_asset_name
 


### PR DESCRIPTION
## Changelog Description
Multiple reviewable assetVersion components with better grouping to asset version name.

## Additional info
- Add a condition to also check if multiple_reviewable is True before updating the asset name.

## Testing notes:
1. very difficult to test but basically you need multiple reviewable representations marked as `ftrackreview`.
