### PR TITLE
Arnold Scene Source Raw - OP-8014

### DIFF
--- a/openpype/hosts/maya/api/lib.py
+++ b/openpype/hosts/maya/api/lib.py
@@ -1326,18 +1326,12 @@ def is_visible(node,
             return False
 
     if displayLayer:
-        # If a display layer is connected, it'll override the value of
-        # "overrideVisibility" which ends up returning 0, so we need to query
-        # the connected display layer.
-        display_layers = cmds.listConnections(node, type="displayLayer")
-        if display_layers:
-            if not cmds.getAttr("{}.visibility".format(display_layers[0])):
-                return False
-        else:
+        # Display layers set overrideEnabled and overrideVisibility on members
+        if cmds.attributeQuery('overrideEnabled', node=node, exists=True):
             override_enabled = cmds.getAttr('{}.overrideEnabled'.format(node))
             override_visibility = cmds.getAttr('{}.overrideVisibility'.format(
                 node))
-            if override_enabled and override_visibility:
+            if override_enabled and not override_visibility:
                 return False
 
     if parentHidden:

--- a/openpype/hosts/maya/api/lib.py
+++ b/openpype/hosts/maya/api/lib.py
@@ -1326,8 +1326,14 @@ def is_visible(node,
             return False
 
     if displayLayer:
-        # Display layers set overrideEnabled and overrideVisibility on members
-        if cmds.attributeQuery('overrideEnabled', node=node, exists=True):
+        # If a display layer is connected, it'll override the value of
+        # "overrideVisibility" which ends up returning 0, so we need to query
+        # the connected display layer.
+        display_layers = cmds.listConnections(node, type="displayLayer")
+        if display_layers:
+            if not cmds.getAttr("{}.visibility".format(display_layers[0])):
+                return False
+        else:
             override_enabled = cmds.getAttr('{}.overrideEnabled'.format(node))
             override_visibility = cmds.getAttr('{}.overrideVisibility'.format(
                 node))

--- a/openpype/hosts/maya/plugins/create/create_arnold_scene_source.py
+++ b/openpype/hosts/maya/plugins/create/create_arnold_scene_source.py
@@ -89,11 +89,6 @@ class CreateArnoldSceneSource(plugin.MayaCreator):
 
         return defs
 
-    def create(self, subset_name, instance_data, pre_create_data):
-        super(CreateArnoldSceneSource, self).create(
-            subset_name, instance_data, pre_create_data
-        )
-
 
 class CreateArnoldSceneSourceProxy(CreateArnoldSceneSource):
     """Arnold Scene Source Proxy

--- a/openpype/hosts/maya/plugins/create/create_arnold_scene_source.py
+++ b/openpype/hosts/maya/plugins/create/create_arnold_scene_source.py
@@ -1,3 +1,5 @@
+from maya import cmds
+
 from openpype.hosts.maya.api import (
     lib,
     plugin
@@ -88,15 +90,28 @@ class CreateArnoldSceneSource(plugin.MayaCreator):
         return defs
 
     def create(self, subset_name, instance_data, pre_create_data):
+        super(CreateArnoldSceneSource, self).create(
+            subset_name, instance_data, pre_create_data
+        )
 
-        from maya import cmds
 
+class CreateArnoldSceneSourceProxy(CreateArnoldSceneSource):
+    """Arnold Scene Source Proxy
+
+    This product type facilitates working with proxy geometry in the viewport.
+    """
+
+    identifier = "io.openpype.creators.maya.assproxy"
+    label = "Arnold Scene Source Proxy"
+    family = "assProxy"
+    icon = "cube"
+
+    def create(self, subset_name, instance_data, pre_create_data):
         instance = super(CreateArnoldSceneSource, self).create(
             subset_name, instance_data, pre_create_data
         )
 
         instance_node = instance.get("instance_node")
 
-        content = cmds.sets(name=instance_node + "_content_SET", empty=True)
         proxy = cmds.sets(name=instance_node + "_proxy_SET", empty=True)
-        cmds.sets([content, proxy], forceElement=instance_node)
+        cmds.sets([proxy], forceElement=instance_node)

--- a/openpype/hosts/maya/plugins/load/load_arnold_standin.py
+++ b/openpype/hosts/maya/plugins/load/load_arnold_standin.py
@@ -156,12 +156,12 @@ class ArnoldStandinLoader(load.LoaderPlugin):
         )
         cmds.setAttr(
             string_replace_operator + ".match",
-            proxy_basename,
+            proxy_basename.split(".")[0],
             type="string"
         )
         cmds.setAttr(
             string_replace_operator + ".replace",
-            os.path.basename(path),
+            os.path.basename(path).split(".")[0],
             type="string"
         )
 

--- a/openpype/hosts/maya/plugins/load/load_arnold_standin.py
+++ b/openpype/hosts/maya/plugins/load/load_arnold_standin.py
@@ -142,6 +142,18 @@ class ArnoldStandinLoader(load.LoaderPlugin):
         proxy_path = "/".join([os.path.dirname(path), proxy_basename])
         return proxy_basename, proxy_path
 
+    def _update_operators(self, string_replace_operator, proxy_basename, path):
+        cmds.setAttr(
+            string_replace_operator + ".match",
+            proxy_basename.split(".")[0],
+            type="string"
+        )
+        cmds.setAttr(
+            string_replace_operator + ".replace",
+            os.path.basename(path).split(".")[0],
+            type="string"
+        )
+
     def _setup_proxy(self, shape, path, namespace):
         proxy_basename, proxy_path = self._get_proxy_path(path)
 
@@ -164,16 +176,7 @@ class ArnoldStandinLoader(load.LoaderPlugin):
             "*.(@node=='{}')".format(node_type),
             type="string"
         )
-        cmds.setAttr(
-            string_replace_operator + ".match",
-            proxy_basename.split(".")[0],
-            type="string"
-        )
-        cmds.setAttr(
-            string_replace_operator + ".replace",
-            os.path.basename(path).split(".")[0],
-            type="string"
-        )
+        self._update_operators(string_replace_operator, proxy_basename, path)
 
         cmds.connectAttr(
             string_replace_operator + ".out",
@@ -207,18 +210,9 @@ class ArnoldStandinLoader(load.LoaderPlugin):
         path = get_representation_path(representation)
         proxy_basename, proxy_path = self._get_proxy_path(path)
 
-        # Whether there is proxy or so, we still update the string operator.
+        # Whether there is proxy or not, we still update the string operator.
         # If no proxy exists, the string operator won't replace anything.
-        cmds.setAttr(
-            string_replace_operator + ".match",
-            proxy_basename,
-            type="string"
-        )
-        cmds.setAttr(
-            string_replace_operator + ".replace",
-            os.path.basename(path),
-            type="string"
-        )
+        self._update_operators(string_replace_operator, proxy_basename, path)
 
         dso_path = path
         if os.path.exists(proxy_path):

--- a/openpype/hosts/maya/plugins/load/load_arnold_standin.py
+++ b/openpype/hosts/maya/plugins/load/load_arnold_standin.py
@@ -107,10 +107,8 @@ class ArnoldStandinLoader(load.LoaderPlugin):
             sequence = is_sequence(os.listdir(os.path.dirname(repre_path)))
             cmds.setAttr(standin_shape + ".useFrameExtension", sequence)
 
-            fps = (
-                float(version["data"].get("fps")) or get_current_session_fps()
-            )
-            cmds.setAttr(standin_shape + ".abcFPS", fps)
+            fps = version["data"].get("fps") or get_current_session_fps()
+            cmds.setAttr(standin_shape + ".abcFPS", float(fps))
 
         nodes = [root, standin, standin_shape]
         if operator is not None:

--- a/openpype/hosts/maya/plugins/load/load_arnold_standin.py
+++ b/openpype/hosts/maya/plugins/load/load_arnold_standin.py
@@ -34,7 +34,15 @@ def get_current_session_fps():
 class ArnoldStandinLoader(load.LoaderPlugin):
     """Load as Arnold standin"""
 
-    families = ["ass", "animation", "model", "proxyAbc", "pointcache", "usd"]
+    families = [
+        "ass",
+        "assProxy",
+        "animation",
+        "model",
+        "proxyAbc",
+        "pointcache",
+        "usd"
+    ]
     representations = ["ass", "abc", "usda", "usdc", "usd"]
 
     label = "Load as Arnold standin"
@@ -99,7 +107,9 @@ class ArnoldStandinLoader(load.LoaderPlugin):
             sequence = is_sequence(os.listdir(os.path.dirname(repre_path)))
             cmds.setAttr(standin_shape + ".useFrameExtension", sequence)
 
-            fps = float(version["data"].get("fps"))or get_current_session_fps()
+            fps = (
+                float(version["data"].get("fps")) or get_current_session_fps()
+            )
             cmds.setAttr(standin_shape + ".abcFPS", fps)
 
         nodes = [root, standin, standin_shape]

--- a/openpype/hosts/maya/plugins/publish/validate_arnold_scene_source.py
+++ b/openpype/hosts/maya/plugins/publish/validate_arnold_scene_source.py
@@ -24,7 +24,6 @@ class ValidateArnoldSceneSource(pyblish.api.InstancePlugin):
         ungrouped_nodes = []
         nodes_by_name = {}
         parents = []
-        same_named_nodes = {}
         for node in nodes:
             node_split = node.split("|")
             if len(node_split) == 2:
@@ -35,25 +34,7 @@ class ValidateArnoldSceneSource(pyblish.api.InstancePlugin):
                 parents.append(parent)
 
             node_name = node.rsplit("|", 1)[-1].rsplit(":", 1)[-1]
-
-            # Check for same same nodes, which can happen in different
-            # hierarchies.
-            if node_name in nodes_by_name:
-                try:
-                    same_named_nodes[node_name].append(node)
-                except KeyError:
-                    same_named_nodes[node_name] = [
-                        nodes_by_name[node_name], node
-                    ]
-
             nodes_by_name[node_name] = node
-
-        if same_named_nodes:
-            message = "Found nodes with the same name:"
-            for name, nodes in same_named_nodes.items():
-                message += "\n\n\"{}\":\n{}".format(name, "\n".join(nodes))
-
-            raise PublishValidationError(message)
 
         return ungrouped_nodes, nodes_by_name, parents
 

--- a/openpype/hosts/maya/plugins/publish/validate_arnold_scene_source.py
+++ b/openpype/hosts/maya/plugins/publish/validate_arnold_scene_source.py
@@ -24,7 +24,9 @@ class ValidateArnoldSceneSource(pyblish.api.InstancePlugin):
         # extraction to ignore the node.
         nodes = instance.data["members"] + instance.data.get("proxy", [])
         nodes = [x for x in nodes if cmds.objectType(x, isAType='dagNode')]
-        hidden_nodes = [x for x in nodes if not is_visible(x)]
+        hidden_nodes = [
+            x for x in nodes if not is_visible(x, intermediateObject=False)
+        ]
         if hidden_nodes:
             raise PublishValidationError(
                 "Found hidden nodes:\n\n{}\n\nPlease unhide for"

--- a/openpype/hosts/maya/plugins/publish/validate_arnold_scene_source_cbid.py
+++ b/openpype/hosts/maya/plugins/publish/validate_arnold_scene_source_cbid.py
@@ -13,7 +13,7 @@ class ValidateArnoldSceneSourceCbid(pyblish.api.InstancePlugin):
 
     order = ValidateContentsOrder
     hosts = ["maya"]
-    families = ["ass"]
+    families = ["assProxy"]
     label = "Validate Arnold Scene Source CBID"
     actions = [RepairAction]
 
@@ -28,15 +28,11 @@ class ValidateArnoldSceneSourceCbid(pyblish.api.InstancePlugin):
 
     @classmethod
     def get_invalid_couples(cls, instance):
-        content_nodes_by_name = cls._get_nodes_by_name(
-            instance.data["contentMembers"]
-        )
-        proxy_nodes_by_name = cls._get_nodes_by_name(
-            instance.data.get("proxy", [])
-        )
+        nodes_by_name = cls._get_nodes_by_name(instance.data["members"])
+        proxy_nodes_by_name = cls._get_nodes_by_name(instance.data["proxy"])
 
         invalid_couples = []
-        for content_name, content_node in content_nodes_by_name.items():
+        for content_name, content_node in nodes_by_name.items():
             proxy_node = proxy_nodes_by_name.get(content_name, None)
 
             if not proxy_node:
@@ -56,7 +52,7 @@ class ValidateArnoldSceneSourceCbid(pyblish.api.InstancePlugin):
 
     def process(self, instance):
         # Proxy validation.
-        if not instance.data.get("proxy", []):
+        if not instance.data["proxy"]:
             return
 
         # Validate for proxy nodes sharing the same cbId as content nodes.

--- a/openpype/plugins/publish/integrate.py
+++ b/openpype/plugins/publish/integrate.py
@@ -95,6 +95,7 @@ class IntegrateAsset(pyblish.api.InstancePlugin):
                 "setdress",
                 "layout",
                 "ass",
+                "assProxy",
                 "vdbcache",
                 "scene",
                 "vrayproxy",


### PR DESCRIPTION
## Changelog Description
This PR is to try and re-instate some flexibility to the `Arnold Scene Source` family, which got restricted by https://github.com/ynput/OpenPype/pull/4449

The proxy workflow introduced was actually broken due to https://github.com/ynput/OpenPype/pull/4460.

We can now have any nodes directly in the instance set, which should be backwards compatible of the `Arnold Scene Source` before the overhaul in https://github.com/ynput/OpenPype/pull/4449.
The `content` and `proxy` sets works as well, but not at the same time as the raw nodes directly in the instance set. There is a validator in place to prevent using a single instance for both workflows.

Now the question is whether we should have this as a single family or split somehow?
The workflow of having nodes directly in the instance set, compared to `content` and `proxy` set, can be documented, so I see this as most a matter of terminology.
`Arnold Scene Source` makes sense to have as a family, but only if its a the raw output with little to no validation, similar to `Maya Scene`. But then I'm not sure what to call the other family that has more of a workflow in place, which is similar to `Model` and `Pointcache`.

## Testing notes:
1. Follow Arnold guide for publishing; https://ayon.ynput.io/docs/addon_maya_arnold_artist. Ignoring the `content_SET` does not exists.
