### PR TITLE
AE: fix local render doesn't push thumbnail to Ftrack

### DIFF
--- a/openpype/plugins/publish/extract_thumbnail.py
+++ b/openpype/plugins/publish/extract_thumbnail.py
@@ -35,6 +35,7 @@ class ExtractThumbnail(pyblish.api.InstancePlugin):
         "traypublisher",
         "substancepainter",
         "nuke",
+        "aftereffects"
     ]
     enabled = False
 


### PR DESCRIPTION
## Changelog Description
Without thumbnail review is not clickable from main Versions list


## Testing notes:
1. render from AE locally 
2. render from AE on farm
3. both reviews on Ftrack should be clickable and playable directly from Versions list
