### PR TITLE
Maya: re-introduce old Arnold Scene Source extraction logic

### DIFF
--- a/openpype/hosts/maya/plugins/create/create_arnold_scene_source_legacy.py
+++ b/openpype/hosts/maya/plugins/create/create_arnold_scene_source_legacy.py
@@ -1,0 +1,110 @@
+from openpype.hosts.maya.api import (
+    lib,
+    plugin
+)
+from openpype.lib import (
+    NumberDef,
+    BoolDef
+)
+
+
+class CreateArnoldSceneSourceLegacy(plugin.MayaCreator):
+    """Arnold Scene Source"""
+
+    identifier = "io.openpype.creators.maya.legacy.ass"
+    label = "Arnold Scene Source (Legacy)"
+    family = "ass"
+    icon = "cube"
+    settings_name = "CreateAss"
+
+    expandProcedurals = False
+    motionBlur = True
+    motionBlurKeys = 2
+    motionBlurLength = 0.5
+    maskOptions = False
+    maskCamera = False
+    maskLight = False
+    maskShape = False
+    maskShader = False
+    maskOverride = False
+    maskDriver = False
+    maskFilter = False
+    maskColor_manager = False
+    maskOperator = False
+
+    def get_instance_attr_defs(self):
+
+        defs = lib.collect_animation_defs()
+
+        defs.extend([
+            BoolDef("expandProcedural",
+                    label="Expand Procedural",
+                    default=self.expandProcedurals),
+            BoolDef("motionBlur",
+                    label="Motion Blur",
+                    default=self.motionBlur),
+            NumberDef("motionBlurKeys",
+                      label="Motion Blur Keys",
+                      decimals=0,
+                      default=self.motionBlurKeys),
+            NumberDef("motionBlurLength",
+                      label="Motion Blur Length",
+                      decimals=3,
+                      default=self.motionBlurLength),
+
+            # Masks
+            BoolDef("maskOptions",
+                    label="Export Options",
+                    default=self.maskOptions),
+            BoolDef("maskCamera",
+                    label="Export Cameras",
+                    default=self.maskCamera),
+            BoolDef("maskLight",
+                    label="Export Lights",
+                    default=self.maskLight),
+            BoolDef("maskShape",
+                    label="Export Shapes",
+                    default=self.maskShape),
+            BoolDef("maskShader",
+                    label="Export Shaders",
+                    default=self.maskShader),
+            BoolDef("maskOverride",
+                    label="Export Override Nodes",
+                    default=self.maskOverride),
+            BoolDef("maskDriver",
+                    label="Export Drivers",
+                    default=self.maskDriver),
+            BoolDef("maskFilter",
+                    label="Export Filters",
+                    default=self.maskFilter),
+            BoolDef("maskOperator",
+                    label="Export Operators",
+                    default=self.maskOperator),
+            BoolDef("maskColor_manager",
+                    label="Export Color Managers",
+                    default=self.maskColor_manager),
+        ])
+
+        return defs
+
+    def get_publish_families(self):
+        return ["ass.legacy"]
+
+    def create(self, subset_name, instance_data, pre_create_data):
+
+        from maya import cmds
+
+        members = list()
+        if pre_create_data.get("use_selection"):
+            members = cmds.ls(selection=True)
+            pre_create_data["use_selection"] = False
+
+        instance = super(CreateArnoldSceneSourceLegacy, self).create(
+            subset_name, instance_data, pre_create_data
+        )
+
+        instance_node = instance.get("instance_node")
+
+        content = cmds.sets(members, name=instance_node + "_content_SET")
+        proxy = cmds.sets(name=instance_node + "_proxy_SET", empty=True)
+        cmds.sets([content, proxy], forceElement=instance_node)

--- a/openpype/hosts/maya/plugins/publish/extract_arnold_scene_source.py
+++ b/openpype/hosts/maya/plugins/publish/extract_arnold_scene_source.py
@@ -18,6 +18,10 @@ class ExtractArnoldSceneSource(publish.Extractor):
     asciiAss = False
 
     def process(self, instance):
+        if "ass.legacy" in instance.data["families"]:
+            self.log.info("Skipping on behalf of legacy extractor.")
+            return
+
         staging_dir = self.staging_dir(instance)
         file_path = os.path.join(staging_dir, "{}.ass".format(instance.name))
 

