### PR TITLE
Chore: Remove deprecated templates profiles

### DIFF
--- a/openpype/pipeline/publish/lib.py
+++ b/openpype/pipeline/publish/lib.py
@@ -93,36 +93,13 @@ def get_hero_template_name_profiles(
     if not project_settings:
         project_settings = get_project_settings(project_name)
 
-    profiles = (
+    return copy.deepcopy(
         project_settings
         ["global"]
         ["tools"]
         ["publish"]
         ["hero_template_name_profiles"]
     )
-    if profiles:
-        return copy.deepcopy(profiles)
-
-    # Use legacy approach for cases new settings are not filled yet for the
-    #   project
-    legacy_profiles = copy.deepcopy(
-        project_settings
-        ["global"]
-        ["publish"]
-        ["IntegrateHeroVersion"]
-        ["template_name_profiles"]
-    )
-    if legacy_profiles:
-        if not logger:
-            logger = Logger.get_logger("get_hero_template_name_profiles")
-
-        logger.warning((
-            "Project \"{}\" is using legacy access to hero publish template."
-            " It is recommended to move settings to new location"
-            " 'project_settings/global/tools/publish/"
-            "hero_template_name_profiles'."
-        ).format(project_name))
-    return legacy_profiles
 
 
 def get_publish_template_name(

--- a/openpype/pipeline/publish/lib.py
+++ b/openpype/pipeline/publish/lib.py
@@ -58,41 +58,13 @@ def get_template_name_profiles(
     if not project_settings:
         project_settings = get_project_settings(project_name)
 
-    profiles = (
+    return copy.deepcopy(
         project_settings
         ["global"]
         ["tools"]
         ["publish"]
         ["template_name_profiles"]
     )
-    if profiles:
-        return copy.deepcopy(profiles)
-
-    # Use legacy approach for cases new settings are not filled yet for the
-    #   project
-    legacy_profiles = (
-        project_settings
-        ["global"]
-        ["publish"]
-        ["IntegrateAssetNew"]
-        ["template_name_profiles"]
-    )
-    if legacy_profiles:
-        if not logger:
-            logger = Logger.get_logger("get_template_name_profiles")
-
-        logger.warning((
-            "Project \"{}\" is using legacy access to publish template."
-            " It is recommended to move settings to new location"
-            " 'project_settings/global/tools/publish/template_name_profiles'."
-        ).format(project_name))
-
-    # Replace "tasks" key with "task_names"
-    profiles = []
-    for profile in copy.deepcopy(legacy_profiles):
-        profile["task_names"] = profile.pop("tasks", [])
-        profiles.append(profile)
-    return profiles
 
 
 def get_hero_template_name_profiles(

--- a/openpype/plugins/publish/integrate_hero_version.py
+++ b/openpype/plugins/publish/integrate_hero_version.py
@@ -54,7 +54,6 @@ class IntegrateHeroVersion(pyblish.api.InstancePlugin):
     # permissions error on files (files were used or user didn't have perms)
     # *but all other plugins must be sucessfully completed
 
-    template_name_profiles = []
     _default_template_name = "hero"
 
     def process(self, instance):

--- a/openpype/settings/entities/schemas/projects_schema/schemas/schema_global_publish.json
+++ b/openpype/settings/entities/schemas/projects_schema/schemas/schema_global_publish.json
@@ -1023,49 +1023,6 @@
                 {
                     "type": "label",
                     "label": "<b>NOTE:</b> Hero publish template profiles settings were moved to <a href=\"settings://project_settings/global/tools/publish/hero_template_name_profiles\"><b>Tools/Publish/Hero template name profiles</b></a>. Please move values there."
-                },
-                {
-                    "type": "list",
-                    "key": "template_name_profiles",
-                    "label": "Template name profiles (DEPRECATED)",
-                    "use_label_wrap": true,
-                    "object_type": {
-                        "type": "dict",
-                        "children": [
-                            {
-                                "key": "families",
-                                "label": "Families",
-                                "type": "list",
-                                "object_type": "text"
-                            },
-                            {
-                                "type": "hosts-enum",
-                                "key": "hosts",
-                                "label": "Hosts",
-                                "multiselection": true
-                            },
-                            {
-                                "key": "task_types",
-                                "label": "Task types",
-                                "type": "task-types-enum"
-                            },
-                            {
-                                "key": "task_names",
-                                "label": "Task names",
-                                "type": "list",
-                                "object_type": "text"
-                            },
-                            {
-                                "type": "separator"
-                            },
-                            {
-                                "type": "text",
-                                "key": "template_name",
-                                "label": "Template name",
-                                "tooltip": "Name of template from Anatomy templates"
-                            }
-                        ]
-                    }
                 }
             ]
         },

--- a/server_addon/core/server/settings/publish_plugins.py
+++ b/server_addon/core/server/settings/publish_plugins.py
@@ -697,13 +697,6 @@ class IntegrateHeroVersionModel(BaseSettingsModel):
     optional: bool = Field(False, title="Optional")
     active: bool = Field(True, title="Active")
     families: list[str] = Field(default_factory=list, title="Families")
-    # TODO remove when removed from client code
-    template_name_profiles: list[IntegrateHeroTemplateNameProfileModel] = (
-        Field(
-            default_factory=list,
-            title="Template name profiles"
-        )
-    )
 
 
 class CleanUpModel(BaseSettingsModel):
@@ -1049,19 +1042,6 @@ DEFAULT_PUBLISH_VALUES = {
             "layout",
             "mayaScene",
             "simpleUnrealTexture"
-        ],
-        "template_name_profiles": [
-            {
-                "product_types": [
-                    "simpleUnrealTexture"
-                ],
-                "hosts": [
-                    "standalonepublisher"
-                ],
-                "task_types": [],
-                "task_names": [],
-                "template_name": "simpleUnrealTextureHero"
-            }
         ]
     },
     "CleanUp": {


### PR DESCRIPTION
## Changelog Description
Remove deprecated usage of template profiles from settings.

## Additional info
Removed template profiles from `IntegrateHeroVersion` plugin and stop using it. Also stop using `IntegrateAssetNew` templates (which are not available). Both settings are deprecated since 22.8.2022 (maybe even more).
