### PR TITLE
Hiero: Add OP settings and convert in plugin - OP-8338

### DIFF
--- a/openpype/hosts/hiero/plugins/publish/collect_clip_effects.py
+++ b/openpype/hosts/hiero/plugins/publish/collect_clip_effects.py
@@ -72,9 +72,13 @@ class CollectClipEffects(pyblish.api.InstancePlugin):
 
         subset_split.insert(0, "effect")
 
-        effect_categories = {
-            x["name"]: x["effect_classes"] for x in self.effect_categories
-        }
+        # Need to convert to dict for AYON settings. This isinstance check can
+        # be removed in the future when OpenPype is no longer.
+        effect_categories = self.effect_categories
+        if isinstance(self.effect_categories, list):
+            effect_categories = {
+                x["name"]: x["effect_classes"] for x in self.effect_categories
+            }
 
         category_by_effect = {"": ""}
         for key, values in effect_categories.items():

--- a/openpype/settings/defaults/project_settings/hiero.json
+++ b/openpype/settings/defaults/project_settings/hiero.json
@@ -69,6 +69,10 @@
             "tags_addition": [
                 "review"
             ]
+        },
+        "CollectClipEffects": {
+            "enabled": true,
+            "effect_categories": {}
         }
     },
     "filters": {},

--- a/openpype/settings/entities/schemas/projects_schema/schema_project_hiero.json
+++ b/openpype/settings/entities/schemas/projects_schema/schema_project_hiero.json
@@ -312,6 +312,31 @@
                             "label": "Tags addition"
                         }
                     ]
+                },
+                {
+                    "type": "dict",
+                    "collapsible": true,
+                    "checkbox_key": "enabled",
+                    "key": "CollectClipEffects",
+                    "label": "Collect Clip Effects",
+                    "is_group": true,
+                    "children": [
+                        {
+                            "type": "boolean",
+                            "key": "enabled",
+                            "label": "Enabled"
+                        },
+                        {
+                            "type": "dict-modifiable",
+                            "key": "effect_categories",
+                            "label": "Effect Categories",
+                            "object_type": {
+                                "type": "list",
+                                "key": "effects_classes",
+                                "object_type": "text"
+                            }
+                        }
+                    ]
                 }
             ]
         },


### PR DESCRIPTION
## Changelog Description
Missing settings for https://github.com/ynput/OpenPype/pull/6143.

## Testing notes:
1. Setup `Effect Categories` in Hiero addon settings (see documentation); `project_settings/hiero/publish/CollectClipEffects/effect_categories`
2. Setup a clip in Hiero with effects corresponding to the settings.
3. Publish clip and effects.
4. Load into Nuke and verify the effects are grouped correctly.
