### PR TITLE
Chore: Define pyblish targets on install host

### DIFF
--- a/openpype/pipeline/context_tools.py
+++ b/openpype/pipeline/context_tools.py
@@ -157,7 +157,7 @@ def install_host(host, pyblish_targets=None):
             json.dumps(legacy_io.Session, indent=4, sort_keys=True)
         ))
 
-    project_name = legacy_io.Session["AVALON_PROJECT"]
+    project_name = os.environ.get("AVALON_PROJECT")
     log.info("Activating %s.." % project_name)
 
     # Optional host install function
@@ -173,7 +173,6 @@ def install_host(host, pyblish_targets=None):
 
     MessageHandler.emit = modified_emit
 
-    project_name = os.environ.get("AVALON_PROJECT")
     host_name = os.environ.get("AVALON_APP")
 
     # Give option to handle host installation


### PR DESCRIPTION
## Changelog Description
It is possible to define pyblish targets in `install_host` which are used instead of auto-detected targets.

### Additional information
This may be necessary for automations which should run very specific target and none of the auto-detected. We've discovered the need with automated [cli publishing of csv editorial](https://github.com/ynput/OpenPype/pull/5795) via traypublisher. There we have to deregister all targets to register only specified targets.

## Testing notes:
1. All hosts should be installed without any changes as did before.
2. It should be possible to use custom targets without using the auto-detected.
