### PR TITLE
Chore: Parenthesis in shell

### DIFF
--- a/openpype/hosts/standalonepublisher/plugins/publish/extract_thumbnail.py
+++ b/openpype/hosts/standalonepublisher/plugins/publish/extract_thumbnail.py
@@ -93,6 +93,14 @@ class ExtractThumbnailSP(pyblish.api.InstancePlugin):
 
         subprocess_jpeg = " ".join(jpeg_items)
 
+        if os.getenv("SHELL") in ("/bin/bash", "/bin/sh"):
+            # Escape parentheses for bash
+            subprocess_jpeg = (
+                subprocess_jpeg
+                .replace("(", "\\(")
+                .replace(")", "\\)")
+            )
+
         # run subprocess
         self.log.debug("Executing: {}".format(subprocess_jpeg))
         run_subprocess(

--- a/openpype/plugins/publish/extract_review.py
+++ b/openpype/plugins/publish/extract_review.py
@@ -418,6 +418,13 @@ class ExtractReview(pyblish.api.InstancePlugin):
                 raise NotImplementedError
 
             subprcs_cmd = " ".join(ffmpeg_args)
+            if os.getenv("SHELL") in ("/bin/bash", "/bin/sh"):
+                # Escape parentheses for bash
+                subprcs_cmd = (
+                    subprcs_cmd
+                    .replace("(", "\\(")
+                    .replace(")", "\\)")
+                )
 
             # run subprocess
             self.log.debug("Executing: {}".format(subprcs_cmd))

--- a/openpype/plugins/publish/extract_review_slate.py
+++ b/openpype/plugins/publish/extract_review_slate.py
@@ -270,6 +270,14 @@ class ExtractReviewSlate(publish.Extractor):
             ]
             slate_subprocess_cmd = " ".join(slate_args)
 
+            if os.getenv("SHELL") in ("/bin/bash", "/bin/sh"):
+                # Escape parentheses for bash
+                slate_subprocess_cmd = (
+                    slate_subprocess_cmd
+                    .replace("(", "\\(")
+                    .replace(")", "\\)")
+                )
+
             # run slate generation subprocess
             self.log.debug(
                 "Slate Executing: {}".format(slate_subprocess_cmd)

--- a/openpype/plugins/publish/extract_thumbnail.py
+++ b/openpype/plugins/publish/extract_thumbnail.py
@@ -447,6 +447,14 @@ class ExtractThumbnail(pyblish.api.InstancePlugin):
         # output file
         jpeg_items.append(path_to_subprocess_arg(dst_path))
         subprocess_command = " ".join(jpeg_items)
+        if os.getenv("SHELL") in ("/bin/bash", "/bin/sh"):
+            # Escape parentheses for bash
+            subprocess_command = (
+                subprocess_command
+                .replace("(", "\\(")
+                .replace(")", "\\)")
+            )
+
         try:
             run_subprocess(
                 subprocess_command, shell=True, logger=self.log


### PR DESCRIPTION
## Changelog Description
Escape parenthesis for shell subprocess when `bash` or `sh` are set as shell applications.

## Additional info
Content of parenthesis is "executed" in bash so it is necessary to escape them. This was discovered when thumbnail extraction should change resolution and command contained something like `(1920-iw)`.

## Testing notes:
I don't know. It requires linux machine and specific settings and case.