### PR TITLE
AfterEffects: added toggle for applying values from DB during creation

### DIFF
--- a/openpype/hosts/aftereffects/plugins/create/create_render.py
+++ b/openpype/hosts/aftereffects/plugins/create/create_render.py
@@ -29,6 +29,7 @@ class RenderCreator(Creator):
 
     # Settings
     mark_for_review = True
+    force_setting_values = True
 
     def create(self, subset_name_from_ui, data, pre_create_data):
         stub = api.get_stub()  # only after After Effects is up
@@ -96,7 +97,9 @@ class RenderCreator(Creator):
             self._add_instance_to_context(new_instance)
 
             stub.rename_item(comp.id, subset_name)
-            set_settings(True, True, [comp.id], print_msg=False)
+
+            if self.force_setting_values:
+                set_settings(True, True, [comp.id], print_msg=False)
 
     def get_pre_create_attr_defs(self):
         output = [
@@ -173,6 +176,7 @@ class RenderCreator(Creator):
         )
 
         self.mark_for_review = plugin_settings["mark_for_review"]
+        self.force_setting_values = plugin_settings["force_setting_values"]
         self.default_variants = plugin_settings.get(
             "default_variants",
             plugin_settings.get("defaults") or []

--- a/openpype/settings/defaults/project_settings/aftereffects.json
+++ b/openpype/settings/defaults/project_settings/aftereffects.json
@@ -15,7 +15,8 @@
             "default_variants": [
                 "Main"
             ],
-            "mark_for_review": true
+            "mark_for_review": true,
+            "force_setting_values": true
         }
     },
     "publish": {

--- a/openpype/settings/entities/schemas/projects_schema/schema_project_aftereffects.json
+++ b/openpype/settings/entities/schemas/projects_schema/schema_project_aftereffects.json
@@ -42,6 +42,12 @@
                             "key": "mark_for_review",
                             "label": "Review",
                             "default": true
+                         },
+                        {
+                            "type": "boolean",
+                            "key": "force_setting_values",
+                            "label": "Force resolution and duration values from Asset",
+                            "default": true
                          }
                     ]
                 }

--- a/server_addon/aftereffects/server/settings/creator_plugins.py
+++ b/server_addon/aftereffects/server/settings/creator_plugins.py
@@ -7,6 +7,8 @@ class CreateRenderPlugin(BaseSettingsModel):
         default_factory=list,
         title="Default Variants"
     )
+    force_setting_values: bool = SettingsField(
+        True, title="Force resolution and duration values from Asset")
 
 
 class AfterEffectsCreatorPlugins(BaseSettingsModel):

--- a/server_addon/aftereffects/server/version.py
+++ b/server_addon/aftereffects/server/version.py
@@ -1,3 +1,3 @@
 # -*- coding: utf-8 -*-
 """Package declaring addon version."""
-__version__ = "0.1.2"
+__version__ = "0.1.3"


### PR DESCRIPTION
## Changelog Description
Previously values (resolution, duration) from Asset (eg. DB) were applied explicitly when instance of `render` product type was created. 
This PR adds toggle to Settings to disable this. (This allows artist to publish non standard length of composition, disabling of `Validate Scene Settings` is still required.)

## Additional info
![image](https://github.com/ynput/OpenPype/assets/4457962/d9c1cea5-57f1-457f-9285-358541c08c0b).

Added only to Settings and not Publisher UI currently. I think it would add too much clutter.

This is mainly target for legacy OP per specific client request.


## Testing notes:
1. play with `project_settings/aftereffects/create/RenderCreator/force_setting_values` value
2. create instance in AE
3. check if duration got/didn't get applied to composition (RMB on comp > Composition Settings)
