### PR TITLE
[QUAD] Maya ABC Camera extraction: Fix relationship bug

### DIFF
--- a/openpype/hosts/maya/plugins/publish/extract_camera_alembic.py
+++ b/openpype/hosts/maya/plugins/publish/extract_camera_alembic.py
@@ -91,7 +91,8 @@ class ExtractCameraAlembic(publish.Extractor,
                     transform = cmds.listRelatives(
                         member, parent=True, fullPath=True)
                     transform = transform[0] if transform else member
-                    job_str += ' -root {0}'.format(transform)
+                    if transform not in camera_root:
+                        job_str += ' -root {0}'.format(transform)
 
             job_str += ' -file "{0}"'.format(path)
 

--- a/openpype/hosts/maya/plugins/publish/extract_camera_mayaScene.py
+++ b/openpype/hosts/maya/plugins/publish/extract_camera_mayaScene.py
@@ -143,7 +143,7 @@ class ExtractCameraMayaScene(publish.Extractor,
         # get cameras
         members = set(cmds.ls(instance.data['setMembers'], leaf=True,
                       shapes=True, long=True, dag=True))
-        cameras = set(cmds.ls(members, leaf=True, shapes=True, long=True,
+        cameras = set(cmds.ls(members, shapes=True, long=True,
                       dag=True, type="camera"))
 
         # validate required settings


### PR DESCRIPTION
## Changelog Description
Paragraphs contain detailed information on the changes made to the product or service, providing an in-depth description of the updates and enhancements. They can be used to explain the reasoning behind the changes, or to highlight the importance of the new features. Paragraphs can often include links to further information or support documentation.

## Additional info
Previous crashlog:
```
Traceback (most recent call last):
  File "/users_roaming/chector/Documents/src/OpenPype/.venv/lib/python3.9/site-packages/pyblish/plugin.py", line 522, in __explicit_process
    runner(*args)
  File "/users_roaming/chector/Documents/src/OpenPype/openpype/hosts/maya/plugins/publish/extract_camera_alembic.py", line 104, in process
  File "/users_roaming/chector/Documents/src/OpenPype/openpype/hosts/maya/plugins/publish/extract_camera_alembic.py", line 2, in AbcExport
RuntimeError: |root and |root|grp_cam|camera_camerarigMain_01:asset|camera_camerarigMain_01:root|camera_camerarigMain_01:grp_camera|camera_camerarigMain_01:camera have parenting relationships
|root and |root|grp_cam|camera_camerarigMain_01:asset|camera_camerarigMain_01:root|camera_camerarigMain_01:grp_camera|camera_camerarigMain_01:camera have an ancestor relationship.
```

## Testing notes:
1. start with this step
2. follow this step
