### PR TITLE
Publisher: Fix issue with parenting of widgets

### DIFF
--- a/openpype/hosts/nuke/api/pipeline.py
+++ b/openpype/hosts/nuke/api/pipeline.py
@@ -259,9 +259,7 @@ def _install_menu():
         menu.addCommand(
             "Create...",
             lambda: host_tools.show_publisher(
-                parent=(
-                    main_window if nuke.NUKE_VERSION_MAJOR >= 14 else None
-                ),
+                parent=main_window,
                 tab="create"
             )
         )
@@ -270,9 +268,7 @@ def _install_menu():
         menu.addCommand(
             "Publish...",
             lambda: host_tools.show_publisher(
-                parent=(
-                    main_window if nuke.NUKE_VERSION_MAJOR >= 14 else None
-                ),
+                parent=main_window,
                 tab="publish"
             )
         )

--- a/openpype/tools/publisher/window.py
+++ b/openpype/tools/publisher/window.py
@@ -189,7 +189,7 @@ class PublisherWindow(QtWidgets.QDialog):
             controller, content_stacked_widget
         )
 
-        report_widget = ReportPageWidget(controller, parent)
+        report_widget = ReportPageWidget(controller, content_stacked_widget)
 
         # Details - Publish details
         publish_details_widget = PublishReportViewerWidget(


### PR DESCRIPTION
## Changelog Description
Don't use publisher window parent (usually main DCC window) as parent for report widget.

## Additional info
This caused issues with parenting. E.g. in older versions of nuke was the publisher empty on re-open.

## Testing notes:
1. Publisher should be possible to open multiple times in Nuke 13 and lower
