### PR TITLE
Fix: Removed double conversion of limit_groups

### DIFF
--- a/openpype/settings/ayon_settings.py
+++ b/openpype/settings/ayon_settings.py
@@ -1041,11 +1041,6 @@ def _convert_deadline_project_settings(ayon_settings, output):
         ayon_deadline.pop(key)
 
     ayon_deadline_publish = ayon_deadline["publish"]
-    limit_groups = {
-        item["name"]: item["value"]
-        for item in ayon_deadline_publish["NukeSubmitDeadline"]["limit_groups"]
-    }
-    ayon_deadline_publish["NukeSubmitDeadline"]["limit_groups"] = limit_groups
 
     maya_submit = ayon_deadline_publish["MayaSubmitDeadline"]
     for json_key in ("jobInfo", "pluginInfo"):


### PR DESCRIPTION
## Changelog Description
`limit_groups` settings got transformed twice. Kept nicer looking conversion.


## Testing notes:
1. try to open Launcher on some project
2. it shouldn't throw
```
    item["name"]: item["value"] for item in nuke_submit.pop("limit_groups")
TypeError: string indices must be integers
```
and show DCCs
