### PR TITLE
Deadline: Expose families transfer setting - OP-8268

### DIFF
--- a/openpype/settings/defaults/project_settings/deadline.json
+++ b/openpype/settings/defaults/project_settings/deadline.json
@@ -129,6 +129,7 @@
             "deadline_priority": 50,
             "publishing_script": "",
             "skip_integration_repre_list": [],
+            "families_transfer": ["render3d", "render2d", "ftrack", "slate"],
             "aov_filter": {
                 "maya": [
                     ".*([Bb]eauty).*"

--- a/openpype/settings/entities/schemas/projects_schema/schema_project_deadline.json
+++ b/openpype/settings/entities/schemas/projects_schema/schema_project_deadline.json
@@ -694,6 +694,14 @@
                             }
                         },
                         {
+                            "type": "list",
+                            "key": "families_transfer",
+                            "label": "List of family names to transfer\nto generated instances (AOVs for example).",
+                            "object_type": {
+                                "type": "text"
+                            }
+                        },
+                        {
                             "type": "dict-modifiable",
                             "docstring": "Regular expression to filter for which subset review should be created in publish job.",
                             "key": "aov_filter",


### PR DESCRIPTION
## Changelog Description
This PR exposes the `families_transfer` attribute on the `ProcessSubmittedJobOnFarm` plugin.

The use case is to remove `ftrack` from the list if a studio does not want all render passes from Maya to become asset versions in Ftrack.

## Testing notes:
1. Go to `project_settings/deadline/publish/ProcessSubmittedJobOnFarm/families_transfer` and remove `ftrack`.
2. Setup render with render passes in Maya and publish to Deadline.
3. Validate only the beauty pass is created as asset version in Ftrack.
