### PR TITLE
Fusion: Use better resolution of Ayon apps on 4k display

### DIFF
--- a/openpype/hosts/fusion/api/menu.py
+++ b/openpype/hosts/fusion/api/menu.py
@@ -173,8 +173,38 @@ class OpenPypeMenu(QtWidgets.QWidget):
         set_asset_framerange()
 
 
+def get_qt_app():
+    """Main Qt application."""
+
+    app = QtWidgets.QApplication.instance()
+    if app is None:
+        for attr_name in (
+            "AA_EnableHighDpiScaling",
+            "AA_UseHighDpiPixmaps",
+        ):
+            attr = getattr(QtCore.Qt, attr_name, None)
+            if attr is not None:
+                QtWidgets.QApplication.setAttribute(attr)
+
+        policy = os.getenv("QT_SCALE_FACTOR_ROUNDING_POLICY")
+        if (
+            hasattr(
+                QtWidgets.QApplication, "setHighDpiScaleFactorRoundingPolicy"
+            )
+            and not policy
+        ):
+            QtWidgets.QApplication.setHighDpiScaleFactorRoundingPolicy(
+                QtCore.Qt.HighDpiScaleFactorRoundingPolicy.PassThrough
+            )
+
+        app = QtWidgets.QApplication(sys.argv)
+
+    return app
+
+
 def launch_openpype_menu():
-    app = QtWidgets.QApplication(sys.argv)
+
+    app = get_qt_app()
 
     pype_menu = OpenPypeMenu()
 

--- a/openpype/hosts/fusion/api/menu.py
+++ b/openpype/hosts/fusion/api/menu.py
@@ -15,6 +15,7 @@ from openpype.hosts.fusion.api.lib import (
 )
 from openpype.pipeline import get_current_asset_name
 from openpype.resources import get_openpype_icon_filepath
+from openpype.tools.utils import get_qt_app
 
 from .pipeline import FusionEventHandler
 from .pulse import FusionPulse
@@ -171,35 +172,6 @@ class OpenPypeMenu(QtWidgets.QWidget):
 
     def on_set_framerange_clicked(self):
         set_asset_framerange()
-
-
-def get_qt_app():
-    """Main Qt application."""
-
-    app = QtWidgets.QApplication.instance()
-    if app is None:
-        for attr_name in (
-            "AA_EnableHighDpiScaling",
-            "AA_UseHighDpiPixmaps",
-        ):
-            attr = getattr(QtCore.Qt, attr_name, None)
-            if attr is not None:
-                QtWidgets.QApplication.setAttribute(attr)
-
-        policy = os.getenv("QT_SCALE_FACTOR_ROUNDING_POLICY")
-        if (
-            hasattr(
-                QtWidgets.QApplication, "setHighDpiScaleFactorRoundingPolicy"
-            )
-            and not policy
-        ):
-            QtWidgets.QApplication.setHighDpiScaleFactorRoundingPolicy(
-                QtCore.Qt.HighDpiScaleFactorRoundingPolicy.PassThrough
-            )
-
-        app = QtWidgets.QApplication(sys.argv)
-
-    return app
 
 
 def launch_openpype_menu():

--- a/openpype/tools/utils/__init__.py
+++ b/openpype/tools/utils/__init__.py
@@ -32,6 +32,7 @@ from .lib import (
     set_style_property,
     DynamicQThread,
     qt_app_context,
+    get_qt_app,
     get_openpype_qt_app,
     get_asset_icon,
     get_asset_icon_by_name,

--- a/openpype/tools/utils/lib.py
+++ b/openpype/tools/utils/lib.py
@@ -154,11 +154,15 @@ def qt_app_context():
         yield app
 
 
-def get_openpype_qt_app():
-    """Main Qt application initialized for OpenPype processed.
+def get_qt_app():
+    """Get Qt application.
 
-    This function should be used only inside OpenPype process and never inside
-        other processes.
+    The function initializes new Qt application if it is not already
+    initialized. It also sets some attributes to the application to
+    ensure that it will work properly on high DPI displays.
+
+    Returns:
+        QtWidgets.QApplication: Current Qt application.
     """
 
     app = QtWidgets.QApplication.instance()
@@ -184,6 +188,17 @@ def get_openpype_qt_app():
 
         app = QtWidgets.QApplication(sys.argv)
 
+    return app
+
+
+def get_openpype_qt_app():
+    """Main Qt application initialized for OpenPype processed.
+
+    This function should be used only inside OpenPype process and never inside
+        other processes.
+    """
+
+    app = get_qt_app()
     app.setWindowIcon(QtGui.QIcon(get_app_icon_path()))
     return app
 


### PR DESCRIPTION
## Changelog Description
Changes size (makes it smaller) of Ayon apps (Workfiles, Loader) in Fusion on high definitions displays.

## Additional info
Special get_qt_app is used instead of shared get_openpype_qt_app as we don't want to set application icon.

## Testing notes:
1. start with this step
2. follow this step
