### PR TITLE
Blender: Fix missing animation data when updating blend assets

### DIFF
--- a/openpype/hosts/blender/plugins/load/load_blend.py
+++ b/openpype/hosts/blender/plugins/load/load_blend.py
@@ -220,6 +220,8 @@ class BlendLoader(plugin.AssetLoader):
         # Restore the actions
         for obj in asset_group.children_recursive:
             if obj.name in actions:
+                if not obj.animation_data:
+                    obj.animation_data_create()
                 obj.animation_data.action = actions[obj.name]
 
         # Restore the old data, but reset memebers, as they don't exist anymore


### PR DESCRIPTION
## Changelog Description
Fix missing animation data when updating blend assets.

## Additional info
There was a specific case when updating assets that were published without animation. If an animation was added after them being loaded, when updating it would throw an error.

## Testing notes:
1. Load an asset that is without any animation data (it must **not** have any animation in the outline when loaded).
![image](https://github.com/ynput/OpenPype/assets/1087869/087671c7-ae46-45de-b7f1-37c967ff6810)
![image](https://github.com/ynput/OpenPype/assets/1087869/3e47ab5c-2e1b-49ea-97a6-94d35137d756)
2. Add an animation to that asset.
3. Try to update the asset.