--- a/openpype/hosts/maya/plugins/publish/extract_ass_raw.py
+++ b/openpype/hosts/maya/plugins/publish/extract_ass_raw.py
@@ -1,0 +1,106 @@
+import os
+
+from maya import cmds
+import arnold
+
+from openpype.pipeline import publish
+from openpype.hosts.maya.api.lib import maintained_selection, attribute_values
+
+
+class ExtractAssStandinLegacy(publish.Extractor):
+    """Extract the content of the instance to a ass file"""
+
+    label = "Arnold Scene Source Legacy (.ass)"
+    hosts = ["maya"]
+    families = ["ass.legacy"]
+    asciiAss = False
+
+    def process(self, instance):
+        staging_dir = self.staging_dir(instance)
+        filename = "{}.ass".format(instance.name)
+        filenames = []
+        file_path = os.path.join(staging_dir, filename)
+
+        # Mask
+        mask = arnold.AI_NODE_ALL
+
+        node_types = {
+            "options": arnold.AI_NODE_OPTIONS,
+            "camera": arnold.AI_NODE_CAMERA,
+            "light": arnold.AI_NODE_LIGHT,
+            "shape": arnold.AI_NODE_SHAPE,
+            "shader": arnold.AI_NODE_SHADER,
+            "override": arnold.AI_NODE_OVERRIDE,
+            "driver": arnold.AI_NODE_DRIVER,
+            "filter": arnold.AI_NODE_FILTER,
+            "color_manager": arnold.AI_NODE_COLOR_MANAGER,
+            "operator": arnold.AI_NODE_OPERATOR
+        }
+
+        for key in node_types.keys():
+            if instance.data.get("mask" + key.title()):
+                mask = mask ^ node_types[key]
+
+        # Motion blur
+        values = {
+            "defaultArnoldRenderOptions.motion_blur_enable": instance.data.get(
+                "motionBlur", True
+            ),
+            "defaultArnoldRenderOptions.motion_steps": instance.data.get(
+                "motionBlurKeys", 2
+            ),
+            "defaultArnoldRenderOptions.motion_frames": instance.data.get(
+                "motionBlurLength", 0.5
+            )
+        }
+
+        # Write out .ass file
+        kwargs = {
+            "filename": file_path,
+            "startFrame": instance.data.get("frameStartHandle", 1),
+            "endFrame": instance.data.get("frameEndHandle", 1),
+            "frameStep": instance.data.get("step", 1),
+            "selected": True,
+            "asciiAss": self.asciiAss,
+            "shadowLinks": True,
+            "lightLinks": True,
+            "boundingBox": True,
+            "expandProcedurals": instance.data.get("expandProcedurals", False),
+            "camera": instance.data["camera"],
+            "mask": mask
+        }
+
+        self.log.info("Writing: '%s'" % file_path)
+        with attribute_values(values):
+            with maintained_selection():
+                self.log.info(
+                    "Writing: {}".format(instance.data["setMembers"])
+                )
+                cmds.select(instance.data["setMembers"], noExpand=True)
+
+                self.log.info(
+                    "Extracting ass sequence with: {}".format(kwargs)
+                )
+
+                exported_files = cmds.arnoldExportAss(**kwargs)
+
+                for file in exported_files:
+                    filenames.append(os.path.split(file)[1])
+
+                self.log.info("Exported: {}".format(filenames))
+
+        if "representations" not in instance.data:
+            instance.data["representations"] = []
+
+        representation = {
+            'name': 'ass',
+            'ext': 'ass',
+            'files': filenames if len(filenames) > 1 else filenames[0],
+            "stagingDir": staging_dir,
+            'frameStart': kwargs["startFrame"]
+        }
+
+        instance.data["representations"].append(representation)
+
+        self.log.info("Extracted instance '%s' to: %s"
+                      % (instance.name, staging_dir))

--- a/openpype/hosts/maya/plugins/publish/validate_arnold_scene_source.py
+++ b/openpype/hosts/maya/plugins/publish/validate_arnold_scene_source.py
@@ -58,6 +58,11 @@ class ValidateArnoldSceneSource(pyblish.api.InstancePlugin):
         return ungrouped_nodes, nodes_by_name, parents
 
     def process(self, instance):
+
+        if "ass.legacy" in instance.data.get("families", []):
+            self.log.info("Skipping, using legacy workflow.")
+            return
+
         ungrouped_nodes = []
 
         nodes, content_nodes_by_name, content_parents = (


### PR DESCRIPTION
## Changelog Description
This PR temporarily re-introduce old Arnold Scene Source (.ass) extraction logic that isn't that restricted as the new one, until functionality of both can be merged together. This is mainly affecting workflow with instances that can't be published in new one because of validation.

## Additional info
It is adding new Creator for legacy behavior that is skipping some validation and is using old extractor.

> [!CAUTION]
> This is temporary backport to 3.17 branch and will be remove once this issue is resolved.
