### PR TITLE
TrayPublisher: adding settings category to base creator classes

### DIFF
--- a/openpype/hosts/traypublisher/api/plugin.py
+++ b/openpype/hosts/traypublisher/api/plugin.py
@@ -32,6 +32,7 @@ SHARED_DATA_KEY = "openpype.traypublisher.instances"
 
 class HiddenTrayPublishCreator(HiddenCreator):
     host_name = "traypublisher"
+    settings_category = "traypublisher"
 
     def collect_instances(self):
         instances_by_identifier = cache_and_get_instances(
@@ -68,6 +69,7 @@ class HiddenTrayPublishCreator(HiddenCreator):
 class TrayPublishCreator(Creator):
     create_allow_context_change = True
     host_name = "traypublisher"
+    settings_category = "traypublisher"
 
     def collect_instances(self):
         instances_by_identifier = cache_and_get_instances(


### PR DESCRIPTION
## Changelog Description
Settings are resolving correctly as they suppose to.

## Additional info
Missing settings category is now correctly identifying settings which should be matched to creator plugins.

## Testing notes:
1. Just open traypublisher.
2. go to your settings and change anything
3. see that it is correctly reflected in creation
