### PR TITLE
Nuke: expose knobs backward compatibility fix - OP-8164

### DIFF
--- a/openpype/hosts/nuke/api/plugin.py
+++ b/openpype/hosts/nuke/api/plugin.py
@@ -1348,7 +1348,9 @@ def _remove_old_knobs(node):
 
 
 def exposed_write_knobs(settings, plugin_name, instance_node):
-    exposed_knobs = settings["nuke"]["create"][plugin_name]["exposed_knobs"]
+    exposed_knobs = settings["nuke"]["create"][plugin_name].get(
+        "exposed_knobs", []
+    )
     if exposed_knobs:
         instance_node.addKnob(nuke.Text_Knob('', 'Write Knobs'))
     write_node = nuke.allNodes(group=instance_node, filter="Write")[0]


### PR DESCRIPTION
## Changelog Description
Fix backwards compatibility for settings `project_settings/nuke/create/CreateWriteRender/exposed_knobs`.

## Testing notes:
1. In Nuke create a write instance.
