### PR TITLE
TrayPublisher: Pre-fill of version works in AYON

### DIFF
--- a/openpype/hosts/traypublisher/api/plugin.py
+++ b/openpype/hosts/traypublisher/api/plugin.py
@@ -221,9 +221,16 @@ class SettingsCreator(TrayPublishCreator):
             ):
                 filtered_instance_data.append(instance)
 
-        asset_names = {
-            instance["asset"]
-            for instance in filtered_instance_data}
+        if AYON_SERVER_ENABLED:
+            asset_names = {
+                instance["folderPath"]
+                for instance in filtered_instance_data
+            }
+        else:
+            asset_names = {
+                instance["asset"]
+                for instance in filtered_instance_data
+            }
         subset_names = {
             instance["subset"]
             for instance in filtered_instance_data}
@@ -231,7 +238,10 @@ class SettingsCreator(TrayPublishCreator):
             asset_names, subset_names
         )
         for instance in filtered_instance_data:
-            asset_name = instance["asset"]
+            if AYON_SERVER_ENABLED:
+                asset_name = instance["folderPath"]
+            else:
+                asset_name = instance["asset"]
             subset_name = instance["subset"]
             version = subset_docs_by_asset_id[asset_name][subset_name]
             instance["creator_attributes"]["version_to_use"] = version


### PR DESCRIPTION
## Description
Use `folderPath` instead of `asset` in AYON mode to calculate next available version.

## Testing notes:
1. Publish something on Traypublisher
2. Click `reload` icon
