### PR TITLE
Publish report viewer: Report items sorting

### DIFF
--- a/openpype/tools/publisher/control.py
+++ b/openpype/tools/publisher/control.py
@@ -4,7 +4,6 @@ import logging
 import traceback
 import collections
 import uuid
-import datetime
 import tempfile
 import shutil
 import inspect

--- a/openpype/tools/publisher/control.py
+++ b/openpype/tools/publisher/control.py
@@ -4,6 +4,7 @@ import logging
 import traceback
 import collections
 import uuid
+import datetime
 import tempfile
 import shutil
 import inspect
@@ -285,6 +286,8 @@ class PublishReportMaker:
 
     def get_report(self, publish_plugins=None):
         """Report data with all details of current state."""
+
+        now = datetime.datetime.now()
         instances_details = {}
         for instance in self._all_instances_by_id.values():
             instances_details[instance.id] = self._extract_instance_data(
@@ -334,7 +337,8 @@ class PublishReportMaker:
             "context": self._extract_context_data(self._current_context),
             "crashed_file_paths": crashed_file_paths,
             "id": uuid.uuid4().hex,
-            "report_version": "1.0.0"
+            "created_at": now.strftime("%Y-%m-%d %H:%M:%S"),
+            "report_version": "1.0.1",
         }
 
     def _extract_context_data(self, context):

--- a/openpype/tools/publisher/control.py
+++ b/openpype/tools/publisher/control.py
@@ -11,6 +11,7 @@ import inspect
 from abc import ABCMeta, abstractmethod
 
 import six
+import arrow
 import pyblish.api
 
 from openpype import AYON_SERVER_ENABLED
@@ -287,7 +288,7 @@ class PublishReportMaker:
     def get_report(self, publish_plugins=None):
         """Report data with all details of current state."""
 
-        now = datetime.datetime.now()
+        now = arrow.utcnow().to("local")
         instances_details = {}
         for instance in self._all_instances_by_id.values():
             instances_details[instance.id] = self._extract_instance_data(
@@ -337,7 +338,7 @@ class PublishReportMaker:
             "context": self._extract_context_data(self._current_context),
             "crashed_file_paths": crashed_file_paths,
             "id": uuid.uuid4().hex,
-            "created_at": now.strftime("%Y-%m-%d %H:%M:%S"),
+            "created_at": now.isoformat(),
             "report_version": "1.0.1",
         }
 

--- a/openpype/tools/publisher/publish_report_viewer/model.py
+++ b/openpype/tools/publisher/publish_report_viewer/model.py
@@ -27,9 +27,8 @@ class InstancesModel(QtGui.QStandardItemModel):
 
     def set_report(self, report_item):
         root_item = self.invisibleRootItem()
-        if root_item.rowCount():
+        if root_item.rowCount() > 0:
             root_item.removeRows(0, root_item.rowCount())
-
         self._items_by_id.clear()
         self._plugin_items_by_id.clear()
         if not report_item:

--- a/openpype/tools/publisher/publish_report_viewer/model.py
+++ b/openpype/tools/publisher/publish_report_viewer/model.py
@@ -26,13 +26,14 @@ class InstancesModel(QtGui.QStandardItemModel):
         return self._items_by_id
 
     def set_report(self, report_item):
-        self.clear()
+        root_item = self.invisibleRootItem()
+        if root_item.rowCount():
+            root_item.removeRows(0, root_item.rowCount())
+
         self._items_by_id.clear()
         self._plugin_items_by_id.clear()
         if not report_item:
             return
-
-        root_item = self.invisibleRootItem()
 
         families = set(report_item.instance_items_by_family.keys())
         families.remove(None)
@@ -125,13 +126,13 @@ class PluginsModel(QtGui.QStandardItemModel):
         return self._items_by_id
 
     def set_report(self, report_item):
-        self.clear()
+        root_item = self.invisibleRootItem()
+        if root_item.rowCount() > 0:
+            root_item.removeRows(0, root_item.rowCount())
         self._items_by_id.clear()
         self._plugin_items_by_id.clear()
         if not report_item:
             return
-
-        root_item = self.invisibleRootItem()
 
         labels_iter = iter(self.order_label_mapping)
         cur_order, cur_label = next(labels_iter)

--- a/openpype/tools/publisher/publish_report_viewer/window.py
+++ b/openpype/tools/publisher/publish_report_viewer/window.py
@@ -260,7 +260,7 @@ class PublishReportItem:
 
 
 class PublisherReportHandler:
-    """Class handling storing publish report tool."""
+    """Class handling storing publish report items."""
 
     def __init__(self):
         self._reports = None

--- a/openpype/tools/publisher/publish_report_viewer/window.py
+++ b/openpype/tools/publisher/publish_report_viewer/window.py
@@ -538,7 +538,8 @@ class LoadedFilesView(QtWidgets.QTreeView):
         if index.isValid():
             return
 
-        index = self._model.index(0, 0)
+        model = self.model()
+        index = model.index(0, 0)
         if index.isValid():
             self.setCurrentIndex(index)
 

