### PR TITLE
Maya: Ensure unique class name compared to `extract_yeti_cache.py`

### DIFF
--- a/openpype/hosts/maya/plugins/publish/extract_unreal_yeticache.py
+++ b/openpype/hosts/maya/plugins/publish/extract_unreal_yeticache.py
@@ -5,13 +5,13 @@ from maya import cmds
 from openpype.pipeline import publish
 
 
-class ExtractYetiCache(publish.Extractor):
+class ExtractUnrealYetiCache(publish.Extractor):
     """Producing Yeti cache files using scene time range.
 
     This will extract Yeti cache file sequence and fur settings.
     """
 
-    label = "Extract Yeti Cache"
+    label = "Extract Yeti Cache (Unreal)"
     hosts = ["maya"]
     families = ["yeticacheUE"]
 


### PR DESCRIPTION
## Changelog Description

Fix duplicate `ExtractYetiCache` plug-in name.

## Additional info

I mentioned [that issue on Discord a while back](https://discord.com/channels/517362899170230292/517382145552154634/1181190681490894858)

Likely also fixes this community topic: https://community.ynput.io/t/yeticache-error-in-3-18-7/1323/5

Ayon equivalent: https://github.com/ynput/ayon-core/pull/251

## Testing notes:

1. Extract Yeti cache should work.
2. Extract Yeti cache to unreal should work.
