### PR TITLE
SceneInventory: Fix site sync icon conversion

### DIFF
--- a/openpype/tools/ayon_sceneinventory/control.py
+++ b/openpype/tools/ayon_sceneinventory/control.py
@@ -84,9 +84,9 @@ class SceneInventoryController:
     def get_containers(self):
         host = self._host
         if isinstance(host, ILoadHost):
-            return host.get_containers()
+            return list(host.get_containers())
         elif hasattr(host, "ls"):
-            return host.ls()
+            return list(host.ls())
         return []
 
     # Site Sync methods

--- a/openpype/tools/ayon_sceneinventory/model.py
+++ b/openpype/tools/ayon_sceneinventory/model.py
@@ -23,6 +23,7 @@ from openpype.pipeline import (
 )
 from openpype.style import get_default_entity_icon_color
 from openpype.tools.utils.models import TreeModel, Item
+from openpype.tools.ayon_utils.widgets import get_qt_icon
 
 
 def walk_hierarchy(node):
@@ -71,8 +72,8 @@ class InventoryModel(TreeModel):
         site_icons = self._controller.get_site_provider_icons()
 
         self._site_icons = {
-            provider: QtGui.QIcon(icon_path)
-            for provider, icon_path in site_icons.items()
+            provider: get_qt_icon(icon_def)
+            for provider, icon_def in site_icons.items()
         }
 
     def outdated(self, item):

--- a/openpype/tools/ayon_sceneinventory/models/site_sync.py
+++ b/openpype/tools/ayon_sceneinventory/models/site_sync.py
@@ -150,12 +150,12 @@ class SiteSyncModel:
         return self._remote_site_provider
 
     def _cache_sites(self):
-        site_sync = self._get_sync_server_module()
         active_site = None
         remote_site = None
         active_site_provider = None
         remote_site_provider = None
-        if site_sync is not None:
+        if self.is_sync_server_enabled():
+            site_sync = self._get_sync_server_module()
             project_name = self._controller.get_current_project_name()
             active_site = site_sync.get_active_site(project_name)
             remote_site = site_sync.get_remote_site(project_name)

--- a/openpype/tools/ayon_sceneinventory/models/site_sync.py
+++ b/openpype/tools/ayon_sceneinventory/models/site_sync.py
@@ -162,11 +162,11 @@ class SiteSyncModel:
             active_site_provider = "studio"
             remote_site_provider = "studio"
             if active_site != "studio":
-                active_site_provider = site_sync.get_active_provider(
+                active_site_provider = site_sync.get_provider_for_site(
                     project_name, active_site
                 )
             if remote_site != "studio":
-                remote_site_provider = site_sync.get_active_provider(
+                remote_site_provider = site_sync.get_provider_for_site(
                     project_name, remote_site
                 )
 


### PR DESCRIPTION
## Changelog Description
Use 'get_qt_icon' to convert icon definitions from site sync.

## Testing notes:
1. SiteSync icons should be showed in SceneManager tool
