### PR TITLE
Deadline: Submit Publish job error

### DIFF
--- a/openpype/modules/deadline/plugins/publish/submit_maya_remote_publish_deadline.py
+++ b/openpype/modules/deadline/plugins/publish/submit_maya_remote_publish_deadline.py
@@ -108,7 +108,6 @@ class MayaSubmitRemotePublishDeadline(
                             if key in os.environ}, **legacy_io.Session)
 
         # TODO replace legacy_io with context.data
-        environment["AVALON_DB"] = os.environ.get("AVALON_DB")
         environment["AVALON_PROJECT"] = project_name
         environment["AVALON_ASSET"] = instance.context.data["asset"]
         environment["AVALON_TASK"] = instance.context.data["task"]
@@ -122,6 +121,7 @@ class MayaSubmitRemotePublishDeadline(
             environment["AYON_REMOTE_PUBLISH"] = "1"
         else:
             environment["OPENPYPE_REMOTE_PUBLISH"] = "1"
+            environment["AVALON_DB"] = os.environ.get("AVALON_DB")
         for key, value in environment.items():
             job_info.EnvironmentKeyValue[key] = value
 

--- a/openpype/modules/deadline/plugins/publish/submit_publish_cache_job.py
+++ b/openpype/modules/deadline/plugins/publish/submit_publish_cache_job.py
@@ -131,7 +131,6 @@ class ProcessSubmittedCacheJobOnFarm(pyblish.api.InstancePlugin,
             create_metadata_path(instance, anatomy)
 
         environment = {
-            "AVALON_DB": os.environ["AVALON_DB"],
             "AVALON_PROJECT": instance.context.data["projectName"],
             "AVALON_ASSET": instance.context.data["asset"],
             "AVALON_TASK": instance.context.data["task"],
@@ -147,6 +146,7 @@ class ProcessSubmittedCacheJobOnFarm(pyblish.api.InstancePlugin,
             environment["AYON_BUNDLE_NAME"] = os.environ["AYON_BUNDLE_NAME"]
             deadline_plugin = "Ayon"
         else:
+            environment["AVALON_DB"] = os.environ["AVALON_DB"]
             environment["OPENPYPE_PUBLISH_JOB"] = "1"
             environment["OPENPYPE_RENDER_JOB"] = "0"
             environment["OPENPYPE_REMOTE_PUBLISH"] = "0"

--- a/openpype/modules/deadline/plugins/publish/submit_publish_job.py
+++ b/openpype/modules/deadline/plugins/publish/submit_publish_job.py
@@ -202,7 +202,7 @@ class ProcessSubmittedJobOnFarm(pyblish.api.InstancePlugin,
             environment["AYON_BUNDLE_NAME"] = os.environ["AYON_BUNDLE_NAME"]
             deadline_plugin = "Ayon"
         else:
-            environment["AVALON_DB"] = os.getenv("AVALON_DB")
+            environment["AVALON_DB"] = os.environ["AVALON_DB"]
             environment["OPENPYPE_PUBLISH_JOB"] = "1"
             environment["OPENPYPE_RENDER_JOB"] = "0"
             environment["OPENPYPE_REMOTE_PUBLISH"] = "0"

--- a/openpype/modules/deadline/plugins/publish/submit_publish_job.py
+++ b/openpype/modules/deadline/plugins/publish/submit_publish_job.py
@@ -187,7 +187,7 @@ class ProcessSubmittedJobOnFarm(pyblish.api.InstancePlugin,
             create_metadata_path(instance, anatomy)
 
         environment = {
-            "AVALON_DB": os.environ["AVALON_DB"],
+            "AVALON_DB": os.getenv("AVALON_DB"),
             "AVALON_PROJECT": instance.context.data["projectName"],
             "AVALON_ASSET": instance.context.data["asset"],
             "AVALON_TASK": instance.context.data["task"],

--- a/openpype/modules/deadline/plugins/publish/submit_publish_job.py
+++ b/openpype/modules/deadline/plugins/publish/submit_publish_job.py
@@ -187,7 +187,6 @@ class ProcessSubmittedJobOnFarm(pyblish.api.InstancePlugin,
             create_metadata_path(instance, anatomy)
 
         environment = {
-            "AVALON_DB": os.getenv("AVALON_DB"),
             "AVALON_PROJECT": instance.context.data["projectName"],
             "AVALON_ASSET": instance.context.data["asset"],
             "AVALON_TASK": instance.context.data["task"],
@@ -203,6 +202,7 @@ class ProcessSubmittedJobOnFarm(pyblish.api.InstancePlugin,
             environment["AYON_BUNDLE_NAME"] = os.environ["AYON_BUNDLE_NAME"]
             deadline_plugin = "Ayon"
         else:
+            environment["AVALON_DB"] = os.getenv("AVALON_DB")
             environment["OPENPYPE_PUBLISH_JOB"] = "1"
             environment["OPENPYPE_RENDER_JOB"] = "0"
             environment["OPENPYPE_REMOTE_PUBLISH"] = "0"


### PR DESCRIPTION
## Changelog Description
Use get env to get the value of `AVALON_DB`
`AVALON_DB` environment variable is not initialized when using OpenPype in Ayon mode. 
which raise an error when using `os.environ["AVALON_DB"]`
This PR changes it to `os.getenv("AVALON_DB")` 

## Testing notes:
1. Open a dcc
2. Publish a render, publisher shouldn't complain about  `AVALON_DB` being non exist.
