### PR TITLE
Nuke: Update camera node type to Camera3 as Camera2 is deprecated in Nuke 15

### DIFF
--- a/openpype/hosts/nuke/plugins/load/load_camera_abc.py
+++ b/openpype/hosts/nuke/plugins/load/load_camera_abc.py
@@ -62,7 +62,7 @@ class AlembicCameraLoader(load.LoaderPlugin):
 
         with maintained_selection():
             camera_node = nuke.createNode(
-                "Camera2",
+                "Camera3",
                 "name {} file {} read_from_file True".format(
                     object_name, file),
                 inpanel=False


### PR DESCRIPTION
## Testing notes:
1. Load a camera in OP and try render it out in Nuke 15
