### PR TITLE
Publisher: Show message with error on action failure

### DIFF
--- a/openpype/tools/publisher/control.py
+++ b/openpype/tools/publisher/control.py
@@ -2329,6 +2329,21 @@ class PublisherController(BasePublisherController):
         result = pyblish.plugin.process(
             plugin, self._publish_context, None, action.id
         )
+        exception = result.get("error")
+        if exception:
+            self._emit_event(
+                "action.failed",
+                {
+                    "title": "Action failed",
+                    "message": "Action failed.",
+                    "traceback": "".join(
+                        traceback.format_exception(exception)
+                    ),
+                    "label": "",
+                    "identifier": action.__name__
+                }
+            )
+
         self._publish_report.add_action_result(action, result)
 
     def _publish_next_process(self):

--- a/openpype/tools/publisher/control.py
+++ b/openpype/tools/publisher/control.py
@@ -2346,6 +2346,8 @@ class PublisherController(BasePublisherController):
 
         self._publish_report.add_action_result(action, result)
 
+        self.emit_card_message("Action finished.")
+
     def _publish_next_process(self):
         # Validations of progress before using iterator
         # - same conditions may be inside iterator but they may be used

--- a/openpype/tools/publisher/control.py
+++ b/openpype/tools/publisher/control.py
@@ -2339,8 +2339,8 @@ class PublisherController(BasePublisherController):
                     "traceback": "".join(
                         traceback.format_exception(exception)
                     ),
-                    "label": "",
-                    "name": action.__name__
+                    "label": action.__name__,
+                    "identifier": action.id
                 }
             )
 

--- a/openpype/tools/publisher/control.py
+++ b/openpype/tools/publisher/control.py
@@ -2332,7 +2332,7 @@ class PublisherController(BasePublisherController):
         exception = result.get("error")
         if exception:
             self._emit_event(
-                "action.failed",
+                "publish.action.failed",
                 {
                     "title": "Action failed",
                     "message": "Action failed.",

--- a/openpype/tools/publisher/control.py
+++ b/openpype/tools/publisher/control.py
@@ -2340,7 +2340,7 @@ class PublisherController(BasePublisherController):
                         traceback.format_exception(exception)
                     ),
                     "label": "",
-                    "identifier": action.__name__
+                    "name": action.__name__
                 }
             )
 

--- a/openpype/tools/publisher/window.py
+++ b/openpype/tools/publisher/window.py
@@ -322,6 +322,9 @@ class PublisherWindow(QtWidgets.QWidget):
             "convertors.find.failed", self._on_convertor_error
         )
         controller.event_system.add_callback(
+            "action.failed", self._on_action_error
+        )
+        controller.event_system.add_callback(
             "export_report.request", self._export_report
         )
         controller.event_system.add_callback(
@@ -1010,6 +1013,18 @@ class PublisherWindow(QtWidgets.QWidget):
             new_failed_info.append(new_item)
         self.add_error_message_dialog(
             event["title"], new_failed_info, "Convertor:"
+        )
+
+    def _on_action_error(self, event):
+        self.add_error_message_dialog(
+            event["title"],
+            [{
+                "message": event["message"],
+                "traceback": event["traceback"],
+                "label": event["label"],
+                "identifier": event["identifier"]
+            }],
+            "Action:"
         )
 
     def _update_create_overlay_size(self):

--- a/openpype/tools/publisher/window.py
+++ b/openpype/tools/publisher/window.py
@@ -1022,7 +1022,7 @@ class PublisherWindow(QtWidgets.QWidget):
                 "message": event["message"],
                 "traceback": event["traceback"],
                 "label": event["label"],
-                "identifier": event["identifier"]
+                "identifier": event["name"]
             }],
             "Action:"
         )

--- a/openpype/tools/publisher/window.py
+++ b/openpype/tools/publisher/window.py
@@ -1022,7 +1022,7 @@ class PublisherWindow(QtWidgets.QWidget):
                 "message": event["message"],
                 "traceback": event["traceback"],
                 "label": event["label"],
-                "identifier": event["name"]
+                "identifier": event["identifier"]
             }],
             "Action:"
         )

--- a/openpype/tools/publisher/window.py
+++ b/openpype/tools/publisher/window.py
@@ -322,7 +322,7 @@ class PublisherWindow(QtWidgets.QWidget):
             "convertors.find.failed", self._on_convertor_error
         )
         controller.event_system.add_callback(
-            "action.failed", self._on_action_error
+            "publish.action.failed", self._on_action_error
         )
         controller.event_system.add_callback(
             "export_report.request", self._export_report


### PR DESCRIPTION
## Changelog Description
This PR adds support for the publisher to show error message from running actions.

Errors from actions will otherwise be hidden from user in various console outputs.

Also include card for when action is finished.

## Testing notes:
Not sure about a simpler test case, so this where I caught it.
1. Checkout #6137
2. Merge this PR into the checked out PR.
3. In `ayon+settings://nuke/create/CreateWriteRender/exposed_knobs` enter an invalid knob name like `create_directo`.
4. Create `render` in Nuke. Error will appear about missing knob.
5. Delete knob `create_directo` on the created instance node.
6. Validate and run repair action. Error message should appear.
