### PR TITLE
TimersManager: Idle dialog always on top

### DIFF
--- a/openpype/modules/timers_manager/timers_manager.py
+++ b/openpype/modules/timers_manager/timers_manager.py
@@ -162,6 +162,7 @@ class TimersManager(
     def tray_start(self, *_a, **_kw):
         if self._idle_manager:
             self._idle_manager.start()
+        self.show_message()
 
     def tray_exit(self):
         if self._idle_manager:
@@ -373,8 +374,8 @@ class TimersManager(
                     ).format(module.name))
 
     def show_message(self):
-        if self.is_running is False:
-            return
+        # if self.is_running is False:
+        #     return
         if not self._widget_user_idle.is_showed():
             self._widget_user_idle.reset_countdown()
             self._widget_user_idle.show()

--- a/openpype/modules/timers_manager/timers_manager.py
+++ b/openpype/modules/timers_manager/timers_manager.py
@@ -162,7 +162,6 @@ class TimersManager(
     def tray_start(self, *_a, **_kw):
         if self._idle_manager:
             self._idle_manager.start()
-        self.show_message()
 
     def tray_exit(self):
         if self._idle_manager:
@@ -374,8 +373,8 @@ class TimersManager(
                     ).format(module.name))
 
     def show_message(self):
-        # if self.is_running is False:
-        #     return
+        if self.is_running is False:
+            return
         if not self._widget_user_idle.is_showed():
             self._widget_user_idle.reset_countdown()
             self._widget_user_idle.show()

--- a/openpype/modules/timers_manager/widget_user_idle.py
+++ b/openpype/modules/timers_manager/widget_user_idle.py
@@ -17,6 +17,7 @@ class WidgetUserIdle(QtWidgets.QWidget):
         self.setWindowFlags(
             QtCore.Qt.WindowCloseButtonHint
             | QtCore.Qt.WindowMinimizeButtonHint
+            | QtCore.Qt.WindowStaysOnTopHint
         )
 
         self._is_showed = False


### PR DESCRIPTION
## Changelog Description
Make stop timer dialog always on top
https://app.clickup.com/t/6658547/OP-8033

## Testing notes:
1. leave system idle for a long time
2. wait for idle popup dialog