### PR TITLE
AYON settings: Use bundle name as variant in dev mode

### DIFF
--- a/openpype/settings/ayon_settings.py
+++ b/openpype/settings/ayon_settings.py
@@ -1458,7 +1458,7 @@ class _AyonSettingsCache:
 
             variant = "production"
             if is_dev_mode_enabled():
-                variant = cls._get_dev_mode_settings_variant()
+                variant = cls._get_bundle_name()
             elif is_staging_enabled():
                 variant = "staging"
 
@@ -1473,28 +1473,6 @@ class _AyonSettingsCache:
     @classmethod
     def _get_bundle_name(cls):
         return os.environ["AYON_BUNDLE_NAME"]
-
-    @classmethod
-    def _get_dev_mode_settings_variant(cls):
-        """Develop mode settings variant.
-
-        Returns:
-            str: Name of settings variant.
-        """
-
-        con = get_ayon_server_api_connection()
-        bundles = con.get_bundles()
-        user = con.get_user()
-        username = user["name"]
-        for bundle in bundles["bundles"]:
-            if (
-                bundle.get("isDev")
-                and bundle.get("activeUser") == username
-            ):
-                return bundle["name"]
-        # Return fake variant - distribution logic will tell user that he
-        #   does not have set any dev bundle
-        return "dev"
 
     @classmethod
     def get_value_by_project(cls, project_name):


### PR DESCRIPTION
## Changelog Description
Make sure the bundle name is used in dev mode for settings variant.

## Additional info
Bundle name was used as variant only if was assigned to current user which broke most of automations where service users were used.

## Testing notes:
1. Use dev bundle name for automation where service API key is used (e.g. on farm).
2. It should not crash on settings call where would be variant `"dev"`.
