### PR TITLE
Remove multi-context restrictions for publishing image sequences on farm

### DIFF
--- a/openpype/plugins/publish/collect_rendered_files.py
+++ b/openpype/plugins/publish/collect_rendered_files.py
@@ -75,24 +75,6 @@ class CollectRenderedFiles(pyblish.api.ContextPlugin):
                     "job", "instances", "session", "version"]
         assert all(elem in data.keys() for elem in required), data_err
 
-        # set context by first json file
-        ctx = self._context.data
-
-        ctx["asset"] = ctx.get("asset") or data.get("asset")
-        ctx["intent"] = ctx.get("intent") or data.get("intent")
-        ctx["comment"] = ctx.get("comment") or data.get("comment")
-        ctx["user"] = ctx.get("user") or data.get("user")
-        ctx["version"] = ctx.get("version") or data.get("version")
-
-        # basic sanity check to see if we are working in same context
-        # if some other json file has different context, bail out.
-        ctx_err = "inconsistent contexts in json files - %s"
-        assert ctx.get("asset") == data.get("asset"), ctx_err % "asset"
-        assert ctx.get("intent") == data.get("intent"), ctx_err % "intent"
-        assert ctx.get("comment") == data.get("comment"), ctx_err % "comment"
-        assert ctx.get("user") == data.get("user"), ctx_err % "user"
-        assert ctx.get("version") == data.get("version"), ctx_err % "version"
-
         # ftrack credentials are passed as environment variables by Deadline
         # to publish job, but Muster doesn't pass them.
         if data.get("ftrack") and not os.environ.get("FTRACK_API_USER"):


### PR DESCRIPTION
## Changelog Description
Removing assert that context data must be same as instance data will allow publishing image data to different context in one go.
That sanity check was there because we didn't support publishing to different context before (like multishot workflow), but this should be possible now.

## Additional info
More work on different DCCs needs to be done to seamlessly support multishot workflow - like Maya restrict only one rendering instance, Nuke enforce unique instance name (so you can't publish `renderMain` to multiple shots), etc.

## Testing notes:
1. Open Nuke
2. Create 3 write instances (you need to change variant name to make them unique)
3. Direct them in the Publisher to different shots
4. Render and publish on farm.
