### PR TITLE
Nuke: render use existing frames with slate offsets the published render - AY-1433

### DIFF
--- a/openpype/hosts/nuke/plugins/publish/collect_slate_node.py
+++ b/openpype/hosts/nuke/plugins/publish/collect_slate_node.py
@@ -17,7 +17,8 @@ class CollectSlate(pyblish.api.InstancePlugin):
             (
                 n_ for n_ in nuke.allNodes()
                 if "slate" in n_.name().lower()
-                if not n_["disable"].getValue()
+                if not n_["disable"].getValue() and
+                "publish_instance" not in n_.knobs()  # Exclude instance nodes.
             ),
             None
         )

--- a/openpype/hosts/nuke/plugins/publish/collect_writes.py
+++ b/openpype/hosts/nuke/plugins/publish/collect_writes.py
@@ -194,7 +194,6 @@ class CollectNukeWrites(pyblish.api.InstancePlugin,
                 "frameEndHandle": last_frame,
             })
 
-
         # TODO temporarily set stagingDir as persistent for backward
         # compatibility. This is mainly focused on `renders`folders which
         # were previously not cleaned up (and could be used in read notes)
@@ -268,10 +267,6 @@ class CollectNukeWrites(pyblish.api.InstancePlugin,
             "stagingDir": output_dir,
             "tags": []
         }
-
-        frame_start_str = self._get_frame_start_str(first_frame, last_frame)
-
-        representation['frameStart'] = frame_start_str
 
         # set slate frame
         collected_frames = self._add_slate_frame_to_collected_frames(


### PR DESCRIPTION
## Changelog Description
Due to `frameStart` data member on representation for existing frames, the frame indexes would be re-numbered when integrating due to this; https://github.com/ynput/OpenPype/blob/develop/openpype/plugins/publish/integrate.py#L712-L726

Removing `frameStart` had no effect on publishing workflows, local or farm.

Also fixed an issues with slate collection which could misbehave if the instance node had "slate" in the name.

Resolves #5883

## Testing notes:
1. Add nuke slate to the script
2. Publish render using local machine rendering
3. Publish render with `Use existing frames` option (will reuse render from previous step)
4. Check integration logs where it copied files to publish destination, which should keep frame indexes intact. Looks like this:
```
Copying file ... P:\PROJECTS\toke_testing\OP_7336_slate_workflow_broken_if_existing_frames\work\compositing\renders\nuke\renderCompositingSlate\renderCompositingSlate.0000.exr -> P:\PROJECTS\toke_testing\OP_7336_slate_workflow_broken_if_existing_frames\publish\render\renderCompositingSlate\v031\toke_testing_OP_7336_slate_workflow_broken_if_existing_frames_renderCompositingSlate_v031.0000.exr
```
