### PR TITLE
Nuke: Extract Review Intermediate disabled when both Extract Review Mov and Extract Review Intermediate disabled in setting

### DIFF
--- a/openpype/hosts/nuke/plugins/publish/extract_review_intermediates.py
+++ b/openpype/hosts/nuke/plugins/publish/extract_review_intermediates.py
@@ -34,6 +34,11 @@ class ExtractReviewIntermediates(publish.Extractor):
         nuke_publish = project_settings["nuke"]["publish"]
         deprecated_setting = nuke_publish["ExtractReviewDataMov"]
         current_setting = nuke_publish.get("ExtractReviewIntermediates")
+        if not deprecated_setting["enabled"] and (
+            not current_setting["enabled"]
+        ):
+            cls.enabled = False
+
         if deprecated_setting["enabled"]:
             # Use deprecated settings if they are still enabled
             cls.viewer_lut_raw = deprecated_setting["viewer_lut_raw"]


### PR DESCRIPTION
## Changelog Description
Report in Discord https://discord.com/channels/517362899170230292/563751989075378201/1187874498234556477

## Additional info
n/a
## Testing notes:
1. Go to Settings, disabled both Extract Review Mov and Extract Review Intermediate in Nuke Publish
2. Launch Nuke
3. Create Render Instance
4. Publish
5. It won't show up the extract review intermediate
6. If you turn on either Extract Review Mov or Extract Review Intermediate, the extractor show up and the related setting applied to the extraction
7. If you turn on both settings, it will apply the setting from  Extract Review Mov
