### PR TITLE
:wrench: fix and update pydocstyle configuration

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -181,3 +181,8 @@ reportMissingTypeStubs = false
 
 [tool.poetry.extras]
 docs = ["Sphinx", "furo", "sphinxcontrib-napoleon"]
+
+[tool.pydocstyle]
+inherit = false
+convetion = "google"
+match = "(?!test_).*\\.py"

--- a/setup.cfg
+++ b/setup.cfg
@@ -16,10 +16,6 @@ max-complexity = 30
 [pylint.'MESSAGES CONTROL']
 disable = no-member
 
-[pydocstyle]
-convention = google
-ignore = D107
-
 [coverage:run]
 branch = True
 omit = /tests


### PR DESCRIPTION
## Changelog Description
Fix [pydocstyle](https://www.pydocstyle.org/en/6.3.0/usage.html) configuration and move it to `pyproject.toml`

## Testing notes:
Run pydocstyle on any relevant python file
