### PR TITLE
AYON: OpenPype addon dependencies

### DIFF
--- a/server_addon/openpype/client/pyproject.toml
+++ b/server_addon/openpype/client/pyproject.toml
@@ -7,6 +7,7 @@ python = ">=3.9.1,<3.10"
 aiohttp_json_rpc = "*" # TVPaint server
 aiohttp-middlewares = "^2.0.0"
 wsrpc_aiohttp = "^3.1.1" # websocket server
+Click = "^8"
 clique = "1.6.*"
 jsonschema = "^2.6.0"
 pymongo = "^3.11.2"

--- a/server_addon/openpype/client/pyproject.toml
+++ b/server_addon/openpype/client/pyproject.toml
@@ -14,8 +14,9 @@ pymongo = "^3.11.2"
 log4mongo = "^1.7"
 pyblish-base = "^1.8.11"
 pynput = "^1.7.2" # Timers manager - TODO remove
-qtawesome = "0.7.3"
 speedcopy = "^2.1"
+six = "^1.15"
+qtawesome = "0.7.3"
 
 [ayon.runtimeDependencies]
 OpenTimelineIO = "0.14.1"

--- a/server_addon/openpype/client/pyproject.toml
+++ b/server_addon/openpype/client/pyproject.toml
@@ -14,7 +14,6 @@ pymongo = "^3.11.2"
 log4mongo = "^1.7"
 pyblish-base = "^1.8.11"
 pynput = "^1.7.2" # Timers manager - TODO remove
-"Qt.py" = "^1.3.3"
 qtawesome = "0.7.3"
 speedcopy = "^2.1"
 


### PR DESCRIPTION
## Changelog Description
Added `click` and `six` to requirements of openpype addon, and removed `Qt.py` requirement, which is not used anywhere.

## Additional info
Right now are the added requirements defined by ayon-launcher, but should be defined by openpype addon, as they are not used in ayon-launcher. The requirements must be first added to openpype before removing them from ayon launcher.
