### PR TITLE
Kitsu: Clear credentials is safe

### DIFF
--- a/openpype/modules/kitsu/utils/credentials.py
+++ b/openpype/modules/kitsu/utils/credentials.py
@@ -64,8 +64,10 @@ def clear_credentials():
     user_registry = OpenPypeSecureRegistry("kitsu_user")
 
     # Set local settings
-    user_registry.delete_item("login")
-    user_registry.delete_item("password")
+    if user_registry.get_item("login", None) is not None:
+        user_registry.delete_item("login")
+    if user_registry.get_item("password", None) is not None:
+        user_registry.delete_item("password")
 
 
 def save_credentials(login: str, password: str):
@@ -92,8 +94,9 @@ def load_credentials() -> Tuple[str, str]:
     # Get user registry
     user_registry = OpenPypeSecureRegistry("kitsu_user")
 
-    return user_registry.get_item("login", None), user_registry.get_item(
-        "password", None
+    return (
+        user_registry.get_item("login", None),
+        user_registry.get_item("password", None)
     )
 
 


### PR DESCRIPTION
## Changelog Description
Do not remove not existing keyring items.

## Testing notes:
1. Enable kitsu and setup url
2. Make sure you don't have existing kitsu login in keyring (credentials manager on windows)
3. Start tray and open kitsu login dialog
4. Uncheck `Remember` checkbox
5. Login
6. It should not crash

Resolves https://github.com/ynput/OpenPype/issues/6115