--- a/openpype/tools/publisher/publish_report_viewer/window.py
+++ b/openpype/tools/publisher/publish_report_viewer/window.py
@@ -283,8 +283,9 @@ class PublisherReportHandler:
                 continue
             filepath = os.path.join(report_dir, filename)
             item = PublishReportItem.from_filepath(filepath)
-            reports.append(item)
-            reports_by_id[item.id] = item
+            if item is not None:
+                reports.append(item)
+                reports_by_id[item.id] = item
 
         self._reports = reports
         self._reports_by_id = reports_by_id

--- a/openpype/tools/publisher/publish_report_viewer/window.py
+++ b/openpype/tools/publisher/publish_report_viewer/window.py
@@ -438,7 +438,7 @@ class LoadedFilesModel(QtGui.QStandardItemModel):
         self._handler.remove_report_item(item_id)
 
         self._report_items_by_id.pop(item_id, None)
-        item = self._items_by_id.pop(item_id)
+        item = self._items_by_id.pop(item_id, None)
         if item is not None:
             parent = self.invisibleRootItem()
             parent.removeRow(item.row())

--- a/openpype/tools/publisher/publish_report_viewer/window.py
+++ b/openpype/tools/publisher/publish_report_viewer/window.py
@@ -290,7 +290,15 @@ class PublisherReportHandler:
         self._reports_by_id = reports_by_id
         return reports
 
-    def remove_report_items(self, item_id):
+    def remove_report_item(self, item_id):
+        """Remove report item by id.
+
+        Remove from cache and also remove the file with the content.
+
+        Args:
+            item_id (str): Report item id.
+        """
+
         item = self._reports_by_id.get(item_id)
         if item:
             try:
@@ -439,7 +447,7 @@ class LoadedFilesModel(QtGui.QStandardItemModel):
         if not report_item:
             return
 
-        self._handler.remove_report_items(item_id)
+        self._handler.remove_report_item(item_id)
         item = self._items_by_id.get(item_id)
 
         parent = self.invisibleRootItem()

--- a/openpype/tools/publisher/publish_report_viewer/window.py
+++ b/openpype/tools/publisher/publish_report_viewer/window.py
@@ -241,7 +241,7 @@ class PublishReportItem:
             return False
 
         # Auto fix 'created_at', use file modification time if it is not set
-        #   , or current time if modification could not be received.
+        #   or current time if modification could not be received.
         if file_modified is not None:
             created_at_obj = datetime.datetime.fromtimestamp(file_modified)
         else:

--- a/openpype/tools/publisher/publish_report_viewer/window.py
+++ b/openpype/tools/publisher/publish_report_viewer/window.py
@@ -435,15 +435,13 @@ class LoadedFilesModel(QtGui.QStandardItemModel):
             root_item.appendRows(new_items)
 
     def remove_item_by_id(self, item_id):
-        report_item = self._report_items_by_id.get(item_id)
-        if not report_item:
-            return
-
         self._handler.remove_report_item(item_id)
-        item = self._items_by_id.get(item_id)
 
-        parent = self.invisibleRootItem()
-        parent.removeRow(item.row())
+        self._report_items_by_id.pop(item_id, None)
+        item = self._items_by_id.pop(item_id)
+        if item is not None:
+            parent = self.invisibleRootItem()
+            parent.removeRow(item.row())
 
     def get_report_by_id(self, item_id):
         report_item = self._report_items_by_id.get(item_id)

--- a/openpype/tools/publisher/publish_report_viewer/window.py
+++ b/openpype/tools/publisher/publish_report_viewer/window.py
@@ -59,7 +59,7 @@ class PublishReportItem:
         created_at_obj = datetime.datetime.strptime(
             content["created_at"], "%Y-%m-%d %H:%M:%S"
         )
-        created_at = self.date_obj_to_timestamp(created_at_obj)
+        created_at = created_at_obj.timestamp()
 
         self.content = content
         self.report_path = report_path
@@ -200,15 +200,6 @@ class PublishReportItem:
 
         self.content = content
         self.file_modified = file_modified
-
-    @staticmethod
-    def date_obj_to_timestamp(date_obj):
-        if hasattr(date_obj, "timestamp"):
-            return date_obj.timestamp()
-
-        # Python 2 support
-        epoch = datetime.datetime.fromtimestamp(0)
-        return (date_obj - epoch).total_seconds()
 
     @classmethod
     def _fix_content(cls, content, file_modified=None):


### PR DESCRIPTION
## Changelog Description
Proposal of items sorting in Publish report viewer tool. Items are sorted by report creation time. Creation time is also added to publish report data when saved from publisher tool.

## Additional info
For older report items is used file modification time as 'created_at'. Possible issues with this approach is that new dropped report may not be as last but in the middle, which may not be ideal. ISO timestamp should be probably used instead of "current timezone" timestamp.

### Other possible approaches:
1. Add 'stored_at' information when report file is dropped to the UI, and use the 'stored_at' for sorting instead.
2. Completelly ignore value (column) sorting but use "custom sorting". User can manually move items around and `int` with sort value is stored for each item.

## Testing notes:
- New reports from publisher contain 'created_at'.
1. Open Publish report viewer.
2. Existing items should work as before.
3. Drop new report item. Which should load just fine.
4. UI should show 2 columns: 'Reports' and 'Created'. Second column is used for sorting by default. 