### PR TITLE
AYON Applications: Remove djvview group from default applications

### DIFF
--- a/server_addon/applications/server/applications.json
+++ b/server_addon/applications/server/applications.json
@@ -1175,30 +1175,6 @@
                 }
             ]
         },
-        "djvview": {
-            "enabled": true,
-            "label": "DJV View",
-            "icon": "{}/app_icons/djvView.png",
-            "host_name": "",
-            "environment": "{}",
-            "variants": [
-                {
-                    "name": "1-1",
-                    "label": "1.1",
-                    "executables": {
-                        "windows": [],
-                        "darwin": [],
-                        "linux": []
-                    },
-                    "arguments": {
-                        "windows": [],
-                        "darwin": [],
-                        "linux": []
-                    },
-                    "environment": "{}"
-                }
-            ]
-        },
         "wrap": {
             "enabled": true,
             "label": "Wrap",


### PR DESCRIPTION
## Changelog Description
The djv does not have group defined in models so the values are not used anywhere.

## Additional info
Values were probably remainders after movement of the settings from OpenPype. DJV has own addon with own path settings. Version change is not necessary as this change does not affect anything in the addon.

## Testing notes:
Validate that any applications addon before this PR did not have djv in UI.
1. Create packages
2. Upload applications addon
3. Validate nothing changed
