### PR TITLE
Maya: Apply initial viewport shader for Redshift Proxy after loading

### DIFF
--- a/openpype/hosts/maya/plugins/load/load_redshift_proxy.py
+++ b/openpype/hosts/maya/plugins/load/load_redshift_proxy.py
@@ -139,13 +139,8 @@ class RedshiftProxyLoader(load.LoaderPlugin):
 
         # TODO: use the assigned shading group as shaders if existed
         # assign default shader to redshift proxy
-        shader_grp = next(
-            (
-                shader_group for shader_group in
-                cmds.ls("initialShadingGroup", type="shadingEngine")
-            )
-        )
-        cmds.sets(mesh_shape, forceElement=shader_grp)
+        if cmds.ls("initialShadingGroup", type="shadingEngine"):
+            cmds.sets(mesh_shape, forceElement="initialShadingGroup")
 
         group_node = cmds.group(empty=True, name="{}_GRP".format(name))
         mesh_transform = cmds.listRelatives(mesh_shape,

--- a/openpype/hosts/maya/plugins/load/load_redshift_proxy.py
+++ b/openpype/hosts/maya/plugins/load/load_redshift_proxy.py
@@ -140,8 +140,9 @@ class RedshiftProxyLoader(load.LoaderPlugin):
         # TODO: use the assigned shading group as shaders if existed
         # assign default shader to redshift proxy
         shader_grp = next(
-            (shader_group for shader_group in cmds.ls(type="shadingEngine")
-             if shader_group == "initialShadingGroup")
+            (shader_group for shader_group in
+             cmds.ls("initialShadingGroup", type="shadingEngine")
+            )
         )
         cmds.sets(mesh_shape, forceElement=shader_grp)
 

--- a/openpype/hosts/maya/plugins/load/load_redshift_proxy.py
+++ b/openpype/hosts/maya/plugins/load/load_redshift_proxy.py
@@ -139,10 +139,9 @@ class RedshiftProxyLoader(load.LoaderPlugin):
 
         # TODO: use the assigned shading group as shaders if existed
         # assign default shader to redshift proxy
-        shader_grp = next(
-            (shader_group for shader_group in cmds.ls(type="shadingEngine")
-             if shader_group=="initialShadingGroup")
-        )
+        shader_grp = next((shader_group for shader_group
+                           in cmds.ls(type="shadingEngine")
+                           if shader_group=="initialShadingGroup"))
         if shader_grp:
             cmds.sets(mesh_shape, forceElement=shader_grp)
 

--- a/openpype/hosts/maya/plugins/load/load_redshift_proxy.py
+++ b/openpype/hosts/maya/plugins/load/load_redshift_proxy.py
@@ -139,11 +139,11 @@ class RedshiftProxyLoader(load.LoaderPlugin):
 
         # TODO: use the assigned shading group as shaders if existed
         # assign default shader to redshift proxy
-        shader_grp = next((shader_group for shader_group
-                           in cmds.ls(type="shadingEngine")
-                           if shader_group=="initialShadingGroup"))
-        if shader_grp:
-            cmds.sets(mesh_shape, forceElement=shader_grp)
+        shader_grp = next(
+            (shader_group for shader_group in cmds.ls(type="shadingEngine")
+             if shader_group == "initialShadingGroup")
+        )
+        cmds.sets(mesh_shape, forceElement=shader_grp)
 
         group_node = cmds.group(empty=True, name="{}_GRP".format(name))
         mesh_transform = cmds.listRelatives(mesh_shape,

--- a/openpype/hosts/maya/plugins/load/load_redshift_proxy.py
+++ b/openpype/hosts/maya/plugins/load/load_redshift_proxy.py
@@ -137,6 +137,14 @@ class RedshiftProxyLoader(load.LoaderPlugin):
         cmds.connectAttr("{}.outMesh".format(rs_mesh),
                          "{}.inMesh".format(mesh_shape))
 
+        # TODO: use the assigned shading group as shaders if existed
+        # assign default shader to redshift proxy
+        shader_grp = next(
+            (shader_group for shader_group in cmds.ls(type="shadingEngine")
+             if shader_group=="initialShadingGroup")
+        )
+        cmds.sets(mesh_shape, forceElement=shader_grp)
+
         group_node = cmds.group(empty=True, name="{}_GRP".format(name))
         mesh_transform = cmds.listRelatives(mesh_shape,
                                             parent=True, fullPath=True)

--- a/openpype/hosts/maya/plugins/load/load_redshift_proxy.py
+++ b/openpype/hosts/maya/plugins/load/load_redshift_proxy.py
@@ -143,7 +143,8 @@ class RedshiftProxyLoader(load.LoaderPlugin):
             (shader_group for shader_group in cmds.ls(type="shadingEngine")
              if shader_group=="initialShadingGroup")
         )
-        cmds.sets(mesh_shape, forceElement=shader_grp)
+        if shader_grp:
+            cmds.sets(mesh_shape, forceElement=shader_grp)
 
         group_node = cmds.group(empty=True, name="{}_GRP".format(name))
         mesh_transform = cmds.listRelatives(mesh_shape,

--- a/openpype/hosts/maya/plugins/load/load_redshift_proxy.py
+++ b/openpype/hosts/maya/plugins/load/load_redshift_proxy.py
@@ -140,8 +140,9 @@ class RedshiftProxyLoader(load.LoaderPlugin):
         # TODO: use the assigned shading group as shaders if existed
         # assign default shader to redshift proxy
         shader_grp = next(
-            (shader_group for shader_group in
-             cmds.ls("initialShadingGroup", type="shadingEngine")
+            (
+                shader_group for shader_group in
+                cmds.ls("initialShadingGroup", type="shadingEngine")
             )
         )
         cmds.sets(mesh_shape, forceElement=shader_grp)


### PR DESCRIPTION
## Changelog Description
When the published redshift proxy is being loaded, the shader of the proxy is missing. This is different from the manual load through creating redshift proxy for files. This PR is to assign the default lambert to the redshift proxy, which replicates the same approach when the user manually loads the proxy with filepath.

## Additional info
If there is a way of which we should get attributes of proxy materials in redshift proxy mesh, some conditions can be set up for assigning the shader if it exists in the scene. 

## Testing notes:
1. Launch Maya via launcher
2. Load redshift proxy
3. The shader of the redshift proxy is no longer in green (i.e. with no shader)
