### PR TITLE
General: added fallback for broken ffprobe return

### DIFF
--- a/openpype/lib/transcoding.py
+++ b/openpype/lib/transcoding.py
@@ -1355,9 +1355,17 @@ def _get_image_dimensions(application, input_path, log):
     """
     # ffmpeg command
     input_file_metadata = get_ffprobe_data(input_path, logger=log)
-    stream = input_file_metadata["streams"][0]
-    input_width = int(stream["width"])
-    input_height = int(stream["height"])
+    input_width = input_height = 0
+    stream = next(
+        (
+            s for s in input_file_metadata["streams"]
+            if s.get("codec_type") == "video"
+        ),
+        {}
+    )
+    if stream:
+        input_width = int(stream["width"])
+        input_height = int(stream["height"])
 
     # fallback for weird files with width=0, height=0
     if (input_width == 0 or input_height == 0) and application == "oiiotool":

--- a/openpype/lib/transcoding.py
+++ b/openpype/lib/transcoding.py
@@ -1232,6 +1232,17 @@ def get_rescaled_command_arguments(
     stream = input_file_metadata["streams"][0]
     input_width = int(stream["width"])
     input_height = int(stream["height"])
+
+    # fallback for weird files with width=0, height=0
+    if (input_width == 0 or input_height == 0) and application == "oiiotool":
+        # Load info about file from oiio tool
+        input_info = get_oiio_info_for_input(input_path, logger=log)
+        if not input_info:
+            raise RuntimeError("Couldn't read {} ".format(input_path) +
+                               "either with ffprobe or oiiotool")
+        input_width = int(input_info["width"])
+        input_height = int(input_info["height"])
+
     stream_input_par = stream.get("sample_aspect_ratio")
     if stream_input_par:
         input_par = (


### PR DESCRIPTION
## Changelog Description
Customer provided .exr returned width and height equal to 0 which caused error in `extract_thumbnail`. This tries to use oiiotool to get metadata about file, in our case it read it correctly.

## Additional info
<img width="270" alt="AnyDesk_XwH276p3SU" src="https://github.com/ynput/OpenPype/assets/4457962/722d5238-ac32-4697-a8fd-10429e16b9c4">

This PR is a bit weird as it solves very specific use case, which could be reoccurring though as source `.exr` comes from Deadline render from Maya and it is not supposed to be special. This update provide just one more layer of safety.

## Testing notes:
1. test on customer site OR
2. use attached test file from Clickup issue and run this in `Tray > Console`:
```
from openpype.lib.transcoding import  get_rescaled_command_arguments

input_path = "FILE_PATH"
args = get_rescaled_command_arguments("oiiotool", input_path, 1900, 1200)
print(args )
```