### PR TITLE
OP-6382 - Thumbnail Integration Problem

### DIFF
--- a/openpype/hosts/traypublisher/plugins/publish/collect_simple_instances.py
+++ b/openpype/hosts/traypublisher/plugins/publish/collect_simple_instances.py
@@ -216,6 +216,11 @@ class CollectSettingsSimpleInstances(pyblish.api.InstancePlugin):
             instance.data["thumbnailSource"] = first_filepath
 
         review_representation["tags"].append("review")
+
+        # Adding "review" to representation name since it can clash with main
+        # representation if they share the same extension.
+        review_representation["outputName"] = "review"
+
         self.log.debug("Representation {} was marked for review. {}".format(
             review_representation["name"], review_path
         ))

--- a/openpype/plugins/publish/extract_color_transcode.py
+++ b/openpype/plugins/publish/extract_color_transcode.py
@@ -189,6 +189,13 @@ class ExtractOIIOTranscode(publish.Extractor):
                 if len(new_repre["files"]) == 1:
                     new_repre["files"] = new_repre["files"][0]
 
+                # If the source representation has "review" tag, but its not
+                # part of the output defintion tags, then both the
+                # representations will be transcoded in ExtractReview and
+                # their outputs will clash in integration.
+                if not added_review and "review" in repre.get("tags", []):
+                    added_review = True
+
                 new_representations.append(new_repre)
                 added_representations = True
 

--- a/openpype/plugins/publish/extract_color_transcode.py
+++ b/openpype/plugins/publish/extract_color_transcode.py
@@ -193,7 +193,7 @@ class ExtractOIIOTranscode(publish.Extractor):
                 # part of the output defintion tags, then both the
                 # representations will be transcoded in ExtractReview and
                 # their outputs will clash in integration.
-                if not added_review and "review" in repre.get("tags", []):
+                if "review" in repre.get("tags", []):
                     added_review = True
 
                 new_representations.append(new_repre)

--- a/openpype/plugins/publish/extract_thumbnail.py
+++ b/openpype/plugins/publish/extract_thumbnail.py
@@ -231,7 +231,10 @@ class ExtractThumbnail(pyblish.api.InstancePlugin):
                 "files": jpeg_file,
                 "stagingDir": dst_staging,
                 "thumbnail": True,
-                "tags": new_repre_tags
+                "tags": new_repre_tags,
+                # If source image is jpg then there can be clash when
+                # integrating to making the output name explicit.
+                "outputName": "thumbnail"
             }
 
             # adding representation


### PR DESCRIPTION
## Changelog Description
This ticket alerted to 3 different cases of integration issues;

- [x] Using the Tray Publisher with the same image format (extension) for representation and review representation.
- [x] Clash on publish file path from output definitions in `ExtractOIIOTranscode`.
- [x] Clash on publish file from thumbnail in `ExtractThumbnail`

There might be an issue with this fix, if a studio does not use the `{output}` token in their `render` anatomy template. But thinking if they have customized it, they will be responsible to maintain these edge cases.

## Testing notes:
1. Use Tray Publisher to publish `Image` with two different images of same extension.
![image](https://github.com/ynput/OpenPype/assets/1860085/ec7c6dfa-b870-475f-9ad2-6d24720b4a45)
2. Publish should succeed.

1. Setup `ayon+settings://core/publish/ExtractOIIOTranscode/profiles` with settings below.
![Capture](https://github.com/ynput/OpenPype/assets/1860085/154bc999-d0c2-4c95-be10-1cb0d95c64a7)
2. Setup single frame render from Maya and publish to Deadline.
3. Publish on Deadline should succeed.

1. Setup `ayon+settings://core/publish/ExtractOIIOTranscode/profiles` with settings below (just adding `review` tag from above settings).
![Capture](https://github.com/ynput/OpenPype/assets/1860085/e327f114-b463-455e-9d27-e4ac426fddad)
2. Setup single frame render from Maya and publish to Deadline.
3. Publish on Deadline should succeed.