### PR TITLE
Site Sync: small fixes in Loader

### DIFF
--- a/openpype/client/server/entity_links.py
+++ b/openpype/client/server/entity_links.py
@@ -124,23 +124,24 @@ def get_linked_representation_id(
         if not versions_to_check:
             break
 
-        links = con.get_versions_links(
+        versions_links = con.get_versions_links(
             project_name,
             versions_to_check,
             link_types=link_types,
             link_direction="out")
 
         versions_to_check = set()
-        for link in links:
-            # Care only about version links
-            if link["entityType"] != "version":
-                continue
-            entity_id = link["entityId"]
-            # Skip already found linked version ids
-            if entity_id in linked_version_ids:
-                continue
-            linked_version_ids.add(entity_id)
-            versions_to_check.add(entity_id)
+        for _, links in versions_links.items():
+            for link in links:
+                # Care only about version links
+                if link["entityType"] != "version":
+                    continue
+                entity_id = link["entityId"]
+                # Skip already found linked version ids
+                if entity_id in linked_version_ids:
+                    continue
+                linked_version_ids.add(entity_id)
+                versions_to_check.add(entity_id)
 
     linked_version_ids.remove(version_id)
     if not linked_version_ids:

--- a/openpype/client/server/entity_links.py
+++ b/openpype/client/server/entity_links.py
@@ -131,7 +131,7 @@ def get_linked_representation_id(
             link_direction="out")
 
         versions_to_check = set()
-        for _, links in versions_links.items():
+        for links in versions_links.values():
             for link in links:
                 # Care only about version links
                 if link["entityType"] != "version":

--- a/openpype/tools/ayon_loader/models/site_sync.py
+++ b/openpype/tools/ayon_loader/models/site_sync.py
@@ -140,12 +140,10 @@ class SiteSyncModel:
             Union[dict[str, Any], None]: Site icon definition.
         """
 
-        if not project_name:
+        if not project_name or not self.is_site_sync_enabled(project_name):
             return None
-
         active_site = self.get_active_site(project_name)
-        provider = self._get_provider_for_site(project_name, active_site)
-        return self._get_provider_icon(provider)
+        return self._get_site_icon_def(project_name, active_site)
 
     def get_remote_site_icon_def(self, project_name):
         """Remote site icon definition.
@@ -160,7 +158,14 @@ class SiteSyncModel:
         if not project_name or not self.is_site_sync_enabled(project_name):
             return None
         remote_site = self.get_remote_site(project_name)
-        provider = self._get_provider_for_site(project_name, remote_site)
+        return self._get_site_icon_def(project_name, remote_site)
+
+    def _get_site_icon_def(self, project_name, site_name):
+        # use different icon for studio even if provider is 'local_drive'
+        if site_name == self._site_sync_addon.DEFAULT_SITE:
+            provider = "studio"
+        else:
+            provider = self._get_provider_for_site(project_name, site_name)
         return self._get_provider_icon(provider)
 
     def get_version_sync_availability(self, project_name, version_ids):

--- a/openpype/tools/ayon_sceneinventory/models/site_sync.py
+++ b/openpype/tools/ayon_sceneinventory/models/site_sync.py
@@ -42,8 +42,16 @@ class SiteSyncModel:
 
         if not self.is_sync_server_enabled():
             return {}
-        site_sync = self._get_sync_server_module()
-        return site_sync.get_site_icons()
+        site_sync_addon = self._get_sync_server_module()
+        icon_paths = {}
+        icon_defs = site_sync_addon.get_site_icons()
+        for provider, icon_def in icon_defs.items():
+            icon_def_type = icon_def.get("type")
+            if icon_def_type != "path":
+                continue
+            icon_paths[provider] = icon_def["path"]
+
+        return icon_paths
 
     def get_sites_information(self):
         return {

--- a/openpype/tools/ayon_sceneinventory/models/site_sync.py
+++ b/openpype/tools/ayon_sceneinventory/models/site_sync.py
@@ -43,15 +43,7 @@ class SiteSyncModel:
         if not self.is_sync_server_enabled():
             return {}
         site_sync_addon = self._get_sync_server_module()
-        icon_paths = {}
-        icon_defs = site_sync_addon.get_site_icons()
-        for provider, icon_def in icon_defs.items():
-            icon_def_type = icon_def.get("type")
-            if icon_def_type != "path":
-                continue
-            icon_paths[provider] = icon_def["path"]
-
-        return icon_paths
+        return site_sync_addon.get_site_icons()
 
     def get_sites_information(self):
         return {


### PR DESCRIPTION
## Changelog Description
Resolves issue:
- local and studio icons were same, they should be different
- `TypeError: string indices must be integers` error when downloading/uploading workfiles


## Testing notes:
1. enable Site Sync for your project (must be enabled in Studio settings and Project Settings too!)
2. set in Local settings `active_site` to 'local' and `remote_site` to 'studio`
3. check Availability icons in Ayon Loader
4. try do download workfile
