### PR TITLE
Chore: Thumbnail representation has 'outputName'

### DIFF
--- a/openpype/plugins/publish/extract_thumbnail_from_source.py
+++ b/openpype/plugins/publish/extract_thumbnail_from_source.py
@@ -65,7 +65,8 @@ class ExtractThumbnailFromSource(pyblish.api.InstancePlugin):
             "files": dst_filename,
             "stagingDir": dst_staging,
             "thumbnail": True,
-            "tags": ["thumbnail"]
+            "tags": ["thumbnail"],
+            "outputName": "thumbnail",
         }
 
         # adding representation


### PR DESCRIPTION
## Changelog Description
Add thumbnail output name to thumbnail representation to prevent same output filename during integration.

## Additional info
This is common issue when source file is `jpg` file (e.g. in traypublisher), in that case the thumbnail representation has same output file for integration which causes `Transfer to destination is already in queue:` error.

## Testing notes:
1. Drop jpg file to traypublisher (e.g. image family) and the same file use as reviewable (or thumbnail)
2. Publish.
3. It should not crash.

NOTE; I didn't try to fill both thumbnail and reviwable, not sure what will actually happen.