### PR TITLE
Nuke: Create camera node with the latest camera node class in Nuke 14

### DIFF
--- a/openpype/hosts/nuke/api/lib.py
+++ b/openpype/hosts/nuke/api/lib.py
@@ -3495,8 +3495,9 @@ def create_camera_node_by_version():
         Node: camera node
     """
     nuke_version = nuke.NUKE_VERSION_STRING
-    nuke_number_version = next(ver for ver in
-                               re.findall("\d+\.\d+", nuke_version))
+    nuke_number_version = next(
+        ver for ver in re.findall(
+            r"\d+\.\d+", nuke_version))
     if float(nuke_number_version) >= 14.0:
         return nuke.createNode("Camera4")
     else:

--- a/openpype/hosts/nuke/api/lib.py
+++ b/openpype/hosts/nuke/api/lib.py
@@ -3483,3 +3483,20 @@ def get_filenames_without_hash(filename, frame_start, frame_end):
             new_filename = filename_without_hashes.format(frame)
             filenames.append(new_filename)
     return filenames
+
+
+def create_camera_node_by_version():
+    """Function to create the camera with the latest node class
+    For Nuke version 14.0 or later, the Camera4 camera node class
+        would be used
+    For the version before, the Camera2 camera node class
+        would be used
+    Returns:
+        Node: camera node
+    """
+    nuke_version = nuke.NUKE_VERSION_STRING
+    nuke_number_version = next(ver for ver in re.findall("\d+\.\d+", nuke_version))
+    if float(nuke_number_version) >= 14.0:
+        return nuke.createNode("Camera4")
+    else:
+        return nuke.createNode("Camera2")

--- a/openpype/hosts/nuke/api/lib.py
+++ b/openpype/hosts/nuke/api/lib.py
@@ -3494,11 +3494,8 @@ def create_camera_node_by_version():
     Returns:
         Node: camera node
     """
-    nuke_version = nuke.NUKE_VERSION_STRING
-    nuke_number_version = next(
-        ver for ver in re.findall(
-            r"\d+\.\d+", nuke_version))
-    if float(nuke_number_version) >= 14.0:
+    nuke_number_version = nuke.NUKE_VERSION_MAJOR
+    if nuke_number_version >= 14:
         return nuke.createNode("Camera4")
     else:
         return nuke.createNode("Camera2")

--- a/openpype/hosts/nuke/api/lib.py
+++ b/openpype/hosts/nuke/api/lib.py
@@ -3495,7 +3495,8 @@ def create_camera_node_by_version():
         Node: camera node
     """
     nuke_version = nuke.NUKE_VERSION_STRING
-    nuke_number_version = next(ver for ver in re.findall("\d+\.\d+", nuke_version))
+    nuke_number_version = next(ver for ver in
+                               re.findall("\d+\.\d+", nuke_version))
     if float(nuke_number_version) >= 14.0:
         return nuke.createNode("Camera4")
     else:

--- a/openpype/hosts/nuke/plugins/create/create_camera.py
+++ b/openpype/hosts/nuke/plugins/create/create_camera.py
@@ -4,6 +4,9 @@ from openpype.hosts.nuke.api import (
     NukeCreatorError,
     maintained_selection
 )
+from openpype.hosts.nuke.api.lib import (
+    create_camera_node_by_version
+)
 
 
 class CreateCamera(NukeCreator):
@@ -32,7 +35,7 @@ class CreateCamera(NukeCreator):
                         "Creator error: Select only camera node type")
                 created_node = self.selected_nodes[0]
             else:
-                created_node = nuke.createNode("Camera2")
+                created_node = create_camera_node_by_version()
 
             created_node["tile_color"].setValue(
                 int(self.node_color, 16))


### PR DESCRIPTION
## Changelog Description
Creating instance fails for certain cameras, and it seems to only exist in Nuke 14. The reason of causing that contributes to the new camera node class `Camera4`  while the camera creator is working with the `Camera2` class.

## Additional info
n/a

## Testing notes:
1. Launch Nuke with a 3D scene where multiple cameras are created.
2. Create camera instances respectively with these cameras 
3. Publish
