### PR TITLE
Chore: Collect template data with hierarchy context

### DIFF
--- a/openpype/plugins/publish/collect_anatomy_instance_data.py
+++ b/openpype/plugins/publish/collect_anatomy_instance_data.py
@@ -412,7 +412,7 @@ class CollectAnatomyInstanceData(pyblish.api.ContextPlugin):
         hierarchy_queue = collections.deque()
         hierarchy_queue.append(hierarchy_context)
         while hierarchy_queue:
-            item = hierarchy_context.popleft()
+            item = hierarchy_queue.popleft()
             if asset_name in item:
                 return item[asset_name].get("tasks") or {}
 

--- a/openpype/plugins/publish/collect_anatomy_instance_data.py
+++ b/openpype/plugins/publish/collect_anatomy_instance_data.py
@@ -410,7 +410,7 @@ class CollectAnatomyInstanceData(pyblish.api.ContextPlugin):
         """
 
         hierarchy_queue = collections.deque()
-        hierarchy_queue.append(hierarchy_context)
+        hierarchy_queue.append(copy.deepcopy(hierarchy_context))
         while hierarchy_queue:
             item = hierarchy_queue.popleft()
             if asset_name in item:

--- a/openpype/plugins/publish/extract_hierarchy_to_ayon.py
+++ b/openpype/plugins/publish/extract_hierarchy_to_ayon.py
@@ -30,8 +30,7 @@ class ExtractHierarchyToAYON(pyblish.api.ContextPlugin):
         if not AYON_SERVER_ENABLED:
             return
 
-        hierarchy_context = context.data.get("hierarchyContext")
-        if not hierarchy_context:
+        if not context.data.get("hierarchyContext"):
             self.log.debug("Skipping ExtractHierarchyToAYON")
             return
 


### PR DESCRIPTION
## Changelog Description
Fixed queue loop where is used wrong variable to pop items from queue.

## Additional info
Also create copy of hierarchy context to be sure it is not modified during the loop in any way (just to be sure for possible future changes), and don't store 'hierarchyContext' to variable when checking if is set.

## Testing notes:
1. Anatomy data should be filled correctly during editorial publishing when new folders/assets are created.
