### PR TITLE
Enhancement: Add help links in Houdini menu.

### DIFF
--- a/openpype/hosts/houdini/startup/MainMenuCommon.xml
+++ b/openpype/hosts/houdini/startup/MainMenuCommon.xml
@@ -108,7 +108,7 @@ host_tools.show_experimental_tools_dialog(parent)
         <separatorItem/>
 
         <scriptItem id="ayon_server">
-            <label>Open Ayon server in browser</label>
+            <label>Open AYON server in browser</label>
             <scriptCode><![CDATA[import os; __import__("webbrowser").open(os.getenv("AYON_SERVER_URL"))]]></scriptCode>
         </scriptItem>
 

--- a/openpype/hosts/houdini/startup/MainMenuCommon.xml
+++ b/openpype/hosts/houdini/startup/MainMenuCommon.xml
@@ -130,11 +130,6 @@ host_tools.show_experimental_tools_dialog(parent)
                 <scriptCode><![CDATA[__import__("webbrowser").open("https://community.ynput.io/")]]></scriptCode>
             </scriptItem>
 
-            <scriptItem id="about_ynput">
-                <label>About Ynput</label>
-                <scriptCode><![CDATA[__import__("webbrowser").open("https://ynput.io/company/")]]></scriptCode>
-            </scriptItem>
-
         </subMenu>
 
         </subMenu>

--- a/openpype/hosts/houdini/startup/MainMenuCommon.xml
+++ b/openpype/hosts/houdini/startup/MainMenuCommon.xml
@@ -104,6 +104,39 @@ parent = hou.qt.mainWindow()
 host_tools.show_experimental_tools_dialog(parent)
 ]]></scriptCode>
             </scriptItem>
+
+        <separatorItem/>
+
+        <scriptItem id="ayon_server">
+            <label>Open Ayon server in browser</label>
+            <scriptCode><![CDATA[import os; __import__("webbrowser").open(os.getenv("AYON_SERVER_URL"))]]></scriptCode>
+        </scriptItem>
+
+        <subMenu id="ayon_help">
+            <label>Help...</label>
+
+            <scriptItem id="ayon_artist_docs">
+                <label>Houdini Artist Docs</label>
+                <scriptCode><![CDATA[__import__("webbrowser").open("https://ayon.ynput.io/docs/addon_houdini_artist")]]></scriptCode>
+            </scriptItem>
+
+            <scriptItem id="ayon_admin_docs">
+                <label>Houdini Admin Docs</label>
+                <scriptCode><![CDATA[__import__("webbrowser").open("https://ayon.ynput.io/docs/addon_houdini_admin")]]></scriptCode>
+            </scriptItem>
+
+            <scriptItem id="community_forums">
+                <label>Community Forums</label>
+                <scriptCode><![CDATA[__import__("webbrowser").open("https://community.ynput.io/")]]></scriptCode>
+            </scriptItem>
+
+            <scriptItem id="about_ynput">
+                <label>About Ynput</label>
+                <scriptCode><![CDATA[__import__("webbrowser").open("https://ynput.io/company/")]]></scriptCode>
+            </scriptItem>
+
+        </subMenu>
+
         </subMenu>
     </menuBar>
 </mainMenu>


### PR DESCRIPTION
## Changelog Description
Add help links in Houdini menu 
I've added 5 links: 
- Ayon server
- [Houdini Artist Docs](https://ayon.ynput.io/docs/addon_houdini_artist)
- [Houdini Admin Docs](https://ayon.ynput.io/docs/addon_houdini_admin)
- [Community Forums](https://community.ynput.io/)

![image](https://github.com/ynput/OpenPype/assets/20871534/901504ba-f744-46d7-b5dd-0c3f99c057b0)


## Testing notes:
1. Launch Houdini
2. Test links
