### PR TITLE
Workfile Template Builder: Use correct variable in create placeholder

### DIFF
--- a/openpype/pipeline/workfile/workfile_template_builder.py
+++ b/openpype/pipeline/workfile/workfile_template_builder.py
@@ -1971,7 +1971,6 @@ class PlaceholderCreateMixin(object):
         if not placeholder.data.get("keep_placeholder", True):
             self.delete_placeholder(placeholder)
 
-
     def create_failed(self, placeholder, creator_data):
         if hasattr(placeholder, "create_failed"):
             placeholder.create_failed(creator_data)
@@ -2036,7 +2035,7 @@ class CreatePlaceholderItem(PlaceholderItem):
         self._failed_created_publish_instances = []
 
     def get_errors(self):
-        if not self._failed_representations:
+        if not self._failed_created_publish_instances:
             return []
         message = (
             "Failed to create {} instance using Creator {}"


### PR DESCRIPTION
## Changelog Description
Use correct variable where failed instances are stored for validation.

## Additional info
Current implementation was using `_failed_representations` which was copied from load, but should use `_failed_created_publish_instances`.

## Testing notes:
Not sure how to test. Probably cause an error of create placeholder during workfile template builder.
