### PR TITLE
[DRAFT] Houdini: Launch workfile tool for Houdini on startup

### DIFF
--- a/openpype/hosts/houdini/api/lib.py
+++ b/openpype/hosts/houdini/api/lib.py
@@ -10,8 +10,6 @@ import json
 
 import six
 
-from qtpy import QtCore, QtWidgets
-
 from openpype.lib import StringTemplate, env_value_to_bool
 from openpype.client import get_project, get_asset_by_name
 from openpype.settings import get_current_project_settings

--- a/openpype/hosts/houdini/api/pipeline.py
+++ b/openpype/hosts/houdini/api/pipeline.py
@@ -25,6 +25,8 @@ from openpype.lib import (
     emit_event,
 )
 
+from .lib import launch_workfiles_app
+
 
 log = logging.getLogger("openpype.hosts.houdini")
 
@@ -80,10 +82,8 @@ class HoudiniHost(HostBase, IWorkfileHost, ILoadHost, IPublishHost):
             # initialization during start up delays Houdini UI by minutes
             # making it extremely slow to launch.
             hdefereval.executeDeferred(shelves.generate_shelves)
-
-        if not IS_HEADLESS:
-            import hdefereval # noqa, hdefereval is only available in ui mode
             hdefereval.executeDeferred(creator_node_shelves.install)
+            hdefereval.executeDeferred(launch_workfiles_app)
 
     def workfile_has_unsaved_changes(self):
         return hou.hipFile.hasUnsavedChanges()

--- a/openpype/lib/applications.py
+++ b/openpype/lib/applications.py
@@ -1917,13 +1917,6 @@ def _prepare_last_workfile(data, workdir, modules_manager):
     data["env"]["AVALON_LAST_WORKFILE"] = last_workfile_path
     data["last_workfile_path"] = last_workfile_path
 
-    # If last workfile path is found, don't launch workfile tool
-    if start_last_workfile and last_workfile_path:
-        data["env"]["OPENPYPE_WORKFILE_TOOL_ON_START"] = "0"
-        log.debug(
-            "Last workfile path found so workfile tool won't be launched."
-        )
-
 
 def should_start_last_workfile(
     project_name, host_name, task_name, task_type, default_output=False

--- a/openpype/lib/applications.py
+++ b/openpype/lib/applications.py
@@ -1917,6 +1917,13 @@ def _prepare_last_workfile(data, workdir, modules_manager):
     data["env"]["AVALON_LAST_WORKFILE"] = last_workfile_path
     data["last_workfile_path"] = last_workfile_path
 
+    # If last workfile path is found, don't launch workfile tool
+    if start_last_workfile and last_workfile_path:
+        data["env"]["OPENPYPE_WORKFILE_TOOL_ON_START"] = "0"
+        log.debug(
+            "Last workfile path found so workfile tool won't be launched."
+        )
+
 
 def should_start_last_workfile(
     project_name, host_name, task_name, task_type, default_output=False


### PR DESCRIPTION
## Changelog Description
Quick copy paste from Nuke's integration to launch workfile tool on startup. This feels very much like something that could be abstracted for all hosts on startup instead of needing to copy paste on each host so I'm mostly creating this PR to discuss if there's a plan to aligning that or not

## Testing notes:
1. Set setting to open workfile tool on launch
2. Start Houdini
