### PR TITLE
Blender: Use the new API for override context

### DIFF
--- a/openpype/hosts/blender/api/capture.py
+++ b/openpype/hosts/blender/api/capture.py
@@ -127,8 +127,9 @@ def isolate_objects(window, objects):
 
     context = create_blender_context(selected=objects, window=window)
 
-    bpy.ops.view3d.view_axis(context, type="FRONT")
-    bpy.ops.view3d.localview(context)
+    with bpy.context.temp_override(**context):
+        bpy.ops.view3d.view_axis(type="FRONT")
+        bpy.ops.view3d.localview()
 
     deselect_all()
 
@@ -270,10 +271,12 @@ def _independent_window():
     """Create capture-window context."""
     context = create_blender_context()
     current_windows = set(bpy.context.window_manager.windows)
-    bpy.ops.wm.window_new(context)
+    with bpy.context.temp_override(**context):
+        bpy.ops.wm.window_new()
     window = list(set(bpy.context.window_manager.windows) - current_windows)[0]
     context["window"] = window
     try:
         yield window
     finally:
-        bpy.ops.wm.window_close(context)
+        with bpy.context.temp_override(**context):
+            bpy.ops.wm.window_close()

--- a/openpype/hosts/blender/api/capture.py
+++ b/openpype/hosts/blender/api/capture.py
@@ -273,7 +273,8 @@ def _independent_window():
     current_windows = set(bpy.context.window_manager.windows)
     with bpy.context.temp_override(**context):
         bpy.ops.wm.window_new()
-        window = list(set(bpy.context.window_manager.windows) - current_windows)[0]
+        window = list(
+            set(bpy.context.window_manager.windows) - current_windows)[0]
         context["window"] = window
         try:
             yield window

--- a/openpype/hosts/blender/api/capture.py
+++ b/openpype/hosts/blender/api/capture.py
@@ -273,10 +273,9 @@ def _independent_window():
     current_windows = set(bpy.context.window_manager.windows)
     with bpy.context.temp_override(**context):
         bpy.ops.wm.window_new()
-    window = list(set(bpy.context.window_manager.windows) - current_windows)[0]
-    context["window"] = window
-    try:
-        yield window
-    finally:
-        with bpy.context.temp_override(**context):
+        window = list(set(bpy.context.window_manager.windows) - current_windows)[0]
+        context["window"] = window
+        try:
+            yield window
+        finally:
             bpy.ops.wm.window_close()

--- a/openpype/hosts/blender/plugins/load/load_audio.py
+++ b/openpype/hosts/blender/plugins/load/load_audio.py
@@ -67,7 +67,8 @@ class AudioLoader(plugin.AssetLoader):
         oc = bpy.context.copy()
         oc["area"] = window_manager.windows[-1].screen.areas[0]
 
-        bpy.ops.sequencer.sound_strip_add(oc, filepath=libpath, frame_start=1)
+        with bpy.context.temp_override(**oc):
+            bpy.ops.sequencer.sound_strip_add(filepath=libpath, frame_start=1)
 
         window_manager.windows[-1].screen.areas[0].type = old_type
 
@@ -156,17 +157,18 @@ class AudioLoader(plugin.AssetLoader):
         oc = bpy.context.copy()
         oc["area"] = window_manager.windows[-1].screen.areas[0]
 
-        # We deselect all sequencer strips, and then select the one we
-        # need to remove.
-        bpy.ops.sequencer.select_all(oc, action='DESELECT')
-        scene = bpy.context.scene
-        scene.sequence_editor.sequences_all[old_audio].select = True
+        with bpy.context.temp_override(**oc):
+            # We deselect all sequencer strips, and then select the one we
+            # need to remove.
+            bpy.ops.sequencer.select_all(action='DESELECT')
+            scene = bpy.context.scene
+            scene.sequence_editor.sequences_all[old_audio].select = True
 
-        bpy.ops.sequencer.delete(oc)
-        bpy.data.sounds.remove(bpy.data.sounds[old_audio])
+            bpy.ops.sequencer.delete()
+            bpy.data.sounds.remove(bpy.data.sounds[old_audio])
 
-        bpy.ops.sequencer.sound_strip_add(
-            oc, filepath=str(libpath), frame_start=1)
+            bpy.ops.sequencer.sound_strip_add(
+                filepath=str(libpath), frame_start=1)
 
         window_manager.windows[-1].screen.areas[0].type = old_type
 
@@ -205,12 +207,13 @@ class AudioLoader(plugin.AssetLoader):
         oc = bpy.context.copy()
         oc["area"] = window_manager.windows[-1].screen.areas[0]
 
-        # We deselect all sequencer strips, and then select the one we
-        # need to remove.
-        bpy.ops.sequencer.select_all(oc, action='DESELECT')
-        bpy.context.scene.sequence_editor.sequences_all[audio].select = True
-
-        bpy.ops.sequencer.delete(oc)
+        with bpy.context.temp_override(**oc):
+            # We deselect all sequencer strips, and then select the one we
+            # need to remove.
+            bpy.ops.sequencer.select_all(action='DESELECT')
+            scene = bpy.context.scene
+            scene.sequence_editor.sequences_all[audio].select = True
+            bpy.ops.sequencer.delete()
 
         window_manager.windows[-1].screen.areas[0].type = old_type
 

