### PR TITLE
Bugfix/ Houdini: fix default redshift version

### DIFF
--- a/openpype/modules/deadline/plugins/publish/submit_houdini_render_deadline.py
+++ b/openpype/modules/deadline/plugins/publish/submit_houdini_render_deadline.py
@@ -45,7 +45,7 @@ class VrayRenderPluginInfo():
 @attr.s
 class RedshiftRenderPluginInfo():
     SceneFile = attr.ib(default=None)
-    Version = attr.ib(default=None)
+    Version = attr.ib(default="1")
 
 
 class HoudiniSubmitDeadline(

--- a/openpype/modules/deadline/plugins/publish/submit_houdini_render_deadline.py
+++ b/openpype/modules/deadline/plugins/publish/submit_houdini_render_deadline.py
@@ -45,8 +45,9 @@ class VrayRenderPluginInfo():
 @attr.s
 class RedshiftRenderPluginInfo():
     SceneFile = attr.ib(default=None)
-    # "1" was selected as the default RS version as it's the default
-    #  version in RS deadline plugin.
+    # Use "1" as the default Redshift version just because it
+    # default fallback version in Deadline's Redshift plugin
+    # if no version was specified
     Version = attr.ib(default="1")
 
 

--- a/openpype/modules/deadline/plugins/publish/submit_houdini_render_deadline.py
+++ b/openpype/modules/deadline/plugins/publish/submit_houdini_render_deadline.py
@@ -47,7 +47,6 @@ class RedshiftRenderPluginInfo():
     SceneFile = attr.ib(default=None)
     # "1" was selected as the default RS version as it's the default
     #  version in RS deadline plugin.
-    # https://docs.thinkboxsoftware.com/products/deadline/10.1/1_User%20Manual/manual/app-redshift.html#plug-in-configuration
     Version = attr.ib(default="1")
 
 

--- a/openpype/modules/deadline/plugins/publish/submit_houdini_render_deadline.py
+++ b/openpype/modules/deadline/plugins/publish/submit_houdini_render_deadline.py
@@ -45,6 +45,9 @@ class VrayRenderPluginInfo():
 @attr.s
 class RedshiftRenderPluginInfo():
     SceneFile = attr.ib(default=None)
+    # "1" was selected as the default RS version as it's the default
+    #  version in RS deadline plugin.
+    # https://docs.thinkboxsoftware.com/products/deadline/10.1/1_User%20Manual/manual/app-redshift.html#plug-in-configuration
     Version = attr.ib(default="1")
 
 


### PR DESCRIPTION
## Changelog Description
Fixing the bug reported here  https://community.ynput.io/t/houdini-redshift-deadline-executable-error/1210
Let me quote BigRoy's comment: 
If we specify Version as `""` then indeed it tries to access the version as `Redshift_Executable_` instead of the Deadline default `Redshift_Executable_1`

## Testing notes:
1. (As far as I know) Make sure  `REDSHIFT_VERSION` env doesn't exist
2. Enable render archives in Redshift ROP
3. Publish