### PR TITLE
AYON Workfiles tool: Copy and open of published workfile works

### DIFF
--- a/openpype/tools/ayon_workfiles/control.py
+++ b/openpype/tools/ayon_workfiles/control.py
@@ -573,6 +573,7 @@ class BaseWorkfileController(
                 workdir,
                 filename,
                 template_key,
+                src_filepath=representation_filepath
             )
         except Exception:
             failed = True


### PR DESCRIPTION
## Changelog Description
Fix copy and open published workfiles.

## Additional info
The button just saved as current workfile instead of using the representation path.

## Testing notes:
1. Make sure a workfile is published.
2. Launch the host/dcc.
3. Open workfiles tool.
4. Check `Published workfile` checkbox.
5. Select published workfile and click `Copy & Open` button.
6. It should copy and open the file.