--- a/openpype/hosts/blender/plugins/publish/extract_abc_animation.py
+++ b/openpype/hosts/blender/plugins/publish/extract_abc_animation.py
@@ -55,13 +55,13 @@ class ExtractAnimationABC(
         context = plugin.create_blender_context(
             active=asset_group, selected=selected)
 
-        # We export the abc
-        bpy.ops.wm.alembic_export(
-            context,
-            filepath=filepath,
-            selected=True,
-            flatten=False
-        )
+        with bpy.context.temp_override(**context):
+            # We export the abc
+            bpy.ops.wm.alembic_export(
+                filepath=filepath,
+                selected=True,
+                flatten=False
+            )
 
         plugin.deselect_all()
 

--- a/openpype/hosts/blender/plugins/publish/extract_camera_fbx.py
+++ b/openpype/hosts/blender/plugins/publish/extract_camera_fbx.py
@@ -50,19 +50,19 @@ class ExtractCamera(publish.Extractor, publish.OptionalPyblishPluginMixin):
         scale_length = bpy.context.scene.unit_settings.scale_length
         bpy.context.scene.unit_settings.scale_length = 0.01
 
-        # We export the fbx
-        bpy.ops.export_scene.fbx(
-            context,
-            filepath=filepath,
-            use_active_collection=False,
-            use_selection=True,
-            bake_anim_use_nla_strips=False,
-            bake_anim_use_all_actions=False,
-            add_leaf_bones=False,
-            armature_nodetype='ROOT',
-            object_types={'CAMERA'},
-            bake_anim_simplify_factor=0.0
-        )
+        with bpy.context.temp_override(**context):
+            # We export the fbx
+            bpy.ops.export_scene.fbx(
+                filepath=filepath,
+                use_active_collection=False,
+                use_selection=True,
+                bake_anim_use_nla_strips=False,
+                bake_anim_use_all_actions=False,
+                add_leaf_bones=False,
+                armature_nodetype='ROOT',
+                object_types={'CAMERA'},
+                bake_anim_simplify_factor=0.0
+            )
 
         bpy.context.scene.unit_settings.scale_length = scale_length
 

--- a/openpype/hosts/blender/plugins/publish/extract_fbx.py
+++ b/openpype/hosts/blender/plugins/publish/extract_fbx.py
@@ -57,15 +57,15 @@ class ExtractFBX(publish.Extractor, publish.OptionalPyblishPluginMixin):
         scale_length = bpy.context.scene.unit_settings.scale_length
         bpy.context.scene.unit_settings.scale_length = 0.01
 
-        # We export the fbx
-        bpy.ops.export_scene.fbx(
-            context,
-            filepath=filepath,
-            use_active_collection=False,
-            use_selection=True,
-            mesh_smooth_type='FACE',
-            add_leaf_bones=False
-        )
+        with bpy.context.temp_override(**context):
+            # We export the fbx
+            bpy.ops.export_scene.fbx(
+                filepath=filepath,
+                use_active_collection=False,
+                use_selection=True,
+                mesh_smooth_type='FACE',
+                add_leaf_bones=False
+            )
 
         bpy.context.scene.unit_settings.scale_length = scale_length
 

--- a/openpype/hosts/blender/plugins/publish/extract_fbx_animation.py
+++ b/openpype/hosts/blender/plugins/publish/extract_fbx_animation.py
@@ -153,17 +153,20 @@ class ExtractAnimationFBX(
 
         override = plugin.create_blender_context(
             active=root, selected=[root, armature])
-        bpy.ops.export_scene.fbx(
-            override,
-            filepath=filepath,
-            use_active_collection=False,
-            use_selection=True,
-            bake_anim_use_nla_strips=False,
-            bake_anim_use_all_actions=False,
-            add_leaf_bones=False,
-            armature_nodetype='ROOT',
-            object_types={'EMPTY', 'ARMATURE'}
-        )
+
+        with bpy.context.temp_override(**override):
+            # We export the fbx
+            bpy.ops.export_scene.fbx(
+                filepath=filepath,
+                use_active_collection=False,
+                use_selection=True,
+                bake_anim_use_nla_strips=False,
+                bake_anim_use_all_actions=False,
+                add_leaf_bones=False,
+                armature_nodetype='ROOT',
+                object_types={'EMPTY', 'ARMATURE'}
+            )
+
         armature.name = armature_name
         asset_group.name = asset_group_name
         root.select_set(True)

--- a/openpype/hosts/blender/plugins/publish/extract_layout.py
+++ b/openpype/hosts/blender/plugins/publish/extract_layout.py
@@ -80,17 +80,18 @@ class ExtractLayout(publish.Extractor, publish.OptionalPyblishPluginMixin):
 
             override = plugin.create_blender_context(
                 active=asset, selected=[asset, obj])
-            bpy.ops.export_scene.fbx(
-                override,
-                filepath=filepath,
-                use_active_collection=False,
-                use_selection=True,
-                bake_anim_use_nla_strips=False,
-                bake_anim_use_all_actions=False,
-                add_leaf_bones=False,
-                armature_nodetype='ROOT',
-                object_types={'EMPTY', 'ARMATURE'}
-            )
+            with bpy.context.temp_override(**override):
+                # We export the fbx
+                bpy.ops.export_scene.fbx(
+                    filepath=filepath,
+                    use_active_collection=False,
+                    use_selection=True,
+                    bake_anim_use_nla_strips=False,
+                    bake_anim_use_all_actions=False,
+                    add_leaf_bones=False,
+                    armature_nodetype='ROOT',
+                    object_types={'EMPTY', 'ARMATURE'}
+                )
             obj.name = armature_name
             asset.name = asset_group_name
             asset.select_set(False)


### PR DESCRIPTION
## Changelog Description
Blender 4.0 disabled the old API to override context. This API updates the code to use the new API.

## Additional info
This change is compatible with Blender versions up to 3.2. Previous versions are not compatible with this new API.

## Testing notes:
In Blender 4.0:
1. Test FBX and Alembic extractors.
2. Test load audio.
3. Test Review extraction.