### PR TITLE
fix project name duplication in project folders

### DIFF
--- a/openpype/pipeline/project_folders.py
+++ b/openpype/pipeline/project_folders.py
@@ -28,8 +28,14 @@ def concatenate_splitted_paths(split_paths, anatomy):
         # backward compatibility
         if "__project_root__" in path_items:
             for root, root_path in anatomy.roots.items():
-                if not root_path:
+                if not root_path or not os.path.exists(str(root_path)):
+                    log.debug(
+                        "Root {} path path {} not exist on computer!".format(
+                            root, root_path
+                        )
+                    )
                     continue
+
                 root_items = [
                     "{{root[{}]}}".format(root),
                     "{project[name]}"

--- a/openpype/pipeline/project_folders.py
+++ b/openpype/pipeline/project_folders.py
@@ -28,13 +28,14 @@ def concatenate_splitted_paths(split_paths, anatomy):
         # backward compatibility
         if "__project_root__" in path_items:
             for root, root_path in anatomy.roots.items():
-                if not os.path.exists(str(root_path)):
-                    log.debug("Root {} path path {} not exist on \
-                        computer!".format(root, root_path))
+                if not root_path:
                     continue
-                clean_items = ["{{root[{}]}}".format(root),
-                               r"{project[name]}"] + clean_items[1:]
-                output.append(os.path.normpath(os.path.sep.join(clean_items)))
+                root_items = [
+                    "{{root[{}]}}".format(root),
+                    "{project[name]}"
+                ]
+                root_items.extend(clean_items[1:])
+                output.append(os.path.normpath(os.path.sep.join(root_items)))
             continue
 
         output.append(os.path.normpath(os.path.sep.join(clean_items)))


### PR DESCRIPTION
## Changelog Description
Small fix in project folders. It is not used same variable name to change values which breaks values on any next loop.

## Additional info
Avoid reusing `clean_items` variable during for loop.

## Testing notes:
1. Keep `__project_root__` in folder structure settings.
2. Create a project and make sure it has more than one root.
3. Run create folders action (e.g. in Project manager in OpenPype or action in ftrack).