### PR TITLE
Chore tools: Make sure style object is not garbage collected

### DIFF
--- a/openpype/tools/utils/lib.py
+++ b/openpype/tools/utils/lib.py
@@ -91,7 +91,8 @@ def set_style_property(widget, property_name, property_value):
     if cur_value == property_value:
         return
     widget.setProperty(property_name, property_value)
-    widget.style().polish(widget)
+    style = widget.style()
+    style.polish(widget)
 
 
 def paint_image_with_color(image, color):


### PR DESCRIPTION
## Changelog Description
Minor fix in tool utils to make sure style C++ object is not garbage collected when not stored into variable.

### Traceback from houdini
```
Traceback (most recent call last):
  File "some_test", line 1, in <module>
  File "C:\OpenPype\openpype\hosts\houdini\api\lib.py", line 1056, in self_publish
    publisher_show_and_publish(comment)
  File "C:\OpenPype\openpype\hosts\houdini\api\lib.py", line 976, in publisher_show_and_publish
    publisher_window = get_tool_by_name(
  File "C:\OpenPype\openpype\tools\utils\host_tools.py", line 416, in get_tool_by_name
    return _SingletonPoint.get_tool_by_name(tool_name, parent, *args, **kwargs)
  File "C:\OpenPype\openpype\tools\utils\host_tools.py", line 411, in get_tool_by_name
    return cls.helper.get_tool_by_name(tool_name, parent, *args, **kwargs)
  File "C:\OpenPype\openpype\tools\utils\host_tools.py", line 341, in get_tool_by_name
    return self.get_publisher_tool(parent, *args, **kwargs)
  File "C:\OpenPype\openpype\tools\utils\host_tools.py", line 298, in get_publisher_tool
    publisher_window = PublisherWindow(
  File "C:\OpenPype\openpype\tools\publisher\window.py", line 107, in __init__
    create_tab = tabs_widget.add_tab("Create", "create")
  File "C:\OpenPype\openpype\tools\publisher\widgets\tabs_widget.py", line 71, in add_tab
    self.set_current_tab(identifier)
  File "C:\OpenPype\openpype\tools\publisher\widgets\tabs_widget.py", line 100, in set_current_tab
    new_btn.activate()
  File "C:\OpenPype\openpype\tools\publisher\widgets\tabs_widget.py", line 26, in activate
    set_style_property(self, "active", "1")
  File "C:\OpenPype\openpype\tools\utils\lib.py", line 94, in set_style_property
    widget.style().polish(widget)
RuntimeError: Internal C++ object (PySide2.QtWidgets.QProxyStyle) already deleted.
```

## Testing notes:
1. Publisher should work as expected in Houdini
