### PR TITLE
Unreal: Fix Render Instance Collector to use folderPath

### DIFF
--- a/openpype/hosts/unreal/plugins/publish/collect_render_instances.py
+++ b/openpype/hosts/unreal/plugins/publish/collect_render_instances.py
@@ -64,7 +64,7 @@ class CollectRenderInstances(pyblish.api.InstancePlugin):
 
                     new_data = new_instance.data
 
-                    new_data["asset"] = seq_name
+                    new_data["asset"] = f"/{s.get('output')}"
                     new_data["setMembers"] = seq_name
                     new_data["family"] = "render"
                     new_data["families"] = ["render", "review"]


### PR DESCRIPTION
## Changelog Description
Fix Render Instance Collector to use folderPath instead of just the asset name.

## Additional info
This was causing the `ValidateSequenceFrames` validator to fail because couldn't find the asset data in the database.
