### PR TITLE
Chore: Add addons dir only if exists

### DIFF
--- a/openpype/modules/base.py
+++ b/openpype/modules/base.py
@@ -542,7 +542,8 @@ def _load_modules():
     module_dirs.insert(0, current_dir)
 
     addons_dir = os.path.join(os.path.dirname(current_dir), "addons")
-    module_dirs.append(addons_dir)
+    if os.path.exists(addons_dir):
+        module_dirs.append(addons_dir)
 
     ignored_host_names = set(IGNORED_HOSTS_IN_AYON)
     ignored_current_dir_filenames = set(IGNORED_DEFAULT_FILENAMES)


### PR DESCRIPTION
## Changelog Description
Do not add addons directory path for addons discovery if does not exists.

## Additional info
The main reason is that this folder is causing warning log which is confusing for users.
```
*** WRN: >>> { ModulesLoader }: [  Could not find path when loading OpenPype modules "C:\Users\USER\AppData\Local\Ynput\AYON\addons\openpype_3.18.4-nightly.1\openpype\addons"  ]
```
## Testing notes:
1. The warning should not appear anymore
