### PR TITLE
Transcoding: Fix reading image sequences through oiiotool

### DIFF
--- a/openpype/lib/transcoding.py
+++ b/openpype/lib/transcoding.py
@@ -120,6 +120,10 @@ def get_oiio_info_for_input(filepath, logger=None, subimages=False):
 
     output = []
     for subimage_lines in subimages_lines:
+        # First line of oiiotool for xml format is "Reading path/to/file.ext".
+        if not subimage_lines[0].startswith("<ImageSpec"):
+            subimage_lines = subimage_lines[1:]
+
         xml_text = "\n".join(subimage_lines)
         output.append(parse_oiio_xml_output(xml_text, logger=logger))
 

--- a/openpype/lib/transcoding.py
+++ b/openpype/lib/transcoding.py
@@ -110,8 +110,9 @@ def get_oiio_info_for_input(filepath, logger=None, subimages=False):
             if line == "</ImageSpec>":
                 subimages_lines.append(lines)
                 lines = []
+                xml_started = False
 
-    if not xml_started:
+    if not subimages_lines:
         raise ValueError(
             "Failed to read input file \"{}\".\nOutput:\n{}".format(
                 filepath, output
@@ -120,10 +121,6 @@ def get_oiio_info_for_input(filepath, logger=None, subimages=False):
 
     output = []
     for subimage_lines in subimages_lines:
-        # First line of oiiotool for xml format is "Reading path/to/file.ext".
-        if not subimage_lines[0].startswith("<ImageSpec"):
-            subimage_lines = subimage_lines[1:]
-
         xml_text = "\n".join(subimage_lines)
         output.append(parse_oiio_xml_output(xml_text, logger=logger))
 


### PR DESCRIPTION
## Changelog Description
When transcoding image sequences, the second image onwards includes the invalid xml line of `Reading path/to/file.exr` of the oiiotool output.

This is most likely not the best solution, but it fixes the issue and illustrates the problem.

Error:
```
ERROR:pyblish.plugin:Traceback (most recent call last):
  File "C:\Users\tokejepsen\AppData\Local\Ynput\AYON\dependency_packages\ayon_2310271602_windows.zip\dependencies\pyblish\plugin.py", line 527, in __explicit_process
    runner(*args)
  File "C:\Users\tokejepsen\OpenPype\openpype\plugins\publish\extract_color_transcode.py", line 152, in process
  File "C:\Users\tokejepsen\OpenPype\openpype\lib\transcoding.py", line 1136, in convert_colorspace
    input_info = get_oiio_info_for_input(input_path, logger=logger)
  File "C:\Users\tokejepsen\OpenPype\openpype\lib\transcoding.py", line 124, in get_oiio_info_for_input
    output.append(parse_oiio_xml_output(xml_text, logger=logger))
  File "C:\Users\tokejepsen\OpenPype\openpype\lib\transcoding.py", line 276, in parse_oiio_xml_output
    tree = xml.etree.ElementTree.fromstring(xml_string)
  File "xml\etree\ElementTree.py", line 1347, in XML
xml.etree.ElementTree.ParseError: syntax error: line 1, column 0
Traceback (most recent call last):
  File "C:\Users\tokejepsen\AppData\Local\Ynput\AYON\dependency_packages\ayon_2310271602_windows.zip\dependencies\pyblish\plugin.py", line 527, in __explicit_process
    runner(*args)
  File "<string>", line 152, in process
  File "C:\Users\tokejepsen\OpenPype\openpype\lib\transcoding.py", line 1136, in convert_colorspace
    input_info = get_oiio_info_for_input(input_path, logger=logger)
  File "C:\Users\tokejepsen\OpenPype\openpype\lib\transcoding.py", line 124, in get_oiio_info_for_input
    output.append(parse_oiio_xml_output(xml_text, logger=logger))
  File "C:\Users\tokejepsen\OpenPype\openpype\lib\transcoding.py", line 276, in parse_oiio_xml_output
    tree = xml.etree.ElementTree.fromstring(xml_string)
  File "xml\etree\ElementTree.py", line 1347, in XML
xml.etree.ElementTree.ParseError: syntax error: line 1, column 0
```

## Testing notes:
1. Ensure `ayon+settings://core/publish/ExtractOIIOTranscode?project=demo_Commercial` is setup to transcode.
2. Publish an image sequence (render) from Maya.
3. Should error in Deadline on the publish job.
