### PR TITLE
Nuke: Add product key to template for node names

### DIFF
--- a/openpype/hosts/nuke/plugins/load/load_clip.py
+++ b/openpype/hosts/nuke/plugins/load/load_clip.py
@@ -445,9 +445,12 @@ class LoadClip(plugin.NukeLoader):
             "representation": representation["name"],
             "ext": repre_cont["representation"],
             "id": representation["_id"],
-            "class_name": self.__class__.__name__
+            "class_name": self.__class__.__name__,
+            "product": {
+                "name": repre_cont["subset"],
+                "type": repre_cont["family"],
+            },
         }
-
         return self.node_name_template.format(**name_data)
 
     def _set_colorspace(self, node, version_data, repre_data, path):


### PR DESCRIPTION
## Changelog Description
Product key was missing from Nuke template node name

## Testing notes:
1. Try use `{product[name]}` on the LoadClip template
