### PR TITLE
Nuke: openpype expose knobs validator - OP-8166

### DIFF
--- a/openpype/hosts/nuke/plugins/publish/validate_exposed_knobs.py
+++ b/openpype/hosts/nuke/plugins/publish/validate_exposed_knobs.py
@@ -65,7 +65,7 @@ class ValidateExposedKnobs(
         group_node = instance.data["transientData"]["node"]
         nuke_settings = instance.context.data["project_settings"]["nuke"]
         create_settings = nuke_settings["create"][plugin]
-        exposed_knobs = create_settings["exposed_knobs"]
+        exposed_knobs = create_settings.get("exposed_knobs", [])
         unexposed_knobs = []
         for knob in exposed_knobs:
             if knob not in group_node.knobs():


### PR DESCRIPTION
## Changelog Description
Fix exposed knobs validator for backwards compatibility with missing settings.

## Testing notes:
1. Create write instance in Nuke.
3. Publish and check validator run successfully.
