### PR TITLE
Ftrack: Status update settings are not case insensitive.

### DIFF
--- a/openpype/modules/ftrack/launch_hooks/post_ftrack_changes.py
+++ b/openpype/modules/ftrack/launch_hooks/post_ftrack_changes.py
@@ -131,6 +131,8 @@ class PostFtrackHook(PostLaunchHook):
             for key, value in status_mapping.items():
                 if key in already_tested:
                     continue
+
+                value = value.lower()
                 if actual_status in value or "__any__" in value:
                     if key != "__ignore__":
                         next_status_name = key


### PR DESCRIPTION
## Changelog Description
Make values for project_settings/ftrack/events/status_update case insensitive.

## Testing notes:
1. `project_settings/ftrack/events/status_update` changes values to cases different to what is in Ftrack or go nuts with cases.
2. When launching a task action, the status should still update as expected.
